### PR TITLE
Show idle status in waybar

### DIFF
--- a/bin/omarchy-toggle-idle
+++ b/bin/omarchy-toggle-idle
@@ -3,7 +3,17 @@
 if pgrep -x hypridle >/dev/null; then
   pkill -x hypridle
   notify-send "Stop locking computer when idle"
+  pkill -SIGRTMIN+8 waybar
 else
   uwsm app -- hypridle >/dev/null 2>&1 &
-  notify-send "Now locking computer when idle"
+
+  # Wait up to 1 second for hypridle to start
+  for i in $(seq 1 50); do
+    if pgrep -x hypridle >/dev/null; then
+      notify-send "Now locking computer when idle"
+      pkill -SIGRTMIN+8 waybar
+      break
+    fi
+    sleep 0.02
+  done
 fi

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -16,7 +16,8 @@
     "network",
     "pulseaudio",
     "cpu",
-    "battery"
+    "battery",
+    "custom/idle"
   ],
   "hyprland/workspaces": {
     "on-click": "activate",
@@ -116,6 +117,12 @@
       "custom/expand-icon",
     "tray"
     ]
+  },
+  "custom/idle": {
+    "format": "{text}",
+    "signal": 8,
+    "on-click": "~/.local/share/omarchy/bin/omarchy-toggle-idle",
+    "exec": "if pgrep -x hypridle >/dev/null; then echo '󰒲'; else echo '󰒳'; fi"
   },
   "custom/expand-icon": {
     "format": " ",


### PR DESCRIPTION
The idle status is determined from the state of hypridle, and a pair of nerd font glyphs are used to represent the sleep state being on or off.

This uses a custom signal, for waybar to notify it of a status change to the idle state.