### PR TITLE
fix(detect): Correctly assign gpu_info before use

### DIFF
--- a/install/nvidia.sh
+++ b/install/nvidia.sh
@@ -9,7 +9,8 @@
 # ==============================================================================
 
 # --- GPU Detection ---
-if [ -n "$(lspci | grep -i 'nvidia')" ]; then
+gpu_info=$(lspci | grep -i 'nvidia')
+if [ -n "$gpu_info" ]; then
   # --- Driver Selection ---
   # Turing (16xx, 20xx), Ampere (30xx), Ada (40xx), and newer recommend the open-source kernel modules
   if echo "$gpu_info" | grep -q -E "RTX [2-9][0-9]|GTX 16"; then


### PR DESCRIPTION
The script attempted to perform driver selection by echoing the `$gpu_info` variable, but the variable had not yet been populated
with the output from the `lspci` command.

This resulted in the `if` condition always failing and the driver package incorrectly defaulting to `nvidia-dkms` for all hardware.

This commit moves the `gpu_info` assignment to occur before it is referenced, restoring the correct behavior.
