### PR TITLE
Add collapsing tray to waybar

### DIFF
--- a/config/waybar/config
+++ b/config/waybar/config
@@ -10,6 +10,7 @@
       "clock"
     ],
     "modules-right": [
+      "group/tray",
       "bluetooth",
       "network",
       "pulseaudio",
@@ -100,5 +101,23 @@
       "tooltip-format": "Playing at {volume}%",
       "on-click-right": "pamixer -t",
       "ignored-sinks": ["Easy Effects Sink"]
+    },
+    "group/tray": {
+      "orientation": "inherit",
+      "drawer": {
+        "transition-duration": 600
+      },
+      "modules": [
+        "custom/expand",
+        "tray"
+      ]
+    },
+    "custom/expand": {
+      "format": " ",
+      "tooltip": false
+    },
+    "tray": {
+      "icon-size": 12,
+      "spacing": 12
     }
 }

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -17,6 +17,8 @@
 }
 
 #custom-dropbox,
+#custom-expand,
+#tray,
 #cpu,
 #battery,
 #network,


### PR DESCRIPTION
This adds an expanding/collapsing group containing tray app icons to Waybar. I know you want to keep the bar minimal, so even if you don't want to use it for 'tray' icons, it might be a useful way to let you add more to the bar without cluttering it. I'm thinking things like #63 

Poor quality preview:

[tray.webm](https://github.com/user-attachments/assets/26e0943e-a434-494f-9de0-42972cc64880)
