### PR TITLE
Add GBM_BACKEND env for nvidia cards

### DIFF
--- a/install/nvidia.sh
+++ b/install/nvidia.sh
@@ -76,6 +76,7 @@ if [ -n "$(lspci | grep -i 'nvidia')" ]; then
 # NVIDIA environment variables
 env = NVD_BACKEND,direct
 env = LIBVA_DRIVER_NAME,nvidia
+env = GBM_BACKEND,nvidia-drm
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
   fi

--- a/migrations/1751767831.sh
+++ b/migrations/1751767831.sh
@@ -1,0 +1,8 @@
+if [ -n "$(lspci | grep -i 'nvidia')" ]; then
+  echo "Add GBM_BACKEND env variable for NVIDIA systems"
+
+  HYPRLAND_CONF="$HOME/.config/hypr/hyprland.conf"
+  if [ -f "$HYPRLAND_CONF" ]; then
+    sed -i -E '/\# NVIDIA environment variables/a env = GBM_BACKEND,nvidia-drm' $HYPRLAND_CONF
+  fi
+fi


### PR DESCRIPTION
Can help on hybrid GPU systems and picky programs to recognize and make use of the NVIDIA GPU.

Not having this env variable caused my install to priorize the less powerful integrated graphics (happened to me on Blender). Sometimes, for some reason, the GPU wasn't detected by some programs without it.