### PR TITLE
Enable save to clipboard on selection and paste in terminal

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -1,3 +1,5 @@
+general.import = [ "~/.config/omarchy/current/theme/alacritty.toml" ]
+
 [env]
 TERM = "xterm-256color"
 

--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -1,5 +1,3 @@
-general.import = [ "~/.config/omarchy/current/theme/alacritty.toml" ]
-
 [env]
 TERM = "xterm-256color"
 
@@ -17,5 +15,9 @@ opacity = 0.98
 
 [keyboard]
 bindings = [
-{ key = "F11", action = "ToggleFullscreen" }
+{ key = "F11", action = "ToggleFullscreen" },
+{ key = "V", mods = "Control", action = "Paste" }
 ]
+
+[selection]
+save_to_clipboard = true


### PR DESCRIPTION
This enables Mac users to have a better experience when moving to Linux.  Since cmd + c and cmd + v aren't a thing in Linux, Mac users might have a difficult time using `ctrl + shift + c` and `ctrl + shift + v` when using just the terminal.  Enabling copy on selection and mapping `ctrl + v` to paste allows a similar experience.  This is what I do on my setups (using Kitty) and it makes everything much easier.

I know Ghostty is on the horizon, so make sure to enable it there, too. https://ghostty.org/docs/config/reference#copy-on-select.  

I know from personal experience, switching to Linux, that the default terminal behavior alone can discourage many potential users.