### PR TITLE
Add MariaDB to Docker databases

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -119,12 +119,13 @@ setup_menu() {
 }
 
 setup_docker_dbs() {
-  options=("MySQL" "Redis" "PostgreSQL")
+  options=("MariaDB" "MySQL" "Redis" "PostgreSQL")
   choices=$(printf "%s\n" "${options[@]}" | gum choose --no-limit --header "Select databases (space to select, return to install, esc to cancel)") || main_menu
 
   if [[ -n "$choices" ]]; then
     for db in $choices; do
       case $db in
+      MariaDB) sudo docker run -d --restart unless-stopped -p "127.0.0.1:3306:3306" --name=mariadb11 -e MARIADB_ROOT_PASSWORD= -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=true mariadb:11.8 ;;
       MySQL) sudo docker run -d --restart unless-stopped -p "127.0.0.1:3306:3306" --name=mysql8 -e MYSQL_ROOT_PASSWORD= -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.4 ;;
       Redis) sudo docker run -d --restart unless-stopped -p "127.0.0.1:6379:6379" --name=redis redis:7 ;;
       PostgreSQL) sudo docker run -d --restart unless-stopped -p "127.0.0.1:5432:5432" --name=postgres16 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:16 ;;


### PR DESCRIPTION
Add MariaDB as an option for the Docker databases.