### PR TITLE
Add structured folders to screenshots

### DIFF
--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -100,9 +100,9 @@ bindl = , XF86AudioPlay, exec, playerctl play-pause
 bindl = , XF86AudioPrev, exec, playerctl previous
 
 # Screenshots
-bind = , PRINT, exec, hyprshot -m region
-bind = SHIFT, PRINT, exec, hyprshot -m window
-bind = CTRL, PRINT, exec, hyprshot -m output
+bind = , PRINT, exec, sh -c 'hyprshot -m region -o "$HOME/Pictures/Screenshots/$(date +%Y-%m)"'
+bind = SHIFT, PRINT, exec, sh -c 'hyprshot -m window -o "$HOME/Pictures/Screenshots/$(date +%Y-%m)"'
+bind = CTRL, PRINT, exec, sh -c 'hyprshot -m output -o "$HOME/Pictures/Screenshots/$(date +%Y-%m)"'
 
 # Color picker
 bind = SUPER, PRINT, exec, hyprpicker -a


### PR DESCRIPTION
As title says, I think this may follow the "opinionated" setup. 
Screenshots will be saved into Pictures/Screenshots/YYYY-MM depending on the date. Separating screenshots into months makes organizing them much easier. I was going to add the same functionality but using the var $XDG_PICTURES_DIR but that will require change a bit more and check if exists, the actual commit is the least intrusive way I found to follow this structure. 

Hyprshot creates the folder if it doesn't exist. Hope you like the idea :). 