### PR TITLE
Prevent opening multiple instances of the theme menu

### DIFF
--- a/bin/omarchy-theme-menu
+++ b/bin/omarchy-theme-menu
@@ -3,6 +3,29 @@
 THEMES_DIR="$HOME/.config/omarchy/themes/"
 CURRENT_THEME_DIR="$HOME/.config/omarchy/current/theme"
 CURRENT_THEME_NAME=$(basename "$(realpath "$CURRENT_THEME_DIR")")
+LOCK_FILE="/tmp/omarchy-theme-menu.lock"
+
+# Check if another instance is already running
+if [[ -f "$LOCK_FILE" ]]; then
+    # Check if the process is still running
+    if kill -0 "$(cat "$LOCK_FILE")" 2>/dev/null; then
+        # Dismiss existing wofi window
+        pkill wofi 2>/dev/null
+        exit 0
+    else
+        # Remove stale lock file
+        rm -f "$LOCK_FILE"
+    fi
+fi
+
+# Create lock file with current PID
+echo $$ > "$LOCK_FILE"
+
+# Cleanup function to remove lock file on exit
+cleanup() {
+    rm -f "$LOCK_FILE"
+}
+trap cleanup EXIT INT TERM
 
 # Build themes list with pretty display names
 mapfile -t themes < <(


### PR DESCRIPTION
Hitting SUPER CTRL SHIFT SPACE multiple times would stack multiple instances of the theme selector and end in a state where you had to dismiss multiple instances using ESC to get it back in a working state.

Now it is dismissed if you hit the key combination again.

<img width="566" height="737" alt="2025-07-16-151202_hyprshot" src="https://github.com/user-attachments/assets/66a0fd87-82c8-447d-80a5-b3457ed53315" />

