### PR TITLE
Add yayf alias for easy package search

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -33,3 +33,6 @@ alias r='rails'
 alias gcm='git commit -m'
 alias gcam='git commit -a -m'
 alias gcad='git commit -a --amend'
+
+# Find packages without leaving the terminal
+alias yayf="yay -Slq | fzf --multi --preview 'yay -Sii {1}' --preview-window=down:75% | xargs -ro yay -S"


### PR DESCRIPTION
This alias makes it easier to search for packages from the AUR or main repository and get information about them.

![image](https://github.com/user-attachments/assets/6a18d924-a5e8-4f3b-a1e8-3b799444478e)
