### PR TITLE
System Time ~ Adds automatic time-zone support

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -95,12 +95,13 @@ remove_theme_prompt() {
 
 setup_menu() {
   show_ascii_art
-  local menu=("Dropbox" "Docker DBs" "Fingerprint sensor" "Fido2 device" "Back")
+  local menu=("Dropbox" "Docker DBs" "Fingerprint sensor" "Fido2 device" "Timezone" "Back")
   local commands=(
     "omarchy-setup-dropbox"
     "setup_docker_dbs"
     "omarchy-setup-fingerprint"
     "omarchy-setup-fido2"
+    "omarchy-setup-timezone"
     "main_menu"
   )
   local choice

--- a/bin/omarchy-setup-timezone
+++ b/bin/omarchy-setup-timezone
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Ensure tzupdate is installed
+if ! command -v tzupdate &>/dev/null; then
+  echo "Installing tzupdate..."
+  yay -S --noconfirm --needed tzupdate
+fi
+
+# Check if passwordless sudo is available for tzupdate and timedatectl
+can_sudo_tzupdate() {
+  sudo -n tzupdate --version &>/dev/null
+}
+can_sudo_timedatectl() {
+  sudo -n timedatectl show &>/dev/null
+}
+
+show_menu() {
+  local options=("Auto-detect timezone (tzupdate)" "Manually set timezone" "Show current timezone" "Help (VPN/offline)" "Back")
+  local choice
+  choice=$(printf "%s\n" "${options[@]}" | gum choose --header="Timezone Setup") || exit 0
+  case "$choice" in
+    "Auto-detect timezone (tzupdate)")
+      echo "Running tzupdate..."
+      if can_sudo_tzupdate; then
+        if sudo -n tzupdate; then
+          echo -e "\e[32mTimezone updated successfully!\e[0m"
+        else
+          echo -e "\e[31mFailed to update timezone.\e[0m"
+        fi
+      else
+        echo -e "\e[31mPasswordless sudo is not available for tzupdate. Please run the Omarchy migration or contact your administrator.\e[0m"
+      fi
+      gum confirm "Back to timezone menu?" && show_menu
+      ;;
+    "Manually set timezone")
+      current=$(timedatectl | grep "Time zone" | awk '{print $3}')
+      tz=$(gum input --placeholder="e.g. Europe/London" --value="$current" --header="Enter your desired timezone (see 'timedatectl list-timezones'):")
+      if [[ -n "$tz" ]]; then
+        if timedatectl list-timezones | grep -qx "$tz"; then
+          if can_sudo_timedatectl; then
+            if sudo -n timedatectl set-timezone "$tz"; then
+              echo -e "\e[32mTimezone set to $tz\e[0m"
+            else
+              echo -e "\e[31mFailed to set timezone.\e[0m"
+            fi
+          else
+            echo -e "\e[31mPasswordless sudo is not available for timedatectl. Please run the Omarchy migration or contact your administrator.\e[0m"
+          fi
+        else
+          echo -e "\e[31mInvalid timezone: $tz\e[0m"
+        fi
+      fi
+      gum confirm "Back to timezone menu?" && show_menu
+      ;;
+    "Show current timezone")
+      timedatectl | grep "Time zone"
+      gum confirm "Back to timezone menu?" && show_menu
+      ;;
+    "Help (VPN/offline)")
+      echo -e "\nIf you are on a VPN or have no network access, auto-detect may fail.\nYou can manually set your timezone using the option above.\nTo see all valid timezones, run: timedatectl list-timezones\n"
+      gum confirm "Back to timezone menu?" && show_menu
+      ;;
+    "Back")
+      clear
+      exit 0
+      ;;
+  esac
+}
+
+show_menu 

--- a/bin/omarchy-setup-timezone
+++ b/bin/omarchy-setup-timezone
@@ -10,6 +10,7 @@ fi
 can_sudo_tzupdate() {
   sudo -n tzupdate --version &>/dev/null
 }
+
 can_sudo_timedatectl() {
   sudo -n timedatectl show &>/dev/null
 }
@@ -19,52 +20,49 @@ show_menu() {
   local choice
   choice=$(printf "%s\n" "${options[@]}" | gum choose --header="Timezone Setup") || exit 0
   case "$choice" in
-    "Auto-detect timezone (tzupdate)")
-      echo "Running tzupdate..."
-      if can_sudo_tzupdate; then
-        if sudo -n tzupdate; then
-          echo -e "\e[32mTimezone updated successfully!\e[0m"
-        else
-          echo -e "\e[31mFailed to update timezone.\e[0m"
-        fi
+  "Auto-detect timezone (tzupdate)")
+    echo "Running tzupdate..."
+    if can_sudo_tzupdate; then
+      if sudo -n tzupdate; then
+        echo -e "\e[32mTimezone updated successfully!\e[0m"
       else
-        echo -e "\e[31mPasswordless sudo is not available for tzupdate. Please run the Omarchy migration or contact your administrator.\e[0m"
+        echo -e "\e[31mFailed to update timezone.\e[0m"
       fi
-      gum confirm "Back to timezone menu?" && show_menu
-      ;;
-    "Manually set timezone")
-      current=$(timedatectl | grep "Time zone" | awk '{print $3}')
-      tz=$(gum input --placeholder="e.g. Europe/London" --value="$current" --header="Enter your desired timezone (see 'timedatectl list-timezones'):")
-      if [[ -n "$tz" ]]; then
-        if timedatectl list-timezones | grep -qx "$tz"; then
-          if can_sudo_timedatectl; then
-            if sudo -n timedatectl set-timezone "$tz"; then
-              echo -e "\e[32mTimezone set to $tz\e[0m"
-            else
-              echo -e "\e[31mFailed to set timezone.\e[0m"
-            fi
+    else
+      echo -e "\e[31mPasswordless sudo is not available for tzupdate. Please run the Omarchy migration or contact your administrator.\e[0m"
+    fi
+    gum confirm "Back to timezone menu?" && show_menu
+    ;;
+  "Manually set timezone")
+    current=$(timedatectl | grep "Time zone" | awk '{print $3}')
+    tz=$(gum input --placeholder="e.g. Europe/London" --value="$current" --header="Enter your desired timezone (see 'timedatectl list-timezones'):")
+    if [[ -n "$tz" ]]; then
+      if timedatectl list-timezones | grep -qx "$tz"; then
+        if can_sudo_timedatectl; then
+          if sudo -n timedatectl set-timezone "$tz"; then
+            echo -e "\e[32mTimezone set to $tz\e[0m"
           else
-            echo -e "\e[31mPasswordless sudo is not available for timedatectl. Please run the Omarchy migration or contact your administrator.\e[0m"
+            echo -e "\e[31mFailed to set timezone.\e[0m"
           fi
         else
-          echo -e "\e[31mInvalid timezone: $tz\e[0m"
+          echo -e "\e[31mPasswordless sudo is not available for timedatectl. Please run the Omarchy migration or contact your administrator.\e[0m"
         fi
+      else
+        echo -e "\e[31mInvalid timezone: $tz\e[0m"
       fi
-      gum confirm "Back to timezone menu?" && show_menu
-      ;;
-    "Show current timezone")
-      timedatectl | grep "Time zone"
-      gum confirm "Back to timezone menu?" && show_menu
-      ;;
-    "Help (VPN/offline)")
-      echo -e "\nIf you are on a VPN or have no network access, auto-detect may fail.\nYou can manually set your timezone using the option above.\nTo see all valid timezones, run: timedatectl list-timezones\n"
-      gum confirm "Back to timezone menu?" && show_menu
-      ;;
-    "Back")
-      clear
-      exit 0
-      ;;
+    fi
+    gum confirm "Back to timezone menu?" && show_menu
+    ;;
+  "Show current timezone")
+    timedatectl | grep "Time zone"
+    gum confirm "Back to timezone menu?" && show_menu
+    ;;
+  "Back")
+    clear
+    exit 0
+    ;;
   esac
 }
 
-show_menu 
+show_menu
+

--- a/bin/omarchy-timezone-monitor
+++ b/bin/omarchy-timezone-monitor
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script is for post-install or manual hooks, not for login automation.
+case "$1" in
+post)
+  /usr/bin/tzupdate
+  ;;
+esac

--- a/bin/omarchy-timezone-monitor
+++ b/bin/omarchy-timezone-monitor
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# This script is for post-install or manual hooks, not for login automation.
-case "$1" in
-post)
-  /usr/bin/tzupdate
-  ;;
-esac

--- a/install/system-time.sh
+++ b/install/system-time.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Install tzupdate if not present
+yay -S --noconfirm --needed tzupdate
+
+# Ensure the current user is in the wheel group
+if ! groups $USER | grep -qw wheel; then
+  echo "Adding $USER to wheel group (admin privileges required)..."
+  sudo usermod -aG wheel $USER
+  echo -e "\e[32m$USER added to wheel group. You may need to log out and back in for this to take effect.\e[0m"
+fi
+
+# Create sudoers file for tzupdate and timedatectl set-timezone
+SUDOERS_FILE="/etc/sudoers.d/omarchy-tzupdate"
+SUDOERS_CONTENT="%wheel ALL=(root) NOPASSWD: /usr/bin/tzupdate, /usr/bin/timedatectl set-timezone *"
+
+echo "$SUDOERS_CONTENT" | sudo tee "$SUDOERS_FILE" >/dev/null
+sudo chmod 0440 "$SUDOERS_FILE"
+
+echo -e "\e[32mPasswordless sudo for timezone updates is now enabled for all wheel users.\e[0m"
+
+# Create systemd user service for tzupdate
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/omarchy-tzupdate.service <<EOF
+[Unit]
+Description=Update timezone using tzupdate at login
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$(command -v tzupdate)
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Enable the service for the user
+systemctl --user daemon-reload
+systemctl --user enable omarchy-tzupdate.service
+
+echo -e "\e[32mTimezone auto-sync is now enabled for this user.\e[0m" 

--- a/install/system-time.sh
+++ b/install/system-time.sh
@@ -21,7 +21,7 @@ echo -e "\e[32mPasswordless sudo for timezone updates is now enabled for all whe
 
 # Create systemd user service for tzupdate
 mkdir -p ~/.config/systemd/user
-cat > ~/.config/systemd/user/omarchy-tzupdate.service <<EOF
+cat >~/.config/systemd/user/omarchy-tzupdate.service <<EOF
 [Unit]
 Description=Update timezone using tzupdate at login
 After=network-online.target
@@ -38,4 +38,5 @@ EOF
 systemctl --user daemon-reload
 systemctl --user enable omarchy-tzupdate.service
 
-echo -e "\e[32mTimezone auto-sync is now enabled for this user.\e[0m" 
+echo -e "\e[32mTimezone auto-sync is now enabled for this user.\e[0m"
+

--- a/migrations/1753290000.sh
+++ b/migrations/1753290000.sh
@@ -1,0 +1,38 @@
+echo "Install tzupdate, enable automatic timezone sync at login, and configure passwordless sudo for timezone updates (tzupdate, timedatectl set-timezone) for all wheel users."
+
+# Install tzupdate if not present
+yay -S --noconfirm --needed tzupdate
+
+# Ensure the current user is in the wheel group
+if ! groups $USER | grep -qw wheel; then
+  echo "Adding $USER to wheel group (admin privileges required)..."
+  sudo usermod -aG wheel $USER
+  echo -e "\e[32m$USER added to wheel group. You may need to log out and back in for this to take effect.\e[0m"
+fi
+
+# Create sudoers file for tzupdate and timedatectl set-timezone
+SUDOERS_FILE="/etc/sudoers.d/omarchy-tzupdate"
+SUDOERS_CONTENT="%wheel ALL=(root) NOPASSWD: /usr/bin/tzupdate, /usr/bin/timedatectl set-timezone *"
+
+echo "$SUDOERS_CONTENT" | sudo tee "$SUDOERS_FILE" >/dev/null
+sudo chmod 0440 "$SUDOERS_FILE"
+
+echo -e "\e[32mPasswordless sudo for timezone updates is now enabled for all wheel users.\e[0m"
+
+# Create systemd user service for tzupdate
+cat > ~/.config/systemd/user/omarchy-tzupdate.service <<EOF
+[Unit]
+Description=Update timezone using tzupdate at login
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$(command -v tzupdate)
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Enable the service for the user
+systemctl --user daemon-reload
+systemctl --user enable omarchy-tzupdate.service 


### PR DESCRIPTION
## Description
This PR solves: https://github.com/basecamp/omarchy/issues/283

This adds tzupdate, a library that uses multiple sources for time-lookups and syncronization.  Your system will now have the correct time zone upon booting up and accessing the network.  Furthermore you may now access the System Time from the Omarchy  TUI.

## Manual Usage

Run `omarchy` in the terminal:


<img width="774" height="404" alt="screenshot-2025-07-23_20-41-35" src="https://github.com/user-attachments/assets/ed878112-e038-4d14-b5f9-10e83058f8f9" />
<img width="755" height="395" alt="screenshot-2025-07-23_20-41-50" src="https://github.com/user-attachments/assets/a898b390-b936-4e8f-ae1d-2d3c8df3f682" />
<img width="762" height="378" alt="screenshot-2025-07-23_20-42-05" src="https://github.com/user-attachments/assets/c108f33a-2f26-4ade-93fa-1d42ec948826" />

## Testing
- Please fully reboot your machine after pulling in these changes to your machine and ensure on boot up your system does not hang.
- Disconnect the internet and reboot, ensure your system does not hang.
- Change the timezone to either `America/Los_Angeles` if  East of California, change timezone to `America/Chicago` if West of Chicago and either wait a minute or click on the time in waybar, it should show the new timezone.
- Reboot after manually changing time, you should now be in your timezone again?