### PR TITLE
[envs.conf] - Provide toolkit backend fallbacks

### DIFF
--- a/default/hypr/envs.conf
+++ b/default/hypr/envs.conf
@@ -3,8 +3,8 @@ env = XCURSOR_SIZE,24
 env = HYPRCURSOR_SIZE,24
 
 # Force all apps to use Wayland
-env = GDK_BACKEND,wayland
-env = QT_QPA_PLATFORM,wayland
+env = GDK_BACKEND,wayland,x11,*
+env = QT_QPA_PLATFORM,wayland;xcb
 env = QT_STYLE_OVERRIDE,kvantum
 env = SDL_VIDEODRIVER,wayland
 env = MOZ_ENABLE_WAYLAND,1


### PR DESCRIPTION
Provides `GDK_BACKEND` and `QT_QPA_PLATFORM` as described in the [hyprland documentation](https://wiki.hypr.land/Configuring/Environment-variables/#toolkit-backend-variables). Without this certain applications may fail to start. 

```text
INFO         | Warning: Could not find the Qt platform plugin "wayland" in "/home/blaz/Android/Sdk/emulator/lib64/qt/plugins" (:0, )
INFO         | Fatal: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: linuxfb, offscreen, vnc, minimal, xcb.
```