### PR TITLE
Clock application

### DIFF
--- a/install/xtras.sh
+++ b/install/xtras.sh
@@ -1,7 +1,7 @@
 yay -S --noconfirm --needed \
   signal-desktop spotify dropbox-cli zoom \
   obsidian typora libreoffice obs-studio kdenlive \
-  pinta xournalpp
+  pinta xournalpp gnome-clocks
 
 # Copy over Omarchy applications
 source ~/.local/share/omarchy/bin/omarchy-sync-applications


### PR DESCRIPTION
Having a clock app is necessary to have for a full distro. That's why I added the **gnome-clocks** package in the **xtras.sh** file. I used the app on omakub and it does the job.