### PR TITLE
Better handle chaotic aur installation

### DIFF
--- a/install/preflight/aur.sh
+++ b/install/preflight/aur.sh
@@ -1,27 +1,34 @@
 #!/bin/bash
 
+chaotic_ok=0
+
 # Only add Chaotic-AUR if the architecture is x86_64 so ARM users can build the packages
 if [[ "$(uname -m)" == "x86_64" ]]; then
-  # Import Chaotic-AUR key
-  sudo pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com
-  sudo pacman-key --lsign-key 3056513887B78AEB
+  # Try installing Chaotic-AUR keyring and mirrorlist
+  if sudo pacman-key --recv-key 3056513887B78AEB &&
+    sudo pacman-key --lsign-key 3056513887B78AEB &&
+    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' &&
+    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'; then
 
-  # Install Chaotic-AUR keyring and mirrorlist
-  sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst'
-  sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'
+    # Add Chaotic-AUR repo to pacman config
+    echo -e '\n[chaotic-aur]\nInclude = /etc/pacman.d/chaotic-mirrorlist' | sudo tee -a /etc/pacman.conf >/dev/null
 
-  # Add Chaotic-AUR repo to pacman config
-  echo -e '\n[chaotic-aur]\nInclude = /etc/pacman.d/chaotic-mirrorlist' | sudo tee -a /etc/pacman.conf >/dev/null
+    # Refresh pacman package databases
+    sudo pacman -Sy
 
-  # Refresh pacman package databases
-  sudo pacman -Sy
+    chaotic_ok=1
+  else
+    echo "Failed to install Chaotic-AUR, so won't include it in pacman config!"
+  fi
+fi
 
-  # Install yay
+if [[ $chaotic_ok -eq 1 ]]; then
   sudo pacman -S --needed --noconfirm yay
 else
-  sudo pacman -S --needed --noconfirm base-devel
-
+  # Manually install yay from AUR if not already available
   if ! command -v yay &>/dev/null; then
+    # Install build tools
+    sudo pacman -S --needed --noconfirm base-devel
     cd /tmp
     git clone https://aur.archlinux.org/yay-bin.git
     cd yay-bin
@@ -30,7 +37,6 @@ else
     rm -rf yay-bin
     cd ~
   fi
-
 fi
 
 # Add fun and color to the pacman installer

--- a/migrations/1753352057.sh
+++ b/migrations/1753352057.sh
@@ -1,21 +1,20 @@
 echo "Add Chaotic-AUR to get compiled binaries"
 
 if [[ "$(uname -m)" == "x86_64" ]] && ! grep -q '^\[chaotic-aur\]' /etc/pacman.conf; then
-  # Import Chaotic-AUR key
-  sudo pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com
-  sudo pacman-key --lsign-key 3056513887B78AEB
+  # Try installing Chaotic-AUR keyring and mirrorlist
+  if sudo pacman-key --recv-key 3056513887B78AEB &&
+    sudo pacman-key --lsign-key 3056513887B78AEB &&
+    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' &&
+    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'; then
 
-  # Install Chaotic-AUR keyring and mirrorlist
-  sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst'
-  sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'
-
-  if [[ -f /etc/pacman.d/chaotic-mirrorlist ]]; then
     # Add Chaotic-AUR repo to pacman config
     echo -e '\n[chaotic-aur]\nInclude = /etc/pacman.d/chaotic-mirrorlist' | sudo tee -a /etc/pacman.conf >/dev/null
-  else
-    echo "Failed to download chaotic-mirrorlist, so won't include it in pacman config!"
-  fi
 
-  # Refresh pacman package databases
-  sudo pacman -Sy
+    # Refresh pacman package databases
+    sudo pacman -Sy
+
+    chaotic_ok=1
+  else
+    echo "Failed to install Chaotic-AUR, so won't include it in pacman config!"
+  fi
 fi


### PR DESCRIPTION
Now, if the Chaotic-AUR keyring or mirrorlist fails to install, the script just skips it.