### PR TITLE
feat(mako): adds bindings to close notifications fix #67

### DIFF
--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -16,6 +16,10 @@ bind = SUPER CTRL, SPACE, exec, ~/.local/share/omarchy/bin/swaybg-next
 bind = SUPER SHIFT CTRL, SPACE, exec, ~/.local/share/omarchy/bin/omarchy-theme-next
 bind = SUPER, K, exec, ~/.local/share/omarchy/bin/omarchy-show-keybindings
 
+# Notifications
+bind = SUPER, comma, exec, makoctl dismiss
+bind = SUPER SHIFT, comma, exec, makoctl dismiss --all
+
 bind = SUPER, W, killactive,
 
 # End active session


### PR DESCRIPTION
This PR adds the keybinds:

`SUPER + ,` -> Closes the last mako notification (You can also do this with the mouse by right clicking the notif also! might be worth adding this to the docs!!)

`SUPER + SHIFT + ,` -> Closes all notifications.

--- 

I tested it and it's working fine.

I also considered using the C key, but I think that `,` is better.


---

Another feature we could add (but not in this PR) is support for Mako modes:
https://man.archlinux.org/man/mako.5.en#MODES

For example, we could have a button somewhere to toggle "Do Not Disturb" mode or something similar.
Just a suggestion!