### PR TITLE
Enhance Bash prompt: display current directory name before caret

### DIFF
--- a/default/bash/prompt
+++ b/default/bash/prompt
@@ -3,5 +3,5 @@ force_color_prompt=yes
 color_prompt=yes
 
 # Simple prompt with path in the window/pane title and caret for typing line
-PS1=$'\uf0a9 '
+PS1=$'\W \uf0a9 '
 PS1="\[\e]0;\w\a\]$PS1"


### PR DESCRIPTION
Hi,

I'm not sure if you will accept, but I propose to add `\W` to PS1 to show the current working directory in the prompt, providing better context when using the terminal :

![20250704_18h19m17s_grim](https://github.com/user-attachments/assets/9a8bd3ff-4c92-448c-8bd7-9c9c05eff515)
