### PR TITLE
Removed 1Password: Key Signature Error

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -8,7 +8,7 @@ $terminal = alacritty
 $fileManager = nautilus --new-window
 $browser = chromium --new-window --ozone-platform=wayland
 $music = spotify
-$passwordManager = 1password
+$passwordManager = 
 $messenger = signal-desktop
 $webapp = $browser --app
 

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -3,7 +3,6 @@ yay -S --noconfirm --needed \
   fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool \
   wl-clip-persist clipse-bin \
   nautilus sushi ffmpegthumbnailer gnome-calculator \
-  1password-beta 1password-cli \
   chromium mpv \
   evince imv \
   localsend-bin


### PR DESCRIPTION
This removes 1Password from the install script.

Hi DHH, Linux noob (and Hey customer) here! Appreciate this project. I was having trouble installing Omarchy, which I traced to a 1Password key sync issue. I couldn't resolve it after many (many) attempts, so I tried removing 1Password from the install script, after which it went through smoothly.

Thought others may benefit and install 1Password later as needed.