### PR TITLE
Add uwsm as package

### DIFF
--- a/install/hyprlandia.sh
+++ b/install/hyprlandia.sh
@@ -3,4 +3,4 @@
 yay -S --noconfirm --needed \
   hyprland hyprshot hyprpicker hyprlock hypridle polkit-gnome hyprland-qtutils \
   walker-bin libqalculate waybar mako swaybg swayosd \
-  xdg-desktop-portal-hyprland xdg-desktop-portal-gtk
+  xdg-desktop-portal-hyprland xdg-desktop-portal-gtk uwsm


### PR DESCRIPTION
uwsm was missing after last omarchy-upgrade waybar and other parts in autostart was not starting because uwsm is not installed by default