### PR TITLE
Additional keyservers

### DIFF
--- a/default/gpg/dirmngr.conf
+++ b/default/gpg/dirmngr.conf
@@ -1,6 +1,7 @@
-keyserver hkps://keys.openpgp.org
 keyserver hkps://keyserver.ubuntu.com
 keyserver hkps://pgp.surfnet.nl
 keyserver hkps://keys.mailvelope.com
+keyserver hkps://keyring.debian.org
+keyserver hkps://pgp.mit.edu
 
 connect-quick-timeout 4

--- a/default/gpg/dirmngr.conf
+++ b/default/gpg/dirmngr.conf
@@ -1,0 +1,7 @@
+keyserver hkps://keys.openpgp.org
+keyserver hkps://keyserver.ubuntu.com
+keyserver hkps://pgp.surfnet.nl
+keyserver hkps://keys.mailvelope.com
+
+connect-quick-timeout 4
+no-honor-keyserver-url

--- a/default/gpg/dirmngr.conf
+++ b/default/gpg/dirmngr.conf
@@ -4,4 +4,3 @@ keyserver hkps://pgp.surfnet.nl
 keyserver hkps://keys.mailvelope.com
 
 connect-quick-timeout 4
-no-honor-keyserver-url

--- a/install/4-config.sh
+++ b/install/4-config.sh
@@ -9,6 +9,7 @@ sudo mkdir -p /etc/gnupg
 sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/
 sudo chmod 644 /etc/gnupg/dirmngr.conf
 sudo gpgconf --kill dirmngr || true
+sudo gpgconf --launch dirmngr || true
 
 # Use default bashrc from Omarchy
 echo "source ~/.local/share/omarchy/default/bash/rc" >~/.bashrc

--- a/install/4-config.sh
+++ b/install/4-config.sh
@@ -4,6 +4,12 @@ cp -R ~/.local/share/omarchy/config/* ~/.config/
 # Ensure application directory exists for update-desktop-database
 mkdir -p ~/.local/share/applications
 
+# Setup GPG configuration with multiple keyservers for better reliability
+sudo mkdir -p /etc/gnupg
+sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/
+sudo chmod 644 /etc/gnupg/dirmngr.conf
+sudo gpgconf --kill dirmngr || true
+
 # Use default bashrc from Omarchy
 echo "source ~/.local/share/omarchy/default/bash/rc" >~/.bashrc
 

--- a/migrations/1752535341.sh
+++ b/migrations/1752535341.sh
@@ -3,3 +3,4 @@ sudo mkdir -p /etc/gnupg
 sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/
 sudo chmod 644 /etc/gnupg/dirmngr.conf
 sudo gpgconf --kill dirmngr || true
+sudo gpgconf --launch dirmngr || true

--- a/migrations/1752535341.sh
+++ b/migrations/1752535341.sh
@@ -1,0 +1,5 @@
+echo "Setting up GPG configuration with multiple keyservers for better reliability"
+sudo mkdir -p /etc/gnupg
+sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/
+sudo chmod 644 /etc/gnupg/dirmngr.conf
+sudo gpgconf --kill dirmngr || true


### PR DESCRIPTION
There are multiple reports of ubuntu keyserver being unreliable for various regions, so this adds additional fallback keyservers.

This is still failing for me on spotify as it says their key isn't found - maybe their latest key hasn't propagated fully yet? 
I'm not sure what the optimum order of keyservers should be, but this seems like a good starting point.

This will fix #173 

Note: Spotify does work now when I just tried it - def just hadn't propagated