### PR TITLE
Add Ctrl+P Ctrl+N keybinds to wofi

### DIFF
--- a/config/wofi/config
+++ b/config/wofi/config
@@ -13,3 +13,5 @@ insensitive=true
 allow_images=true
 image_size=40
 gtk_dark=true
+key_up=Ctrl-p
+key_down=Ctrl-n


### PR DESCRIPTION
This PR brings to wofi the Ctrl+P and Ctrl+N keybindings commonly used on vim to navigate up and down on menus.