### PR TITLE
Show path in prompt

### DIFF
--- a/default/bash/prompt
+++ b/default/bash/prompt
@@ -4,4 +4,4 @@ color_prompt=yes
 
 # Simple prompt with path in the window/pane title and caret for typing line
 PS1=$'\uf0a9 '
-PS1="\[\e]0;\w\a\]$PS1"
+PS1="\[\e]0;\w\a\]\w $PS1"


### PR DESCRIPTION
Currently, the prompt is the left-arrow symbol, with no path.

This adds the path back in.