### PR TITLE
Increase pamlimit lockout

### DIFF
--- a/install/4-config.sh
+++ b/install/4-config.sh
@@ -3,6 +3,9 @@
 # Copy over Omarchy configs
 cp -R ~/.local/share/omarchy/config/* ~/.config/
 
+# Use default bashrc from Omarchy
+echo "source ~/.local/share/omarchy/default/bash/rc" >~/.bashrc
+
 # Ensure application directory exists for update-desktop-database
 mkdir -p ~/.local/share/applications
 
@@ -13,8 +16,9 @@ sudo chmod 644 /etc/gnupg/dirmngr.conf
 sudo gpgconf --kill dirmngr || true
 sudo gpgconf --launch dirmngr || true
 
-# Use default bashrc from Omarchy
-echo "source ~/.local/share/omarchy/default/bash/rc" >~/.bashrc
+# Increase lockout limit to 10 and decrease timeout to 2 minutes
+sudo sed -i 's|^\(auth\s\+required\s\+pam_faillock.so\)\s\+preauth.*$|\1 preauth silent deny=10 unlock_time=120|' "/etc/pam.d/system-auth"
+sudo sed -i 's|^\(auth\s\+\[default=die\]\s\+pam_faillock.so\)\s\+authfail.*$|\1 authfail deny=10 unlock_time=120|' "/etc/pam.d/system-auth"
 
 # Set common git aliases
 git config --global alias.co checkout

--- a/migrations/1753286633.sh
+++ b/migrations/1753286633.sh
@@ -1,0 +1,6 @@
+echo "Increase lockout limit to 10, decrease timeout to 2 minutes"
+
+if ! grep -q 'deny=10' /etc/pam.d/system-auth; then
+  sudo sed -i 's|^\(auth\s\+required\s\+pam_faillock.so\)\s\+preauth.*$|\1 preauth silent deny=10 unlock_time=120|' "/etc/pam.d/system-auth"
+  sudo sed -i 's|^\(auth\s\+\[default=die\]\s\+pam_faillock.so\)\s\+authfail.*$|\1 authfail deny=10 unlock_time=120|' "/etc/pam.d/system-auth"
+fi


### PR DESCRIPTION
The default is 3 attempts and then a 10 minute lockout. That's too easy to trip, and it's not clear what to do when you do that. So let's be a bit more forgiving here. 10 attempts, then a 2 minute lockout.