### PR TITLE
Fix for persistent workspaces shown in waybar

### DIFF
--- a/config/waybar/config
+++ b/config/waybar/config
@@ -34,7 +34,7 @@
         "9": "9",
         "active": "󱓻"
       },
-      "persistent_workspaces": {
+      "persistent-workspaces": {
         "1": [],
         "2": [],
         "3": [],


### PR DESCRIPTION
An underscore in stead of a dash in the waybar config made that the persistent workspaces were missing.