### PR TITLE
Skip previously run migrations via a small SQLite DB

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -1,6 +1,30 @@
 #!/bin/bash
 
-cd ~/.local/share/omarchy
+OMARCHY_DIR="$HOME/.local/share/omarchy"
+MIGRATIONS_DB="$OMARCHY_DIR/migrations/migrations.sqlite3"
+
+# Create the migrations DB and table to store migrations and their statuses if necessary
+mkdir -p "$(dirname "$MIGRATIONS_DB")"
+sqlite3 "$MIGRATIONS_DB" << SQL
+  CREATE TABLE IF NOT EXISTS migrations(
+    version   TEXT PRIMARY KEY,
+    ran_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+    success   INTEGER NOT NULL
+  );
+SQL
+
+record_migration() {
+  local version="$1"
+  local status="$2"
+  sqlite3 "$MIGRATIONS_DB" "INSERT OR REPLACE INTO migrations(version, success) VALUES("$version", $status);"
+}
+
+# Gather all of the already-run migrations
+mapfile -t applied_versions < <(
+  sqlite3 "$MIGRATIONS_DB" "SELECT version FROM migrations WHERE success=1;"
+)
+
+cd "$OMARCHY_DIR"
 
 if [[ $1 == "all" ]]; then
   # Run all migrations since the root commit
@@ -19,8 +43,20 @@ for file in $(git diff --name-only --diff-filter=A $migration_starting_point.. m
   filename=$(basename "$file")
   migrate_at="${filename%.sh}"
 
+  if printf "%s\n" "${applied_versions[@]}" | grep -xq "$migrate_at"; then
+    echo "Skipping $migrate_at (already applied)"
+    continue
+  fi
+
   echo -e "\e[32m\nRunning migration ($migrate_at)\e[0m"
-  source $file
+  if source $file; then
+    record_migration $migrate_at 1
+    echo -e "\e[32m✔  Migration $migrate_at succeeded\e[0m"
+  else
+    record_migration $migrate_at 0
+    echo -e "\e[31m✖  Migration $migrate_at FAILED\e[0m"
+    exit 1
+  fi
 done
 
 # Update system packages

--- a/migrations/1752091783.sh
+++ b/migrations/1752091783.sh
@@ -1,2 +1,2 @@
 echo "Install Plymouth splash screen"
-source "$HOME/.local/share/omarchy/install/login.sh"
+source "$HOME/.local/share/omarchy/install/config/login.sh"


### PR DESCRIPTION
To avoid all migrations from needing to be wrapped in conditionals, this uses a small SQLite DB to track which migration files have already been run.

If the concept is worth keeping, I'm happy to tweak things!

Sample output:


```
 ./omarchy-update all
Already up to date.
...
Skipping 1753062084 (already applied)
Skipping 1753064164 (already applied)
Skipping 1753138691 (already applied)
Skipping 1753176520 (already applied)
Skipping 1753224615 (already applied)
Skipping 1753286633 (already applied)

Running migration (1753302134)
Reload Waybar on unlock to prevent stacking
✔  Migration 1753302134 succeeded
Skipping 1753352057 (already applied)
Skipping 1753468218 (already applied)

Running migration (1753495989)
Allow updating of timezone by right-clicking on the clock (or running omarchy-cmd-tzupdate)
...
✔  Migration 1753495989 succeeded

Running migration (1753558374)
Update Walker config to include = as the leader key for the calculator
✔  Migration 1753558374 succeeded
```

I'm not sold on it printing all of the migrations that it skips since it will just continue to grow. I'm also torn on listing whether a migration is running and when it completes/finishes as it may clutter the output. Could be worth it for long running migrations though?

This would also partially fix https://github.com/basecamp/omarchy/issues/370, as the same migration wouldn't have wiped the `.bak` files. (This does not fix the concept of multiple migrations re-running the same waybar reload command though)