### PR TITLE
Enables Hyprland to move whole workspaces to another monitor

### DIFF
--- a/bin/hypr-move-active-workspace-left
+++ b/bin/hypr-move-active-workspace-left
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Move active workspace to the previous monitor (with wraparound)
+
+# Get list of connected monitor names
+readarray -t monitors < <(hyprctl monitors | grep "Monitor" | awk '{print $2}')
+
+# Exit if no monitors or only one monitor
+if (( ${#monitors[@]} <= 1 )); then
+  exit 0
+fi
+
+# Get current workspace info
+current_workspace_info=$(hyprctl activeworkspace -j)
+current_workspace_id=$(echo "$current_workspace_info" | jq -r '.id')
+current_monitor=$(echo "$current_workspace_info" | jq -r '.monitor')
+
+# Find current monitor index
+current_index=-1
+for i in "${!monitors[@]}"; do
+  if [[ "${monitors[$i]}" == "$current_monitor" ]]; then
+    current_index=$i
+    break
+  fi
+done
+
+# If current monitor not found, exit
+if (( current_index == -1 )); then
+  exit 1
+fi
+
+# Calculate previous monitor index (with wraparound)
+prev_index=$(( (current_index - 1 + ${#monitors[@]}) % ${#monitors[@]} ))
+target_monitor="${monitors[$prev_index]}"
+
+# Move current workspace to target monitor
+hyprctl dispatch moveworkspacetomonitor "$current_workspace_id" "$target_monitor" &>/dev/null

--- a/bin/hypr-move-active-workspace-right
+++ b/bin/hypr-move-active-workspace-right
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Move active workspace to the next monitor (with wraparound)
+
+# Get list of connected monitor names
+readarray -t monitors < <(hyprctl monitors | grep "Monitor" | awk '{print $2}')
+
+# Exit if no monitors or only one monitor
+if (( ${#monitors[@]} <= 1 )); then
+  exit 0
+fi
+
+# Get current workspace info
+current_workspace_info=$(hyprctl activeworkspace -j)
+current_workspace_id=$(echo "$current_workspace_info" | jq -r '.id')
+current_monitor=$(echo "$current_workspace_info" | jq -r '.monitor')
+
+# Find current monitor index
+current_index=-1
+for i in "${!monitors[@]}"; do
+  if [[ "${monitors[$i]}" == "$current_monitor" ]]; then
+    current_index=$i
+    break
+  fi
+done
+
+# If current monitor not found, exit
+if (( current_index == -1 )); then
+  exit 1
+fi
+
+# Calculate next monitor index (with wraparound)
+next_index=$(( (current_index + 1) % ${#monitors[@]} ))
+target_monitor="${monitors[$next_index]}"
+
+# Move current workspace to target monitor
+hyprctl dispatch moveworkspacetomonitor "$current_workspace_id" "$target_monitor" &>/dev/null

--- a/bin/hypr-move-workspace-to-monitor
+++ b/bin/hypr-move-workspace-to-monitor
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Get the desired monitor index from the first argument
+target_index=$1
+
+# Get list of connected monitor names
+readarray -t monitors < <(hyprctl monitors | grep "Monitor" | awk '{print $2}')
+
+# Check if the index is within bounds
+if ((target_index < 0 || target_index >= ${#monitors[@]})); then
+  # Invalid index
+  exit 1
+fi
+
+# Get monitor name from index
+target_monitor="${monitors[$target_index]}"
+
+# Get current workspace ID
+current_workspace=$(hyprctl activeworkspace -j | jq -r '.id')
+
+# Move current workspace to target monitor
+hyprctl dispatch moveworkspacetomonitor "$current_workspace" "$target_monitor" &>/dev/null

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -48,6 +48,21 @@ bind = SUPER, equal, resizeactive, 100 0
 bind = SUPER SHIFT, minus, resizeactive, 0 -100
 bind = SUPER SHIFT, equal, resizeactive, 0 100
 
+# Move active workspace to monitor with ALT + SUPER + SHIFT + [1+9]
+bind = SUPER ALT SHIFT, 1, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 0
+bind = SUPER ALT SHIFT, 2, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 1
+bind = SUPER ALT SHIFT, 3, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 2
+bind = SUPER ALT SHIFT, 4, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 3
+bind = SUPER ALT SHIFT, 5, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 4
+bind = SUPER ALT SHIFT, 6, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 5
+bind = SUPER ALT SHIFT, 7, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 6
+bind = SUPER ALT SHIFT, 8, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 7
+bind = SUPER ALT SHIFT, 9, exec, ~/.local/share/omarchy/bin/hypr-move-workspace-to-monitor 8
+
+# Move active workspace to previous/next monitor
+bind = SUPER ALT SHIFT, left, exec, ~/.local/share/omarchy/bin/hypr-move-active-workspace-left
+bind = SUPER ALT SHIFT, right, exec, ~/.local/share/omarchy/bin/hypr-move-active-workspace-right
+
 # Scroll through existing workspaces with mainMod + scroll
 bind = SUPER, mouse_down, workspace, e+1
 bind = SUPER, mouse_up, workspace, e-1


### PR DESCRIPTION
This PR introduces the ability to move the current workspace to a different monitor, either by specifying the monitor directly or by cycling through monitors using the arrow keys.

While single-monitor setups are increasingly popular, some users (myself included 😉) still rely on multi-monitor workflows. This feature makes it easier to organize and shift workspaces between monitors efficiently.

### Implementation Details

This feature builds on the existing Hyprland command hyprctl dispatch moveworkspacetomonitor. To support it, I added a few lightweight Bash scripts to:
- Identify connected monitor IDs
- Retrieve the current active workspace number

These scripts provide the necessary context for workspace movement logic.

Tested on a dual-monitor setup.

### Keybindings
- Move to monitor 1–9: SHIFT + SUPER + ALT + [1–9]
- Move workspace to the monitor left of the current: SHIFT + SUPER + ALT + Left Arrow
- Move workspace to the monitor right of the current: SHIFT + SUPER + ALT + Right Arrow

### How to Test

After installing Arch Linux, run the following command:
`wget -qO- https://raw.githubusercontent.com/jonashan/omarchy/refs/heads/move-workspace-to-monitor-test/boot.sh | bash`