### PR TITLE
Be able to switch to current theme for neovim

### DIFF
--- a/config/nvim/lua/plugins/theme.lua
+++ b/config/nvim/lua/plugins/theme.lua
@@ -1,4 +1,8 @@
-return {
+local uv = vim.uv
+local file_path = vim.fn.expand("~/.config/omarchy/current/theme/neovim.lua")
+
+-- Default configuration
+local default = {
 	{
 		"LazyVim/LazyVim",
 		opts = {
@@ -6,3 +10,13 @@ return {
 		},
 	},
 }
+
+-- Try to load custom theme, fallback to default
+if uv.fs_stat(file_path) then
+	local success, result = pcall(dofile, file_path)
+	if success and type(result) == "table" then
+		return result
+	end
+end
+
+return default


### PR DESCRIPTION
Additionally, check if the current theme is accessible and loadable else, fallback to a default theme as to not break the theme.

fixes: #36 