### PR TITLE
Set minimum window size for satty when making screenshot

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -7,6 +7,7 @@ windowrule = tile, class:^(Chromium)$
 # Float and center settings and previews
 windowrule = float, class:^(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|Omarchy)$
 windowrule = size 800 600, class:^(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer)$
+windowrule = minsize 800 600, class:^(com.gabm.satty)$
 windowrule = size 645 450, class:Omarchy
 windowrule = center, class:^(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|Omarchy)$
 


### PR DESCRIPTION
This PR provides a minimum window size rule for the Satty screenshot editor to prevent UI elements from being hidden when editing small screenshots.
By setting minsize instead of size, the window will be automatically expanded if the size of screenshot is bigger than 800x600.

Before:
<img width="388" height="257" alt="screenshot-2025-07-23_13-15-31" src="https://github.com/user-attachments/assets/0b4e7224-e2f0-4fca-b40d-fc8912f3d36a" />

After:
<img width="892" height="690" alt="screenshot-2025-07-23_13-14-31" src="https://github.com/user-attachments/assets/e68c1e89-6687-402f-8258-4bd3356aa59a" />
