### PR TITLE
Fix Plymouth login positioning in multi-monitor setups + limit password from overflowing

### DIFF
--- a/default/plymouth/omarchy.script
+++ b/default/plymouth/omarchy.script
@@ -5,8 +5,8 @@ Window.SetBackgroundBottomColor(0.101, 0.105,  0.149);
 
 logo.image = Image("logo.png");
 logo.sprite = Sprite(logo.image);
-logo.sprite.SetX (Window.GetX() + Window.GetWidth()  / 2 - logo.image.GetWidth()  / 2);
-logo.sprite.SetY (Window.GetY() + Window.GetHeight() / 2 - logo.image.GetHeight() / 2);
+logo.sprite.SetX (Window.GetWidth()  / 2 - logo.image.GetWidth()  / 2);
+logo.sprite.SetY (Window.GetHeight() / 2 - logo.image.GetHeight() / 2);
 logo.sprite.SetOpacity (1);
 
 # Use these to adjust the progress bar timing
@@ -119,7 +119,7 @@ entry.image = Image("entry.png");
 bullet.image = Image("bullet.png");
 
 entry.sprite = Sprite(entry.image);
-entry.x = Window.GetX() + Window.GetWidth()/2 - entry.image.GetWidth() / 2;
+entry.x = Window.GetWidth()/2 - entry.image.GetWidth() / 2;
 entry.y = logo.sprite.GetY() + logo.image.GetHeight() + 40;
 entry.sprite.SetPosition(entry.x, entry.y, 10001);
 entry.sprite.SetOpacity(0);
@@ -200,7 +200,7 @@ Plymouth.SetDisplayPasswordFunction(display_password_callback);
 progress_box.image = Image("progress_box.png");
 progress_box.sprite = Sprite(progress_box.image);
 
-progress_box.x = Window.GetX() + Window.GetWidth() / 2 - progress_box.image.GetWidth() / 2;
+progress_box.x = Window.GetWidth() / 2 - progress_box.image.GetWidth() / 2;
 progress_box.y = entry.y + entry.image.GetHeight() / 2 - progress_box.image.GetHeight() / 2;
 progress_box.sprite.SetPosition(progress_box.x, progress_box.y, 0);
 progress_box.sprite.SetOpacity(0);
@@ -209,7 +209,7 @@ progress_bar.original_image = Image("progress_bar.png");
 progress_bar.sprite = Sprite();
 progress_bar.image = progress_bar.original_image.Scale(1, progress_bar.original_image.GetHeight());
 
-progress_bar.x = Window.GetX() + Window.GetWidth() / 2 - progress_bar.original_image.GetWidth() / 2;
+progress_bar.x = Window.GetWidth() / 2 - progress_bar.original_image.GetWidth() / 2;
 progress_bar.y = progress_box.y + (progress_box.image.GetHeight() - progress_bar.original_image.GetHeight()) / 2;
 progress_bar.sprite.SetPosition(progress_bar.x, progress_bar.y, 1);
 progress_bar.sprite.SetOpacity(0);

--- a/default/plymouth/omarchy.script
+++ b/default/plymouth/omarchy.script
@@ -171,8 +171,13 @@ fun display_password_callback (prompt, bullets)
     for (index = 0; bullet.sprites[index]; index++)
       bullet.sprites[index].SetOpacity(0);
     
-    # Create and show bullets for current password
-    for (index = 0; index < bullets; index++)
+    # Create and show bullets for current password (max 21)
+    max_bullets = 21;
+    bullets_to_show = bullets;
+    if (bullets_to_show > max_bullets)
+      bullets_to_show = max_bullets;
+    
+    for (index = 0; index < bullets_to_show; index++)
       {
         if (!bullet.sprites[index])
           {

--- a/migrations/1754108993.sh
+++ b/migrations/1754108993.sh
@@ -1,0 +1,2 @@
+echo "Fix Plymouth login positioning in multi-monitor setups + limit password from overflowing"
+omarchy-refresh-plymouth


### PR DESCRIPTION
This solves the issue we've seen where in multi-monitor setups, the login prompt will be drawn off to the bottom right of the screen. Credit to @RaphaelKimmig for helping me identify the issue via PR #419.

This also resolves the issue where people with passwords > 21 characters would see bullets drawn outside of the password field.

Fixes #142. Fixes #355.