### PR TITLE
Restore zoom package installation

### DIFF
--- a/install/xtras.sh
+++ b/install/xtras.sh
@@ -12,6 +12,9 @@ if [ -z "$OMARCHY_BARE" ]; then
   yay -S --noconfirm --needed typora ||
     echo -e "\e[31mFailed to install Typora. Continuing without!\e[0m"
 
+  yay -S --noconfirm --needed zoom ||
+    echo -e "\e[31mFailed to install Zoom. Continuing without!\e[0m"
+
   yay -S --noconfirm --needed dropbox libappindicator-gtk3 python-gpgme nautilus-dropbox ||
     echo -e "\e[31mFailed to install Dropbox. Continuing without!\e[0m"
 

--- a/migrations/1752983008.sh
+++ b/migrations/1752983008.sh
@@ -1,0 +1,4 @@
+if ! command -v zoom &>/dev/null; then
+  echo "Add missing installation of Zoom"
+  yay -S --noconfirm --needed zoom
+fi


### PR DESCRIPTION
The zoom package was removed in commit 72e863f. This PR restores it.

If the removal was intentional, maybe we should also remove the Zoom.desktop file and update the manual.