### PR TITLE
add low power notfication issue #59

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Omarchy Battery Monitor
+# One-shot script that checks battery and sends notification if needed
+# Designed to be run by systemd timer every 30 seconds
+
+BATTERY_THRESHOLD=10
+NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
+
+get_battery_percentage() {
+  upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
+}
+
+get_battery_state() {
+  upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}'
+}
+
+send_notification() {
+  notify-send -u critical "Battery Low" "Battery level is at ${1}%! Please plug in your charger." -i battery-caution
+}
+
+BATTERY_LEVEL=$(get_battery_percentage)
+BATTERY_STATE=$(get_battery_state)
+
+if [[ "$BATTERY_STATE" == "discharging" && "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
+  if [[ ! -f "$NOTIFICATION_FLAG" ]]; then
+    send_notification "$BATTERY_LEVEL"
+    touch "$NOTIFICATION_FLAG"
+  fi
+else
+  rm -f "$NOTIFICATION_FLAG"
+fi

--- a/config/systemd/user/omarchy-battery-monitor.service
+++ b/config/systemd/user/omarchy-battery-monitor.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Omarchy Battery Monitor Check
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/share/omarchy/bin/omarchy-battery-monitor
+Environment=DISPLAY=:0

--- a/config/systemd/user/omarchy-battery-monitor.timer
+++ b/config/systemd/user/omarchy-battery-monitor.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Omarchy Battery Monitor Timer
+Requires=omarchy-battery-monitor.service
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=30sec
+AccuracySec=10sec
+
+[Install]
+WantedBy=timers.target

--- a/install/power.sh
+++ b/install/power.sh
@@ -5,6 +5,9 @@ yay -S --noconfirm power-profiles-daemon
 if ls /sys/class/power_supply/BAT* &>/dev/null; then
   # This computer runs on a battery
   powerprofilesctl set balanced || true
+  
+  # Enable battery monitoring timer for low battery notifications
+  systemctl --user enable --now omarchy-battery-monitor.timer || true
 else
   # This computer runs on power outlet
   powerprofilesctl set performance || true

--- a/migrations/1752168292.sh
+++ b/migrations/1752168292.sh
@@ -1,0 +1,15 @@
+echo "Enable battery low notifications for laptops"
+
+if ls /sys/class/power_supply/BAT* &>/dev/null; then
+  mkdir -p ~/.config/systemd/user
+
+  cp ~/.local/share/omarchy/config/systemd/user/omarchy-battery-monitor.* ~/.config/systemd/user/
+
+  systemctl --user daemon-reload
+  systemctl --user enable --now omarchy-battery-monitor.timer || true
+
+  echo "Battery monitoring enabled - you'll receive notifications at 10% battery"
+else
+  echo "No battery detected - skipping battery monitor setup"
+fi
+


### PR DESCRIPTION
Implementation of the systemd timer-based battery monitoring, that i described in:
https://github.com/basecamp/omarchy/issues/59  
 
in the issue i made it seem like i wanted to do the simple solution with bash script, but i backed tracked on this idea and went with the time based systemd approach.

Might do the udev for my own setup, if i care later..
 
  - Implements systemd timer-based battery monitoring
  - Sends notification at 10% battery level
  - uses /run/user/$UID/omarchy_battery_notified to save the state, if notification has been sent to avoid spamming.
  - Only enables on battery-powered systems

-- Reviewer focus: grep and sed command or pray that they are okay. 


--- to test set either have patience or set the threshold higher and reload service? (not sure if just goes with what ever is in the script at trigger time).

