### PR TITLE
Add vi and vim as additional neovim aliases

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -25,7 +25,7 @@ alias ...='cd ../..'
 alias ....='cd ../../..'
 
 # Tools
-alias n='nvim'
+alias {n,vi,vim}='nvim'
 alias g='git'
 alias d='docker'
 alias r='rails'


### PR DESCRIPTION
On most distros `vi` is used as an alias for `vim` (or starts vim in vi mode). We could do the same for nvim.