### PR TITLE
Add Vim-style j/k navigation to walker config

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -15,8 +15,8 @@ force_keyboard_focus = true
 [keys]
 accept_typeahead = ["tab"]
 trigger_labels = "lalt"
-next = ["down"]
-prev = ["up"]
+next = ["down", "j"]
+prev = ["up", "k"]
 close = ["esc"]
 remove_from_history = ["shift backspace"]
 resume_query = ["ctrl r"]


### PR DESCRIPTION
This pull request adds Vim-style navigation support to walkers default configuration as well as retaining the original navigation in Omarchy.

I noticed we can use `j` and `k` in the Omarchy TUI but not when choosing themes and at the power menu and thought it would add a small quality of life improvement for users who prefer Vim bindings whilst maintaining some consistency.