### PR TITLE
Opacity for indicators of empty waybar workspaces

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -26,6 +26,10 @@
   min-width: 9px;
 }
 
+#workspaces button.empty {
+  opacity: 0.35;
+}
+
 #tray,
 #cpu,
 #battery,

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -27,7 +27,7 @@
 }
 
 #workspaces button.empty {
-  opacity: 0.35;
+  opacity: 0.5;
 }
 
 #tray,

--- a/migrations/1754133148.sh
+++ b/migrations/1754133148.sh
@@ -1,6 +1,6 @@
 echo "Update Waybar CSS to dim unused workspaces"
 
-if ! grep -q "#workspaces button\.empty"; then
+if ! grep -q "#workspaces button\.empty" ~/.config/waybar/style.css; then
   omarchy-refresh-config waybar/style.css
   pkill -SIGUSR2 waybar
 fi

--- a/migrations/1754133148.sh
+++ b/migrations/1754133148.sh
@@ -1,0 +1,6 @@
+echo "Update Waybar CSS to dim unused workspaces"
+
+if ! grep -q "#workspaces button\.empty"; then
+  omarchy-refresh-config waybar/style.css
+  pkill -SIGUSR2 waybar
+fi


### PR DESCRIPTION
Adds opacity to the workspace indicators on waybar, if the workspace is empty. Makes the indicator appear dimmer for empty workspaces so they can be identifed from workspaces that have windows. Purely cosmetic UI tweak.