### PR TITLE
Add gum confirm to omarchy-refresh-waybar

### DIFF
--- a/bin/omarchy-refresh-waybar
+++ b/bin/omarchy-refresh-waybar
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+gum confirm "Refresh Waybar config? This will replace your current Waybar settings with Omarchy defaults." || exit 0
+
 # Overwrite local waybar settings with the latest in Omarchy
 cp -f ~/.local/share/omarchy/config/waybar/config ~/.config/waybar/ 2>/dev/null
 cp -f ~/.local/share/omarchy/config/waybar/style.css ~/.config/waybar/ 2>/dev/null

--- a/bin/omarchy-refresh-waybar
+++ b/bin/omarchy-refresh-waybar
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-gum confirm "Refresh Waybar config? This will replace your current Waybar settings with Omarchy defaults." || exit 0
+if gum confirm "Refresh Waybar config? This will replace your current Waybar settings with Omarchy defaults."; then
+    # Overwrite local waybar settings with the latest in Omarchy
+    cp -f ~/.local/share/omarchy/config/waybar/config ~/.config/waybar/ 2>/dev/null
+    cp -f ~/.local/share/omarchy/config/waybar/style.css ~/.config/waybar/ 2>/dev/null
 
-# Overwrite local waybar settings with the latest in Omarchy
-cp -f ~/.local/share/omarchy/config/waybar/config ~/.config/waybar/ 2>/dev/null
-cp -f ~/.local/share/omarchy/config/waybar/style.css ~/.config/waybar/ 2>/dev/null
-
-# Restart waybar
-pkill waybar &>/dev/null
-setsid waybar &>/dev/null &
+    # Restart waybar
+    pkill waybar &>/dev/null
+    setsid waybar &>/dev/null &
+fi


### PR DESCRIPTION
Small addition to `omarchy-refresh-waybar`. Added a gum confirm dialog before overwriting the user's Waybar configuration. The prompt warns users that their current settings will be replaced with Omarchy defaults, preventing accidental loss of customizations.

![image](https://github.com/user-attachments/assets/e40ee780-ee10-44c7-bfd2-0ed7cfe3dc6c)
