### PR TITLE
Added backup timestamps to various omarchy-refresh-* files to prevent clobbering

### DIFF
--- a/bin/omarchy-refresh-hyprlock
+++ b/bin/omarchy-refresh-hyprlock
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # Overwrite local Hyprlock settings with the latest in Omarchy, but create a backup if it differs
-cp -f ~/.config/hypr/hyprlock.conf ~/.config/hypr/hyprlock.conf.bak 2>/dev/null
+backup_filename=hyprlock.conf.bak.$(date +%s)
+cp -f ~/.config/hypr/hyprlock.conf ~/.config/hypr/${backup_filename} 2>/dev/null
 cp -f ~/.local/share/omarchy/config/hypr/hyprlock.conf ~/.config/hypr/ 2>/dev/null
 
-if cmp -s ~/.config/hypr/hyprlock.conf.bak ~/.config/hypr/hyprlock.conf; then
-  rm ~/.config/hypr/hyprlock.conf.bak
+if cmp -s ~/.config/hypr/${backup_filename} ~/.config/hypr/hyprlock.conf; then
+  rm ~/.config/hypr/${backup_filename}
 else
-  echo -e "\e[31mExisting .config/hypr/hyprlock.conf replaced with new Omarchy default, but a .bak file was made.\e[0m"
+  echo -e "\e[31mExisting .config/hypr/hyprlock.conf replaced with new Omarchy default, but a ${backup_filename} file was made.\e[0m"
 fi

--- a/bin/omarchy-refresh-swayosd
+++ b/bin/omarchy-refresh-swayosd
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-cp -f ~/.config/swayosd/config.toml ~/.config/swayosd/config.toml.bak 2>/dev/null
+backup_filename=config.toml.bak.$(date +%s)
+cp -f ~/.config/swayosd/config.toml ~/.config/swayosd/${backup_filename} 2>/dev/null
 cp -f ~/.local/share/omarchy/config/swayosd/config.toml ~/.config/swayosd/ 3>/dev/null
 
-if cmp -s ~/.config/swayosd/config.toml.bak ~/.config/swayosd/config.toml; then
-  rm ~/.config/swayosd//config.toml.bak
+if cmp -s ~/.config/swayosd/${backup_filename} ~/.config/swayosd/config.toml; then
+  rm ~/.config/swayosd/${backup_filename}
 else
-  echo -e "\e[31mExisting .config/swayosd/config.toml replaced with new Omarchy default, but a .bak file was made.\e[0m"
+  echo -e "\e[31mExisting .config/swayosd/config.toml replaced with new Omarchy default, but a ${backup_filename} file was made.\e[0m"
 fi
 
 pkill swayosd-server

--- a/bin/omarchy-refresh-walker
+++ b/bin/omarchy-refresh-walker
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-cp -f ~/.config/walker/config.toml ~/.config/walker/config.toml.bak 2>/dev/null
+backup_filename=config.toml.bak.$(date +%s)
+cp -f ~/.config/walker/config.toml ~/.config/walker/${backup_filename} 2>/dev/null
 cp -f ~/.local/share/omarchy/config/walker/config.toml ~/.config/walker/ 2>/dev/null
 
-if cmp -s ~/.config/walker/config.toml.bak ~/.config/walker/config.toml; then
-  rm ~/.config/walker/config.toml.bak
+if cmp -s ~/.config/walker/${backup_filename} ~/.config/walker/config.toml; then
+  rm ~/.config/walker/${backup_filename}
 else
-  echo -e "\e[31mExisting .config/walker/config.toml replaced with new Omarchy default, but a .bak file was made.\e[0m"
+  echo -e "\e[31mExisting .config/walker/config.toml replaced with new Omarchy default, but a ${backup_filename} file was made.\e[0m"
 fi
 
 pkill walker

--- a/bin/omarchy-refresh-waybar
+++ b/bin/omarchy-refresh-waybar
@@ -1,24 +1,28 @@
 #!/bin/bash
 
 # Backup existing settings
-cp -f ~/.config/waybar/config.jsonc ~/.config/waybar/config.jsonc.bak 2>/dev/null
-cp -f ~/.config/waybar/style.css ~/.config/waybar/style.css.bak 2>/dev/null
+timestamp=$(date +%s)
+config_backup_filename=config.jsonc.bak.${timestamp}
+style_backup_filename=style.css.bak.${timestamp}
+
+cp -f ~/.config/waybar/config.jsonc ~/.config/waybar/${config_backup_filename} 2>/dev/null
+cp -f ~/.config/waybar/style.css ~/.config/waybar/${style_backup_filename} 2>/dev/null
 
 # Overwrite local waybar settings with the latest in Omarchy
 cp -f ~/.local/share/omarchy/config/waybar/config.jsonc ~/.config/waybar/ 2>/dev/null
 cp -f ~/.local/share/omarchy/config/waybar/style.css ~/.config/waybar/ 2>/dev/null
 
 # Remove identical backup files
-if cmp -s ~/.config/waybar/config.jsonc.bak ~/.config/waybar/config.jsonc; then
-  rm ~/.config/waybar/config.jsonc.bak
+if cmp -s ~/.config/waybar/${config_backup_filename} ~/.config/waybar/config.jsonc; then
+  rm ~/.config/waybar/${config_backup_filename}
 else
-  echo -e "\e[31mExisting .config/waybar/config.jsonc replaced with new Omarchy default, but a .bak file was made.\e[0m"
+  echo -e "\e[31mExisting .config/waybar/config.jsonc replaced with new Omarchy default, but a ${config_backup_filename} file was made.\e[0m"
 fi
 
-if cmp -s ~/.config/waybar/style.css.bak ~/.config/waybar/style.css; then
-  rm ~/.config/waybar/style.css.bak
+if cmp -s ~/.config/waybar/${style_backup_filename} ~/.config/waybar/style.css; then
+  rm ~/.config/waybar/${style_backup_filename}
 else
-  echo -e "\e[31mExisting .config/waybar/style.css replaced with new Omarchy default, but a .bak file was made.\e[0m"
+  echo -e "\e[31mExisting .config/waybar/style.css replaced with new Omarchy default, but a ${style_backup_filename} file was made.\e[0m"
 fi
 
 # Restart waybar


### PR DESCRIPTION
This solves #370 per the recommended fix. Thanks!

Sample output:

```
 ./omarchy-refresh-waybar 
Existing .config/waybar/config.jsonc replaced with new Omarchy default, but a config.jsonc.bak.1753814289 file was made.
Existing .config/waybar/style.css replaced with new Omarchy default, but a style.css.bak.1753814289 file was made.
```