### PR TITLE
Detect and apply keyboard layout configured during Arch installation

### DIFF
--- a/install/detect-keyboard-layout.sh
+++ b/install/detect-keyboard-layout.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+conf="/etc/vconsole.conf"
+hyprconf="$HOME/.config/hypr/hyprland.conf"
+
+layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
+variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
+
+if [[ -n "$layout" ]]; then
+  sed -i "/^[[:space:]]*kb_options *=/i\    kb_layout = $layout" "$hyprconf"
+fi
+
+if [[ -n "$variant" ]]; then
+  sed -i "/^[[:space:]]*kb_options *=/i\    kb_variant = $variant" "$hyprconf"
+fi

--- a/install/detect-keyboard-layout.sh
+++ b/install/detect-keyboard-layout.sh
@@ -7,9 +7,9 @@ layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
 variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
 
 if [[ -n "$layout" ]]; then
-  sed -i "/^[[:space:]]*kb_options *=/i\    kb_layout = $layout" "$hyprconf"
+  sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $layout" "$hyprconf"
 fi
 
 if [[ -n "$variant" ]]; then
-  sed -i "/^[[:space:]]*kb_options *=/i\    kb_variant = $variant" "$hyprconf"
+  sed -i "/^[[:space:]]*kb_options *=/i\  kb_variant = $variant" "$hyprconf"
 fi


### PR DESCRIPTION
This PR addresses #272

Reads the keyboard layout and variant from /etc/vconsole.conf (set by archinstall) and updates ~/.config/hypr/hyprland.conf with the correct values.

Tested with us, us-acentos, and br-abnt2.