### PR TITLE
Add trigger to reload btop when theme changes

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -28,6 +28,9 @@ ln -nsf "$THEME_PATH" "$CURRENT_THEME_DIR"
 # Trigger alacritty config reload
 touch "$HOME/.config/alacritty/alacritty.toml"
 
+# Trigger btop config reload
+pkill -SIGUSR2 btop
+
 # Restart components to apply new theme
 pkill waybar
 setsid waybar >/dev/null 2>&1 &


### PR DESCRIPTION
This PR adds a SIGUSR2 command in the "omarchy-theme-set"  script in order to reload btop config when changing themes.

You can test this quickly by:
- Changing your theme while btop ("Activity") is open.
- Running this command in the terminal.