### PR TITLE
envvars: remove xdg-data-dir env for wofi, it's not needed

### DIFF
--- a/default/hypr/envs.conf
+++ b/default/hypr/envs.conf
@@ -15,9 +15,6 @@ xwayland {
   force_zero_scaling = true
 }
 
-# Make .desktop files available for wofi
-env = XDG_DATA_DIRS,/usr/share:/usr/local/share:~/.local/share
-
 # Use XCompose file
 env = XCOMPOSEFILE,~/.XCompose
 


### PR DESCRIPTION
The envvar should't be needed. It also leads to "broken" behaviour when installing flatpak or wine, since those add their paths to the env.