### PR TITLE
Fix: add mini.icons compatibility to monokai-pro ristretto Neovim theme

### DIFF
--- a/themes/ristretto/neovim.lua
+++ b/themes/ristretto/neovim.lua
@@ -7,6 +7,14 @@ return {
 				override = function()
 					return {
 						NonText = { fg = "#948a8b" },
+						MiniIconsGrey = { fg = "#948a8b" },
+						MiniIconsRed = { fg = "#fd6883" },
+						MiniIconsBlue = { fg = "#85dacc" },
+						MiniIconsGreen = { fg = "#adda78" },
+						MiniIconsYellow = { fg = "#f9cc6c" },
+						MiniIconsOrange = { fg = "#f38d70" },
+						MiniIconsPurple = { fg = "#a8a9eb" },
+						MiniIconsCyan = { fg = "#85dacc" }, -- same value as MiniIconsBlue for consistency
 					}
 				end,
 			})


### PR DESCRIPTION
Without this change, launching Neovim on my computer with the Omarchy Ristretto theme enabled returns `Invalid highlight name` errors.  The issue is that the gthelding/monokai-pro.nvim color scheme doesn't have support for the MiniIcon highlight groups. Possibly a PR could be made to that repo to add mini.icons support, but it can also be added with the color scheme's `override` function as is done in this PR.

For context, most, hopefully all other Neovim color schemes used by Omarchy have explicit support for the MiniIcons highlight groups.