### PR TITLE
Add hyprlock attempt tracking and lockout placeholder

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -29,14 +29,14 @@ input-field {
     outer_color = $outer_color
     outline_thickness = 4
 
-    font_family = CaskaydiaMono Nerd Font
+    font_family = CaskaydiaMono Nerd Font:style=Bold Italic
     font_size = 32
     font_color = $font_color
 
     placeholder_color = $placeholder_color
     placeholder_text =   Enter Password 󰈷 
     check_color = $check_color
-    fail_text = Wrong
+    fail_text = <i>$PAMFAIL</i> — Attempts: <i>$ATTEMPTS</i>
 
     rounding = 0
     shadow_passes = 0


### PR DESCRIPTION
### Description:
This pull request improves Hyprlock configuration in omarchy by:

Using the $PAMFAIL and $ATTEMPTS variables as documented by Hyprlock to show authentication failure messages and attempt count

Enhancing the visual styling of the input field by applying a bold italic font style

### Related Issue
Closes #163 

### Video
https://github.com/user-attachments/assets/dbdcce0b-df2c-4f9b-ac66-16537ffa68b0



### How to test:

1. Open your Hyprland config directory:

```bash
   nvim ~/.config/hypr/hyprlock.conf
```
2. Replace or modify the existing hyprlock config block with the changes from this PR.

3. Open a new terminal window and run:

```bash
   hyprlock
```
4. Test the behavior:

   - Enter incorrect passwords to trigger PAM failure
   - Observe the failure message (PAMFAIL) and the attempt count (ATTEMPTS)
   - Confirm the input field uses bold italic font styling

5. (Optional) If you trigger a lockout after multiple failed attempts:

   a. Switch to a new TTY with: Ctrl + Alt + F2  
   b. Log in and run:

      sudo faillock --user yourusername --reset

   c. Return to your main session with: Ctrl + Alt + F1


PS: This is my first open-source contribution, so I'm very open to suggestions or changes.
I hope this is useful — and I'm happy to revise anything to better align with the project's style or goals.