### PR TITLE
Modify omarch-launch-screensaver to launch on all detected monitors.

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -10,6 +10,7 @@ if command -v tte &>/dev/null; then
     while pgrep tte >/dev/null; do
       if read -n 1 -t 0.01; then
         pkill tte 2>/dev/null
+        pkill -f "alacritty --class Screensaver" 2>/dev/null
         exit 0
       fi
     done
@@ -17,4 +18,3 @@ if command -v tte &>/dev/null; then
 else
   gum spin --title "Can't find tte. Try: pip install terminaltexteffects" -- sleep 2
 fi
-

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -1,5 +1,17 @@
 #!/bin/bash
 
-pgrep -f "alacritty --class Screensaver" ||
-  alacritty --class Screensaver --title Screensaver -o 'colors.primary.background="#000000"' \
-    -o 'colors.cursor.cursor="#000000"' -e ~/.local/share/omarchy/bin/omarchy-cmd-screensaver
+# exit early if screensave is already running
+pgrep -f "alacritty --class Screensaver" && exit 0
+
+focused=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')
+
+for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
+  hyprctl dispatch focusmonitor $m
+  hyprctl dispatch exec -- \
+    alacritty --class Screensaver --title Screensaver \
+    -o 'colors.primary.background="#000000"' \
+    -o 'colors.cursor.cursor="#000000"' \
+    -e ~/.local/share/omarchy/bin/omarchy-cmd-screensaver
+done
+
+hyprctl dispatch focusmonitor $focused


### PR DESCRIPTION
If you have multiple monitors `omarchy-launch-screensaver` only launches on the currently focused one.

- Modify `omarchy-launch-screensaver` and iterates through the detected monitors and launch the screensaver on each. Then focus back on the original monitor.
- Add a pkill in `omarchy-cmd-screensaver` to kill all instances of `alacritty --class Screensaver` on the way way down .