### PR TITLE
Split package installation to handle failures gracefully

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,4 +13,22 @@ done
 # Ensure locate is up to date now that everything has been installed
 sudo updatedb
 
+# Show summary of failed packages if any
+if [ -n "${omarchy_failed_packages+x}" ] && [ ${#omarchy_failed_packages[@]} -gt 0 ]; then
+  echo
+  gum style --foreground 196 --bold "Failed Package Summary"
+  gum style --foreground 196 "The following ${#omarchy_failed_packages[@]} package(s) failed to install:"
+  echo
+  
+  # Remove duplicates and sort
+  printf '%s\n' "${omarchy_failed_packages[@]}" | sort -u | while read -r pkg; do
+    echo "  • $pkg"
+  done
+  
+  echo
+  gum style --foreground 214 "You can try installing these packages manually later with:"
+  echo "yay -S <package-name>"
+  echo
+fi
+
 gum confirm "Reboot to apply all settings?" && reboot

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -1,4 +1,4 @@
-packages=(
+omarchy_desktop_packages=(
   brightnessctl
   playerctl
   pamixer
@@ -35,3 +35,5 @@ for pkg in "${packages[@]}"; do
     omarchy_failed_packages+=("$pkg")
   fi
 done
+
+unset omarchy_desktop_packages

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -1,9 +1,37 @@
-yay -S --noconfirm --needed \
-  brightnessctl playerctl pamixer pavucontrol wireplumber \
-  fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool \
-  wl-clip-persist clipse-bin \
-  nautilus sushi ffmpegthumbnailer gnome-calculator \
-  1password-beta 1password-cli \
-  chromium mpv \
-  evince imv \
+packages=(
+  brightnessctl
+  playerctl
+  pamixer
+  pavucontrol
+  wireplumber
+  fcitx5
+  fcitx5-gtk
+  fcitx5-qt
+  fcitx5-configtool
+  wl-clip-persist
+  clipse-bin
+  nautilus
+  sushi
+  ffmpegthumbnailer
+  gnome-calculator
+  1password-beta
+  1password-cli
+  chromium
+  mpv
+  evince
+  imv
   localsend-bin
+)
+
+# Initialize global array if it doesn't exist
+if [ -z "${omarchy_failed_packages+x}" ]; then
+  omarchy_failed_packages=()
+fi
+
+for pkg in "${packages[@]}"; do
+  echo "Installing $pkg..."
+  if ! yay -S --noconfirm --needed "$pkg"; then
+    gum style --foreground 196 --bold "✗ Failed to install $pkg"
+    omarchy_failed_packages+=("$pkg")
+  fi
+done

--- a/install/xtras.sh
+++ b/install/xtras.sh
@@ -1,5 +1,5 @@
 if [ -z "$OMARCHY_BARE" ]; then
-  packages=(
+  omarchy_xtras_packages=(
     signal-desktop
     spotify
     dropbox-cli
@@ -25,6 +25,8 @@ if [ -z "$OMARCHY_BARE" ]; then
       omarchy_failed_packages+=("$pkg")
     fi
   done
+
+  unset omarchy_xtras_packages
 fi
 
 # Copy over Omarchy applications

--- a/install/xtras.sh
+++ b/install/xtras.sh
@@ -1,7 +1,31 @@
-yay -S --noconfirm --needed \
-  signal-desktop spotify dropbox-cli zoom \
-  obsidian-bin typora libreoffice obs-studio kdenlive \
-  pinta xournalpp
+if [ -z "$OMARCHY_BARE" ]; then
+  packages=(
+    signal-desktop
+    spotify
+    dropbox-cli
+    zoom
+    obsidian-bin
+    typora
+    libreoffice
+    obs-studio
+    kdenlive
+    pinta
+    xournalpp
+  )
+
+  # Initialize global array if it doesn't exist
+  if [ -z "${omarchy_failed_packages+x}" ]; then
+    omarchy_failed_packages=()
+  fi
+
+  for pkg in "${packages[@]}"; do
+    echo "Installing $pkg..."
+    if ! yay -S --noconfirm --needed "$pkg"; then
+      gum style --foreground 196 --bold "✗ Failed to install $pkg"
+      omarchy_failed_packages+=("$pkg")
+    fi
+  done
+fi
 
 # Copy over Omarchy applications
 source ~/.local/share/omarchy/bin/omarchy-sync-applications || true


### PR DESCRIPTION
Desktop and xtras scripts now install packages individually rather than in bulk. This prevents a single package failure (often due to PGP key issues) from blocking the installation of all other packages. Failed packages are collected and reported at the end of the installation.

Some non-critical packages may fail to install during installation, resulting in Omarchy installation failing in a partially installed state. Now, installation will complete, keeping track of failed packages, allowing a user to choose to manually install those packages which Omarchy reports have failed to install.

Testing shows this has minimal impact on performance (no impact I could measure or perceive). The only downside is that dependency resolution happens incrementally instead of all at once, but the end result seems to be the same.

One additional upside to this approach, it's much easier to see which packages are being installed, and simpler to add another to the list.

Some examples of packages which fail to install from time to time:

__Spotify__ - Usually due to GPG Keys
- https://aur.archlinux.org/packages/spotify#comment-953231
> It is expected that the package will break now and then, as spotify continuously changes download binaries, gpg keys etc (which is not appropriate, but we cannot change this). Please be patient if an update does not occur the next day, you can still use an existing spotify install or update the version yourself.

__1Password__ - GPG key needs to be installed sometimes
- https://aur.archlinux.org/packages/1password#comment-1028287
> If you encounter public key expiry, run
> `curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --import`
- Should we just do this as a part of the install script?

__Typora__ - Good maintainer but sometimes the package breaks
- https://aur.archlinux.org/packages/typora#comment-1012909
- Probably don't want to halt all of Omarchy install just because this package breaks. Can be manually installed later after maintainer gets time to fix.

__Dropbox__ - Since 2019 still breaks in the same way occasionally
- https://aur.archlinux.org/packages/dropbox#comment-676597
> Run the following command in case you got errors during "Verifying source file signatures with gpg..."
> `gpg --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E`
> Alternatively, you can download Dropbox's public key from https://linux.dropbox.com/fedora/rpm-public-key.asc and import it with:
> `gpg --import rpm-public-key.asc`
- Maybe we should do this automatically?

