### PR TITLE
Add Theme Menu Switcher

### DIFF
--- a/bin/omarchy-theme-menu
+++ b/bin/omarchy-theme-menu
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Theme menu for Omarchy
+# Provides an interactive dmenu to switch between available themes
+
+THEMES_DIR="$HOME/.local/share/omarchy/themes/"
+CURRENT_THEME_LINK="$HOME/.config/omarchy/current/theme"
+
+# Show theme selection menu and apply changes
+show_theme_menu() {
+  # Get current theme name
+  if [[ -L "$CURRENT_THEME_LINK" ]]; then
+    CURRENT_THEME_NAME=$(basename "$(realpath "$CURRENT_THEME_LINK")")
+  else
+    CURRENT_THEME_NAME="unknown"
+  fi
+  
+  # Build menu options from available themes
+  local themes=($(find "$THEMES_DIR" -mindepth 1 -maxdepth 1 -type d -printf "%f\n" | sort))
+  
+  # Create formatted input for wofi with current theme at top
+  local wofi_input=""
+  
+  # Add current theme first with asterisk (using invisible Unicode for sorting)
+  if [[ "$CURRENT_THEME_NAME" != "unknown" ]]; then
+    wofi_input+="\u200B* ${CURRENT_THEME_NAME}"
+  fi
+  
+  # Add remaining themes in alphabetical order
+  for theme in "${themes[@]}"; do
+    if [[ "$theme" != "$CURRENT_THEME_NAME" ]]; then
+      # Add newline before each theme (except the first one)
+      if [[ -n "$wofi_input" ]]; then
+        wofi_input+="\n"
+      fi
+      wofi_input+="  ${theme}"
+    fi
+  done
+  
+  # Display theme selection menu
+  local selection=$(echo -e "$wofi_input" | wofi \
+    --show dmenu \
+    --width 300 \
+    --height 225 \
+    --style ~/.local/share/omarchy/default/wofi/select.css)
+  
+  # Extract theme name from selection (remove asterisk and leading spaces)
+  local selected_theme=$(echo "$selection" | sed 's/^[* ]*//')
+  
+  # Apply theme changes if a new theme was selected
+  if [[ -n "$selected_theme" && "$selected_theme" != "$CURRENT_THEME_NAME" ]]; then
+    # Update theme symlinks
+    ln -nsf "$HOME/.config/omarchy/backgrounds/$selected_theme" "$HOME/.config/omarchy/current/backgrounds"
+    ln -nsf "$THEMES_DIR/$selected_theme" "$HOME/.config/omarchy/current/theme"
+    
+    # Trigger alacritty config reload
+    touch "$HOME/.config/alacritty/alacritty.toml"
+    
+    # Restart components to apply new theme
+    pkill -SIGUSR2 waybar
+    makoctl reload
+    hyprctl reload
+    
+    # Set new background
+    ln -nsf $(find "$HOME/.config/omarchy/current/backgrounds/" -type f | head -n 1) "$HOME/.config/omarchy/current/background"
+    pkill -x swaybg
+    setsid swaybg -i "$HOME/.config/omarchy/current/background" -m fill &
+  fi
+}
+
+# Main execution
+show_theme_menu

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -6,6 +6,7 @@ bind = SUPER, K, exec, ~/.local/share/omarchy/bin/omarchy-show-keybindings
 bind = SUPER SHIFT, SPACE, exec, pkill -SIGUSR1 waybar
 bind = SUPER CTRL, SPACE, exec, ~/.local/share/omarchy/bin/swaybg-next
 bind = SUPER SHIFT CTRL, SPACE, exec, ~/.local/share/omarchy/bin/omarchy-theme-next
+bind = SUPER SHIFT, T, exec, ~/.local/share/omarchy/bin/omarchy-theme-menu
 
 # Notifications
 bind = SUPER, comma, exec, makoctl dismiss


### PR DESCRIPTION
This PR introduces the `omarchy-theme-menu`. 

- `SUPER` + `SHIFT` + `T` toggles the theme menu, listing the current themes installed (in alphabetical order).
- The current theme is pinned to the top with an asterisk. 
- Allows the user to quickly toggle between themes.
- You can also quickly search for options by typing the theme name (like power menu).

<img width="664" height="381" alt="image" src="https://github.com/user-attachments/assets/aeb288c8-86d8-4600-8ff0-0b966a4b59b3" />

## Files Added
- `bin/omarchy-theme-menu`: New theme switching script with interactive menu

## Demo

https://github.com/user-attachments/assets/ba255888-077a-4343-81ee-0674aae8d4f2
