### PR TITLE
Add omarchy-set-background script

### DIFF
--- a/bin/omarchy-set-background
+++ b/bin/omarchy-set-background
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Sets background from URL or local path
+# Usage: omarchy-set-background [url|path]
+
+if [ $# -eq 0 ]; then
+  echo "Usage: omarchy-set-background [url|path]"
+  exit 1
+fi
+
+INPUT="$1"
+CURRENT_THEME_LINK="$HOME/.config/omarchy/current/theme"
+CURRENT_BACKGROUND_LINK="$HOME/.config/omarchy/current/background"
+
+# Get current theme name
+if [[ -L "$CURRENT_THEME_LINK" ]]; then
+  CURRENT_THEME=$(readlink "$CURRENT_THEME_LINK")
+  THEME_NAME=$(basename "$CURRENT_THEME")
+else
+  echo "Error: No current theme found"
+  exit 1
+fi
+
+BACKGROUNDS_DIR="$HOME/.config/omarchy/backgrounds/$THEME_NAME"
+
+# Create backgrounds directory if it doesn't exist
+mkdir -p "$BACKGROUNDS_DIR"
+
+# Determine if input is URL or local path
+if [[ "$INPUT" =~ ^https?:// ]]; then
+  # It's a URL - download it
+  echo "Downloading from URL: $INPUT"
+
+  # Extract filename from URL or generate one
+  FILENAME=$(basename "$INPUT")
+  if [[ ! "$FILENAME" =~ \.(jpg|jpeg|png|webp|bmp|gif)$ ]]; then
+    # If no extension or not an image extension, use a default
+    FILENAME="background-$(date +%s).png"
+  fi
+
+  TARGET_PATH="$BACKGROUNDS_DIR/$FILENAME"
+
+  # Download the file
+  if command -v curl >/dev/null 2>&1; then
+    curl -L -o "$TARGET_PATH" "$INPUT"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$TARGET_PATH" "$INPUT"
+  else
+    echo "Error: Neither curl nor wget found. Cannot download from URL."
+    exit 1
+  fi
+
+  if [ $? -ne 0 ]; then
+    echo "Error: Failed to download from URL"
+    exit 1
+  fi
+
+  echo "Downloaded to: $TARGET_PATH"
+else
+  # It's a local path - copy it
+  if [ ! -f "$INPUT" ]; then
+    echo "Error: File not found: $INPUT"
+    exit 1
+  fi
+
+  FILENAME=$(basename "$INPUT")
+  TARGET_PATH="$BACKGROUNDS_DIR/$FILENAME"
+
+  cp "$INPUT" "$TARGET_PATH"
+  if [ $? -ne 0 ]; then
+    echo "Error: Failed to copy file"
+    exit 1
+  fi
+
+  echo "Copied to: $TARGET_PATH"
+fi
+
+# Set the new background as current
+ln -nsf "$TARGET_PATH" "$CURRENT_BACKGROUND_LINK"
+
+# Apply the background
+pkill -x swaybg
+setsid swaybg -i "$TARGET_PATH" -m fill >/dev/null 2>&1 &
+
+echo "Background set successfully!"
+

--- a/bin/omarchy-set-background
+++ b/bin/omarchy-set-background
@@ -52,7 +52,26 @@ if [[ "$INPUT" =~ ^https?:// ]]; then
 
   if [ $? -ne 0 ]; then
     echo "Error: Failed to download from URL"
+    rm -f "$TARGET_PATH"
     exit 1
+  fi
+
+  # Validate that the downloaded file is actually an image
+  if command -v file >/dev/null 2>&1; then
+    FILE_TYPE=$(file -b --mime-type "$TARGET_PATH")
+    if [[ ! "$FILE_TYPE" =~ ^image/ ]]; then
+      echo "Error: Downloaded file is not a valid image (detected: $FILE_TYPE)"
+      rm -f "$TARGET_PATH"
+      exit 1
+    fi
+  else
+    # Fallback: check file size (empty or very small files are likely errors)
+    FILE_SIZE=$(stat -c%s "$TARGET_PATH" 2>/dev/null || echo "0")
+    if [ "$FILE_SIZE" -lt 1024 ]; then
+      echo "Error: Downloaded file appears to be invalid (too small: ${FILE_SIZE} bytes)"
+      rm -f "$TARGET_PATH"
+      exit 1
+    fi
   fi
 
   echo "Downloaded to: $TARGET_PATH"
@@ -83,4 +102,3 @@ pkill -x swaybg
 setsid swaybg -i "$TARGET_PATH" -m fill >/dev/null 2>&1 &
 
 echo "Background set successfully!"
-


### PR DESCRIPTION
# omarchy-set-background

**Purpose:** Sets desktop backgrounds from URLs or local file paths for the current Omarchy theme.

**Usage:**
```
omarchy-set-background <url|path>
```

**Details:**
- Downloads images from URLs or copies from local file paths.
- Automatically saves images to the current theme's `/backgrounds` folder.
- Applies the background immediately using swaybg.
- Includes validation for invalid URLs and file types.
- Supports common image formats (jpg, jpeg, png, webp, bmp, gif).
