### PR TITLE
Update migration to ensure walker is refreshed after finder prefix was added.

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -213,7 +213,7 @@ concurrency = 8
 show_icon_when_single = true
 preview_images = true
 hidden = false
-prefix = '.'
+prefix = "."
 
 [builtins.runner]
 eager_loading = true

--- a/migrations/1753910761.sh
+++ b/migrations/1753910761.sh
@@ -1,4 +1,4 @@
 echo "Update Walker config to include . as the leader key for the finder"
-if ! grep -q 'prefix = "."' ~/.config/walker/config.toml; then
+if ! grep -q 'prefix = "\."' ~/.config/walker/config.toml; then
   omarchy-refresh-walker
 fi


### PR DESCRIPTION
It looks like the conditional in the [1753910761.sh](https://github.com/basecamp/omarchy/compare/master...ardavis:omarchy:fix_walker_migration_for_finder_leader_key?expand=1#diff-ee1f09f44fd036ea01813b6a5e8790cf6a1e9818f70671a8ac634b5c2011035e) migration was returning true due to the other prefixes.

```
 grep 'prefix = "."' ~/.config/walker/config.toml
prefix = "="
prefix = ":"
prefix = "/"
```

Because of this, the `omarchy-refresh-walker` command was never fired and the `config.toml` which included the `prefix = "."` was never updated.

This PR:
  - Changes the prefix to use double quotes to be consistent with the others.
  - Modifies the migration to escape the dot to avoid searching for other characters.

Please let me know if it's frowned upon for updating older migrations. This really only solves it for those who haven't yet updated to 1.8.0. 

**Should I make a new migration that has the fix instead?**