### PR TITLE
allow override of screenshot/screenrecord output

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -2,8 +2,10 @@
 
 # Set recorder based on GPU
 
+OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-$HOME/Videos}"
+
 screenrecording() {
-  filename="$HOME/Videos/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
+  filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
   notify-send "Screen recording starting..." -t 1000
   sleep 1
 

--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-$HOME/Pictures}"
+
 hyprshot -m ${1:-region} --raw |
   satty --filename - \
-    --output-filename ~/Pictures/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png \
+    --output-filename "$OUTPUT_DIR/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png" \
     --early-exit \
     --actions-on-enter save-to-clipboard \
     --save-after-copy \


### PR DESCRIPTION
Update to the `omarchy-cmd-screenrecord` and `omarchy-cmd-screenshot` commands to allow a user to set the output directory of both while maintaining the default.