### PR TITLE
fix(install/webapps.sh): capitalize YouTube

### DIFF
--- a/install/webapps.sh
+++ b/install/webapps.sh
@@ -3,6 +3,6 @@ web2app "WhatsApp" https://web.whatsapp.com/ https://cdn.jsdelivr.net/gh/homarr-
 web2app "Google Photos" https://photos.google.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/google-photos.png
 web2app "Google Contacts" https://contacts.google.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/google-contacts.png
 web2app "ChatGPT" https://chatgpt.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/chatgpt.png
-web2app "Youtube" https://youtube.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/youtube.png
+web2app "YouTube" https://youtube.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/youtube.png
 web2app "GitHub" https://github.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/github-light.png
 web2app "X" https://x.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/x-light.png


### PR DESCRIPTION
YouTube is "YouTube" not "Youtube". It is correctly capitalized in the Omarchy manual, so I figured this was a simple typo and was not intentional.

Ref: https://manuals.omamix.org/2/the-omarchy-manual/63/web-apps#youtube
Ref: https://en.wikipedia.org/wiki/YouTube