### PR TITLE
Enable input of international charactes

### DIFF
--- a/default/hypr/input.conf
+++ b/default/hypr/input.conf
@@ -1,9 +1,9 @@
 # https://wiki.hyprland.org/Configuring/Variables/#input
 input {
-    kb_layout = us
-    kb_variant =
+    kb_layout = us,us
+    kb_variant = ,intl
     kb_model =
-    kb_options = compose:caps
+    kb_options = compose:caps, grp:alt_space_toggle
     kb_rules =
 
     follow_mouse = 1


### PR DESCRIPTION
As a non-american user I frequently need fast access to international characters, specially accented vowels.

With this change the `us` keyboard variant remains unaffected, but pressing `LeftAlt+Space` enables the international variant, allowing the user to:

  - Type accented vowels with two keystrokes (`'` followed by the `<vowel>`) instead three (`ComposeKey` followed by `'` followed by `<vowel>`). Same thing for `ñ`. Sounds silly but makes a huge difference.
  - It also enables the use of `RightAlt` to input other special characters, like `ß`, `¡`, `¿` and more.

The compose functionality to input emojis remains unaffected.