### PR TITLE
Fix: cascadia mono download issue

### DIFF
--- a/migrations/1752187060.sh
+++ b/migrations/1752187060.sh
@@ -2,6 +2,7 @@ echo "Add missing Propo version of Caskaydia Mono Nerd Font for Waybar use"
 
 if ! fc-list | grep -qi "CaskaydiaMono Nerd Font Propo"; then
   cd /tmp
+  rm -f CascadiaMono.zip*
   wget https://github.com/ryanoasis/nerd-fonts/releases/latest/download/CascadiaMono.zip
   unzip CascadiaMono.zip -d CascadiaFont
   cp CascadiaFont/CaskaydiaMonoNerdFontPropo-Regular.ttf ~/.local/share/fonts


### PR DESCRIPTION
<details>
<summary>Not important</summary>
I recently worked in China and bought a Beelink SER8 to try omarchy.
I've already finished the installation. I barely managed to install it with http proxy and shadowsocks, it took me 5 hours.

The aur mirror site is very slow and even the installation is interrupted, many universities in China have long stopped maintaining arch packages. 
Although people working here will bring their own vpn, but the installation process is still very inconvenient. 
The problem is that yay go to github releases to grab the files when downloading the CascadeFont, and as we all know that site is often blocked in China.
</details>

Some of these packages will download the zip file to /tmp.
If the installation fails or is interrupted at this stage due to network problems, there will be an incomplete zip file. After re-running the install, the download will save a new filename (CascadiaMono.zip.1) which will cause the download to refer to the original filename when unzipping, and then it fails to unzip the incomplete `CascadiaMono.zip`
You have to go back and delete that old file to continue.

### Migration Script Enhancement:

* `migrations/1752187060.sh`: Added a `rm -f` command to remove any existing `CascadiaMono.zip*` files before wget.