### PR TITLE
Add gvim

### DIFF
--- a/install/3-terminal.sh
+++ b/install/3-terminal.sh
@@ -3,4 +3,4 @@ yay -S --noconfirm --needed \
   fd eza fzf ripgrep zoxide bat \
   wl-clipboard fastfetch btop \
   man tldr less whois plocate bash-completion \
-  alacritty
+  alacritty gvim


### PR DESCRIPTION
Install a normal vim. Works a bit better when you use a plain tty (ctrl-alt-F2 for example) without Nerd fonts or other more advanced features.

There is vim and gvim. gvim has more features like clipboard. Possible downside is the GTK3 dependency, but I don't see a problem with that.

See also https://github.com/basecamp/omarchy/pull/117