### PR TITLE
Using vim-Navigations to move around windows

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -8,10 +8,10 @@ bind = SUPER, V, togglefloating,
 bind = SHIFT, F11, fullscreen, 0
 
 # Move focus with mainMod + arrow keys
-bind = SUPER, left, movefocus, l
-bind = SUPER, right, movefocus, r
-bind = SUPER, up, movefocus, u
-bind = SUPER, down, movefocus, d
+bind = SUPER, H, movefocus, l
+bind = SUPER, L, movefocus, r
+bind = SUPER, J, movefocus, d
+bind = SUPER, K, movefocus, u
 
 # Switch workspaces with mainMod + [0-9]
 bind = SUPER, code:10, workspace, 1
@@ -48,10 +48,10 @@ bind = ALT, Tab, cyclenext
 bind = ALT, Tab, bringactivetotop
 
 # Resize active window
-bind = SUPER, minus, resizeactive, -100 0
-bind = SUPER, equal, resizeactive, 100 0
-bind = SUPER SHIFT, minus, resizeactive, 0 -100
-bind = SUPER SHIFT, equal, resizeactive, 0 100
+bind = SUPER SHIFT, H, resizeactive, -100 0
+bind = SUPER SHIFT, L, resizeactive, 100 0
+bind = SUPER SHIFT, K, resizeactive, 0 -100
+bind = SUPER SHIFT, J, resizeactive, 0 100
 
 # Scroll through existing workspaces with mainMod + scroll
 bind = SUPER, mouse_down, workspace, e+1


### PR DESCRIPTION
As everything is set up around vim navigation, this minor change could work well with the other shortcuts.

It's obviously a matter of personal preference, but it could fit well for many. Changing arrows with `SUPER + hjkl` for moving around windows. 

Instead of resizing (the second change), it could also be used for "Swap active window", whichever is used more. As I use resizing more, this is what I set the `SUPER SHIFT, hjkl` to. 

No need to accept, I just wanted to suggest in case this makes sense, but didn't come to mind.