### PR TITLE
Modularize waybar config

### DIFF
--- a/config/waybar/config
+++ b/config/waybar/config
@@ -1,104 +1,19 @@
 {
-  "layer": "top",
-    "position": "top",
-    "spacing": 0,
-    "height": 26,
-    "modules-left": [
-      "hyprland/workspaces"
-    ],
-    "modules-center": [
-      "clock"
-    ],
-    "modules-right": [
-      "bluetooth",
-      "network",
-      "pulseaudio",
-      "cpu",
-      "battery"
-    ],
-    "hyprland/workspaces": {
-      "on-click": "activate",
-      "format": "{icon}",
-      "format-icons": {
-        "default": "",
-        "1": "1",
-        "2": "2",
-        "3": "3",
-        "4": "4",
-        "5": "5",
-        "6": "6",
-        "7": "7",
-        "8": "8",
-        "9": "9",
-        "active": "󱓻"
-      },
-      "persistent-workspaces": {
-        "1": [],
-        "2": [],
-        "3": [],
-        "4": [],
-        "5": []
-      }
-    },
-    "cpu": {
-      "interval": 5,
-      "format": "󰍛",
-      "on-click": "alacritty -e btop"
-    },
-    "clock": {
-      "format": "{:%A %H:%M}",
-      "format-alt": "{:%d %B W%V %Y}",
-      "tooltip": false
-    },
-    "network": {
-      "format-icons": ["󰤯","󰤟","󰤢","󰤥","󰤨"],
-      "format" : "{icon}",
-      "format-wifi" : "{icon}",
-      "format-ethernet" : "󰀂",
-      "format-disconnected" : "󰖪",
-      "tooltip-format-wifi": "{essid} ({frequency} GHz)\n⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
-      "tooltip-format-ethernet": "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
-      "tooltip-format-disconnected": "Disconnected",
-      "interval": 3,
-      "nospacing": 1,
-      "on-click": "alacritty --class=Impala -e impala"
-    },
-    "battery": {
-      "format": "{capacity}% {icon}",
-      "format-discharging": "{icon}",
-      "format-charging":    "{icon}",
-      "format-plugged":     "",
-      "format-icons": {
-        "charging": [
-          "󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"
-        ],
-        "default": [
-          "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"
-        ]
-      },
-      "format-full": "󰂅",
-      "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
-      "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
-      "interval": 5,
-      "states": {
-        "warning": 20,
-        "critical": 10
-      }
-    },
-    "bluetooth": {
-      "format": "",
-      "format-disabled": "󰂲",
-      "format-connected": "",
-      "tooltip-format": "Devices connected: {num_connections}",
-      "on-click": "GTK_THEME=Adwaita-dark blueberry"
-    },
-    "pulseaudio": {
-      "format": "",
-      "format-muted": "󰝟",
-      "scroll-step": 5,
-      "on-click": "GTK_THEME=Adwaita-dark pavucontrol",
-      "tooltip-format": "Playing at {volume}%",
-      "on-click-right": "pamixer -t",
-      "ignored-sinks": ["Easy Effects Sink"]
-    }
+  "include": [
+    "~/.local/share/omarchy/default/waybar/config.json",
+    "~/.config/waybar/module-*.json"
+  ],
+  "modules-left": [
+    "hyprland/workspaces"
+  ],
+  "modules-center": [
+    "clock"
+  ],
+  "modules-right": [
+    "bluetooth",
+    "network",
+    "pulseaudio",
+    "cpu",
+    "battery"
+  ]
 }

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -1,39 +1,12 @@
-* {
-  border: none;
-  border-radius: 0;
-  min-height: 0;
-  font-family: CaskaydiaMono Nerd Font Propo;
-  font-size: 12px;
-}
-
-#workspaces {
-  margin-left: 7px;
-}
-
-#workspaces button {
-  all: initial;
-  padding: 2px 6px;
-  margin-right: 3px;
-}
-
-#custom-dropbox,
-#cpu,
-#battery,
-#network,
-#bluetooth,
-#pulseaudio,
-#clock,
-#custom-power-menu {
-  min-width: 12px;
-  margin-right: 13px;
-}
-
-tooltip {
-  padding: 2px;
-}
-
-tooltip label {
-  padding: 2px;
-}
-
+/* Import Omarchy defaults */
+@import "../../.local/share/omarchy/default/waybar/style.css";
 @import "../omarchy/current/theme/waybar.css";
+
+/* Add your own customizations or imports below
+ * customizations will override defaults */
+/* @import "module-custom.css"; 
+ *
+ * {
+ *  font-size: 16px;
+ * }
+ * */

--- a/default/waybar/config.json
+++ b/default/waybar/config.json
@@ -1,0 +1,117 @@
+{
+  "layer": "top",
+  "position": "top",
+  "spacing": 0,
+  "height": 26,
+  "hyprland/workspaces": {
+    "on-click": "activate",
+    "format": "{icon}",
+    "format-icons": {
+      "default": "",
+      "1": "1",
+      "2": "2",
+      "3": "3",
+      "4": "4",
+      "5": "5",
+      "6": "6",
+      "7": "7",
+      "8": "8",
+      "9": "9",
+      "active": "󱓻"
+    },
+    "persistent-workspaces": {
+      "1": [],
+      "2": [],
+      "3": [],
+      "4": [],
+      "5": []
+    }
+  },
+  "cpu": {
+    "interval": 5,
+    "format": "󰍛",
+    "on-click": "alacritty -e btop"
+  },
+  "clock": {
+    "format": "{:%A %H:%M}",
+    "format-alt": "{:%d %B W%V %Y}",
+    "tooltip": false
+  },
+  "network": {
+    "format-icons": [
+      "󰤯",
+      "󰤟",
+      "󰤢",
+      "󰤥",
+      "󰤨"
+    ],
+    "format": "{icon}",
+    "format-wifi": "{icon}",
+    "format-ethernet": "󰀂",
+    "format-disconnected": "󰖪",
+    "tooltip-format-wifi": "{essid} ({frequency} GHz)\n⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-ethernet": "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-disconnected": "Disconnected",
+    "interval": 3,
+    "nospacing": 1,
+    "on-click": "alacritty --class=Impala -e impala"
+  },
+  "battery": {
+    "format": "{capacity}% {icon}",
+    "format-discharging": "{icon}",
+    "format-charging": "{icon}",
+    "format-plugged": "",
+    "format-icons": {
+      "charging": [
+        "󰢜",
+        "󰂆",
+        "󰂇",
+        "󰂈",
+        "󰢝",
+        "󰂉",
+        "󰢞",
+        "󰂊",
+        "󰂋",
+        "󰂅"
+      ],
+      "default": [
+        "󰁺",
+        "󰁻",
+        "󰁼",
+        "󰁽",
+        "󰁾",
+        "󰁿",
+        "󰂀",
+        "󰂁",
+        "󰂂",
+        "󰁹"
+      ]
+    },
+    "format-full": "󰂅",
+    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
+    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "interval": 5,
+    "states": {
+      "warning": 20,
+      "critical": 10
+    }
+  },
+  "bluetooth": {
+    "format": "",
+    "format-disabled": "󰂲",
+    "format-connected": "",
+    "tooltip-format": "Devices connected: {num_connections}",
+    "on-click": "GTK_THEME=Adwaita-dark blueberry"
+  },
+  "pulseaudio": {
+    "format": "",
+    "format-muted": "󰝟",
+    "scroll-step": 5,
+    "on-click": "GTK_THEME=Adwaita-dark pavucontrol",
+    "tooltip-format": "Playing at {volume}%",
+    "on-click-right": "pamixer -t",
+    "ignored-sinks": [
+      "Easy Effects Sink"
+    ]
+  }
+}

--- a/default/waybar/style.css
+++ b/default/waybar/style.css
@@ -1,0 +1,40 @@
+* {
+  border: none;
+  border-radius: 0;
+  min-height: 0;
+  font-family: CaskaydiaMono Nerd Font Propo;
+  font-size: 12px;
+}
+
+#workspaces button {
+  all: initial;
+  padding: 2px 6px;
+  margin-right: 3px;
+}
+
+#workspaces button:first-child {
+  padding-left: 0;
+}
+
+#workspaces button:last-child {
+  padding-right: 0;
+  margin-right: 0;
+}
+
+.modules-left .module{
+  min-width: 12px;
+  margin-left: 13px;
+}
+.modules-center .module,
+.modules-right .module {
+  min-width: 12px;
+  margin-right: 13px;
+}
+
+tooltip {
+  padding: 2px;
+}
+
+tooltip label {
+  padding: 2px;
+}


### PR DESCRIPTION
Reconfigures Waybar to take a more modular approach and solves for some styling issues that lead to needing overrides like `#workspaces { margin-left: 7px; }` in the past.

My assumption is that Waybar will be one of the most personalized things for people but the current setup is intimidating and difficult to reconcile changes with once you've made some changes. 

By taking a more modular approach, we can load in defaults that can be updated over time without the need to fully reload the user's Waybar config, while still allowing for overriding and customization at whatever level the user wants. 

The `~/.local/share/omarcy/config/waybar/config` that gets copied over pulls in the default config.json, as well as any `~/.config/waybar/module-*.json`, and sets up the current default set of modules. If a user installs Omarchy and wants to move those around, they can just bump things around without dealing with a 100+ line config. 

We could technically slim it down to something like this but then we're requiring a user to delve into the defaults to do something as simple as move their clock or workspace module which just doesn't feel like a nice intro.
```
{
  "include": [
    "~/.local/share/omarchy/default/waybar/config.json",
    "~/.config/waybar/module-*.json"
  ],
}
```

Users are also free to override specific elements of the defaults with something like this to update what the active icon looks like.
```
  "hyprland/workspaces": {
    "format-icons": {
        "active": "💰"
    }
  }
```

### Custom Modules
A new thing here is the import of `~/.config/waybar/module-*.json` where we can allow for user-defined modules to be included in separate json files. This allows us to update the default modules without a user needing to reconcile the changes with their custom ones. 

In my case, I like to have a DND icon as visual feedback but we decided not to include that in the core. I can now have `~/.config/waybar/module-dnd.json` that contains
```
{
  "custom/dnd": {
    "exec": "makoctl mode | grep -q 'do-not-disturb' && echo '{\"alt\":\"dnd\",\"tooltip\":\"Enable notifications\"}' || echo '{\"alt\":\"on\",\"tooltip\":\"Disable notifications\"}'",
    "format": "{icon}",
    "format-icons": {
      "on": " 󰂚",
      "dnd": "󰂛"
    },
    "return-type": "json",
    "interval": 5,
    "tooltip": "{tooltip}",
    "on-click": "makoctl mode -t do-not-disturb"
  }
}
```

and add `"custom/dnd"` where I want in my config file.

### CSS Updates
CSS doesn't allow for globbing imports so we can't do a similar thing for the modules. However, I did some work to update what we have in the default style to solve for everything that exists today. With the updated style, you can put any module anywhere, and they look evenly spaced and align to the edges properly.

I've added my custom DND module, as well as the system tray module from https://github.com/basecamp/omarchy/pull/130 without any need for CSS updates...although the system tray module has a trailing space on the icon I had to remove.

If there was a custom module that required its own CSS, the user could import that in their `~/.config/waybar/style.css`. We could even make it possible to pull these in and add the appropriate import with an installer like the theme installer at some point if we really wanted in the future.