### PR TITLE
Use $HOME/bin instead of ./bin in PATH export

### DIFF
--- a/default/bash/shell
+++ b/default/bash/shell
@@ -10,5 +10,5 @@ if [[ ! -v BASH_COMPLETION_VERSINFO && -f /usr/share/bash-completion/bash_comple
 fi
 
 # Set complete path
-export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omarchy/bin:$PATH"
+export PATH="$HOME/bin:$HOME/.local/bin:$HOME/.local/share/omarchy/bin:$PATH"
 set +h


### PR DESCRIPTION
Use `$HOME/bin` instead of `./bin` in default PATH setup

This update changes the `PATH` export in `default/bash/shell` from:
export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omarchy/bin:$PATH"

to:
export PATH="$HOME/bin:$HOME/.local/bin:$HOME/.local/share/omarchy/bin:$PATH"

Why this matters:

I needed this change to install the Mullvad Browser
 
Using `./bin` makes PATH resolution depend on the current working directory, which can lead to unpredictable behaviour or security concerns.

Replacing it with `$HOME/bin` aligns with standard Unix/Linux environment setups and ensures PATH is consistently scoped to the user’s environment, not the current directory.

This small change improves safety and reliability, especially in multi-shell or scripting environments.


