### PR TITLE
username needs to be set for fprintd-enroll

### DIFF
--- a/bin/omarchy-fingerprint-setup
+++ b/bin/omarchy-fingerprint-setup
@@ -3,7 +3,7 @@
 yay -S --noconfirm --needed fprint
 
 echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\nKeep moving the finger around on sensor until the process completes.\n\e[0m"
-sudo fprintd-enroll
+sudo fprintd-enroll `whoami`
 
 echo -e "\e[32m\nNow let's verify that it's working correctly.\e[0m\n"
 


### PR DESCRIPTION
Without setting the username the fprintd will set the fingerprint to the root user