### PR TITLE
Reset any stash changes before proceeding if there were conflicts

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -12,6 +12,7 @@ fi
 
 # Get the latest while trying to preserve any modifications
 git pull --autostash
+git diff --check || git reset --merge
 
 # Run any pending migrations
 for file in migrations/*.sh; do


### PR DESCRIPTION
If the worktree has conflicts after `omarchy-update` applies the user's changes from the autostash, we should reset them before proceeding to ensure we are in a working state. When there are conflicts, git still keeps the stash entry, so the user will still be able to manually re-pop the stash and resolve the conflicts after `omarchy-update` has finished.