### PR TITLE
Fix fzf completion path for Arch Linux

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -7,8 +7,8 @@ if command -v zoxide &> /dev/null; then
 fi
 
 if command -v fzf &> /dev/null; then
-  if [[ -f /usr/share/bash-completion/completions/fzf ]]; then
-    source /usr/share/bash-completion/completions/fzf
+  if [[ -f /usr/share/fzf/completion.bash ]]; then
+    source /usr/share/fzf/completion.bash
   fi
   if [[ -f /usr/share/fzf/key-bindings.bash ]]; then
     source /usr/share/fzf/key-bindings.bash


### PR DESCRIPTION
## Summary
- Update fzf completion source path from `/usr/share/bash-completion/completions/fzf` to `/usr/share/fzf/completion.bash`

## Test plan
- [x] Verify `/usr/share/fzf/completion.bash` exists on Arch Linux