### PR TITLE
Add omarchy-screenshot

### DIFF
--- a/bin/omarchy-screenshot
+++ b/bin/omarchy-screenshot
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  cat <<'EOF'
+Screenshot script using slurp + grim with smart selection
+
+USAGE:
+  omarchy-screenshot [MODE]
+
+MODES:
+  smart      - Shows window/monitor outlines, and allows free selection (default)
+  region     - Pure region selection
+  windows    - Restricted to clicking predefined windows/monitors only  
+  fullscreen - Instant full screen capture of active monitor
+
+ACTIONS (after capture):
+  Copy    - Copy image to clipboard
+  Edit    - Open in image editor (configurable)
+  Save    - Save to Pictures directory  
+  Discard - Delete and cancel
+
+CONFIGURATION:
+  SCREENSHOT_EDITOR - Image editor command (default: gradia)
+  XDG_PICTURES_DIR  - Screenshot save location (default: ~/Pictures)
+
+EXAMPLES:
+  omarchy-screenshot smart                                  # Smart selection with guides
+  omarchy-screenshot fullscreen                             # Instant full screen
+  SCREENSHOT_EDITOR="satty --filename" omarchy-screenshot   # Edit opens in Satty
+EOF
+  exit 0
+fi
+
+MODE="${1:-smart}"
+SCREENSHOT_DIR="${XDG_PICTURES_DIR:-$HOME/Pictures}"
+TIMESTAMP=$(date +"%Y-%m-%d-%H%M%S")
+TEMP_FILE="/tmp/screenshot-${TIMESTAMP}.png"
+
+# Prevent stacking - kill any existing slurp processes to make toggleable
+if pgrep -x slurp >/dev/null; then
+  pkill -x slurp
+  exit 0
+fi
+
+# Function to get theme color by name
+get_theme_color() {
+  local color_name="$1"
+  local fallback="$2"
+  local wofi_css="$HOME/.config/omarchy/current/theme/wofi.css"
+
+  # Extract color directly or use fallback
+  sed -n 's/.*@define-color.*'"${color_name}"'[[:space:]]*\(#[0-9a-fA-F]\{6\}\).*/\1/p' "$wofi_css" 2>/dev/null | head -1 || echo "$fallback"
+}
+
+# Get the dynamic colors w/ fallbacks
+BORDER_COLOR=$(get_theme_color "border" "#ffffff")
+UNSELECTED_COLOR=$(get_theme_color "base" "#000000")
+
+# Add alpha channels
+BORDER_COLOR_FULL="${BORDER_COLOR}ff"
+UNSELECTED_COLOR_OVERLAY="${UNSELECTED_COLOR}88"
+
+# Function to get predefined rectangles (windows and monitors)
+get_rectangles() {
+  # Get the active workspace ID
+  local active_workspace=$(hyprctl activewindow -j | jq -r '.workspace.id // empty')
+
+  # Get monitors with scale adjustment (divide by scale to get physical resolution)
+  hyprctl monitors -j | jq -r '.[] | 
+    . as $m | 
+    "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor) 🖥️ \(.name)"'
+
+  # Get windows only from active workspace
+  if [ -n "$active_workspace" ]; then
+    hyprctl clients -j | jq -r --arg ws "$active_workspace" '.[] | select(.workspace.id == ($ws | tonumber)) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1]) 🪟 \(.title | .[0:50])"'
+  fi
+}
+
+# Show interactive menu using wofi with compact styling
+show_screenshot_menu() {
+  local menu_options="\u200B󰆏 Copy
+\u200C󰤌 Edit
+\u200D󰆓 Save
+\u2060󰩺 Discard"
+  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Screenshot Actions" --width 180 --height 160 -O alphabetical --style ~/.local/share/omarchy/default/wofi/select.css)
+
+  case "$selection" in
+  *"Copy"*)
+    wl-copy <"$TEMP_FILE"
+    rm -f "$TEMP_FILE"
+    ;;
+  *"Edit"*)
+    # Open in screenshot editor (defaults to gradia)
+    ${SCREENSHOT_EDITOR:-gradia} "$TEMP_FILE"
+    ;;
+  *"Save"*)
+    FINAL_FILE="${SCREENSHOT_DIR}/Screenshot-${TIMESTAMP}.png"
+    cp "$TEMP_FILE" "$FINAL_FILE"
+    rm -f "$TEMP_FILE"
+
+    # Send notification with default action to open folder when clicked
+    ACTION=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
+      -i "$FINAL_FILE" \
+      -A "default=Open Folder" \
+      -t 8000 \
+      --wait)
+
+    # Handle the action if the user clicks it
+    if [ "$ACTION" = "default" ]; then
+      xdg-open "$SCREENSHOT_DIR"
+    fi
+    ;;
+  *"Discard"* | "")
+    # Remove temp file (no saved file to remove since we didn't save it)
+    rm -f "$TEMP_FILE"
+    ;;
+  esac
+}
+
+# Choose selection method based on mode
+case "$MODE" in
+"region")
+  SELECTION=$(slurp -c "$BORDER_COLOR_FULL" -b "$UNSELECTED_COLOR_OVERLAY" 2>/dev/null)
+  ;;
+"windows")
+  # Windows and monitors only - restricted to predefined areas
+  SELECTION=$(get_rectangles | slurp -r -c "$BORDER_COLOR_FULL" -b "$UNSELECTED_COLOR_OVERLAY" -B "$UNSELECTED_COLOR_OVERLAY" 2>/dev/null)
+  ;;
+"fullscreen")
+  # Full screen of active monitor - no selection needed
+  SELECTION=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"')
+  ;;
+"smart" | *)
+  # Smart mode: Shows windows/monitors as guides but allows free selection
+  SELECTION=$(get_rectangles | slurp -c "$BORDER_COLOR_FULL" -b "$UNSELECTED_COLOR_OVERLAY" -B "$UNSELECTED_COLOR_OVERLAY" 2>/dev/null)
+  ;;
+esac
+
+if [ -z "$SELECTION" ]; then
+  exit 0
+fi
+
+# Small delay to let slurp's border disappear before capturing
+sleep 0.1
+
+grim -g "$SELECTION" "$TEMP_FILE"
+
+# Check if screenshot was successful
+if [ ! -f "$TEMP_FILE" ]; then
+  notify-send "Screenshot Failed" "Failed to capture screenshot" -u critical
+  exit 1
+fi
+
+# Show the menu
+show_screenshot_menu

--- a/bin/omarchy-screenshot
+++ b/bin/omarchy-screenshot
@@ -5,7 +5,7 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 Screenshot script using slurp + grim with smart selection
 
 USAGE:
-  omarchy-screenshot [MODE]
+  omarchy-screenshot [MODE] [ACTION]
 
 MODES:
   smart      - Shows window/monitor outlines, and allows free selection (default)
@@ -13,25 +13,29 @@ MODES:
   windows    - Restricted to clicking predefined windows/monitors only  
   fullscreen - Instant full screen capture of active monitor
 
-ACTIONS (after capture):
-  Copy    - Copy image to clipboard
-  Edit    - Open in image editor (configurable)
-  Save    - Save to Pictures directory  
-  Discard - Delete and cancel
+ACTIONS:
+  copy    - Copy image to clipboard
+  edit    - Open in image editor (configurable)
+  save    - Save to Pictures directory  
+  discard - Delete and cancel
+  (if no action specified, shows interactive menu)
 
 CONFIGURATION:
   SCREENSHOT_EDITOR - Image editor command (default: gradia)
   XDG_PICTURES_DIR  - Screenshot save location (default: ~/Pictures)
 
 EXAMPLES:
-  omarchy-screenshot smart                                  # Smart selection with guides
-  omarchy-screenshot fullscreen                             # Instant full screen
-  SCREENSHOT_EDITOR="satty --filename" omarchy-screenshot   # Edit opens in Satty
+  omarchy-screenshot smart                      # Smart selection with menu
+  omarchy-screenshot smart copy                 # Smart selection, auto-copy
+  omarchy-screenshot fullscreen save            # Instant full screen save
+  omarchy-screenshot region edit               # Region select, auto-edit
+  SCREENSHOT_EDITOR=satty omarchy-screenshot    # Edit opens in Satty
 EOF
   exit 0
 fi
 
 MODE="${1:-smart}"
+ACTION="${2:-}"
 SCREENSHOT_DIR="${XDG_PICTURES_DIR:-$HOME/Pictures}"
 TIMESTAMP=$(date +"%Y-%m-%d-%H%M%S")
 TEMP_FILE="/tmp/screenshot-${TIMESTAMP}.png"
@@ -151,5 +155,43 @@ if [ ! -f "$TEMP_FILE" ]; then
   exit 1
 fi
 
-# Show the menu
-show_screenshot_menu
+# Handle action directly or show menu
+if [ -n "$ACTION" ]; then
+  case "$ACTION" in
+    "copy")
+      wl-copy < "$TEMP_FILE"
+      rm -f "$TEMP_FILE"
+      ;;
+    "edit")
+      ${SCREENSHOT_EDITOR:-gradia} "$TEMP_FILE"
+      ;;
+    "save")
+      FINAL_FILE="${SCREENSHOT_DIR}/Screenshot-${TIMESTAMP}.png"
+      cp "$TEMP_FILE" "$FINAL_FILE"
+      rm -f "$TEMP_FILE"
+      
+      # Send notification with default action to open folder when clicked
+      ACTION_RESULT=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
+        -i "$FINAL_FILE" \
+        -A "default=Open Folder" \
+        -t 8000 \
+        --wait)
+      
+      # Handle the action if the user clicks it
+      if [ "$ACTION_RESULT" = "default" ]; then
+        xdg-open "$SCREENSHOT_DIR"
+      fi
+      ;;
+    "discard")
+      rm -f "$TEMP_FILE"
+      ;;
+    *)
+      echo "Invalid action: $ACTION"
+      echo "Valid actions: copy, edit, save, discard"
+      exit 1
+      ;;
+  esac
+else
+  # No action specified, show interactive menu
+  show_screenshot_menu
+fi

--- a/bin/omarchy-screenshot
+++ b/bin/omarchy-screenshot
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Minimum selection area in pixels - selections smaller than this will snap to containing window/monitor
+MIN_SELECTION_AREA=20
+
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   cat <<'EOF'
 Screenshot script using slurp + grim with smart selection
@@ -201,6 +204,77 @@ handle_menu_selection() {
   esac
 }
 
+# Function to check if selection area is too small
+is_selection_too_small() {
+  local selection="$1"
+
+  # Parse selection format: "x,y WxH" (e.g., "1294,346 1x2")
+  if [[ "$selection" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]]; then
+    local width="${BASH_REMATCH[3]}"
+    local height="${BASH_REMATCH[4]}"
+    local area=$((width * height))
+
+    if [ "$area" -le "$MIN_SELECTION_AREA" ]; then
+      return 0 # true - selection is too small
+    fi
+  fi
+
+  return 1 # false - selection is fine
+}
+
+# Function to find the intended selection box containing a point
+find_containing_box() {
+  local selection="$1"
+  local rectangles="$2"
+
+  # Parse selection to get the x,y coordinates
+  if [[ "$selection" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]]; then
+    local x="${BASH_REMATCH[1]}"
+    local y="${BASH_REMATCH[2]}"
+
+    local window_box=""
+    local monitor_box=""
+
+    # Check which rectangle contains the point
+    while IFS= read -r rect; do
+      # Parse rectangle format: "rx,ry rwxrh ..."
+      if [[ "$rect" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+) ]]; then
+        local rx="${BASH_REMATCH[1]}"
+        local ry="${BASH_REMATCH[2]}"
+        local rw="${BASH_REMATCH[3]}"
+        local rh="${BASH_REMATCH[4]}"
+
+        # Check if point (x,y) is within the rectangle bounds
+        if [ "$x" -ge "$rx" ] && [ "$x" -lt $((rx + rw)) ] &&
+          [ "$y" -ge "$ry" ] && [ "$y" -lt $((ry + rh)) ]; then
+          # Format the coordinates exactly as grim expects: "x,y WxH"
+          local coords="${rx},${ry} ${rw}x${rh}"
+
+          # Check if it's a window or monitor
+          if [[ "$rect" == *"🪟"* ]]; then
+            window_box="$coords"
+          elif [[ "$rect" == *"🖥️"* ]]; then
+            monitor_box="$coords"
+          fi
+        fi
+      fi
+    done <<<"$rectangles"
+
+    # Prioritize window box over monitor box
+    if [ -n "$window_box" ]; then
+      echo "$window_box"
+    elif [ -n "$monitor_box" ]; then
+      echo "$monitor_box"
+    else
+      # If no containing box found, return nothing (invalid selection)
+      echo ""
+    fi
+  else
+    # Invalid format, return nothing
+    echo ""
+  fi
+}
+
 # Choose selection method based on mode
 case "$MODE" in
 "region")
@@ -216,7 +290,12 @@ case "$MODE" in
   ;;
 "smart" | *)
   # Smart mode: Shows windows/monitors as guides but allows free selection
-  SELECTION=$(get_rectangles | slurp -c "$BORDER_COLOR_FULL" -b "$UNSELECTED_COLOR_OVERLAY" -B "$UNSELECTED_COLOR_OVERLAY" 2>/dev/null)
+  RECTANGLES=$(get_rectangles)
+  SELECTION=$(echo "$RECTANGLES" | slurp -c "$BORDER_COLOR_FULL" -b "$UNSELECTED_COLOR_OVERLAY" -B "$UNSELECTED_COLOR_OVERLAY" 2>/dev/null)
+
+  if is_selection_too_small "$SELECTION"; then
+    SELECTION=$(find_containing_box "$SELECTION" "$RECTANGLES")
+  fi
   ;;
 esac
 

--- a/bin/omarchy-screenshot
+++ b/bin/omarchy-screenshot
@@ -28,8 +28,8 @@ EXAMPLES:
   omarchy-screenshot smart                      # Smart selection with menu
   omarchy-screenshot smart copy                 # Smart selection, auto-copy
   omarchy-screenshot fullscreen save            # Instant full screen save
-  omarchy-screenshot region edit               # Region select, auto-edit
-  SCREENSHOT_EDITOR=satty omarchy-screenshot    # Edit opens in Satty
+  omarchy-screenshot region edit                # Region select, auto-edit
+  SCREENSHOT_EDITOR=satty omarchy-screenshot    # Edit menu option opens in Satty
 EOF
   exit 0
 fi
@@ -158,38 +158,38 @@ fi
 # Handle action directly or show menu
 if [ -n "$ACTION" ]; then
   case "$ACTION" in
-    "copy")
-      wl-copy < "$TEMP_FILE"
-      rm -f "$TEMP_FILE"
-      ;;
-    "edit")
-      ${SCREENSHOT_EDITOR:-gradia} "$TEMP_FILE"
-      ;;
-    "save")
-      FINAL_FILE="${SCREENSHOT_DIR}/Screenshot-${TIMESTAMP}.png"
-      cp "$TEMP_FILE" "$FINAL_FILE"
-      rm -f "$TEMP_FILE"
-      
-      # Send notification with default action to open folder when clicked
-      ACTION_RESULT=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
-        -i "$FINAL_FILE" \
-        -A "default=Open Folder" \
-        -t 8000 \
-        --wait)
-      
-      # Handle the action if the user clicks it
-      if [ "$ACTION_RESULT" = "default" ]; then
-        xdg-open "$SCREENSHOT_DIR"
-      fi
-      ;;
-    "discard")
-      rm -f "$TEMP_FILE"
-      ;;
-    *)
-      echo "Invalid action: $ACTION"
-      echo "Valid actions: copy, edit, save, discard"
-      exit 1
-      ;;
+  "copy")
+    wl-copy <"$TEMP_FILE"
+    rm -f "$TEMP_FILE"
+    ;;
+  "edit")
+    ${SCREENSHOT_EDITOR:-gradia} "$TEMP_FILE"
+    ;;
+  "save")
+    FINAL_FILE="${SCREENSHOT_DIR}/Screenshot-${TIMESTAMP}.png"
+    cp "$TEMP_FILE" "$FINAL_FILE"
+    rm -f "$TEMP_FILE"
+
+    # Send notification with default action to open folder when clicked
+    ACTION_RESULT=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
+      -i "$FINAL_FILE" \
+      -A "default=Open Folder" \
+      -t 8000 \
+      --wait)
+
+    # Handle the action if the user clicks it
+    if [ "$ACTION_RESULT" = "default" ]; then
+      xdg-open "$SCREENSHOT_DIR"
+    fi
+    ;;
+  "discard")
+    rm -f "$TEMP_FILE"
+    ;;
+  *)
+    echo "Invalid action: $ACTION"
+    echo "Valid actions: copy, edit, save, discard"
+    exit 1
+    ;;
   esac
 else
   # No action specified, show interactive menu

--- a/bin/omarchy-screenshot
+++ b/bin/omarchy-screenshot
@@ -5,37 +5,69 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 Screenshot script using slurp + grim with smart selection
 
 USAGE:
-  omarchy-screenshot [MODE] [ACTION]
+  omarchy-screenshot [OPTIONS] [MODE]
+
+OPTIONS:
+  --action=ACTION    Specify action to perform after capture
+  --editor=COMMAND   Override screenshot editor (default: gradia)
+  -h, --help         Show this help message
 
 MODES:
-  smart      - Shows window/monitor outlines, and allows free selection (default)
-  region     - Pure region selection
+  smart      - Shows window/monitor outlines, allows free selection (default)
+  region     - Pure region selection with crosshair
   windows    - Restricted to clicking predefined windows/monitors only  
   fullscreen - Instant full screen capture of active monitor
 
 ACTIONS:
-  copy    - Copy image to clipboard
-  edit    - Open in image editor (configurable)
-  save    - Save to Pictures directory  
-  discard - Delete and cancel
-  (if no action specified, shows interactive menu)
+  copy       - Copy image to clipboard
+  edit       - Open in image editor (configurable)
+  save       - Save to Pictures directory  
+  discard    - Delete and cancel
+  
+  If no --action= is specified, an interactive menu will be shown.
 
 CONFIGURATION:
-  SCREENSHOT_EDITOR - Image editor command (default: gradia)
   XDG_PICTURES_DIR  - Screenshot save location (default: ~/Pictures)
+  --editor=COMMAND  - Specify image editor (default: gradia)
 
 EXAMPLES:
-  omarchy-screenshot smart                      # Smart selection with menu
-  omarchy-screenshot smart copy                 # Smart selection, auto-copy
-  omarchy-screenshot fullscreen save            # Instant full screen save
-  omarchy-screenshot region edit                # Region select, auto-edit
-  SCREENSHOT_EDITOR=satty omarchy-screenshot    # Edit menu option opens in Satty
+  omarchy-screenshot                              # Smart selection, show menu
+  omarchy-screenshot --action=copy                # Smart selection, auto-copy
+  omarchy-screenshot --editor="satty --filename"  # Use Satty for editing
+  omarchy-screenshot smart --action=copy          # Same as above (explicit mode)
+  omarchy-screenshot windows                      # Window selection, show menu
 EOF
   exit 0
 fi
 
-MODE="${1:-smart}"
-ACTION="${2:-}"
+# Parse arguments
+MODE="smart"
+ACTION=""
+EDITOR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --action=*)
+    ACTION="${1#*=}"
+    shift
+    ;;
+  --editor=*)
+    EDITOR="${1#*=}"
+    shift
+    ;;
+  -*)
+    echo "Unknown option: $1"
+    exit 1
+    ;;
+  *)
+    MODE="$1"
+    shift
+    ;;
+  esac
+done
+
+# Set editor with fallback to gradia
+SCREENSHOT_EDITOR="${EDITOR:-gradia}"
 SCREENSHOT_DIR="${XDG_PICTURES_DIR:-$HOME/Pictures}"
 TIMESTAMP=$(date +"%Y-%m-%d-%H%M%S")
 TEMP_FILE="/tmp/screenshot-${TIMESTAMP}.png"

--- a/bin/omarchy-screenshot
+++ b/bin/omarchy-screenshot
@@ -120,10 +120,40 @@ show_screenshot_menu() {
 \u2060󰩺 Discard"
   local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Screenshot Actions" --width 180 --height 160 -O alphabetical --style ~/.local/share/omarchy/default/wofi/select.css)
 
+  handle_menu_selection "$selection"
+}
+
+# Show post-copy menu (without copy option since it's already copied)
+show_post_copy_menu() {
+  local menu_options="\u200C󰤌 Edit
+\u200D󰆓 Save
+\u2060󰩺 Discard"
+  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Additional Actions" --width 180 --height 120 -O alphabetical --style ~/.local/share/omarchy/default/wofi/select.css)
+
+  handle_menu_selection "$selection"
+}
+
+# Handle menu selection logic (shared between both menus)
+handle_menu_selection() {
+  local selection="$1"
+
   case "$selection" in
   *"Copy"*)
     wl-copy <"$TEMP_FILE"
-    rm -f "$TEMP_FILE"
+    
+    # Send notification with action to reopen menu when clicked
+    ACTION_RESULT=$(notify-send "Screenshot Copied" "Screenshot copied to clipboard\nClick to view more options" \
+      -i "$TEMP_FILE" \
+      -A "default=More Options" \
+      -t 5000 \
+      --wait)
+    
+    # Handle the action if the user clicks it - reopen post-copy menu
+    if [ "$ACTION_RESULT" = "default" ]; then
+      show_post_copy_menu
+    else
+      rm -f "$TEMP_FILE"
+    fi
     ;;
   *"Edit"*)
     # Open in screenshot editor (defaults to gradia)
@@ -192,7 +222,20 @@ if [ -n "$ACTION" ]; then
   case "$ACTION" in
   "copy")
     wl-copy <"$TEMP_FILE"
-    rm -f "$TEMP_FILE"
+    
+    # Send notification with action to reopen menu when clicked
+    ACTION_RESULT=$(notify-send "Screenshot Copied" "Screenshot copied to clipboard\nClick to view more options" \
+      -i "$TEMP_FILE" \
+      -A "default=More Options" \
+      -t 5000 \
+      --wait)
+    
+    # Handle the action if the user clicks it - reopen post-copy menu
+    if [ "$ACTION_RESULT" = "default" ]; then
+      show_post_copy_menu
+    else
+      rm -f "$TEMP_FILE"
+    fi
     ;;
   "edit")
     ${SCREENSHOT_EDITOR:-gradia} "$TEMP_FILE"

--- a/bin/omarchy-screenshot
+++ b/bin/omarchy-screenshot
@@ -8,9 +8,10 @@ USAGE:
   omarchy-screenshot [OPTIONS] [MODE]
 
 OPTIONS:
-  --action=ACTION    Specify action to perform after capture
-  --editor=COMMAND   Override screenshot editor (default: gradia)
-  -h, --help         Show this help message
+  --action=ACTION        Specify action to perform after capture
+  --editor=COMMAND       Override screenshot editor (default: gradia)
+  --copy-path-on-save    Copy saved file path to clipboard when saving
+  -h, --help             Show this help message
 
 MODES:
   smart      - Shows window/monitor outlines, allows free selection (default)
@@ -44,6 +45,7 @@ fi
 MODE="smart"
 ACTION=""
 EDITOR=""
+COPY_PATH_ON_SAVE=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -53,6 +55,10 @@ while [ $# -gt 0 ]; do
     ;;
   --editor=*)
     EDITOR="${1#*=}"
+    shift
+    ;;
+  --copy-path-on-save)
+    COPY_PATH_ON_SAVE="true"
     shift
     ;;
   -*)
@@ -114,21 +120,27 @@ get_rectangles() {
 
 # Show interactive menu using wofi with compact styling
 show_screenshot_menu() {
+  # Kill any existing wofi instances to prevent stacking
+  pkill -x wofi 2>/dev/null
+
   local menu_options="\u200B󰆏 Copy
 \u200C󰤌 Edit
 \u200D󰆓 Save
 \u2060󰩺 Discard"
-  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Screenshot Actions" --width 180 --height 160 -O alphabetical --style ~/.local/share/omarchy/default/wofi/select.css)
+  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Screenshot Actions" --width 180 --height 160 -O alphabetical --normal-window --style ~/.local/share/omarchy/default/wofi/select.css)
 
   handle_menu_selection "$selection"
 }
 
 # Show post-copy menu (without copy option since it's already copied)
 show_post_copy_menu() {
+  # Kill any existing wofi instances to prevent stacking
+  pkill -x wofi 2>/dev/null
+
   local menu_options="\u200C󰤌 Edit
 \u200D󰆓 Save
 \u2060󰩺 Discard"
-  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Additional Actions" --width 180 --height 120 -O alphabetical --style ~/.local/share/omarchy/default/wofi/select.css)
+  local selection=$(echo -e "$menu_options" | wofi --show dmenu --prompt "Additional Actions" --width 180 --height 120 -O alphabetical --normal-window --style ~/.local/share/omarchy/default/wofi/select.css)
 
   handle_menu_selection "$selection"
 }
@@ -140,14 +152,14 @@ handle_menu_selection() {
   case "$selection" in
   *"Copy"*)
     wl-copy <"$TEMP_FILE"
-    
+
     # Send notification with action to reopen menu when clicked
     ACTION_RESULT=$(notify-send "Screenshot Copied" "Screenshot copied to clipboard\nClick to view more options" \
       -i "$TEMP_FILE" \
       -A "default=More Options" \
       -t 5000 \
       --wait)
-    
+
     # Handle the action if the user clicks it - reopen post-copy menu
     if [ "$ACTION_RESULT" = "default" ]; then
       show_post_copy_menu
@@ -164,16 +176,22 @@ handle_menu_selection() {
     cp "$TEMP_FILE" "$FINAL_FILE"
     rm -f "$TEMP_FILE"
 
-    # Send notification with default action to open folder when clicked
-    ACTION=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
-      -i "$FINAL_FILE" \
-      -A "default=Open Folder" \
-      -t 8000 \
-      --wait)
+    # Copy path to clipboard if flag is set
+    if [ "$COPY_PATH_ON_SAVE" = "true" ]; then
+      echo -n "$FINAL_FILE" | wl-copy
+      notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nPath copied to clipboard" -i "$FINAL_FILE" -t 5000
+    else
+      # Send notification with default action to open folder when clicked
+      ACTION=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
+        -i "$FINAL_FILE" \
+        -A "default=Open Folder" \
+        -t 8000 \
+        --wait)
 
-    # Handle the action if the user clicks it
-    if [ "$ACTION" = "default" ]; then
-      xdg-open "$SCREENSHOT_DIR"
+      # Handle the action if the user clicks it
+      if [ "$ACTION" = "default" ]; then
+        xdg-open "$SCREENSHOT_DIR"
+      fi
     fi
     ;;
   *"Discard"* | "")
@@ -222,14 +240,14 @@ if [ -n "$ACTION" ]; then
   case "$ACTION" in
   "copy")
     wl-copy <"$TEMP_FILE"
-    
+
     # Send notification with action to reopen menu when clicked
     ACTION_RESULT=$(notify-send "Screenshot Copied" "Screenshot copied to clipboard\nClick to view more options" \
       -i "$TEMP_FILE" \
       -A "default=More Options" \
       -t 5000 \
       --wait)
-    
+
     # Handle the action if the user clicks it - reopen post-copy menu
     if [ "$ACTION_RESULT" = "default" ]; then
       show_post_copy_menu
@@ -245,16 +263,22 @@ if [ -n "$ACTION" ]; then
     cp "$TEMP_FILE" "$FINAL_FILE"
     rm -f "$TEMP_FILE"
 
-    # Send notification with default action to open folder when clicked
-    ACTION_RESULT=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
-      -i "$FINAL_FILE" \
-      -A "default=Open Folder" \
-      -t 8000 \
-      --wait)
+    # Copy path to clipboard if flag is set
+    if [ "$COPY_PATH_ON_SAVE" = "true" ]; then
+      echo -n "$FINAL_FILE" | wl-copy
+      notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nPath copied to clipboard" -i "$FINAL_FILE" -t 5000
+    else
+      # Send notification with default action to open folder when clicked
+      ACTION_RESULT=$(notify-send "Screenshot Saved" "Saved to: $(basename "$FINAL_FILE")\nClick to open folder" \
+        -i "$FINAL_FILE" \
+        -A "default=Open Folder" \
+        -t 8000 \
+        --wait)
 
-    # Handle the action if the user clicks it
-    if [ "$ACTION_RESULT" = "default" ]; then
-      xdg-open "$SCREENSHOT_DIR"
+      # Handle the action if the user clicks it
+      if [ "$ACTION_RESULT" = "default" ]; then
+        xdg-open "$SCREENSHOT_DIR"
+      fi
     fi
     ;;
   "discard")

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -24,10 +24,10 @@ bind = CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000
 bind = SHIFT CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +60000
 
 # Screenshots
-bind = , PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart
-bind = SHIFT, PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot windows
-bind = CTRL, PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen
-bind = ALT, PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot region  
+bindd = , PRINT,Take a screenshot (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart
+bindd = SHIFT, PRINT,Take a screenshot (window), exec, ~/.local/share/omarchy/bin/omarchy-screenshot windows
+bindd = CTRL, PRINT,Take a screenshot (fullscreen), exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen
+bindd = ALT, PRINT,Take a screenshot (region), exec, ~/.local/share/omarchy/bin/omarchy-screenshot region  
 
 # Color picker
 bind = SUPER, PRINT, exec, hyprpicker -a

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -24,9 +24,10 @@ bind = CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000
 bind = SHIFT CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +60000
 
 # Screenshots
-bind = , PRINT, exec, hyprshot -m region
-bind = SHIFT, PRINT, exec, hyprshot -m window
-bind = CTRL, PRINT, exec, hyprshot -m output
+bind = , PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart
+bind = SHIFT, PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot windows
+bind = CTRL, PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen
+bind = ALT, PRINT, exec, ~/.local/share/omarchy/bin/omarchy-screenshot region  
 
 # Color picker
 bind = SUPER, PRINT, exec, hyprpicker -a

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -24,10 +24,9 @@ bind = CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000
 bind = SHIFT CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +60000
 
 # Screenshots
-bindd = , PRINT,Take a screenshot (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart
-bindd = SHIFT, PRINT,Take a screenshot (window), exec, ~/.local/share/omarchy/bin/omarchy-screenshot windows
+bindd = , PRINT,Copy a screenshot to clipboard (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart --action=copy
+bindd = SHIFT, PRINT,Take a screenshot with options (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart
 bindd = CTRL, PRINT,Take a screenshot (fullscreen), exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen
-bindd = ALT, PRINT,Take a screenshot (region), exec, ~/.local/share/omarchy/bin/omarchy-screenshot region  
 
 # Color picker
 bind = SUPER, PRINT, exec, hyprpicker -a

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -24,9 +24,9 @@ bind = CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000
 bind = SHIFT CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +60000
 
 # Screenshots
-bindd = , PRINT,Copy a screenshot to clipboard (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart --action=copy
-bindd = SHIFT, PRINT,Take a screenshot with options (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart
-bindd = CTRL, PRINT,Take a screenshot (fullscreen), exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen
+bindd = , PRINT,Copy a screenshot to clipboard (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart --action=copy --copy-path-on-save
+bindd = SHIFT, PRINT,Take a screenshot with options (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart --copy-path-on-save
+bindd = CTRL, PRINT,Take a screenshot (fullscreen), exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen --copy-path-on-save
 
 # Color picker
 bind = SUPER, PRINT, exec, hyprpicker -a

--- a/install/hyprlandia.sh
+++ b/install/hyprlandia.sh
@@ -1,5 +1,5 @@
 yay -S --noconfirm --needed \
-  hyprland hyprshot hyprpicker hyprlock hypridle polkit-gnome hyprland-qtutils \
+  hyprland hyprshot hyprpicker hyprlock hypridle polkit-gnome hyprland-qtutils grim slurp gradia \
   wofi waybar mako swaybg \
   xdg-desktop-portal-hyprland xdg-desktop-portal-gtk
 

--- a/migrations/1752348046.sh
+++ b/migrations/1752348046.sh
@@ -1,2 +1,2 @@
 echo "Install omarchy-screenshot dependencies"
-yay -S --no-confirm-needed grim slurp gradia
+yay -S --noconfirm --needed grim slurp gradia

--- a/migrations/1752348046.sh
+++ b/migrations/1752348046.sh
@@ -1,0 +1,2 @@
+echo "Install omarchy-screenshot dependencies"
+yay -S --no-confirm-needed grim slurp gradia


### PR DESCRIPTION
Throughout the conversation yesterday in Discord, @dhh mentioned _"...But would prefer if there was just one hotkey and then you could toggle. Don't recall the mac one I was using, but on space you could toggle between region/window/screen..."_ which got me thinking about ways to get as close to that experience as we can. `omarchy-screenshot` aims to provide that flexibility, and a bit of the best of all worlds.

By default, `omarchy-screenshot` invokes a smart selection (via slurp) that allows you to click a window, a whole display, or drag a region and presents a menu of options of what to do after with the default location being Copy allowing for a **Print Screen, Enter** command sequence to net you whatever you chose to your clipboard.

![untitled](https://github.com/user-attachments/assets/8404e986-f7e9-46c8-968a-2ab1c82f88b0)

### Defaults
The default state is that you get smart selection, a menu after you snap your screenshot, and the edit action opens in Gradia. Those can be changed by setting the mode, passing in an editor to `--editor`, or passing in an action to `--actions`.

The border and overlay colors attempt to extract from `~/.config/omarchy/current/theme/wofi.css` with a fallback if that fails allowing them to better match the active theme but also not fail if something didn't line up.

### Usage Examples
```
  omarchy-screenshot                              # Smart selection, show menu
  omarchy-screenshot --action=copy                # Smart selection, auto-copy
  omarchy-screenshot --editor="satty --filename"  # Use Satty for editing
  omarchy-screenshot smart --action=copy          # Same as above (explicit mode)
  omarchy-screenshot windows                      # Window selection, show menu
```

### Keybinds
Keybinds were kept matched to what the targets are now, but I believe it's feasible to reduce to two but would like feedback prior to making that change since it'll change expected behaviors.

Since the smart mode effectively combines 3, while not locking you into any one path from the outset, we don't need multiple specialized keybinds.

I would recommend we go with this.

```
# Screenshots
bindd = , PRINT,Take a screenshot (smart selection) , exec, ~/.local/share/omarchy/bin/omarchy-screenshot smart
bindd = SHIFT, PRINT,Take a screenshot (fullscreen), exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen

# Eliminate these (changing fullscreen from ctrl + print scr --> shift + print scr)
# bindd = SHIFT, PRINT,Take a screenshot (window), exec, ~/.local/share/omarchy/bin/omarchy-screenshot windows
# bindd = CTRL, PRINT,Take a screenshot (fullscreen), exec, ~/.local/share/omarchy/bin/omarchy-screenshot fullscreen
# bindd = ALT, PRINT,Take a screenshot (region), exec, ~/.local/share/omarchy/bin/omarchy-screenshot region  
```

### Possible Improvement
I didn't set it in the defaults but I find that having the screenshot editor floated brings the best experience since I likely want to carry out some quick actions, then move on right from there. Something like this could be added to the default `windows.conf`.
 
```
windowrule = float, class:^(be.alexandervanhee.gradia)$
windowrule = center, class:^(be.alexandervanhee.gradia)$
```