### PR TITLE
Add DND option to Waybar

### DIFF
--- a/config/waybar/config
+++ b/config/waybar/config
@@ -16,7 +16,9 @@
       "pulseaudio",
       "cpu",
       "power-profiles-daemon",
-      "battery"
+      "battery",
+      "custom/dnd"
+
     ],
     "hyprland/workspaces": {
       "on-click": "activate",
@@ -121,5 +123,18 @@
       "interval": 5,
       "tooltip": true,
       "tooltip-format": "{}"
+    },
+    "custom/dnd": {
+      "exec": "makoctl mode | grep -q 'do-not-disturb' && echo '{\"alt\":\"dnd\",\"tooltip\":\"Enable notifications\"}' || echo '{\"alt\":\"on\",\"tooltip\":\"Disable notifications\"}'",
+      "format": "{icon}",
+      "format-icons": {
+        "on": " 󰂚",
+        "dnd": "󰂛"
+      },
+      "return-type": "json",
+      "interval": 5,
+      "tooltip": "{tooltip}",
+      "on-click": "makoctl mode -t do-not-disturb"
     }
+
 }

--- a/config/waybar/config
+++ b/config/waybar/config
@@ -7,6 +7,7 @@
       "hyprland/workspaces"
     ],
     "modules-center": [
+      "custom/dnd",
       "clock"
     ],
     "modules-right": [
@@ -16,9 +17,7 @@
       "pulseaudio",
       "cpu",
       "power-profiles-daemon",
-      "battery",
-      "custom/dnd"
-
+      "battery"
     ],
     "hyprland/workspaces": {
       "on-click": "activate",

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -16,6 +16,7 @@
   margin-right: 3px;
 }
 
+#custom-dnd,
 #custom-dropbox,
 #cpu,
 #power-profiles-daemon,

--- a/themes/catppuccin/mako.ini
+++ b/themes/catppuccin/mako.ini
@@ -12,3 +12,6 @@ max-icon-size=32
 
 [app-name=Spotify]
 invisible=1
+
+[mode=do-not-disturb]
+invisible=1

--- a/themes/everforest/mako.ini
+++ b/themes/everforest/mako.ini
@@ -12,3 +12,6 @@ max-icon-size=32
 
 [app-name=Spotify]
 invisible=1
+
+[mode=do-not-disturb]
+invisible=1

--- a/themes/gruvbox/mako.ini
+++ b/themes/gruvbox/mako.ini
@@ -12,3 +12,6 @@ max-icon-size=32
 
 [app-name=Spotify]
 invisible=1
+
+[mode=do-not-disturb]
+invisible=1

--- a/themes/kanagawa/mako.ini
+++ b/themes/kanagawa/mako.ini
@@ -12,3 +12,6 @@ max-icon-size=32
 
 [app-name=Spotify]
 invisible=1
+
+[mode=do-not-disturb]
+invisible=1

--- a/themes/nord/mako.ini
+++ b/themes/nord/mako.ini
@@ -12,3 +12,6 @@ max-icon-size=32
 
 [app-name=Spotify]
 invisible=1
+
+[mode=do-not-disturb]
+invisible=1

--- a/themes/tokyo-night/mako.ini
+++ b/themes/tokyo-night/mako.ini
@@ -12,3 +12,6 @@ max-icon-size=32
 
 [app-name=Spotify]
 invisible=1
+
+[mode=do-not-disturb]
+invisible=1


### PR DESCRIPTION
Adds a simple DND option that can be toggled by clicking the bell icon to the default Waybar config. 

### Notifications Enabled
![image](https://github.com/user-attachments/assets/e2415fc2-3cff-40e7-bbb0-328f50417bb6)

### Notifications Disabled
![image](https://github.com/user-attachments/assets/58343548-fc95-498c-8e1f-279452edd298)
