### PR TITLE
Enable audio settings to use default terminal emulator

### DIFF
--- a/applications/wiremix.desktop
+++ b/applications/wiremix.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Audio Settings
 Comment=Using Wiremix
-Exec=alacritty --class=Wiremix --title=Wiremix -e wiremix
+Exec=wiremix
 Icon=audio-card
 Type=Application
-Terminal=false
+Terminal=true


### PR DESCRIPTION
Currently, we're defaulting the audio settings to open using Alacritty. However, if the someone has chosen to go ahead and pivot to a different terminal emulator (i.e. ghostty), then this is the experience upon opening the audio settings from walker. 

<img width="1033" height="631" alt="image" src="https://github.com/user-attachments/assets/be3b7fdb-9d65-43d5-90d0-404d55fff8de" />

<img width="717" height="202" alt="image" src="https://github.com/user-attachments/assets/66f794ce-b348-4b5d-a917-5169072a69a8" />

This change does remove the use of the `--class` and `--title` options, but removing those seems inconsequential. My experience was the same with both of  these configurations:
```
Exec=ghostty --class=Wiremix --title=Wiremix -e wiremix
Terminal=false
```
```
Exec=wiremix
Terminal=true
```

Obviously those options serve a purpose for setting the window class and title, but I don't see the immediate need here.

Certainly open for discussion. Just looking to help out those that have pivoted from Alacritty already so that they can access their audio settings without issue. 