### PR TITLE
Add Power Menu to Waybar

### DIFF
--- a/bin/omarchy-power-menu
+++ b/bin/omarchy-power-menu
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Power menu for Omarchy
+# Provides power off, restart, and sleep options
+
+# Function to show power menu
+show_power_menu() {
+local menu_options="󰐥 Power Off
+󰜉 Restart
+󰤄 Sleep
+󰍃 Logout
+󰒲 Lock"
+  
+# Show menu and get selection
+local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Power Options" --width 200 --height 250)
+  
+if [ -n "$selection" ]; then
+  case "$selection" in
+    "󰐥 Power Off")
+      systemctl poweroff
+      ;;
+    "󰜉 Restart")
+      systemctl reboot
+      ;;
+    "󰤄 Sleep")
+      systemctl suspend
+      ;;
+    "󰍃 Logout")
+      hyprctl dispatch exit
+      ;;
+    "󰒲 Lock")
+      hyprlock
+      ;;
+    *)
+    ;;
+  esac
+fi
+}
+
+# Main execution
+show_power_menu 

--- a/config/waybar/config
+++ b/config/waybar/config
@@ -16,7 +16,8 @@
       "pulseaudio",
       "cpu",
       "power-profiles-daemon",
-      "battery"
+      "battery",
+      "custom/power-menu"
     ],
     "hyprland/workspaces": {
       "on-click": "activate",
@@ -121,5 +122,9 @@
       "interval": 5,
       "tooltip": true,
       "tooltip-format": "{}"
+    },
+    "custom/power-menu": {
+      "format": "󰐥",
+      "on-click": "~/.local/share/omarchy/bin/omarchy-power-menu"
     }
 }

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -23,7 +23,8 @@
 #network,
 #bluetooth,
 #pulseaudio,
-#clock {
+#clock,
+#custom-power-menu {
   min-width: 12px;
   margin-right: 13px;
 }


### PR DESCRIPTION
This PR adds a convenient power menu, providing users with quick access to essential power options, directly from Waybar. 

### New Features
- **Power Menu Script**: Added `bin/omarchy-power-menu` - a bash script that displays a wofi-based power menu
- **Waybar Integration**: Added power menu button to the Waybar interface

### Screenshots
![image](https://github.com/user-attachments/assets/f188b1bf-6ba3-41a4-8157-56efcae8bced)
![image](https://github.com/user-attachments/assets/5a192dde-9c1f-455e-8f78-045f6ae42211)

### Files Modified/Added

#### `bin/omarchy-power-menu` (New File)
- Interactive power menu using wofi as the display manager
- Provides 5 essential options with intuitive icons:
  - Power Off (`systemctl poweroff`)
  - Restart (`systemctl reboot`) 
  - Sleep (`systemctl suspend`)
  - Logout (`hyprctl dispatch exit`)
  - Lock (`hyprlock`)

#### `config/waybar/config`
- Added `custom/power-menu` module to the modules-right array
- Configured power menu button with power icon
- Set up click handler to execute the power menu script

#### `config/waybar/style.css`  
- Extended CSS styling to include `#custom-power-menu`

### Dependencies
- **wofi**: Used for the interactive menu display
- **systemctl**: For power management operations
- **hyprctl**: For Hyprland session management  
- **hyprlock**: For screen locking functionality