### PR TITLE
Fix fzf fuzzy completion

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -7,8 +7,8 @@ if command -v zoxide &> /dev/null; then
 fi
 
 if command -v fzf &> /dev/null; then
-  if [[ -f /usr/share/bash-completion/completions/fzf ]]; then
-    source /usr/share/bash-completion/completions/fzf
+  if [[ -f /usr/share/fzf/completion.bash ]]; then
+    source /usr/share/fzf/completion.bash
   fi
   if [[ -f /usr/share/fzf/key-bindings.bash ]]; then
     source /usr/share/fzf/key-bindings.bash


### PR DESCRIPTION
## Problem

Fzf [fuzzy completion](https://github.com/junegunn/fzf?tab=readme-ov-file#fuzzy-completion-for-bash-and-zsh) doesn't work in fresh Arch + Omarchy install.

### Steps to reproduce

Enter `cd **<TAB>` in terminal (or any other example from the [fzf documentation](https://github.com/junegunn/fzf?tab=readme-ov-file#fuzzy-completion-for-bash-and-zsh)). This should trigger fuzzy find, but it doesn't.

Key bindings, such as `Ctrl + t`, seem to work as expected.

### Cause and fix

In order for the fuzzy completions to work, one should source the `completion.bash` script from `.bashrc`. On Arch the script can be found from `/usr/share/fzf/` directory, which also contains the `key-bindings.bash` script for configuring fzf keybindings. This is documented on the fzf page [in Arch Wiki](https://wiki.archlinux.org/title/Fzf).

Omarchy init script in `~/.local/share/omarchy/default/bash/init` sources `/usr/share/bash-completion/completions/fzf` which does not exist. Replacing that with `/usr/share/fzf/completion.bash` seems to fix the issue. 