### PR TITLE
chore: removed duplicated key in waybar battery config

### DIFF
--- a/config/waybar/config
+++ b/config/waybar/config
@@ -66,7 +66,6 @@
       "on-click": "alacritty -e iwctl"
     },
     "battery": {
-      "interval": 5,
       "format": "{capacity}% {icon}",
       "format-discharging": "{icon}",
       "format-charging":    "{icon}",


### PR DESCRIPTION
Polling interval for battery is declared twice, removed one of them.