### PR TITLE
Prevent wofi from stacking up

### DIFF
--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -10,7 +10,7 @@ bind = SUPER, G, exec, $messenger
 bind = SUPER, O, exec, obsidian -disable-gpu
 bind = SUPER, slash, exec, $passwordManager
 
-bind = SUPER, space, exec, wofi --show drun --sort-order=alphabetical
+bind = SUPER, space, exec, flock --nonblock /tmp/.wofi.lock -c "wofi --show drun --sort-order=alphabetical"
 bind = SUPER SHIFT, SPACE, exec, pkill -SIGUSR1 waybar
 bind = SUPER CTRL, SPACE, exec, ~/.local/share/omarchy/bin/swaybg-next
 bind = SUPER SHIFT CTRL, SPACE, exec, ~/.local/share/omarchy/bin/omarchy-theme-next


### PR DESCRIPTION
When hitting SUPER + space several times, a new instance of wofi is launched each time and they stack upon each other. This change uses a file lock to prevent starting several instances of wofi.

Thanks to everyone from this thread
https://www.reddit.com/r/archlinux/comments/m327pt/prevent_wofi_from_stacking_up/