### PR TITLE
Waybar Power Menu - Remove Search and Add Shortcuts

### DIFF
--- a/bin/omarchy-power-menu
+++ b/bin/omarchy-power-menu
@@ -11,7 +11,7 @@ show_power_menu() {
 \u2060󰜉 Restart (Ctrl + Super + Escape)
 󰐥\u2063 Shutdown (Ctrl + Shift + Super + Escape)" # These first characters are invisible sort keys
 
-  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Power Options" --width 500 --height 195 -O alphabetical --style ~/.config/wofi/omarchy-power-menu.css)
+  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Power Options" --width 500 --height 195 -O alphabetical --style ~/.local/share/omarchy/config/wofi/omarchy-power-menu.css)
 
   case "$selection" in
   *Lock*) hyprlock ;;

--- a/bin/omarchy-power-menu
+++ b/bin/omarchy-power-menu
@@ -5,13 +5,13 @@
 
 # Function to show power menu
 show_power_menu() {
-  local menu_options="\u200B Lock
-\u200C󰤄 Sleep
-\u200D Relaunch
-\u2060󰜉 Restart
-󰐥\u2063 Shutdown" # These first characters are invisible sort keys
+  local menu_options="\u200B Lock (Super + Escape)
+\u200C󰤄 Sleep (Shift + Super + Escape)
+\u200D Relaunch (Alt + Super + Escape)
+\u2060󰜉 Restart (Ctrl + Super + Escape)
+󰐥\u2063 Shutdown (Ctrl + Shift + Super + Escape)" # These first characters are invisible sort keys
 
-  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Power Options" --width 200 --height 195 -O alphabetical --style ~/.config/wofi/omarchy-power-menu.css)
+  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Power Options" --width 500 --height 195 -O alphabetical --style ~/.config/wofi/omarchy-power-menu.css)
 
   case "$selection" in
   *Lock*) hyprlock ;;

--- a/bin/omarchy-power-menu
+++ b/bin/omarchy-power-menu
@@ -11,7 +11,7 @@ show_power_menu() {
 \u2060󰜉 Restart
 󰐥\u2063 Shutdown" # These first characters are invisible sort keys
 
-  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Power Options" --width 200 --height 250 -O alphabetical)
+  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Power Options" --width 200 --height 195 -O alphabetical --style ~/.config/wofi/omarchy-power-menu.css)
 
   case "$selection" in
   *Lock*) hyprlock ;;

--- a/config/wofi/omarchy-power-menu.css
+++ b/config/wofi/omarchy-power-menu.css
@@ -1,0 +1,65 @@
+@define-color	selected-text #7dcfff;
+@define-color	text #cfc9c2;
+@define-color	base #1a1b26;
+
+* {
+    font-family: 'CaskaydiaMono Nerd Font', monospace;
+    font-size: 18px;
+}
+
+window {
+    margin: 0px;
+    padding: 20px;
+    background-color: @base;
+    opacity: 0.95;
+}
+
+#inner-box {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background-color: @base;
+}
+
+#outer-box {
+    margin: 0;
+    padding: 20px;
+    border: none;
+    background-color: @base;
+}
+
+#scroll {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background-color: @base;
+}
+
+#input {
+    display: none;
+    opacity: 0;
+    margin-top: -200px;
+}
+
+#text {
+    margin: 5px;
+    border: none;
+    color: @text;
+}
+
+#entry {
+    background-color: @base;
+}
+
+#entry:selected {
+    outline: none;
+    border: none;
+}
+
+#entry:selected #text {
+    color: @selected-text;
+}
+
+#entry image {
+    -gtk-icon-transform: scale(0.7);
+}

--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -24,7 +24,7 @@ bind = SUPER CTRL, comma, exec, makoctl mode -t do-not-disturb && makoctl mode |
 bind = SUPER, W, killactive,
 
 # End active session
-bind = SUPER, ESCAPE, exec, hyprlock
+bind = SUPER, ESCAPE, exec, pkill wofi 2>/dev/null; hyprlock
 bind = SUPER SHIFT, ESCAPE, exec, systemctl suspend
 bind = SUPER ALT, ESCAPE, exit,
 bind = SUPER CTRL, ESCAPE, exec, reboot


### PR DESCRIPTION
Made some improvements to the Waybar Power Menu as suggested in https://github.com/basecamp/omarchy/pull/65#issuecomment-3042850831.

### New Features
- **Removed the search bar**
- **Add shortcuts for each option**

![image](https://github.com/user-attachments/assets/2035a3bc-596c-450e-aa48-042119a9dd69)

### Files Modified/Added
**`bin/omarchy-power-menu`**
- Added shortcuts in parenthesis.
- Increased width and reduced height to better fit the shortcuts.
- Linked to a new stylesheet, specific to the power menu. This was done to prevent style conflicts for other wofi menus e.g the Application index and launcher.

**`config/wofi/omarchy-power-menu.css`(new file)**
- Styles specific to the power menu. I based this off the current wofi styles.css.
- CSS trick to hide the search for the power menu (this is the best I could find). There is also a hide-search flag you can add to the wofi config file, however, this also applied to the search menu when testing. Open to other suggestions or better ways to hide the search menu, but visually this works.


**`default/hypr/bindings.conf`**
- Updated the lock binding to also kill wofi. Without this, if a user were to open the power menu, use the shortcut, log back in, the menu would persist. This ensures the menu is killed when logging out.