### PR TITLE
add fido2-setup script

### DIFF
--- a/bin/omarchy-fido2-setup
+++ b/bin/omarchy-fido2-setup
@@ -2,6 +2,18 @@
 
 yay -S --noconfirm --needed libfido2 pam-u2f
 
+# Check if the user doesn't want sudo
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  --no-sudo) exit 0 ;;
+  *)
+    echo "Unknown option: $1 \n --no-sudo is the only option"
+    exit 1
+    ;;
+  esac
+  shift
+done
+
 tokens=$(fido2-token -L)
 if [ -z "$tokens" ]; then
   echo -e "\e[31m\nNo fido2 device detected. Plug it in, you may have to unlock it as well\e[0m"


### PR DESCRIPTION
I made the script as requested by this [comment](https://github.com/basecamp/omarchy/pull/27#issuecomment-3067406310)

I tested it by running it locally. 

Here's the docs page for it (the docs don't seem to be in git, if it was I'd just made a PR to it):
# FIDO2/U2F Authentication

If you are looking to use your FIDO2/U2F device with omarchy, all you need to do is run the omarchy-fido2-setup command. That will install the necessary library to enable your browser or other application to interact with the device. By default it also enables you to authenticate for sudo commands with your device, if you don't want that run omarchy-fido2-setup --no-sudo
