### PR TITLE
walker is transparent with the keybindings theme

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -57,8 +57,8 @@ grep -h '^[[:space:]]*bind' $USER_HYPRLAND_CONF $OMARCHY_BINDINGS_CONF |
         gsub(/>/, "\\&gt;", action);
         gsub(/"/, "\\&quot;", action);
         gsub(/'"'"'/, "\\&apos;", action);
-        
+
         printf "%-35s → %s\n", key_combo, action;
     }
 }' |
-  walker --dmenu --theme keybindings -p 'Keybindings'
+  walker --dmenu -p 'Keybindings'


### PR DESCRIPTION
If I do super+k to see the keybindings, it has high transparency and the window is unreadable. Removing this theme option fixes it.