### PR TITLE
Adds a real .config/wofi/style.css file (instead of symlink) so user can tweak wofi styles

### DIFF
--- a/config/wofi/style.css
+++ b/config/wofi/style.css
@@ -1,1 +1,1 @@
-@import ".local/share/omarchy/default/wofi/select.css";
+@import ".local/share/omarchy/default/wofi/search.css";

--- a/config/wofi/style.css
+++ b/config/wofi/style.css
@@ -1,0 +1,1 @@
+@import ".local/share/omarchy/default/wofi/select.css";

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -1,5 +1,5 @@
 # Launching
-bind = SUPER, space, exec, pkill wofi || wofi --show drun --sort-order=alphabetical --style="$HOME/.local/share/omarchy/default/wofi/search.css"
+bind = SUPER, space, exec, pkill wofi || wofi --show drun --sort-order=alphabetical --style="$HOME/.config/wofi/search.css"
 bind = SUPER, K, exec, ~/.local/share/omarchy/bin/omarchy-show-keybindings
 
 # Aesthetics

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -1,5 +1,5 @@
 # Launching
-bind = SUPER, space, exec, pkill wofi || wofi --show drun --sort-order=alphabetical --style="$HOME/.config/wofi/search.css"
+bind = SUPER, space, exec, pkill wofi || wofi --show drun --sort-order=alphabetical --style="$HOME/.config/wofi/style.css"
 bind = SUPER, K, exec, ~/.local/share/omarchy/bin/omarchy-show-keybindings
 
 # Aesthetics

--- a/default/wofi/search.css
+++ b/default/wofi/search.css
@@ -1,4 +1,4 @@
-@import ".config/omarchy/current/theme/wofi.css";
+@import "../../../../../.config/omarchy/current/theme/wofi.css";
 
 * {
   font-family: 'CaskaydiaMono Nerd Font', monospace;

--- a/default/wofi/select.css
+++ b/default/wofi/select.css
@@ -1,5 +1,5 @@
-@import ".config/omarchy/current/theme/wofi.css";
-@import ".local/share/omarchy/default/wofi/search.css";
+@import "../../../../../.config/omarchy/current/theme/wofi.css";
+@import "../../../../../.local/share/omarchy/default/wofi/search.css";
 
 #input {
     display: none;

--- a/default/wofi/select.css
+++ b/default/wofi/select.css
@@ -1,5 +1,5 @@
-@import "../../../../../.config/omarchy/current/theme/wofi.css";
-@import "../../../../../.local/share/omarchy/default/wofi/search.css";
+@import ".config/omarchy/current/theme/wofi.css";
+@import ".local/share/omarchy/default/wofi/search.css";
 
 #input {
     display: none;

--- a/install/theme.sh
+++ b/install/theme.sh
@@ -18,7 +18,6 @@ ln -snf ~/.config/omarchy/backgrounds/tokyo-night ~/.config/omarchy/current/back
 ln -snf ~/.config/omarchy/current/backgrounds/1-Pawel-Czerwinski-Abstract-Purple-Blue.jpg ~/.config/omarchy/current/background
 
 # Set specific app links for current theme
-ln -snf ~/.config/omarchy/current/theme/wofi.css ~/.config/wofi/style.css
 ln -snf ~/.config/omarchy/current/theme/neovim.lua ~/.config/nvim/lua/plugins/theme.lua
 mkdir -p ~/.config/btop/themes
 ln -snf ~/.config/omarchy/current/theme/btop.theme ~/.config/btop/themes/current.theme


### PR DESCRIPTION
This PR turns `~/.config/wofi/style.css` from a symlink into an actual file that the user can then tweak to customize wofi layout/colors/etc.

Currently `.config/wofi/style.css` is a symlink to `~/.config/omarchy/current/theme/wofi.css` which isn't actually used by wofi from that location: the binding for wofi points to the style at `~/.local/share/omarchy/default/wofi/search.css` (which itself then imports the current theme). 

Because `~/.config/wofi/style.css` is just a symlink, if you try to customize the styling at all you end up editing the theme's CSS file down inside the omarchy theme directory, instead of at the top level `.config` directory like for hyprland, waybar, etc.

One quirk of this new import from `~/.config/wofi/style.css` is the that the imported sheet now needs a crazy relative reference of `../../../../../` in order to resolve the current theme properly. I tried every permutation I could think of, but everything only rendered properly with the 5 levels of back tracking (or starting with `/home/[username]` which doesn't help). Please let me know if there's an easier way!

Let me know if we'd like a migration that also performs this switcharoo for existing users!