### PR TITLE
fix the low contrast issue for comments in NeoVim (matte black)

### DIFF
--- a/themes/matte-black/neovim.lua
+++ b/themes/matte-black/neovim.lua
@@ -16,10 +16,10 @@ return {
     local matte_black_palette = {
       -- Base "Matte Black" Palette Overrides
       bg0 = "#0D0D0D", bg1 = "#121212", bg2 = "#1E1E1E", bg3 = "#2C2C2C", bg4 = "#333333",
-      fg0 = "#FFFFFF", fg1 = "#BEBEBE", fg2 = "#BEBEBE", fg3 = "#8A8A8D",
+      fg0 = "#FFFFFF", fg1 = "#EAEAEA", fg2 = "#BEBEBE", fg3 = "#8A8A8D",
       sel0 = "#2C2C2C",
       sel1 = c.from_hex("#2C2C2C"):blend(c.from_hex("#F59E0B"), 0.2):to_css(),
-      comment = "#333333",
+      comment = "#8A8A8D",
       red = Shade.new("#D35F5F", c.from_hex("#D35F5F"):lighten(8):to_css(), "#B91C1C"),
       orange = Shade.new("#F59E0B", "#FFC107", c.from_hex("#F59E0B"):lighten(-8):to_css()),
       yellow = Shade.new("#FFC107", c.from_hex("#FFC107"):lighten(10):to_css(), "#F59E0B"),
@@ -82,6 +82,8 @@ return {
         Whitespace = { fg = "palette.black.bright" },
         NonText = { fg = "palette.black.bright" },
         IncSearch = { bg = "palette.sel1" },
+        CursorLine = { bg = "palette.bg2" },
+        Normal = { fg = "palette.fg1" },
 
         -- Noice Cmdline Overrides
         NoiceCmdlinePopupBorder = { fg = "palette.fg3" },


### PR DESCRIPTION
I should have done this fix sooner...
This PR fixes an issue in the Matte Black NeoVim theme which caused the comments to be unreadable when CursorLine was on the comments. A simple change in colors now makes it better.

**Before**:
<img width="811" height="123" alt="2025-07-20-193651_hyprshot" src="https://github.com/user-attachments/assets/407bf942-da75-4640-b397-486344b076e7" />

**After**:
<img width="766" height="114" alt="2025-07-20-194037_hyprshot" src="https://github.com/user-attachments/assets/57c46f72-037d-4a1f-89e3-e93fb370be0f" />


I am working on turning the matte black theme into a nvim plugin since it allows for more granular design and control. Soon, the matte black theme will just use a plugin like the rest of the themes in Omarchy. 