### PR TITLE
Use `git pull --autostash` in `omarchy-update`

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -11,9 +11,7 @@ else
 fi
 
 # Get the latest while trying to preserve any modifications
-git stash
-git pull
-git stash pop
+git pull --autostash
 
 # Run any pending migrations
 for file in migrations/*.sh; do


### PR DESCRIPTION
This is a minor follow-up to dcc40719793d52d43698108a0b0784c2f3b48655 (from #204) to leverage the [`--autostash` flag of `git pull`](https://git-scm.com/docs/git-pull#Documentation/git-pull.txt---autostash) which does the same thing we were doing in three separate commands.

Importantly, this also avoids the possibility of popping something from the stash that `omarchy-update` didn't actually stash. In other words, if the initial `git stash` was a no-op (because there were no changes in the working tree), it's actually not desirable for `omarchy-update` to `git stash pop` at the end, since that potentially pops something the user had manually stashed (we only want `omarchy-update` to pop its own stash entry). Using `--autostash` handles this correctly.