### PR TITLE
Improve boot times

### DIFF
--- a/install/docker.sh
+++ b/install/docker.sh
@@ -11,3 +11,11 @@ sudo systemctl enable docker
 
 # Give this user privileged Docker access
 sudo usermod -aG docker ${USER}
+
+# Prevent Docker from preventing boot for network-online.target
+sudo tee /etc/systemd/system/docker.service.d/no-block-boot.conf <<'EOF'
+[Unit]
+DefaultDependencies=no
+EOF
+
+sudo systemctl daemon-reload

--- a/install/login.sh
+++ b/install/login.sh
@@ -109,6 +109,15 @@ PAMName=login
 WantedBy=graphical.target
 EOF
 
+# Make plymouth remain until graphical.target
+sudo tee /etc/systemd/system/plymouth-quit.service.d/wait-for-graphical.conf <<'EOF'
+[Unit]
+After=multi-user.target
+EOF
+
+# Prevent plymouth-quit-wait.service
+sudo systemctl unmask plymouth-quit-wait.service
+
 sudo systemctl daemon-reload
 sudo systemctl enable omarchy-seamless-login.service
 

--- a/install/login.sh
+++ b/install/login.sh
@@ -116,7 +116,7 @@ After=multi-user.target
 EOF
 
 # Prevent plymouth-quit-wait.service
-sudo systemctl unmask plymouth-quit-wait.service
+sudo systemctl mask plymouth-quit-wait.service
 
 sudo systemctl daemon-reload
 sudo systemctl enable omarchy-seamless-login.service

--- a/migrations/1752797704.sh
+++ b/migrations/1752797704.sh
@@ -1,9 +1,11 @@
 echo "Prevent docker from requiring network readiness on boot"
+sudo mkdir -p /etc/systemd/system/docker.service.d/
 sudo tee /etc/systemd/system/docker.service.d/no-block-boot.conf <<'EOF'
 [Unit]
 DefaultDependencies=no
 EOF
 
+sudo mkdir -p /etc/systemd/system/plymouth-quit.service.d/
 sudo tee /etc/systemd/system/plymouth-quit.service.d/wait-for-graphical.conf <<'EOF'
 [Unit]
 After=multi-user.target

--- a/migrations/1752797704.sh
+++ b/migrations/1752797704.sh
@@ -1,0 +1,13 @@
+echo "Prevent docker from requiring network readiness on boot"
+sudo tee /etc/systemd/system/docker.service.d/no-block-boot.conf <<'EOF'
+[Unit]
+DefaultDependencies=no
+EOF
+
+sudo tee /etc/systemd/system/plymouth-quit.service.d/wait-for-graphical.conf <<'EOF'
+[Unit]
+After=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl unmask plymouth-quit-wait.service

--- a/migrations/1752797704.sh
+++ b/migrations/1752797704.sh
@@ -12,4 +12,4 @@ After=multi-user.target
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl unmask plymouth-quit-wait.service
+sudo systemctl mask plymouth-quit-wait.service


### PR DESCRIPTION
Recently, some users have experienced some long black screen loading times after the plymouth loader dismisses. This time is typically related to the system awaiting network-online.target status before it can move on to loading a graphical interface. 

This patches this in 2 ways:

1. Prevents the plymouth loader from dismissing until after multi-user.target meaning that even if we do get hung up, you'll be on the plymouth loader the whole time.

2. Prevents Docker (the root cause) from blocking progression of the boot sequence until network-online.target is achieved. 

Everything still boots fine and will finish up while in the GUI. 

I tested this by adding a service that attached to network-online.target and just did a `sleep 30`. This meant I always had a 30sec delay in boot, and even after fixing, could see that the task was still running with `systemctl list-jobs`. The only consequence is that running `docker ps` will hang until you have active networking. 

<img width="867" height="1405" alt="image" src="https://github.com/user-attachments/assets/8bc5268d-4fc4-44ef-baee-f56a1c34a390" />

### Before applying this PR w/ sleep service
```
graphical.target @31.896s
└─multi-user.target @31.896s
  └─docker.service @31.516s +379ms
    └─network-online.target @31.515s
      └─systemd-networkd-wait-online.service @453ms +1.630s
        └─systemd-networkd.service @360ms +90ms
          └─systemd-udevd.service @329ms +29ms
            └─systemd-tmpfiles-setup-dev.service @295ms +32ms
              └─systemd-tmpfiles-setup-dev-early.service @245ms +46ms
                └─kmod-static-nodes.service @212ms +16ms
                  └─systemd-journald.socket @208ms
                    └─-.mount @185ms
                      └─-.slice @185msk
```

### After applying this PR w/ sleep service
```
graphical.target @1.590s
└─omarchy-seamless-login.service @1.590s
  └─plymouth-quit.service @1.558s +30ms
    └─multi-user.target @1.557s
      └─cups.service @1.526s +30ms
        └─network.target @1.525s
          └─iwd.service @1.370s +154ms
            └─basic.target @1.370s
              └─dbus-broker.service @1.357s +11ms
                └─dbus.socket @1.354s
                  └─sysinit.target @1.353s
                    └─systemd-update-utmp.service @1.335s +18ms
                      └─systemd-tmpfiles-setup.service @1.293s +41ms
                        └─systemd-journal-flush.service @1.268s +23ms
                          └─var-log.mount @1.264s +3ms
                            └─dev-mapper-root.device @216ms +229ms
```