### PR TITLE
Auto-load themes for neovim

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -42,6 +42,7 @@ pkill swayosd-server
 setsid uwsm app -- swayosd-server &>/dev/null &
 makoctl reload
 hyprctl reload
+pkill -SIGUSR1 nvim 2>/dev/null || true
 
 # Set new background
 "$HOME/.local/share/omarchy/bin/omarchy-theme-bg-next"

--- a/install/development/nvim.sh
+++ b/install/development/nvim.sh
@@ -5,7 +5,7 @@ if ! command -v nvim &>/dev/null; then
 
   # Install LazyVim
   rm -rf ~/.config/nvim
-  git clone https://github.com/LazyVim/starter ~/.config/nvim
+  git clone https://github.com/tahayvr/omarchy-lazyvim-starter.git ~/.config/nvim
   cp -R ~/.local/share/omarchy/config/nvim/* ~/.config/nvim/
   rm -rf ~/.config/nvim/.git
   echo "vim.opt.relativenumber = false" >>~/.config/nvim/lua/config/options.lua

--- a/install/development/nvim.sh
+++ b/install/development/nvim.sh
@@ -5,7 +5,7 @@ if ! command -v nvim &>/dev/null; then
 
   # Install LazyVim
   rm -rf ~/.config/nvim
-  git clone https://github.com/tahayvr/omarchy-lazyvim-starter.git ~/.config/nvim
+  git clone https://github.com/tahayvr/omarchy-lazyvim-starter ~/.config/nvim
   cp -R ~/.local/share/omarchy/config/nvim/* ~/.config/nvim/
   rm -rf ~/.config/nvim/.git
   echo "vim.opt.relativenumber = false" >>~/.config/nvim/lua/config/options.lua

--- a/themes/catppuccin/neovim.lua
+++ b/themes/catppuccin/neovim.lua
@@ -1,8 +1,20 @@
 return {
 	{
+		"catppuccin/nvim",
+		name = "catppuccin",
+		lazy = false,
+		priority = 1000,
+		config = function()
+			require("catppuccin").setup({
+				flavour = "mocha", -- other options: "mocha", "frappe", "macchiato"
+			})
+			vim.cmd.colorscheme("catppuccin-mocha")
+		end,
+	},
+	{
 		"LazyVim/LazyVim",
 		opts = {
-			colorscheme = "catppuccin",
+			colorscheme = "catppuccin-mocha",
 		},
 	},
 }


### PR DESCRIPTION
This PR adds an automatic reload feature for NeoVim themes when you change your Omarchy theme.

https://github.com/user-attachments/assets/bc552ab4-6733-4687-90d2-2127504fbae1

- It uses a new LazyVim starter repo that includes the required config for this solution to work. 

[Omarchy lazyvim starter repo](https://github.com/tahayvr/omarchy-lazyvim-starter)
(feel free to fork this repo into your own github and switch the git clone command in install/development/nvim.sh)

-  I also needed to add a specific flavour for the regular Catppuccin theme (mocha) for this to work as intended.
-  Finally, I added a line in the omarchy-theme-set that triggers the load of the new theme in NeoVim.

## How does the automatic reload feature work?:

In order to enable the automatic reload feature, each theme in Omarchy must have a neovim.lua file that defines the themes like this:

```lua
-- .config/omarchy/themes/gruvbox/neovim.lua
return {
    { "morhetz/gruvbox", lazy = false },
    {
        "LazyVim/LazyVim",
        opts = {
            colorscheme = "gruvbox",
        },
    },
}
```

Additionally, we must make sure that LazyVim is configured to load every theme on startup. This is done by setting the `spec` and `install` options in the LazyVim configuration.

```lua
-- .config/nvim/lua/config/lazy.lua
spec = {
        -- add LazyVim and import its plugins
        { "LazyVim/LazyVim",           import = "lazyvim.plugins" },
        -- import/override with your plugins
        { import = "plugins" },
        -- import themes on load
        { "ellisonleao/gruvbox.nvim", lazy =false },
        { "catppuccin/nvim",           name = "catppuccin", lazy = false },
        { "folke/tokyonight.nvim", lazy = false },
        { "neanias/everforest-nvim", lazy = false },
        { "rebelot/kanagawa.nvim", lazy = false },
        { "tahayvr/matteblack.nvim", lazy = false },
        { "EdenEast/nightfox.nvim", lazy = false },
        { "rose-pine/neovim",          name = "rose-pine", lazy = false },
    },
install = { colorscheme = { "catppuccin-latte", "catppuccin-mocha", "tokyonight", "habamax", "gruvbox", "everforest", "kanagawa", "nordfox", "matteblack", "rose-pine-dawn" },
```

Then, we need a function to reload the theme based on Omarchy's current theme symlink target. This function will check if the theme has changed and apply the new theme without restarting Neovim.

```lua
-- .config/nvim/lua/init.lua

-- Variable to store the last known theme symlink target
local last_theme_target = nil

-- Function to reload the theme based on Omarchy's current theme
function ReloadTheme()
    local theme_dir = vim.fn.resolve(vim.fn.expand('~/.config/omarchy/current/theme'))
    local theme_config = theme_dir .. '/neovim.lua'

    -- Check if the theme directory has changed
    if theme_dir == last_theme_target then
        return -- No change, skip reload
    end

    if vim.fn.filereadable(theme_config) == 1 then
        local ok, result = pcall(dofile, theme_config)
        if not ok then
            print("Error loading theme: " .. result)
            return
        end
        -- Check if result is a table
        if type(result) == "table" then
            -- Look for LazyVim opts with colorscheme
            for _, entry in ipairs(result) do
                if entry[1] == "LazyVim/LazyVim" and entry.opts and entry.opts.colorscheme then
                    local ok, err = pcall(vim.cmd, 'colorscheme ' .. entry.opts.colorscheme)
                    if not ok then
                        print("Error applying colorscheme: " .. err)
                        return
                    end
                    vim.cmd('redraw!')
                    last_theme_target = theme_dir -- Update last known target
                    return
                end
            end
            print("No valid colorscheme found in " .. theme_config)
        else
            print("Invalid theme config format in " .. theme_config)
        end
    else
        print("Theme config not found: " .. theme_config)
    end
end

-- Load the theme on startup
ReloadTheme()
```

How does Neovim know when to reload the theme?:
We can use a signal handler that listens for the `SIGUSR1` signal. When this signal is received, it will trigger the `ReloadTheme` function.

```lua
-- .config/nvim/lua/init.lua

-- Reload theme on SIGUSR1 signal
vim.api.nvim_create_autocmd('User', {
    pattern = 'OmarchyThemeReload',
    callback = function()
        ReloadTheme()
    end,
})

-- Set up SIGUSR1 handler using vim.loop
local uv = vim.loop
local signal = uv.new_signal()
uv.signal_start(signal, "sigusr1", function()
    vim.schedule(function()
        vim.cmd('doautocmd User OmarchyThemeReload')
    end)
end)
```

and finally, we need to send the `SIGUSR1` signal to Neovim when the theme is changed. This can be done using a shell command or a script that changes the theme symlink and sends the signal to Neovim.

````bash
# omarchy-theme-set.sh

# Send SIGUSR1 signal to Neovim
pkill -SIGUSR1 nvim 2>/dev/null || true
```
````