### PR TITLE
Fixes to window rules for Jetbrains IDEs

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -28,3 +28,16 @@ windowrule = opacity 1 1, class:^(com.libretro.RetroArch|steam)$
 
 # Fix some dragging issues with XWayland
 windowrule = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0
+
+# Jetbrains
+# Fix tooltips (always have a title of `win.<id>`)
+# Fix for sidebar menus being unclickable
+windowrulev2 = noinitialfocus, class:^(.*jetbrains.*)$, title:^(win.*)$
+windowrulev2 = nofocus, class:^(.*jetbrains.*)$, title:^(win.*)$
+# Fix tab dragging (always have a single space character as their title)
+windowrulev2 = noinitialfocus, class:^(.*jetbrains.*)$, title:^\\s$
+windowrulev2 = nofocus, class:^(.*jetbrains.*)$, title:^\\s$
+# Additional fixes for tab dragging
+windowrulev2 = tag +jb, class:^jetbrains-.+$,floating:1
+windowrulev2 = stayfocused, tag:jb
+windowrulev2 = noinitialfocus, tag:jb


### PR DESCRIPTION
Jetbrains IDEs are unusable out of the box with Hyprland and Omarchy. 

Issues:
- Disappearing tool windows when you move your cursor
- Sidebar menus cannot be clicked reliably 
- Tabs cannot be dragged
- Tooltip rendering issues

ref: https://github.com/hyprwm/Hyprland/issues/4257

For us Jetbrains enjoyers, it would be really nice if these issues were fixed out of the box on Omarchy!

I've tested and confirmed the following window rules fix these issues. 

Thanks for the great project!
