### PR TITLE
Add simple screen recordings

### DIFF
--- a/bin/omarchy-screenrecord
+++ b/bin/omarchy-screenrecord
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if pgrep -x wl-screenrec >/dev/null; then
+  pkill -x wl-screenrec
+  notify-send "Screen recording saved to ~/Videos" -t 2000
+else
+  region=$(slurp) || exit 1
+  notify-send "Screen recording starting..." -t 1000
+  sleep 1
+  wl-screenrec \
+    -g "$region" \
+    -f "$HOME/Videos/screen-recording-$(date +'%Y-%m-%d_%H-%M-%S').mp4" \
+    --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart"
+fi

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -28,5 +28,8 @@ bind = , PRINT, exec, hyprshot -m region
 bind = SHIFT, PRINT, exec, hyprshot -m window
 bind = CTRL, PRINT, exec, hyprshot -m output
 
+# Screenshots
+bind = ALT, PRINT, exec, omarchy-screenrecord
+
 # Color picker
 bind = SUPER, PRINT, exec, hyprpicker -a

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -4,5 +4,6 @@ yay -S --noconfirm --needed \
   brightnessctl playerctl pamixer pavucontrol wireplumber \
   fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool wl-clip-persist \
   nautilus sushi ffmpegthumbnailer \
-  mpv evince imv wl-screenrec \
+  slurp wl-screenrec \
+  mpv evince imv \
   chromium

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -4,5 +4,5 @@ yay -S --noconfirm --needed \
   brightnessctl playerctl pamixer pavucontrol wireplumber \
   fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool wl-clip-persist \
   nautilus sushi ffmpegthumbnailer \
-  mpv evince imv \
+  mpv evince imv wl-screenrec \
   chromium

--- a/migrations/1752885858.sh
+++ b/migrations/1752885858.sh
@@ -1,2 +1,2 @@
-echo "Install wl-screenrec for new ALT+PrintScreen screen recorder"
-yay -S --noconfirm --needed wl-screenrec
+echo "Install slurp + wl-screenrec for new ALT+PrintScreen screen recorder"
+yay -S --noconfirm --needed slurp wl-screenrec

--- a/migrations/1752885858.sh
+++ b/migrations/1752885858.sh
@@ -1,0 +1,2 @@
+echo "Install wl-screenrec for new ALT+PrintScreen screen recorder"
+yay -S --noconfirm --needed wl-screenrec


### PR DESCRIPTION
`ALT + PrtScreen` will start a region-defined screen recording and hitting the binding again will stop it. Nothing fancy, but great for bug reports and the like. 

Inspired by @robzolkos's more involved script in https://www.zolkos.com/2025/07/18/screen-recording-omarchy.