### PR TITLE
Fix: 1Password SSH Agent auth popup not shown in Hyperland

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -28,7 +28,7 @@ bind = SUPER, T, exec, $terminal -e btop
 bind = SUPER, D, exec, $terminal -e lazydocker
 bind = SUPER, G, exec, signal-desktop
 bind = SUPER, O, exec, obsidian -disable-gpu
-bind = SUPER, slash, exec, 1password
+bind = SUPER, slash, exec, 1password --ozone-platform=x11
 
 bind = SUPER, A, exec, $webapp="https://chatgpt.com"
 bind = SUPER SHIFT, A, exec, $webapp="https://grok.com"


### PR DESCRIPTION
The [1Password SSH Agent](https://developer.1password.com/docs/ssh/agent/) authorization dialog does not appear in Hyprland.

I spent some time debugging the issue but couldn’t determine the cause. However, forcing 1Password to launch with X11 resolves the problem.