### PR TITLE
Default to highrr in monitor config to support high refresh displays …

### DIFF
--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -6,7 +6,7 @@ env = GDK_SCALE,2
 
 # Use single default monitor (see all monitors with: hyprctl monitors)
 # Format: monitor = [port], resolution, position, scale
-monitor=,preferred,auto,auto
+monitor=,highrr,auto,auto
 
 # Exmaple for fractional scaling that works well with GDK_SCALE,1.75
 # monitor=,preferred,auto,1.666667


### PR DESCRIPTION
## Problem

The default monitor config uses:

```
monitor=,preferred,auto,auto
```

On systems with high refresh rate displays (like 120Hz or 144Hz), the default `preferred` setting often falls back to 60Hz which feels jarring if you're used to high refresh displays. That was the case for me running on an NVIDIA 4090 with a 120Hz monitor.

Hyprland limited the display to 60Hz out of the box, and manually specifying the resolution and refresh rate (e.g., `3840x2160@120.00`) didn’t work - no changes even after a reload or reboot. This might be due to NVIDIA’s quirks on Wayland, or possibly because I'm still pretty new to Linux.

Switching to `highrr` worked instantly and used the full refresh rate without any other tinkering. This seems like a safer default for anyone on a high refresh monitor, regardless of GPU vendor and provides a much nicer out of the box experience.

### Solution

Replacing the line with:
```
monitor=,highrr,auto,auto
```
automatically selects the highest available refresh rate for each display. It should fall back safely on other hardware as well. This makes for a better default experience for users with high refresh monitors without needing to tweak anything manually.