### PR TITLE
fix: check for iwctl instead of iwd

### DIFF
--- a/install/network.sh
+++ b/install/network.sh
@@ -1,6 +1,6 @@
 # Install iwd explicitly if it wasn't included in archinstall
 # This can happen if archinstall used ethernet
-if ! command -v iwd &>/dev/null; then
+if ! command -v iwctl &>/dev/null; then
   yay -S --noconfirm --needed iwd
   sudo systemctl enable --now iwd.service
 fi


### PR DESCRIPTION
I noticed the current `network.sh` script checks for `iwd` using  `command -v iwd` but iwd is the daemon not the user facing binary. 
