### PR TITLE
Expose inputMethod to hyprland.conf

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -5,6 +5,7 @@ source = ~/.config/hypr/monitors.conf
 
 # Default applications
 $terminal = alacritty
+$inputMethod = fcitx5
 $fileManager = nautilus --new-window
 $browser = chromium --new-window --ozone-platform=wayland
 $music = spotify

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -1,4 +1,4 @@
-exec-once = hypridle & mako & waybar & fcitx5
+exec-once = hypridle & mako & waybar & $inputMethod
 exec-once = swaybg -i ~/.config/omarchy/current/background -m fill
 exec-once = systemctl --user start hyprpolkitagent
 exec-once = wl-clip-persist --clipboard regular & clipse -listen


### PR DESCRIPTION
I use [kime](https://github.com/Riey/kime) as Korean IME. fcitx5 is more general utility I know but kime is better user experience for me.

changing default ime is hard work, so I think it would be great if I changeable.