### PR TITLE
Prevent installer from aborting on non-NVIDIA systems

### DIFF
--- a/install/nvidia.sh
+++ b/install/nvidia.sh
@@ -12,7 +12,7 @@
 # Check if nvidia gpu exists, exit silently if not found
 gpu_info=$(lspci | grep -i 'nvidia')
 if [ -z "$gpu_info" ]; then
-    exit 0
+    return 0
 fi
 
 # --- Driver Selection ---


### PR DESCRIPTION
install/nvidia.sh was using 'exit 0' which terminates parent shell when no NVIDIA GPU is detected. Replacing with 'return 0' lets installed continue on if no NVIDIA GPU found. Fixes #30