### PR TITLE
Fix: restrict Steam centering to only the main window

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -16,7 +16,7 @@ windowrule = center, class:xdg-desktop-portal-gtk, title:^(Open.*Files?|Save.*Fi
 
 # Float Steam, fullscreen RetroArch
 windowrule = float, class:steam
-windowrule = center, class:steam
+windowrule = center, class:steam, title:Steam
 windowrule = fullscreen, class:^(com.libretro.RetroArch)$
 
 # Just dash of opacity


### PR DESCRIPTION
### Fix: Prevent Steam context menus from being centered

The existing rule`windowrule = center, class:steam`  (introduced in commit 46d135025e64d6e19e599c996d0bbc9e5cf457d9) causes Steam's popup windows (like right-click context menus) to be centered on the screen, which impacts the user experience.

This PR restricts the rule to only apply to the main Steam window by matching both class and title. As far as I could test, only the main Steam window has a title and is still centered correctly with this change.