### PR TITLE
Omarchy Theme Installer

### DIFF
--- a/bin/omarchy-theme-install
+++ b/bin/omarchy-theme-install
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# omarchy-theme-install: Install a new theme from a git repo for Omarchy 
+# Usage: omarchy-theme-install <git-repo-url>
+
+REPO_URL="$1"
+THEMES_SRC_DIR="$HOME/.local/share/omarchy/themes"
+THEMES_LINK_DIR="$HOME/.config/omarchy/themes"
+THEME_NAME=$(basename "$REPO_URL" .git)
+THEME_SRC_PATH="$THEMES_SRC_DIR/$THEME_NAME"
+THEME_LINK_PATH="$THEMES_LINK_DIR/$THEME_NAME"
+BACKGROUND_DIR="$HOME/.config/omarchy/backgrounds"
+FONTS_DIR="$HOME/.config/omarchy/fonts"
+CURRENT_DIR="$HOME/.config/omarchy/current"
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: omarchy-theme-install <git-repo-url>"
+  exit 1
+fi
+
+# Ensure theme directories exist
+mkdir -p "$THEMES_SRC_DIR" "$THEMES_LINK_DIR" "$BACKGROUND_DIR" "$CURRENT_DIR"
+
+# Remove existing theme if present
+if [ -d "$THEME_SRC_PATH" ]; then
+  echo "Theme '$THEME_NAME' already exists in $THEMES_SRC_DIR. Removing old version..."
+  rm -rf "$THEME_SRC_PATH"
+fi
+if [ -L "$THEME_LINK_PATH" ]; then
+  rm -f "$THEME_LINK_PATH"
+fi
+
+# Clone the repo
+if ! git clone "$REPO_URL" "$THEME_SRC_PATH"; then
+  echo "Failed to clone theme repo."
+  exit 1
+fi
+
+# Create symlink in ~/.config/omarchy/themes
+ln -nsf "$THEME_SRC_PATH" "$THEME_LINK_PATH"
+
+# Copy backgrounds if present
+if [ -d "$THEME_SRC_PATH/backgrounds" ]; then
+  DEST_BG="$BACKGROUND_DIR/$THEME_NAME"
+  rm -rf "$DEST_BG"
+  mkdir -p "$DEST_BG"
+  cp -r "$THEME_SRC_PATH/backgrounds/." "$DEST_BG/"
+  echo "Copied backgrounds for $THEME_NAME."
+fi
+
+# Copy fonts if present
+if [ -d "$THEME_SRC_PATH/fonts" ]; then
+  DEST_FONTS="$FONTS_DIR/$THEME_NAME"
+  rm -rf "$DEST_FONTS"
+  mkdir -p "$DEST_FONTS"
+  cp -r "$THEME_SRC_PATH/fonts/." "$DEST_FONTS/"
+  echo "Copied fonts for $THEME_NAME."
+  
+  # Install fonts to system font directory
+  USER_FONT_DIR="$HOME/.local/share/fonts"
+  mkdir -p "$USER_FONT_DIR"
+  
+  # Copy fonts to system font directory
+  cp -r "$THEME_SRC_PATH/fonts/." "$USER_FONT_DIR/"
+  echo "Installed fonts to system font directory: $USER_FONT_DIR"
+  
+  # Update font cache
+  if command -v fc-cache >/dev/null 2>&1; then
+    echo "Updating font cache..."
+    fc-cache -f -v "$USER_FONT_DIR" 2>/dev/null || true
+  fi
+fi
+
+# Set as current theme (update symlinks)
+ln -nsf "$THEME_LINK_PATH" "$CURRENT_DIR/theme"
+ln -nsf "$BACKGROUND_DIR/$THEME_NAME" "$CURRENT_DIR/backgrounds"
+
+# Check for backgrounds and set the first as current, or warn if none
+FIRST_BG=$(find "$BACKGROUND_DIR/$THEME_NAME" -type f | sort | head -n 1)
+if [ -n "$FIRST_BG" ]; then
+  ln -nsf "$FIRST_BG" "$CURRENT_DIR/background"
+  # Use swaybg-next to set the background if available
+  if command -v swaybg-next >/dev/null 2>&1; then
+    swaybg-next
+  elif [ -x "$HOME/.local/share/omarchy/bin/swaybg-next" ]; then
+    "$HOME/.local/share/omarchy/bin/swaybg-next"
+  fi
+fi
+
+# Reload waybar, mako, hyprland if available
+echo "Restarting applications to apply font changes..."
+pkill -SIGUSR2 waybar 2>/dev/null || true
+makoctl reload 2>/dev/null || true
+hyprctl reload 2>/dev/null || true
+
+# Restart mako notification daemon if it's running (for font changes)
+if pgrep mako >/dev/null 2>&1; then
+  echo "Restarting mako notification daemon for font changes..."
+  pkill mako 2>/dev/null || true
+  sleep 1
+  mako >/dev/null 2>&1 &
+fi
+
+# Touch alacritty config to pickup the changed theme
+if [ -f "$HOME/.config/alacritty/alacritty.toml" ]; then
+  touch "$HOME/.config/alacritty/alacritty.toml"
+fi
+
+# Notify of the new theme
+notify-send "Theme changed to $THEME_NAME" -t 2000
+
+echo "Theme '$THEME_NAME' installed and set as current." 

--- a/bin/omarchy-theme-remove
+++ b/bin/omarchy-theme-remove
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# omarchy-theme-remove: Remove a theme from Omarchy by name
+# Usage: omarchy-theme-remove <theme-name>
+
+THEME_NAME="$1"
+THEMES_SRC_DIR="$HOME/.local/share/omarchy/themes"
+THEMES_LINK_DIR="$HOME/.config/omarchy/themes"
+BACKGROUND_DIR="$HOME/.config/omarchy/backgrounds"
+CURRENT_DIR="$HOME/.config/omarchy/current"
+
+THEME_SRC_PATH="$THEMES_SRC_DIR/$THEME_NAME"
+THEME_LINK_PATH="$THEMES_LINK_DIR/$THEME_NAME"
+BACKGROUND_PATH="$BACKGROUND_DIR/$THEME_NAME"
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: omarchy-theme-remove <theme-name>"
+  exit 1
+fi
+
+# Count available themes (symlinks in ~/.config/omarchy/themes)
+THEMES=($(find "$THEMES_LINK_DIR" -mindepth 1 -maxdepth 1 -type l | sort))
+if [ ${#THEMES[@]} -le 1 ]; then
+  echo "Error: Cannot remove the last remaining theme. At least one theme must be installed."
+  exit 1
+fi
+
+# Check if theme exists before attempting removal
+if [ ! -d "$THEME_SRC_PATH" ] && [ ! -L "$THEME_LINK_PATH" ]; then
+  echo "Error: Theme '$THEME_NAME' not found."
+  exit 1
+fi
+
+# If the theme is current, unset current symlinks and switch to next theme if available
+if [ "$(readlink "$CURRENT_DIR/theme")" = "$THEME_LINK_PATH" ]; then
+  rm -f "$CURRENT_DIR/theme" "$CURRENT_DIR/backgrounds" "$CURRENT_DIR/background"
+
+  # Find next available theme
+  THEMES=($(find "$THEMES_LINK_DIR" -mindepth 1 -maxdepth 1 -type l | sort))
+  THEMES=("${THEMES[@]/$THEME_LINK_PATH}")
+  if [ ${#THEMES[@]} -gt 0 ]; then
+    # Use omarchy-theme-next to switch to the next theme
+    "$HOME/.local/share/omarchy/bin/omarchy-theme-next"
+    echo "Switched to next theme."
+  fi
+fi
+
+# Remove theme repo
+if [ -d "$THEME_SRC_PATH" ]; then
+  rm -rf "$THEME_SRC_PATH"
+  echo "Removed $THEME_SRC_PATH"
+fi
+
+# Remove theme symlink
+if [ -L "$THEME_LINK_PATH" ]; then
+  rm -f "$THEME_LINK_PATH"
+  echo "Removed $THEME_LINK_PATH"
+fi
+
+# Remove backgrounds
+if [ -d "$BACKGROUND_PATH" ]; then
+  rm -rf "$BACKGROUND_PATH"
+  echo "Removed $BACKGROUND_PATH"
+fi
+
+echo "Theme '$THEME_NAME' uninstalled." 


### PR DESCRIPTION
Creating a new PR, as there have been a few changes since opening #102.

Resolves #7. This PR adds two new scripts to improve theme management in Omarchy:

---

### `omarchy-theme-install`

- **Purpose:** Installs an Omarchy theme from a GitHub repository, directly to your machine.
- **Usage:**  
  ```sh
  omarchy-theme-install <git-repo-url>
  ```
- **Details:**  
  - Clones the theme repo.
  - Sets up necessary symlinks, moving the backgrounds and fonts into their respective folders. 
  - Switches to the new theme and sends a notification.

**A change from the original PR: we are no longer running any scripts provided by the theme repo, and I have omitted `backgrounds.sh` from the demo theme repo. The installer expects the theme repo to have the following structure:**

```
.
├── backgrounds/
│   ├── 1-background.png
│   └── 2-background.png
├── fonts/
│   └── themefont.ttf
├── alacritty.toml
├── btop.theme
├── hyprland.conf
├── hyprlock.conf
├── mako.ini
├── neovim.lua
├── waybar.css
└── wofi.css
```

Backgrounds and Fonts are optional, but if they are included in the theme, they need to be included in the source, under their respective directories.

---

### `omarchy-theme-remove`

- **Purpose:** Safely removes a theme.
- **Usage:**  
  ```sh
  omarchy-theme-remove <theme-name>
  ```
- **Details:**  
  - Removes the theme’s files, symlinks, and backgrounds. (Fonts remain installed)
  - Prevents removal of the last remaining theme.
  - If the theme is currently active, automatically switches to the next available theme.

---

#### **Demo Theme Repo**

A demo theme repository is available for testing:  
https://github.com/npenza/omarchy-demo-theme

https://github.com/user-attachments/assets/f203e4ce-cdc4-4004-b89f-a46a16c112fc


