### PR TITLE
Add xdg-utils for Neovim gx command support

### DIFF
--- a/install/nvim.sh
+++ b/install/nvim.sh
@@ -1,5 +1,5 @@
 if ! command -v nvim &>/dev/null; then
-  yay -S --noconfirm --needed nvim luarocks tree-sitter-cli
+  yay -S --noconfirm --needed nvim luarocks tree-sitter-cli xdg-utils
 
   # Install LazyVim
   rm -rf ~/.config/nvim

--- a/migrations/1752666411.sh
+++ b/migrations/1752666411.sh
@@ -1,0 +1,2 @@
+echo "Installing xdg-utils for Neovim gx command support"
+yay -S --noconfirm --needed xdg-utils


### PR DESCRIPTION
In Neovim you can open the URL under your cursor with `gx`. This uses xdg-open to open the url in the browser.

- Add xdg-utils to nvim.sh installation script for new installations
- Create migration to install xdg-utils for existing users