### PR TITLE
Add Synaptics support to the fingerprint setup script

### DIFF
--- a/bin/omarchy-fingerprint-setup
+++ b/bin/omarchy-fingerprint-setup
@@ -2,7 +2,7 @@
 
 yay -S --noconfirm --needed fprintd usbutils
 
-if ! lsusb | grep -iq fingerprint; then
+if ! lsusb | grep -Eiq 'fingerprint|synaptics'; then
   echo -e "\e[31m\nNo fingerprint sensor detected.\e[0m"
 else
   # Add fingerprint authentication as an option for sudo


### PR DESCRIPTION
Many laptops use a Synaptics fingerprint reader so this PR adds Synaptics to the check to see if one exists