### PR TITLE
Add blue light filter

### DIFF
--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -1,4 +1,4 @@
-exec-once = hypridle & mako & waybar & fcitx5
+exec-once = hypridle & mako & waybar & fcitx5 & hyprsunset
 exec-once = swaybg -i ~/.config/omarchy/current/background -m fill
 exec-once = systemctl --user start hyprpolkitagent
 exec-once = wl-clip-persist --clipboard regular & clipse -listen

--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -88,6 +88,10 @@ bindel = ,XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle
 bindel = ,XF86MonBrightnessUp, exec, brightnessctl -e4 -n2 set 5%+
 bindel = ,XF86MonBrightnessDown, exec, brightnessctl -e4 -n2 set 5%-
 
+# Hyprsunset color temperature control
+bindel = CTRL, XF86MonBrightnessUp, exec, hyprctl hyprsunset temperature +500
+bindel = CTRL, XF86MonBrightnessDown, exec, hyprctl hyprsunset temperature -500
+
 # Control Apple Display brightness
 bind = CTRL, F1, exec, ~/.local/share/omarchy/bin/apple-display-brightness -5000
 bind = CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000

--- a/install/hyprlandia.sh
+++ b/install/hyprlandia.sh
@@ -1,5 +1,5 @@
 yay -S --noconfirm --needed \
-  hyprland hyprshot hyprpicker hyprlock hypridle hyprpolkitagent hyprland-qtutils \
+  hyprland hyprshot hyprpicker hyprlock hypridle hyprpolkitagent hyprland-qtutils hyprsunset \
   wofi waybar mako swaybg \
   xdg-desktop-portal-hyprland xdg-desktop-portal-gtk
 

--- a/install/nvidia.sh
+++ b/install/nvidia.sh
@@ -12,7 +12,7 @@
 if [ -n "$(lspci | grep -i 'nvidia')" ]; then
   # --- Driver Selection ---
   # Turing (16xx, 20xx), Ampere (30xx), Ada (40xx), and newer recommend the open-source kernel modules
-  if echo "$gpu_info" | grep -q -E "RTX [2-9][0-9]|GTX 16"; then
+  if echo "$(lspci | grep -i 'nvidia')" | grep -q -E "RTX [2-9][0-9]|GTX 16"; then
     NVIDIA_DRIVER_PACKAGE="nvidia-open-dkms"
   else
     NVIDIA_DRIVER_PACKAGE="nvidia-dkms"

--- a/migrations/1751848081.sh
+++ b/migrations/1751848081.sh
@@ -1,0 +1,2 @@
+echo "Add hyprsunset for blue light filtering"
+yay -S --noconfirm --needed hyprsunset


### PR DESCRIPTION
This PR adds support for https://github.com/hyprwm/hyprsunset, a blue light filter daemon for Hyprland that allows users to adjust their screen's color temperature for reduced eye strain.

After installation, users can adjust their screen's color temperature using the Ctrl key combined with their laptop's brightness keys. This provides a convenient way to reduce blue light exposure, especially useful during evening hours.