### PR TITLE
install: explicitly install iwd

### DIFF
--- a/install/network.sh
+++ b/install/network.sh
@@ -1,0 +1,6 @@
+# Install iwd explicitly if it wasn't included in archinstall
+# This can happen if archinstall used ethernet
+if ! command -v iwd &>/dev/null; then
+  yay -S --noconfirm --needed iwd
+  sudo systemctl enable --now iwd.service
+fi


### PR DESCRIPTION
When archinstall is run using an ethernet connection, iwd will not be
installed. Explicitly install and enable the service
