### PR TITLE
Bugfix/259

### DIFF
--- a/install/hyprlandia.sh
+++ b/install/hyprlandia.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
+if ! command -v pactree &>/dev/null; then
+    yay -S --noconfirm --needed pacman-contrib
+fi
+
+if pacman -Qi hyprutils-git &> /dev/null; then
+    if pacman -Qi hyprsunset-git &> /dev/null; then
+        # basically leftovers from other Hyprland installations lihe JaCoolit that can mess things up
+        yay -R --noconfirm hyprsunset-git
+        yay -S --noconfirm hyprutils hyprsunset
+fi
+
 yay -S --noconfirm --needed \
-  hyprland hyprshot hyprpicker hyprlock hypridle polkit-gnome hyprland-qtutils \
-  wofi waybar mako swaybg \
-  xdg-desktop-portal-hyprland xdg-desktop-portal-gtk
+    hyprland hyprshot hyprpicker hyprlock hypridle polkit-gnome hyprland-qtutils \
+    wofi waybar mako swaybg \
+    xdg-desktop-portal-hyprland xdg-desktop-portal-gtk

--- a/install/login.sh
+++ b/install/login.sh
@@ -93,7 +93,7 @@ PartOf=graphical.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/seamless-login uwsm start -- hyprland.desktop
-Restart=always
+Restart=on-success
 RestartSec=2
 User=$USER
 TTYPath=/dev/tty1

--- a/migrations/1752797801.sh
+++ b/migrations/1752797801.sh
@@ -1,0 +1,3 @@
+echo "fix omarchy seamless login service"
+sed -i 's/Restart=always/Restart=on-success/' /etc/systemd/system/omarchy-seamless-login.service
+sudo systemctl daemon-reload


### PR DESCRIPTION
This little patch will prevent bricking the PC if for any reason Hyprland can't load properly, and it also tries to prevent at least one scenario where that happened with Hyprland 0.50.0 and newer