### PR TITLE
[FIX] // Scales the theme menu down 10px in width

### DIFF
--- a/bin/omarchy-theme-menu
+++ b/bin/omarchy-theme-menu
@@ -22,7 +22,7 @@ mapfile -t themes < <(
 selection=$(printf '%s\n' "${themes[@]}" | wofi \
   --show dmenu \
   --allow-markup \
-  --width 150 \
+  --width 190 \
   --height 400 \
   -O alphabetical \
   --style ~/.config/wofi/select.css 2>/dev/null)


### PR DESCRIPTION
## PR HOT-FIX
This fix modifies the width which is set to `200px` on the PR: https://github.com/basecamp/omarchy/pull/212

## Dependants
- This pull-request expects https://github.com/basecamp/omarchy/pull/212 to make it into `dev`

## Challenge
- The lock screen and the theme picker share the same css file, thus changes made to the theme menu, change the lock screen.

## Solution
- Long-term, we need to split up the styles and create a base shared style
- Short-term, this PR changes the width to `190px` which seems to show the entire `Catppuccin Latte` on one line, and narrows the lock screen so it does not look out of place.