### PR TITLE
Use delta for diff in lazygit

### DIFF
--- a/config/lazygit/config.yml
+++ b/config/lazygit/config.yml
@@ -1,0 +1,3 @@
+git:
+  paging:
+    pager: delta --light --paging=never --line-numbers

--- a/install/development/development.sh
+++ b/install/development/development.sh
@@ -5,4 +5,4 @@ yay -S --noconfirm --needed \
   imagemagick \
   mariadb-libs postgresql-libs \
   github-cli \
-  lazygit lazydocker-bin
+  lazygit git-delta lazydocker-bin


### PR DESCRIPTION
https://dandavison.github.io/delta/ can be used with lazygit for a better diff view in lazygit.

Check out screenshots for sample diff of this PR itself.

## Without `delta`

<img width="2560" height="1415" alt="Screenshot_2025-08-01_23-14-57" src="https://github.com/user-attachments/assets/8655058b-8908-42e4-963a-6f66a9ba291c" />

## With `delta`

<img width="2560" height="1415" alt="Screenshot_2025-08-01_23-14-33" src="https://github.com/user-attachments/assets/2292f0d5-da7b-47be-b203-7b30cad91fe5" />
