### PR TITLE
Add support for picture-in-picture windows

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -30,8 +30,10 @@ windowrule = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned
 
 # Picture in picture
 windowrule = float, title:^(Picture.{0,1}in.{0,1}[Pp]icture)$
-windowrule = size 400 225, title:^(Picture.{0,1}in.{0,1}[Pp]icture)$
 windowrule = pin, title:^(Picture.{0,1}in.{0,1}[Pp]icture)$
+windowrule = keepaspectratio, title:^(Picture.{0,1}in.{0,1}[Pp]icture)$
+windowrule = noborder, title:^(Picture.{0,1}in.{0,1}[Pp]icture)$
+windowrule = opacity 1.0 1.0, title:^(Picture.{0,1}in.{0,1}[Pp]icture)$
 
 # Proper background blur for wofi
 layerrule = blur,wofi


### PR DESCRIPTION
Add support for picture-in-picture windows. Tested in Brave, Chromium and Firefox. It has the following characteristics:
1. Floats over other windows.
2. It is present in all the Hyprland workspaces.
3. Keeps its aspect ratio when resized.
4. Removed border.
5. Removed transparency.

**Before:**
<img width="1887" height="1009" alt="image" src="https://github.com/user-attachments/assets/9809d221-d6f2-4b71-be64-26804dc71d47" />

**After:**
<img width="1887" height="1017" alt="image" src="https://github.com/user-attachments/assets/b4b3bffd-b7e4-4738-bcad-74a1f8140567" />

Additional notes:
- Originally I was defining a specific size for the window but the default one is good enough and also because some browsers (i.e. Brave) store the previous size giving more flexibility to the users.
