### PR TITLE
hypr: added custom script to use wofi as xdph share-picker

### DIFF
--- a/bin/omarchy-xdph-share-picker
+++ b/bin/omarchy-xdph-share-picker
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+monitors=$(wlr-randr --json | jq '.[] | .name')
+windows="${XDPH_WINDOW_SHARING_LIST}"
+
+result=""
+
+# Add monitors to result
+while IFS= read -r monitor; do
+    monitor=$(echo "$monitor" | tr -d '"')  # Remove quotes from monitor name
+    if [ -n "$result" ]; then
+        result="${result}\n"
+    fi
+    result="${result}${monitor}\tscreen: ${monitor}"
+done <<< "$monitors"
+
+# Add region entry
+if [ -n "$result" ]; then
+    result="${result}\n"
+fi
+result="${result}region\tSelection Region"
+
+# Add windows to result
+while IFS= read -r line; do
+    if [ -n "$result" ]; then
+        result="${result}\n"
+    fi
+    result="${result}${line}"
+done < <(echo "$windows" | awk -F'\\[HE>\\]' '{
+    for(i=1; i<=NF; i++) {
+        if ($i == "") continue;
+
+        split($i, window, "\\[HC>\\]");
+        id = window[1];
+
+        split(window[2], parts, "\\[HT>\\]");
+        class = parts[1];
+        title = parts[2];
+
+        if (id != "")
+            print id "\t" "window: " title;
+    }
+}')
+
+selection=$(echo -e "$result" | wofi -d)
+
+if [[ $selection == *"screen"* ]]; then
+    monitor=$(echo "$selection" | cut -f1)
+    echo "[SELECTION]/screen:${monitor}"
+elif [[ $selection == *"window"* ]]; then
+    window_id=$(echo "$selection" | cut -f1)
+    echo "[SELECTION]/window:${window_id}"
+elif [[ $selection == *"region"* ]]; then
+    region=$(slurp -f "%o@%x,%y,%w,%h")
+    echo "[SELECTION]/region:${region}"
+fi

--- a/config/hypr/xdph.conf
+++ b/config/hypr/xdph.conf
@@ -1,0 +1,3 @@
+screencopy {
+    custom_picker_binary=omarchy-xdph-share-picker
+}


### PR DESCRIPTION
I've added a script that let's you use any dmenu as a xdph share picker. It'll use wofi, as wofi is the default launcher (for now... ).