### PR TITLE
Add Centralized omarchy CLI with Version Flag and Help Menu

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -13,6 +13,21 @@ NC='\033[0m'
 
 # Show help menu
 show_help() {
+    local COLUMNS=$(tput cols 2>/dev/null || echo 80)
+    if [ "$COLUMNS" -ge 100 ]; then
+    echo ""
+        cat <<'EOF'
+ ▄██████▄    ▄▄▄▄███▄▄▄▄      ▄████████    ▄████████  ▄████████    ▄█    █▄    ▄██   ▄  
+███    ███ ▄██▀▀▀███▀▀▀██▄   ███    ███   ███    ███ ███    ███   ███    ███   ███   ██▄
+███    ███ ███   ███   ███   ███    ███   ███    ███ ███    █▀    ███    ███   ███▄▄▄███
+███    ███ ███   ███   ███   ███    ███  ▄███▄▄▄▄██▀ ███         ▄███▄▄▄▄███▄▄ ▀▀▀▀▀▀███
+███    ███ ███   ███   ███ ▀███████████ ▀▀███▀▀▀▀▀   ███        ▀▀███▀▀▀▀███▀  ▄██   ███
+███    ███ ███   ███   ███   ███    ███ ▀███████████ ███    █▄    ███    ███   ███   ███
+███    ███ ███   ███   ███   ███    ███   ███    ███ ███    ███   ███    ███   ███   ███
+ ▀██████▀   ▀█   ███   █▀    ███    █▀    ███    ███ ████████▀    ███    █▀     ▀█████▀ 
+                                          ███    ███                                    
+EOF
+    fi
     echo ""
     echo "Usage: omarchy [command] [options]"
     echo ""
@@ -26,6 +41,7 @@ show_help() {
     echo "  omarchy -v                    # Show current version"
     echo "  omarchy update                # Update omarchy to latest version"
     echo "  omarchy refresh-waybar        # Refresh waybar configuration"
+    echo ""
 }
 
 # Show version information

--- a/bin/omarchy
+++ b/bin/omarchy
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# omarchy: Main CLI interface for Omarchy
+# Usage: omarchy [command] [options]
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' 
+
+# Show help menu
+show_help() {
+    echo ""
+    echo "Usage: omarchy [command] [options]"
+    echo ""
+    echo "Commands:"
+    echo "  -v, --version     Show version information"
+    echo "  update            Update to latest version"
+    echo "  refresh-waybar    Refresh waybar configuration"
+    echo "  help              Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  omarchy -v                    # Show current version"
+    echo "  omarchy update                # Update omarchy to latest version"
+    echo "  omarchy refresh-waybar        # Refresh waybar configuration"
+}
+
+# Show version information
+show_version() {
+    cd ~/.local/share/omarchy
+    
+    if [ -d ".git" ]; then
+        # Get the latest tag (release version)
+        LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+        COMMIT_HASH=$(git rev-parse --short HEAD)
+        
+        echo -e "${BLUE}Omarchy Version:${NC} $LATEST_TAG"
+    fi
+}
+
+# Main command handler
+case "${1:-help}" in
+    -v|--version|version)
+        show_version
+        ;;
+    update)
+        echo -e "${BLUE}🔄 Updating Omarchy...${NC}"
+        ~/.local/share/omarchy/bin/omarchy-update
+        ;;
+    refresh-waybar)
+        echo -e "${BLUE}🔄 Refreshing waybar...${NC}"
+        ~/.local/share/omarchy/bin/omarchy-refresh-waybar
+        ;;
+    help|--help|-h)
+        show_help
+        ;;
+    *)
+        echo -e "${RED}Unknown command: $1${NC}"
+        echo ""
+        show_help
+        exit 1
+        ;;
+esac 


### PR DESCRIPTION
With the release of 1.3.0, I came across a post asking how to check the current version of Omarchy. While implementing a standalone `omarchy-version` script would suffice, using a flag (like `-v`) feels much more natural. I thought it would be nice to simply run `omarchy -v` and see the latest version.

#### What’s new:
- **New `omarchy` CLI script:**  
  - Centralizes all Omarchy management commands.
  - Provides a help menu with usage examples and a list of available commands.
  - Most importantly, shows some cool ASCII art in the help menu (if the terminal is wide enough).
- **Version flag:**  
  - Run `omarchy -v` to see the current installed version (git tag/commit).
- **Command wrappers:**  
  - Existing scripts can now be run as subcommands, e.g. `omarchy update`, `omarchy refresh-waybar`.
- **Consistent UX:**  
  - Having a centralized CLI means users have a consistent way to call Omarchy scripts.
  - This also lays the groundwork for future features, e.g. `omarchy install-theme <git-repo>`.

#### Why?
- Improves discoverability and usability for new and existing users.
- Makes it easier to add new features and commands in the future.
- Provides a more “standard” CLI experience (like `git`, `npm`, etc).

![image](https://github.com/user-attachments/assets/ee001b87-5c13-4730-81b3-2d69add11219)