### PR TITLE
Add F11 keybind to toggle fullscreen for active window in hyprland

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -5,6 +5,7 @@ bind = SUPER, W, killactive,
 bind = SUPER, J, togglesplit, # dwindle
 bind = SUPER, P, pseudo, # dwindle
 bind = SUPER, V, togglefloating,
+bind = , F11, fullscreen, 0
 
 # Move focus with mainMod + arrow keys
 bind = SUPER, left, movefocus, l


### PR DESCRIPTION
This PR adds `F11` as a global hotkey to toggle fullscreen.

The manual's Hotkeys section already lists `F11` for fullscreen, but currently, only `Chromium` (default behavior) and `Alacritty` (via config) support it. This change ensures consistent fullscreen toggling across all applications.