### PR TITLE
Improve keyboard layout compatibility

### DIFF
--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -36,28 +36,28 @@ bind = SUPER, up, movefocus, u
 bind = SUPER, down, movefocus, d
 
 # Switch workspaces with mainMod + [0-9]
-bind = SUPER, 1, workspace, 1
-bind = SUPER, 2, workspace, 2
-bind = SUPER, 3, workspace, 3
-bind = SUPER, 4, workspace, 4
-bind = SUPER, 5, workspace, 5
-bind = SUPER, 6, workspace, 6
-bind = SUPER, 7, workspace, 7
-bind = SUPER, 8, workspace, 8
-bind = SUPER, 9, workspace, 9
-bind = SUPER, 0, workspace, 10
+bind = SUPER, code:10, workspace, 1
+bind = SUPER, code:11, workspace, 2
+bind = SUPER, code:12, workspace, 3
+bind = SUPER, code:13, workspace, 4
+bind = SUPER, code:14, workspace, 5
+bind = SUPER, code:15, workspace, 6
+bind = SUPER, code:16, workspace, 7
+bind = SUPER, code:17, workspace, 8
+bind = SUPER, code:18, workspace, 9
+bind = SUPER, code:19, workspace, 10
 
 # Move active window to a workspace with mainMod + SHIFT + [0-9]
-bind = SUPER SHIFT, 1, movetoworkspace, 1
-bind = SUPER SHIFT, 2, movetoworkspace, 2
-bind = SUPER SHIFT, 3, movetoworkspace, 3
-bind = SUPER SHIFT, 4, movetoworkspace, 4
-bind = SUPER SHIFT, 5, movetoworkspace, 5
-bind = SUPER SHIFT, 6, movetoworkspace, 6
-bind = SUPER SHIFT, 7, movetoworkspace, 7
-bind = SUPER SHIFT, 8, movetoworkspace, 8
-bind = SUPER SHIFT, 9, movetoworkspace, 9
-bind = SUPER SHIFT, 0, movetoworkspace, 10
+bind = SUPER SHIFT, code:10, movetoworkspace, 1
+bind = SUPER SHIFT, code:11, movetoworkspace, 2
+bind = SUPER SHIFT, code:12, movetoworkspace, 3
+bind = SUPER SHIFT, code:13, movetoworkspace, 4
+bind = SUPER SHIFT, code:14, movetoworkspace, 5
+bind = SUPER SHIFT, code:15, movetoworkspace, 6
+bind = SUPER SHIFT, code:16, movetoworkspace, 7
+bind = SUPER SHIFT, code:17, movetoworkspace, 8
+bind = SUPER SHIFT, code:18, movetoworkspace, 9
+bind = SUPER SHIFT, code:19, movetoworkspace, 10
 
 # Swap active window with the one next to it with mainMod + SHIFT + arrow keys
 bind = SUPER SHIFT, left, swapwindow, l


### PR DESCRIPTION
## Improve keyboard layout compatibility

### Problem
Some keyboard layouts, such as French Bépo or AZERTY, do not provide direct access to number keys. Relying on numeric key values (e.g., '1', '2') causes issues for users of these layouts : impossible to change desktop or move window to other desktop.

### Solution
Replaced hardcoded numeric key values with layout-independent key codes.

- Validated on my French Bepo layout (and Azerty).
- No Impact in Qwerty.