### PR TITLE
force package database refresh after adding multilib repo

### DIFF
--- a/install/nvidia.sh
+++ b/install/nvidia.sh
@@ -35,6 +35,9 @@ if [ -n "$(lspci | grep -i 'nvidia')" ]; then
     sudo sed -i '/^#\[multilib\]/,/^#Include/ s/^#//' /etc/pacman.conf
   fi
 
+  # force package database refresh
+  sudo pacman -Syy
+
   # Install packages
   PACKAGES_TO_INSTALL=(
     "${KERNEL_HEADERS}"


### PR DESCRIPTION
This will prevent errors trying to install nvidia packages due to a stale local package database.