### PR TITLE
Add "=" as default walker prefix

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -139,6 +139,7 @@ name = "Calculator"
 icon = "accessories-calculator"
 placeholder = "Calculator"
 min_chars = 3                   # Min chars to calculate. 3 allows "3+3"
+prefix = "="
 
 [builtins.windows]
 weight = 5


### PR DESCRIPTION
Ensures the calculator module only engages when prefixed with `=` or accessed via the switcher menu.

Closes #345