### PR TITLE
Replace Blueberry with bluetui

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -92,7 +92,7 @@
     "format-disabled": "󰂲",
     "format-connected": "",
     "tooltip-format": "Devices connected: {num_connections}",
-    "on-click": "blueberry"
+    "on-click": "alacritty --class=Bluetui -e bluetui"
   },
   "pulseaudio": {
     "format": "{icon}",

--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -5,10 +5,10 @@ windowrule = suppressevent maximize, class:.*
 windowrule = tile, class:^(Chromium)$
 
 # Float and center settings and previews
-windowrule = float, class:^(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|Omarchy)$
-windowrule = size 800 600, class:^(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty)$
+windowrule = float, class:^(blueberry.py|Impala|Wiremix|Bluetui|org.gnome.NautilusPreviewer|Omarchy)$
+windowrule = size 800 600, class:^(blueberry.py|Impala|Wiremix|Bluetui|org.gnome.NautilusPreviewer|com.gabm.satty)$
 windowrule = size 645 450, class:Omarchy
-windowrule = center, class:^(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|Omarchy)$
+windowrule = center, class:^(blueberry.py|Impala|Wiremix|Bluetui|org.gnome.NautilusPreviewer|Omarchy)$
 
 # Float and center file pickers
 windowrule = float, class:xdg-desktop-portal-gtk, title:^(Open.*Files?|Save.*Files?|All Files|Save)

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 yay -S --noconfirm --needed \
-  brightnessctl playerctl pamixer wiremix wireplumber \
+  brightnessctl playerctl pamixer wiremix wireplumber bluetui \
   fcitx5 fcitx5-gtk fcitx5-qt wl-clip-persist \
   nautilus sushi ffmpegthumbnailer \
   slurp satty \


### PR DESCRIPTION
This is a proposal to replace Blueberry with [bluetui](https://github.com/pythops/bluetui).

The motivation is similar to #225. This will make controlling bluetooth using a TUI app. No need to add additional configs since the defaults are already working great.

Preview: 
<img width="1918" height="1080" alt="image" src="https://github.com/user-attachments/assets/e9ce7849-f0de-4686-9c97-2758009e67dd" />
