### PR TITLE
Make initial install repo configurable

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -12,9 +12,12 @@ echo -e "\n$ascii_art\n"
 
 pacman -Q git &>/dev/null || sudo pacman -Sy --noconfirm --needed git
 
-echo -e "\nCloning Omarchy..."
+# Use custom repo if specified, otherwise default to basecamp/omarchy
+OMARCHY_REPO="${OMARCHY_REPO:-basecamp/omarchy}"
+
+echo -e "\nCloning Omarchy from: https://github.com/${OMARCHY_REPO}.git"
 rm -rf ~/.local/share/omarchy/
-git clone https://github.com/basecamp/omarchy.git ~/.local/share/omarchy >/dev/null
+git clone "https://github.com/${OMARCHY_REPO}.git" ~/.local/share/omarchy >/dev/null
 
 # Use custom branch if instructed
 if [[ -n "$OMARCHY_REF" ]]; then


### PR DESCRIPTION
When testing updates prior to submitting a PR, it's nice to be able to do a full install. This would allow something like `wget -qO- https://omarchy.org/install | OMARCHY_REPO=ryanrhughes/omarchy OMARCHY_REF=test bash` to pull from my own repo on a test branch without jumping through as many hoops.