### PR TITLE
feat: windows rules for Jetbrains products

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -11,6 +11,18 @@ windowrule = float, class:^(org.pulseaudio.pavucontrol|blueberry.py)$
 windowrule = float, class:^(steam)$
 windowrule = fullscreen, class:^(com.libretro.RetroArch)$
 
+# Fix all dialogs in Jetbrains products
+windowrulev2 = tag +jb, class:^jetbrains-.+$,floating:1
+windowrulev2 = stayfocused, tag:jb
+windowrulev2 = noinitialfocus, tag:jb
+windowrulev2 = focusonactivate,class:^jetbrains-(?!toolbox)
+# center the pops excepting context menu
+windowrulev2 = move 30% 30%,class:^jetbrains-(?!toolbox),title:^(?!win.*),floating:1
+windowrulev2 = size 40% 40%,class:^jetbrains-(?!toolbox),title:^(?!win.*),floating:1
+# fix tab dragging (always have a single space character as their title)
+windowrulev2 = noinitialfocus, class:^(.*jetbrains.*)$, title:^\\s$
+windowrulev2 = nofocus, class:^(.*jetbrains.*)$, title:^\\s$
+
 # Just dash of opacity
 windowrule = opacity 0.97 0.9, class:.*
 windowrule = opacity 1 0.97, class:^(Chromium|chromium|google-chrome|google-chrome-unstable)$
@@ -29,6 +41,6 @@ windowrule = float, class:(clipse)
 windowrule = size 622 652, class:(clipse)
 windowrule = stayfocused, class:(clipse)
 
-# Float and cneter file pickers
+# Float and center file pickers
 windowrule = float, class:xdg-desktop-portal-gtk, title:^(Open.*Files?|Save.*Files?)
 windowrule = center, class:xdg-desktop-portal-gtk, title:^(Open.*Files?|Save.*Files?)


### PR DESCRIPTION
Hi.
The goal of this pull request is to add few window rules for all Jetbrains Products such as IDEs and Toolbox. This rules will fix 99% of the issues you will face using IDE such as PHPStorm (which I use daily)

- Fix dragging issues
- Fix "find in files", "replace in files" and other dialog disappear instantly
- Fix mouse focus on every dialog

 