### PR TITLE
Omarchy Plugin Manager

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -171,8 +171,9 @@ show_setup_config_menu() {
 }
 
 show_install_menu() {
-  case $(menu "Install" "󰣇  Package\n  Web App\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming") in
+  case $(menu "Install" "󰣇  Package\n  Plugin\n  Web App\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming") in
   *Package*) terminal omarchy-pkg-install ;;
+  *Plugin*) terminal omarchy-plugin-install ;;
   *Web*) present_terminal omarchy-webapp-install ;;
   *Service*) show_install_service_menu ;;
   *Style*) show_install_style_menu ;;
@@ -280,8 +281,9 @@ show_install_php_menu() {
 }
 
 show_remove_menu() {
-  case $(menu "Remove" "󰣇  Package\n  Web App\n󰸌  Theme\n󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Remove" "󰣇  Package\n  Plugin\n  Web App\n󰸌  Theme\n󰈷  Fingerprint\n  Fido2") in
   *Package*) terminal omarchy-pkg-remove ;;
+  *Plugin*) terminal omarchy-plugin-remove ;;
   *Web*) present_terminal omarchy-webapp-remove ;;
   *Theme*) present_terminal omarchy-theme-remove ;;
   *Fingerprint*) present_terminal "omarchy-setup-fingerprint --remove" ;;
@@ -291,10 +293,11 @@ show_remove_menu() {
 }
 
 show_update_menu() {
-  case $(menu "Update" "󰣇  Omarchy\n  Config\n󰸌  Themes\n  Process\n  Timezone") in
+  case $(menu "Update" "󰣇  Omarchy\n  Config\n󰸌  Themes\n  Plugin\n  Process\n  Timezone") in
   *Omarchy*) present_terminal omarchy-update ;;
   *Config*) show_update_config_menu ;;
   *Themes*) present_terminal omarchy-theme-update ;;
+  *Plugin*) terminal omarchy-plugin-update ;;
   *Process*) show_update_process_menu ;;
   *Timezone*) omarchy-cmd-tzupdate ;;
   *) show_main_menu ;;

--- a/bin/omarchy-plugin-install
+++ b/bin/omarchy-plugin-install
@@ -12,7 +12,7 @@ if [[ -n "$PLUGIN_REPO_URL" ]]; then
 
   echo -e "\n\e[32mInstalling plugin: $PLUGIN_NAME\e[0m"
 
-  if ! mkdir -p "$PLUGIN_PATH" || ! git clone "$PLUGIN_REPO_URL" "$PLUGIN_PATH/$PLUGIN_NAME"; then
+  if ! mkdir -p "$PLUGIN_PATH" || ! git clone --depth 1 "$PLUGIN_REPO_URL" "$PLUGIN_PATH/$PLUGIN_NAME"; then
     echo "Error: Failed to clone the plugin repo."
     exit 1
   fi

--- a/bin/omarchy-plugin-install
+++ b/bin/omarchy-plugin-install
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: omarchy-plugin-install <plugin-repo-url>"
+  exit 1
+fi
+
+PLUGIN_REPO_URL="$1"
+PLUGIN_PATH="$HOME/.config/omarchy/plugins"
+PLUGIN_NAME=$(basename -s .git "$PLUGIN_REPO_URL")
+
+echo -e "\n\e[32mInstalling plugin: $PLUGIN_NAME\e[0m"
+
+if ! mkdir -p "$PLUGIN_PATH" || ! git clone "$PLUGIN_REPO_URL" "$PLUGIN_PATH/$PLUGIN_NAME"; then
+  echo "Error: Failed to clone the plugin repo."
+  exit 1
+fi
+
+cd "$PLUGIN_PATH/$PLUGIN_NAME"
+
+# Running the plugins install command
+./install.sh
+
+notify-send "Plugin: $PLUGIN_NAME has been installed" -t 2000

--- a/bin/omarchy-plugin-install
+++ b/bin/omarchy-plugin-install
@@ -1,24 +1,26 @@
 #!/bin/bash
 
-if [ -z "$1" ]; then
-  echo "Usage: omarchy-plugin-install <plugin-repo-url>"
-  exit 1
-fi
-
 PLUGIN_REPO_URL="$1"
-PLUGIN_PATH="$HOME/.config/omarchy/plugins"
-PLUGIN_NAME=$(basename -s .git "$PLUGIN_REPO_URL")
 
-echo -e "\n\e[32mInstalling plugin: $PLUGIN_NAME\e[0m"
-
-if ! mkdir -p "$PLUGIN_PATH" || ! git clone "$PLUGIN_REPO_URL" "$PLUGIN_PATH/$PLUGIN_NAME"; then
-  echo "Error: Failed to clone the plugin repo."
-  exit 1
+if [[ -z "$1" ]]; then
+  PLUGIN_REPO_URL=$(gum input --placeholder="Git repo URL for plugin" --header="")
 fi
 
-cd "$PLUGIN_PATH/$PLUGIN_NAME"
+if [[ -n "$PLUGIN_REPO_URL" ]]; then
+  PLUGIN_PATH="$HOME/.config/omarchy/plugins"
+  PLUGIN_NAME=$(basename -s .git "$PLUGIN_REPO_URL")
 
-# Running the plugins install command
-./install.sh
+  echo -e "\n\e[32mInstalling plugin: $PLUGIN_NAME\e[0m"
 
-notify-send "Plugin: $PLUGIN_NAME has been installed" -t 2000
+  if ! mkdir -p "$PLUGIN_PATH" || ! git clone "$PLUGIN_REPO_URL" "$PLUGIN_PATH/$PLUGIN_NAME"; then
+    echo "Error: Failed to clone the plugin repo."
+    exit 1
+  fi
+
+  cd "$PLUGIN_PATH/$PLUGIN_NAME"
+
+  # Running the plugins install script
+  ./install
+
+  ~/.local/share/omarchy/bin/omarchy-show-done
+fi

--- a/bin/omarchy-plugin-list
+++ b/bin/omarchy-plugin-list
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+PLUGIN_PATH="$HOME/.config/omarchy/plugins"
+
+echo -e "\n\e[34mInstalled Omarchy Plugins:\e[0m"
+echo "=========================="
+
+if [ ! -d "$PLUGIN_PATH" ]; then
+  echo "No plugins found."
+  exit 0
+fi
+
+for plugin_dir in "$PLUGIN_PATH"/*; do
+  if [ -d "$plugin_dir" ]; then
+    plugin_name=$(basename "$plugin_dir")
+
+    echo -e "\n - $plugin_name"
+
+    # Get repository URL if available
+    if [ -d "$plugin_dir/.git" ]; then
+      cd "$plugin_dir"
+      repo_url=$(git config --get remote.origin.url 2>/dev/null)
+      if [ -n "$repo_url" ]; then
+        echo "   Repository: $repo_url"
+      fi
+
+      # Get description
+      description=$(jq -r ".description" "$plugin_dir/manifest.json")
+      if [ -n "$description" ]; then
+        echo "   Description: $description"
+      fi
+
+      # Get current version
+      version=$(jq -r ".version" "$plugin_dir/manifest.json")
+      if [ -n "$version" ]; then
+        echo "   Version: $version"
+      fi
+
+    fi
+  fi
+done

--- a/bin/omarchy-plugin-remove
+++ b/bin/omarchy-plugin-remove
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: omarchy-plugin-remove <plugin-name>"
+  exit 1
+fi
+
+PLUGIN_PATH="$HOME/.config/omarchy/plugins"
+PLUGIN_NAME="$1"
+
+echo -e "\n\e[31mRemoving plugin: $PLUGIN_NAME\e[0m"
+
+if [ ! -d "$PLUGIN_PATH/$PLUGIN_NAME" ]; then
+  echo "Error: Plugin '$PLUGIN_NAME' not found."
+  exit 1
+fi
+
+cd "$PLUGIN_PATH/$PLUGIN_NAME"
+
+# Running the plugins install command
+./remove.sh
+
+notify-send "Plugin: $PLUGIN_NAME has been removed" -t 2000

--- a/bin/omarchy-plugin-remove
+++ b/bin/omarchy-plugin-remove
@@ -1,23 +1,23 @@
 #!/bin/bash
 
-if [ -z "$1" ]; then
-  echo "Usage: omarchy-plugin-remove <plugin-name>"
-  exit 1
-fi
-
-PLUGIN_PATH="$HOME/.config/omarchy/plugins"
 PLUGIN_NAME="$1"
+PLUGIN_PATH="$HOME/.config/omarchy/plugins"
 
-echo -e "\n\e[31mRemoving plugin: $PLUGIN_NAME\e[0m"
-
-if [ ! -d "$PLUGIN_PATH/$PLUGIN_NAME" ]; then
-  echo "Error: Plugin '$PLUGIN_NAME' not found."
-  exit 1
+if [[ -z "$1" ]]; then
+  PLUGIN_NAME=$(basename -a "$HOME/.config/omarchy/plugins"/* | fzf "${fzf_args[@]}")
 fi
 
-cd "$PLUGIN_PATH/$PLUGIN_NAME"
+if [[ -n "$PLUGIN_NAME" ]]; then
+  echo -e "\n\e[31mRemoving plugin: $PLUGIN_NAME\e[0m"
 
-# Running the plugins install command
-./remove.sh
+  if [ ! -d "$PLUGIN_PATH/$PLUGIN_NAME" ]; then
+    echo "Error: Plugin '$PLUGIN_NAME' not found."
+    exit 1
+  fi
 
-notify-send "Plugin: $PLUGIN_NAME has been removed" -t 2000
+  # Running the plugins remove script
+  "$PLUGIN_PATH/$PLUGIN_NAME/remove"
+  rm -rf "$PLUGIN_PATH/$PLUGIN_NAME"
+
+  ~/.local/share/omarchy/bin/omarchy-show-done
+fi

--- a/bin/omarchy-plugin-update
+++ b/bin/omarchy-plugin-update
@@ -1,23 +1,24 @@
 #!/bin/bash
 
-if [ -z "$1" ]; then
-  echo "Usage: omarchy-plugin-update <plugin-name>"
-  exit 1
-fi
-
-PLUGIN_PATH="$HOME/.config/omarchy/plugins"
 PLUGIN_NAME="$1"
+PLUGIN_PATH="$HOME/.config/omarchy/plugins"
 
-echo -e "\n\e[33mUpdating plugin: $PLUGIN_NAME\e[0m"
-
-if [ ! -d "$PLUGIN_PATH/$PLUGIN_NAME" ]; then
-  echo "Error: Plugin '$PLUGIN_NAME' not found."
-  exit 1
+if [[ -z "$1" ]]; then
+  PLUGIN_NAME=$(basename -a "$HOME/.config/omarchy/plugins"/* | fzf "${fzf_args[@]}")
 fi
 
-cd "$PLUGIN_PATH/$PLUGIN_NAME"
+if [[ -n "$PLUGIN_NAME" ]]; then
+  echo -e "\n\e[33mUpdating plugin: $PLUGIN_NAME\e[0m"
 
-# Running the plugins install command
-./update.sh
+  if [ ! -d "$PLUGIN_PATH/$PLUGIN_NAME" ]; then
+    echo "Error: Plugin '$PLUGIN_NAME' not found."
+    exit 1
+  fi
 
-notify-send "Plugin: $PLUGIN_NAME has been updated" -t 2000
+  cd "$PLUGIN_PATH/$PLUGIN_NAME"
+
+  # Running the plugins update script
+  ./update
+
+  ~/.local/share/omarchy/bin/omarchy-show-done
+fi

--- a/bin/omarchy-plugin-update
+++ b/bin/omarchy-plugin-update
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: omarchy-plugin-update <plugin-name>"
+  exit 1
+fi
+
+PLUGIN_PATH="$HOME/.config/omarchy/plugins"
+PLUGIN_NAME="$1"
+
+echo -e "\n\e[33mUpdating plugin: $PLUGIN_NAME\e[0m"
+
+if [ ! -d "$PLUGIN_PATH/$PLUGIN_NAME" ]; then
+  echo "Error: Plugin '$PLUGIN_NAME' not found."
+  exit 1
+fi
+
+cd "$PLUGIN_PATH/$PLUGIN_NAME"
+
+# Running the plugins install command
+./update.sh
+
+notify-send "Plugin: $PLUGIN_NAME has been updated" -t 2000

--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -17,3 +17,4 @@ source = ~/.config/hypr/input.conf
 source = ~/.config/hypr/bindings.conf
 source = ~/.config/hypr/envs.conf
 source = ~/.config/hypr/autostart.conf
+source = ~/.config/hypr/plugins.conf

--- a/config/hypr/plugins.conf
+++ b/config/hypr/plugins.conf
@@ -1,0 +1,1 @@
+# Plugin configs and sources

--- a/migrations/1754825572.sh
+++ b/migrations/1754825572.sh
@@ -1,0 +1,5 @@
+echo "Installing plugin manager"
+
+if [[ ! -e ~/.config/hypr/plugins.conf ]]; then
+  cp ~/.local/share/omarchy/config/hypr/plugins.conf ~/.config/hypr/plugins.conf
+fi


### PR DESCRIPTION
# Omarchy Plugin Manager

This is my first open-source PR 😊

This PR introduces a basic but extensible plugin manager for Omarchy. The motivation behind this feature is to allow users to extend Omarchy with custom functionality—without adding non-essential code to the core project. This enables developers to improve their local experience while keeping Omarchy's defaults lean and opinionated.

This PR was created because we decided that PR #47 should be implemented as a plugin instead—therefore, we need a plugin manager. 😉

My newly created plugin: https://github.com/jonashan/omarchy-workspace-mover

## Motivation

Initially, I considered a straightforward implementation that would link `bin` files and Hyperland configurations defined in each plugin. However, this approach would have quickly grown in complexity as more features or plugin types were added. To keep things simple and scalable, I pivoted to a more flexible system where plugins follow a defined structure—essentially a contract.

Each plugin must contain the following files:

- `install`
- `remove`
- `update`
- `manifest.json`

This structure delegates all logic to the plugin itself, allowing it to decide how it should be installed, updated, or removed. The plugin manager remains intentionally "dumb," simply cloning the repository and invoking the appropriate script.

The `manifest.json` file is used to display plugin metadata (such as version and description) when listing installed plugins. That said, we could consider dropping this requirement and relying solely on commit hashes for versioning. Feedback on this is welcome.

## Usage

Plugins are installed via a simple command:

```bash
omarchy-plugin-install git@github.com:jonashan/omarchy-workspace-mover.git
```
This clones the repository into `~/.config/omarchy/plugins/` and executes the plugin’s `install.sh`.

### Commands
Four commands are currently implemented:
- omarchy-plugin-install
- omarchy-plugin-remove
- omarchy-plugin-update
- omarchy-plugin-list

Each is a separate script for now, in line with the current pattern in Omarchy. These could be consolidated and DRYed into a single script (e.g., `omarchy-plugin`) that takes a subcommand and an argument (e.g., `install <repo>`), but I opted to follow the existing convention.

## Documentation
This feature will need to be documented in the Omarchy manual, including the expected plugin structure and usage instructions.

Let me know if you'd like a section added for plugin developers, with examples or a template.

## Visuals
### List
<img width="914" height="392" alt="2025-07-19-213921_hyprshot" src="https://github.com/user-attachments/assets/6c5d9df5-5ee3-4fdb-affe-154a2cf6bf1b" />

### Plugin installation
<img width="337" height="551" alt="image" src="https://github.com/user-attachments/assets/01b18acb-a911-449c-bddb-342e60445c4f" />
<img width="713" height="550" alt="image" src="https://github.com/user-attachments/assets/551d918a-7e49-4aac-a76a-f78bbb9db496" />
<img width="671" height="513" alt="image" src="https://github.com/user-attachments/assets/64a632e1-4229-492f-b486-bb8d0af840b5" />


### Plugin removal and updating
<img width="350" height="427" alt="image" src="https://github.com/user-attachments/assets/d9f1a10d-1c64-429a-8473-94cd2f84e2bf" />
<img width="685" height="524" alt="image" src="https://github.com/user-attachments/assets/5ddc23aa-aa6b-417d-bba9-88d1ebe0bd0e" />
<img width="664" height="508" alt="image" src="https://github.com/user-attachments/assets/5200e0bf-92b1-4079-9a87-9a25a0e53358" />
