### PR TITLE
Add default git editor

### DIFF
--- a/install/4-config.sh
+++ b/install/4-config.sh
@@ -33,6 +33,9 @@ if [[ -n "${OMARCHY_USER_EMAIL//[[:space:]]/}" ]]; then
   git config --global user.email "$OMARCHY_USER_EMAIL"
 fi
 
+# Set default git editor
+git config --global core.editor "nvim"
+
 # Set default XCompose that is triggered with CapsLock
 tee ~/.XCompose >/dev/null <<EOF
 include "%H/.local/share/omarchy/default/xcompose"


### PR DESCRIPTION
This PR configures `nvim` as an editor for `git`

Omarchy comes without `vi` editor installed which is used by git by default which results in the following error when editor is needed by git
```bash
 * branch                develop    -> FETCH_HEAD
hint: Waiting for your editor to close the file... error: cannot run vi: No such file or directory
error: unable to start editor 'vi'
Not committing merge; use 'git commit' to complete the merge.
```
