### PR TITLE
Fix fingerprint detection for Framework 16 laptops with Goodix sensors

### DIFF
--- a/bin/omarchy-fingerprint-setup
+++ b/bin/omarchy-fingerprint-setup
@@ -2,7 +2,7 @@
 
 yay -S --noconfirm --needed fprintd usbutils
 
-if ! lsusb | grep -iq fingerprint; then
+if ! lsusb | grep -iq -E "(fingerprint|goodix)"; then
   echo -e "\e[31m\nNo fingerprint sensor detected.\e[0m"
 else
   # Add fingerprint authentication as an option for sudo


### PR DESCRIPTION
## Summary
- Fixed fingerprint detection for Framework 16 laptops with Goodix sensors
- Updated `omarchy-fingerprint-setup` to detect both "fingerprint" and "goodix" devices in lsusb output

## Problem
The fingerprint setup script was failing to detect Goodix fingerprint readers on Framework 16 laptops because it only searched for "fingerprint" in lsusb output. Goodix devices appear as "Goodix USB2.0 MISC" instead.

## Solution
Updated the detection logic in `bin/omarchy-fingerprint-setup` to use regex pattern `(fingerprint|goodix)` instead of just searching for "fingerprint".