### PR TITLE
wf-recorder instead of wl-screenrec (NVIDIA support for screen recording)

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -3,17 +3,17 @@
 screenrecording() {
   notify-send "Screen recording starting..." -t 1000
   sleep 1
-  wl-screenrec \
+  wf-recorder \
     -f "$HOME/Videos/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4" \
-    --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart" \
+    -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart \
     "$@"
 }
 
-if pgrep -x wl-screenrec >/dev/null; then
-  pkill -x wl-screenrec
+if pgrep -x wf-recorder >/dev/null; then
+  pkill -x wf-recorder
   notify-send "Screen recording saved to ~/Videos" -t 2000
 elif [[ "$1" == "output" ]]; then
-  screenrecording -o ""
+  screenrecording
 else
   region=$(slurp) || exit 1
   screenrecording -g "$region"


### PR DESCRIPTION
wl-screenrec does not support NVIDIA drivers as of now, so maybe we can use wf-recorder instead? It is actively maintained, has the same dependencies as far as I can see, has 1k GH stars.

https://github.com/ammen99/wf-recorder

As for the necessary changes: 
the ffmpeg options can be set using the -c (codec) and -p (parameter) flags
For full screen capture, no special flag is needed, therefore omitting the -o flag.