### PR TITLE
Handle F11 fullscreen via script, deferring to app if needed

### DIFF
--- a/bin/omarchy-cmd-fullscreen
+++ b/bin/omarchy-cmd-fullscreen
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+focused_app=$(hyprctl activewindow -j | jq -r '.class')
+
+case "$focused_app" in "Typora")
+  wtype -k F11
+  ;;
+*)
+  hyprctl dispatch fullscreen
+  ;;
+esac

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -5,7 +5,7 @@ bind = SUPER, W, killactive,
 bind = SUPER, J, togglesplit, # dwindle
 bind = SUPER, P, pseudo, # dwindle
 bind = SUPER, V, togglefloating,
-bind = SHIFT, F11, fullscreen, 0
+bind = ,F11, exec, ~/.local/share/omarchy/bin/omarchy-cmd-fullscreen
 
 # Move focus with mainMod + arrow keys
 bind = SUPER, left, movefocus, l

--- a/install/desktop/hyprlandia.sh
+++ b/install/desktop/hyprlandia.sh
@@ -3,4 +3,4 @@
 yay -S --noconfirm --needed \
   hyprland hyprshot hyprpicker hyprlock hypridle polkit-gnome hyprland-qtutils \
   walker-bin libqalculate waybar mako swaybg swayosd \
-  xdg-desktop-portal-hyprland xdg-desktop-portal-gtk
+  xdg-desktop-portal-hyprland xdg-desktop-portal-gtk wtype

--- a/migrations/1753549342.sh
+++ b/migrations/1753549342.sh
@@ -1,0 +1,4 @@
+echo "Add wtype to enable key presses simulation"
+if ! command -v wtype &>/dev/null; then
+  yay -S --noconfirm --needed wtype
+fi


### PR DESCRIPTION
Now we can let apps handle going fullscreen if needed by using `wtype` to simulate keystrokes.

Right now only typora is being allowed but if more apps need permission then we just add to the case statement like this:
`case "$focused_app" in "Typora" | "AppClass")`

I'm also testing `wtype` together with another tool so we can replace fcitx5 for completions.

