### PR TITLE
Enable bash-completion by default

### DIFF
--- a/default/bash/shell
+++ b/default/bash/shell
@@ -5,7 +5,9 @@ HISTSIZE=32768
 HISTFILESIZE="${HISTSIZE}"
 
 # Autocompletion
-# source /usr/share/bash-completion/bash_completion
+if [[ ! -v BASH_COMPLETION_VERSINFO && -f /usr/share/bash-completion/bash_completion ]]; then
+  source /usr/share/bash-completion/bash_completion
+fi
 
 # Set complete path
 export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omarchy/bin:$PATH"

--- a/install/3-terminal.sh
+++ b/install/3-terminal.sh
@@ -3,4 +3,4 @@ yay -S --noconfirm --needed \
   fd eza fzf ripgrep zoxide bat \
   wl-clipboard fastfetch btop \
   man tldr less whois plocate \
-  alacritty
+  alacritty bash-completion

--- a/migrations/1751821819.sh
+++ b/migrations/1751821819.sh
@@ -1,0 +1,2 @@
+echo "Install bash-completion"
+yay -S --noconfirm --needed bash-completion


### PR DESCRIPTION
Enable bash-completion by default:

- First check if `BASH_COMPLETION_VERSINFO` is defined. That means bash completion has already been sourced, perhaps by an earlier configuration.
- Then if `/usr/share/bash-completion/bash_completion` exists, to avoid breaking setups where `bash-completion` is not installed.
- Install `bash-completion` by default.