### PR TITLE
feat: improve screen lock security

### DIFF
--- a/bin/omarchy-toggle-idle
+++ b/bin/omarchy-toggle-idle
@@ -1,9 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# This script uses 'systemd-run' to reliably create a transient service
+# that holds a persistent idle inhibit lock.
 
-if pgrep -x hypridle >/dev/null; then
-  pkill -x hypridle
-  notify-send "Stop locking computer when idle"
-else
-  uwsm app -- hypridle >/dev/null 2>&1 &
+# The predictable systemd unit name we will assign and control.
+UNIT_NAME="hypridle-inhibit-toggle.service"
+
+# Check if the systemd unit is currently active.
+if systemctl --user is-active --quiet "$UNIT_NAME"; then
+  # The unit is active, so we stop it to release the lock.
+  systemctl --user stop "$UNIT_NAME"
   notify-send "Now locking computer when idle"
+else
+  # The unit is not active, so we use systemd-run to create and start it.
+  systemd-run \
+    --user \
+    --unit="$UNIT_NAME" \
+    --description="Persistent hypridle inhibit lock" \
+    /usr/bin/systemd-inhibit --what=idle --who='Toggle Script' --why='User Requested' sleep infinity
+  notify-send "Stop locking computer when idle"
 fi

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -1,4 +1,4 @@
-exec-once = uwsm app -- hypridle
+exec-once = systemctl enable --user --now hypridle
 exec-once = uwsm app -- mako
 exec-once = uwsm app -- waybar
 exec-once = uwsm app -- fcitx5


### PR DESCRIPTION
Hypridle comes with a hypridle.service that automatically restarts the process on error. We make use of that to ensure that the screen can always be locked, even if hypridle dies.

To ensure that the screen will always be locked on suspend we keep hypridle running at all times and inhibit the timers using a systemd service.