### PR TITLE
Update media bindings to only display OSD on the focused display

### DIFF
--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -1,13 +1,16 @@
+# Only display the OSD on the currently focused monitor
+$osdclient = swayosd-client --monitor "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')"
+
 # Laptop multimedia keys for volume and LCD brightness (with OSD)
-bindel = ,XF86AudioRaiseVolume, exec, swayosd-client --output-volume raise
-bindel = ,XF86AudioLowerVolume, exec, swayosd-client --output-volume lower
-bindel = ,XF86AudioMute, exec, swayosd-client --output-volume mute-toggle
-bindel = ,XF86AudioMicMute, exec, swayosd-client --input-volume mute-toggle
-bindel = ,XF86MonBrightnessUp, exec, swayosd-client --brightness raise
-bindel = ,XF86MonBrightnessDown, exec, swayosd-client --brightness lower
+bindel = ,XF86AudioRaiseVolume, exec, $osdclient --output-volume raise
+bindel = ,XF86AudioLowerVolume, exec, $osdclient --output-volume lower
+bindel = ,XF86AudioMute, exec, $osdclient --output-volume mute-toggle
+bindel = ,XF86AudioMicMute, exec, $osdclient --input-volume mute-toggle
+bindel = ,XF86MonBrightnessUp, exec, $osdclient --brightness raise
+bindel = ,XF86MonBrightnessDown, exec, $osdclient --brightness lower
 
 # Requires playerctl
-bindl = , XF86AudioNext, exec, playerctl next
-bindl = , XF86AudioPause, exec, playerctl play-pause
-bindl = , XF86AudioPlay, exec, playerctl play-pause
-bindl = , XF86AudioPrev, exec, playerctl previous
+bindl = , XF86AudioNext, exec, $osdclient --playerctl next
+bindl = , XF86AudioPause, exec, $osdclient --playerctl play-pause
+bindl = , XF86AudioPlay, exec, $osdclient --playerctl play-pause
+bindl = , XF86AudioPrev, exec, $osdclient --playerctl previous


### PR DESCRIPTION
- Update the media bindings to only display on the currently focused monitor.
- sway-osd can also do playerctl