### PR TITLE
Replace pavucontrol with wiremix

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -96,7 +96,7 @@
   },
   "pulseaudio": {
     "format": "{icon}",
-    "on-click": "pavucontrol",
+    "on-click": "alacritty --class=Wiremix -e wiremix",
     "on-click-right": "pamixer -t",
     "tooltip-format": "Playing at {volume}%",
     "scroll-step": 5,

--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -5,10 +5,10 @@ windowrule = suppressevent maximize, class:.*
 windowrule = tile, class:^(Chromium)$
 
 # Float and center settings and previews
-windowrule = float, class:^(org.pulseaudio.pavucontrol|blueberry.py|Impala|org.gnome.NautilusPreviewer|Omarchy)$
-windowrule = size 800 600, class:^(org.pulseaudio.pavucontrol|blueberry.py|Impala|org.gnome.NautilusPreviewer)$
+windowrule = float, class:^(org.pulseaudio.pavucontrol|blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|Omarchy)$
+windowrule = size 800 600, class:^(org.pulseaudio.pavucontrol|blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer)$
 windowrule = size 645 350, class:Omarchy
-windowrule = center, class:^(org.pulseaudio.pavucontrol|blueberry.py|Impala|org.gnome.NautilusPreviewer|Omarchy)$
+windowrule = center, class:^(org.pulseaudio.pavucontrol|blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|Omarchy)$
 
 # Float and center file pickers
 windowrule = float, class:xdg-desktop-portal-gtk, title:^(Open.*Files?|Save.*Files?|All Files|Save)

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 yay -S --noconfirm --needed \
-  brightnessctl playerctl pamixer pavucontrol wireplumber \
+  brightnessctl playerctl pamixer pavucontrol wiremix wireplumber \
   fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool wl-clip-persist \
   nautilus sushi ffmpegthumbnailer \
   mpv evince imv \


### PR DESCRIPTION
This is a proposal to replace `pavucontrol` with [`wiremix`](https://github.com/tsowell/wiremix).

I prefer Wiremix because it is easier to control with the keyboard and I think it is a better fit for Omarchy. 

With `enter` on the first screen you can change the output for an application.
Some default keybindings might be a bit confusing. `d` or right click to change the default for example.
With `?` you can see the shortcuts. 

For now I kept the default values and did not add a separate config.

A preview:

<img width="2880" height="1592" alt="image" src="https://github.com/user-attachments/assets/6cb820e0-85be-41a3-8139-dbb227611680" />

<img width="2880" height="1702" alt="image" src="https://github.com/user-attachments/assets/c756c0b9-d027-4eb4-afb2-d9f053acb648" />

