### PR TITLE
Adds ENV var to get `bat` using the system theme

### DIFF
--- a/default/bash/envs
+++ b/default/bash/envs
@@ -1,3 +1,4 @@
 # Editor used by CLI
 export EDITOR="nvim"
 export SUDO_EDITOR="$EDITOR"
+export BAT_THEME=ansi


### PR DESCRIPTION
We've already got `bat` installed, but it's not using the theme set in Alacritty (this is supposed to be Catppuccin):

<img width="1336" height="659" alt="image" src="https://github.com/user-attachments/assets/11f1b241-0865-4929-939d-074a88066fd1" />

But by setting `BAT_THEME=ansi`, it is!

<img width="1328" height="654" alt="image" src="https://github.com/user-attachments/assets/94bac395-8a65-418e-8162-e319a3bc253c" />

This PR just adds that ENV var to the `default/bash/envs` file. I don't think it needs a migration as this file is updated when the repo is updated?