### PR TITLE
Improvements to Bare Install

### DIFF
--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -10,7 +10,8 @@ mkdir -p ~/.local/share/applications
 cp ~/.local/share/omarchy/applications/*.desktop ~/.local/share/applications/
 cp ~/.local/share/omarchy/applications/hidden/*.desktop ~/.local/share/applications/
 
-if [ -z "$OMARCHY_BARE" ]; then
+# Only copy xtras if user is not in bare mode
+if [[ ! -f ~/.local/state/omarchy/bare.mode ]] && [ -z "$OMARCHY_BARE" ]; then
   cp ~/.local/share/omarchy/applications/xtras/*.desktop ~/.local/share/applications/
 fi
 

--- a/install/config/config.sh
+++ b/install/config/config.sh
@@ -9,6 +9,12 @@ echo "source ~/.local/share/omarchy/default/bash/rc" >~/.bashrc
 # Ensure application directory exists for update-desktop-database
 mkdir -p ~/.local/share/applications
 
+# If bare install, allow a way for its exclusions to not get added in updates
+if [ -n "$OMARCHY_BARE" ]; then
+  mkdir -p ~/.local/state/omarchy
+  touch ~/.local/state/omarchy/bare.mode
+fi
+
 # Setup GPG configuration with multiple keyservers for better reliability
 sudo mkdir -p /etc/gnupg
 sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/

--- a/migrations/1752983008.sh
+++ b/migrations/1752983008.sh
@@ -1,3 +1,6 @@
+# do not run if user is using bare mode
+if [[ -f ~/.local/state/omarchy/bare.mode ]]; then exit; fi
+
 echo "Add missing installation of Zoom"
 
 if ! command -v zoom &>/dev/null; then


### PR DESCRIPTION
##  Description

This PR is intended to finalize the bare install of Omarchy. DHH doesn't want a ton of energy to be put into the bare version, as it already was a concession that kind of goes against the point of the project. However, he does want some things improved.

Once a bare install is run, there is no way for any migrations ran after updates to actually know that the user used the bare install. This results in situations where Zoom is installed on updates, just as one example, even though the user never wanted that in the first place.

In fact, there is just no way period to see if Omarchy was installed bare. This PR adds a `bare.mode` file to `~/.local/state/omarchy/` when installed in bare more to address that problem. 

## How to Check for Bare Mode

To run something in a shell script only if _not_ bare, wrap it in an if block with `if [[ ! -f ~/.local/state/omarchy/bare.mode ]]`. If you need the opposite _(run only if bare)_, do the same thing but without the `!`.

## Existing Bare Users

As of now, users that installed Omarchy in bare mode prior to these changes will need to run the following commands to add the `bare.mode` file to their system to ensure they don't get non-bare stuff added into their system on updates:   
```sh
mkdir -p ~/.local/state/omarchy/
touch ~/.local/state/omarchy/bare.mode
```

##  Issues Addressed
- #330 - Track when we're on a bare install
- #341 - Bare install desktop entry