### PR TITLE
Refactor firewall script to separate ufw and ufw-docker installation steps

### DIFF
--- a/install/firewall.sh
+++ b/install/firewall.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
 if ! command -v ufw &>/dev/null; then
-  yay -Sy --noconfirm --needed ufw ufw-docker
-
+  yay -Sy --noconfirm --needed ufw
   # Allow nothing in, everything out
   sudo ufw default deny incoming
   sudo ufw default allow outgoing
@@ -19,8 +19,23 @@ if ! command -v ufw &>/dev/null; then
 
   # Turn on the firewall
   sudo ufw enable
+fi
 
-  # Turn on Docker protections
+# Remove any existing ufw-docker installation
+yay -Rns --noconfirm ufw-docker || true
+command -v ufw-docker &>/dev/null && sudo ufw-docker uninstall || true
+# Install ufw-docker
+if ! command -v ufw-docker &>/dev/null; then
+  sudo rm -f /usr/local/bin/ufw-docker
+
+  # Download and install ufw-docker
+  sudo wget -O /usr/local/bin/ufw-docker \
+  https://github.com/chaifeng/ufw-docker/raw/master/ufw-docker
+
+  # Make it executable
+  sudo chmod +x /usr/local/bin/ufw-docker
+
+  # Install ufw-docker
   sudo ufw-docker install
   sudo ufw reload
 fi


### PR DESCRIPTION
Make changes to firewall.sh so that it can install from source rather than from AUR, as it is marked as outdated, so yay keeps throwing an warning about the same. 

```
 core is up to date
 extra is up to date
 multilib is up to date
:: Searching AUR for updates...
:: Searching databases for updates...
 -> Flagged Out Of Date AUR Packages: ufw-docker
```

And I think it's better to build from source, maybe?

Let me know if you required any changes.


P.S. also didn't know how to create migrations so if someone can guide me through it, I could make another commit. :cry: 