### PR TITLE
Add collapsing tray to waybar

### DIFF
--- a/config/waybar/config
+++ b/config/waybar/config
@@ -10,6 +10,7 @@
       "clock"
     ],
     "modules-right": [
+      "group/tray-expander",
       "bluetooth",
       "network",
       "pulseaudio",
@@ -100,5 +101,24 @@
       "tooltip-format": "Playing at {volume}%",
       "on-click-right": "pamixer -t",
       "ignored-sinks": ["Easy Effects Sink"]
+    },
+    "group/tray-expander": {
+      "orientation": "inherit",
+      "drawer": {
+        "transition-duration": 600,
+        "children-class": "tray-group-item"
+      },
+      "modules": [
+        "custom/expand-icon",
+        "tray"
+      ]
+    },
+    "custom/expand-icon": {
+      "format": " ",
+      "tooltip": false
+    },
+    "tray": {
+      "icon-size": 12,
+      "spacing": 12
     }
 }

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -17,6 +17,7 @@
 }
 
 #custom-dropbox,
+#tray,
 #cpu,
 #battery,
 #network,
@@ -26,6 +27,10 @@
 #custom-power-menu {
   min-width: 12px;
   margin-right: 13px;
+}
+
+#custom-expand-icon {
+  margin-right: 12px;
 }
 
 tooltip {


### PR DESCRIPTION
Take 2 of  #118 - I'd messed up trying to selectively grab just this change from my config and called the group `group/tray`. That was applying the right margin twice when applied to `#tray`. I've properly tested with this exact config this time.

Adds an expanding/collapsing group containing tray app icons to Waybar to keep clutter down.

I tried making the expand icon not show at all if there were no tray icons without much success. omarchy autostarts `fcitx5` by default so there should be something in the tray to show/hide.

**Preview**

https://github.com/user-attachments/assets/8653befa-3c54-445c-ba40-cc6558dabb05


