### PR TITLE
Less invasive user hyprland configuration

### DIFF
--- a/install/hyprlandia.sh
+++ b/install/hyprlandia.sh
@@ -4,4 +4,12 @@ yay -S --noconfirm --needed \
   xdg-desktop-portal-hyprland xdg-desktop-portal-gtk
 
 # Start Hyprland on first session
-echo "[[ -z \$DISPLAY && \$(tty) == /dev/tty1 ]] && exec Hyprland" >~/.bash_profile
+cat <<EOF >~/.bash_profile
+if [[ -z \$DISPLAY && \$(tty) == /dev/tty1 ]] ; then
+  if [ -r ~/.config/hypr/hyprland-custom.conf ] ; then
+    exec Hyprland -c ~/.config/hypr/hyprland-custom.conf
+  else
+    exec Hyprland
+  fi
+fi
+EOF


### PR DESCRIPTION
This patch allows users to configure hyprland with less need to change omarchy managed files. The idea is to start hyprland with a user managed `hyperland-custom.conf` file instead of the default config when the former one exists.

Hyprland parses linearly using "last one wins"/"no deep merge" strategies, and there are also unbind directives.

If the user opts in, she could pick whatever she wants from the omarchy managed files. I currently use it to override/append customization.

```
# ~/.config/hypr/hyprland-custom.conf

source = ~/.config/hypr/hyprland.conf

env = SSH_AUTH_SOCK,$XDG_RUNTIME_DIR/ssh-agent.socket
env = GDK_SCALE,1
```
