### PR TITLE
Replace tldr with tealdeer

### DIFF
--- a/install/development/terminal.sh
+++ b/install/development/terminal.sh
@@ -4,5 +4,5 @@ yay -S --noconfirm --needed \
   wget curl unzip inetutils impala \
   fd eza fzf ripgrep zoxide bat jq \
   wl-clipboard fastfetch btop \
-  man tldr less whois plocate bash-completion \
+  man tealdeer less whois plocate bash-completion \
   alacritty


### PR DESCRIPTION
tealdeer is a popular faster replacement of tldr. In particular, CachyOS uses it (main reason for this PR).

I installed CachyOS with Omarchy successfully, but had to resolve a dependency conflict between tldr and tealdeer in the process. It would be better user experience if omarchy could be installed on CachyOS in one shot.

For beginners, this would be an interesting alternative to the archinstall TUI, where CachyOS with no desktop gives you a full-fledged GUI installer initially, then you just run the single omarchy install command.