### PR TITLE
vi alias to nvim

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -25,6 +25,7 @@ alias ....='cd ../../..'
 
 # Tools
 alias n='nvim'
+alias vi='nvim'
 alias g='git'
 alias d='docker'
 alias r='rails'


### PR DESCRIPTION
I prefer vi as alias to nvim. I can just add this in my own .bashrc, but I don't think I'm alone here? Don't add this if I'm the only one :-)