### PR TITLE
Prevent screensaver shifting up after each instance

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -5,6 +5,6 @@ trap "exit" SIGINT
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)
   tte -i ~/.local/share/omarchy/logo.txt \
-    --frame-rate 240 --canvas-width 0 --canvas-height 0 --anchor-canvas c --anchor-text c \
+    --frame-rate 240 --canvas-width 0 --canvas-height $(($(tput lines) - 2)) --anchor-canvas c --anchor-text c \
     "$effect"
 done

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -2,4 +2,4 @@
 
 pkill -f "alacritty --class Screensaver" ||
   alacritty --class Screensaver --title Screensaver -o 'colors.primary.background="#000000"' \
-    -e ~/.local/share/omarchy/bin/omarchy-cmd-screensaver
+    -o 'colors.cursor.cursor="#000000"' -e ~/.local/share/omarchy/bin/omarchy-cmd-screensaver


### PR DESCRIPTION
After each instance of the current screensaver, you see the cursor show up in the bottom left and the screen jumps up a touch. Reducing the canvas height by 2 lines and making the cursor the same color as the background solves this and is nearly unnoticeable providing a better screensaver experience. :smile: 