### PR TITLE
Add custom brightness control module for Waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -16,7 +16,7 @@
     "network",
     "pulseaudio",
     "cpu",
-    "custom/brightness",
+    "backlight",
     "battery"
   ],
   "hyprland/workspaces": {
@@ -66,13 +66,25 @@
     "nospacing": 1,
     "on-click": "alacritty --class=Impala -e impala"
   },
-  "custom/brightness": {
-    "exec": "b=$(brightnessctl -d $(ls /sys/class/backlight/ | head -n1) g); m=$(brightnessctl -d $(ls /sys/class/backlight/ | head -n1) m); p=$((b * 100 / m)); if [ $p -ge 90 ]; then icon>
-    "interval": 5,
-    "on-scroll-up": "brightnessctl -d $(ls /sys/class/backlight/ | head -n1) set +5%",
-    "on-scroll-down": "brightnessctl -d $(ls /sys/class/backlight/ | head -n1) set 5%-",
-    "format": "{}",
-    "tooltip": false
+  "backlight": {
+    "device": "", // Empty This For Autodetect
+    "format": "{icon}",
+    "tooltip-format": "Brightness: {percent}%",
+    "interval": 2,
+    "on-scroll-up": "brightnessctl set +5%",
+    "on-scroll-down": "brightnessctl set 5%-",
+    "format-icons": [
+       "",  // 0–10%
+       "",  // 11–20%
+       "",  // 21–30%
+       "",  // 31–40%
+       "",  // 41–50%
+       "",  // 51–60%
+       "",  // 61–70%
+       "",  // 71–80%
+       "",  // 81–90%
+       ""   // 91–100%
+     ]
   },
   "battery": {
     "format": "{capacity}% {icon}",

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -16,6 +16,7 @@
     "network",
     "pulseaudio",
     "cpu",
+    "custom/brightness",
     "battery"
   ],
   "hyprland/workspaces": {
@@ -64,6 +65,14 @@
     "interval": 3,
     "nospacing": 1,
     "on-click": "alacritty --class=Impala -e impala"
+  },
+  "custom/brightness": {
+    "exec": "b=$(brightnessctl -d $(ls /sys/class/backlight/ | head -n1) g); m=$(brightnessctl -d $(ls /sys/class/backlight/ | head -n1) m); p=$((b * 100 / m)); if [ $p -ge 90 ]; then icon>
+    "interval": 5,
+    "on-scroll-up": "brightnessctl -d $(ls /sys/class/backlight/ | head -n1) set +5%",
+    "on-scroll-down": "brightnessctl -d $(ls /sys/class/backlight/ | head -n1) set 5%-",
+    "format": "{}",
+    "tooltip": false
   },
   "battery": {
     "format": "{capacity}% {icon}",

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -41,6 +41,11 @@
   margin-right: 12px;
 }
 
+#backlight {
+  font-size: 15px;
+  padding: 0 8px;
+}
+
 tooltip {
   padding: 2px;
 }


### PR DESCRIPTION
This PR introduces a custom `brightness` module for Waybar to make it easier to control screen brightness directly from the status bar.

By default, Waybar does not provide built-in brightness control, which can be a challenge for new Linux users. While it may seem like a small detail, changing screen brightness is a common and essential task — yet not always intuitive without a GUI tool.

✨ Features:
- Uses `brightnessctl` to fetch and set brightness
- Scroll up/down to increase/decrease brightness by 5%
- Minimal format with no tooltip
- Integrated into the right side of the bar next to CPU, battery, etc.

⚠️ Note:
Currently, this solution **does not work** with Apple Display Brightness (e.g., MacBook or Studio Display) since they often require different protocols or tools. I may explore support for Apple-specific displays in the future.

---

#### 💡 Preview:

![Brightness module preview](https://github.com/user-attachments/assets/7b964f50-c113-4dbd-b4b9-d05c05cf51f2)

This screenshot shows the brightness icon (with current percentage) displayed clearly between the CPU icon and battery indicator.

Hope this helps new users have a smoother experience on Wayland!
