### PR TITLE
feat: screensaver after 30 seconds

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -6,6 +6,11 @@ general {
 }
 
 listener {
+    timeout = 30                                                        # 30 seconds
+    on-timeout = ~/.local/share/omarchy/bin/omarchy-launch-screensaver  # screen off when timeout has passed
+}
+
+listener {
     timeout = 300                      # 5min
     on-timeout = loginctl lock-session # lock screen when timeout has passed
 }

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -101,5 +101,5 @@ master {
 misc {
     disable_hyprland_logo = true
     disable_splash_rendering  = true
-    focus_on_activate = true
+    focus_on_activate = false
 }

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -101,5 +101,5 @@ master {
 misc {
     disable_hyprland_logo = true
     disable_splash_rendering  = true
-    focus_on_activate = false
+    focus_on_activate = true
 }


### PR DESCRIPTION
I'm adding this configuration that sets the screensaver after 30s.

**on-resume**: I've tried to kill tte on resume but it doesn't work. CTRL+C seems to do the trick if you find a way to leverage on-resume that would be great