### PR TITLE
Updated to send warning at 30%

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -1,30 +1,72 @@
 #!/bin/bash
 
-# Designed to be run by systemd timer every 30 seconds and alerts if battery is low
+# Designed to be run by a systemd timer, every 30 seconds, to alert if the battery is low.
 
-BATTERY_THRESHOLD=10
-NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
+# --- Configuration ---
+BATTERY_WARNING=30
+BATTERY_CRITICAL=10
+
+# --- Notification Flags ---
+NOTIFICATION_WARNING_FLAG="/run/user/$UID/battery_warning_notified"
+NOTIFICATION_CRITICAL_FLAG="/run/user/$UID/battery_critical_notified"
+
+# --- Functions ---
+get_battery_info() {
+  upower -i $(upower -e | grep 'BAT')
+}
 
 get_battery_percentage() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
+  echo "$1" | grep -E "percentage" | grep -o '[0-9]\+'
 }
 
 get_battery_state() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}'
+  echo "$1" | grep -E "state" | awk '{print $2}'
 }
 
 send_notification() {
-  notify-send -u critical "Battery Low" "Time to recharge! (battery is at ${1}%)" -i battery-caution
+  # Usage: send_notification "urgency" "Title" "Message" "icon"
+  notify-send -u "$1" "$2" "$3" -i "$4"
 }
 
-BATTERY_LEVEL=$(get_battery_percentage)
-BATTERY_STATE=$(get_battery_state)
+# --- Main ---
 
-if [[ "$BATTERY_STATE" == "discharging" && "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
-  if [[ ! -f "$NOTIFICATION_FLAG" ]]; then
-    send_notification "$BATTERY_LEVEL"
-    touch "$NOTIFICATION_FLAG"
-  fi
+# 1. Get current battery status
+BATTERY_INFO=$(get_battery_info)
+BATTERY_LEVEL=$(get_battery_percentage "$BATTERY_INFO")
+BATTERY_STATE=$(get_battery_state "$BATTERY_INFO")
+
+# 2. Determine the single current status
+# This block's only job is to figure out what state we are in.
+if [[ "$BATTERY_STATE" != "discharging" ]]; then
+  CURRENT_STATUS="charging"
+elif [[ "$BATTERY_LEVEL" -le "$BATTERY_CRITICAL" ]]; then
+  CURRENT_STATUS="critical"
+elif [[ "$BATTERY_LEVEL" -le "$BATTERY_WARNING" ]]; then
+  CURRENT_STATUS="warning"
 else
-  rm -f "$NOTIFICATION_FLAG"
+  CURRENT_STATUS="ok"
 fi
+
+# 3. Send notificatoin, acccoding to the status
+case "$CURRENT_STATUS" in
+critical)
+  if [[ ! -f "$NOTIFICATION_CRITICAL_FLAG" ]]; then
+    send_notification "critical" "Battery Critically Low" "Plug in immediately! (${BATTERY_LEVEL}%)" "battery-critical"
+    touch "$NOTIFICATION_CRITICAL_FLAG"
+  fi
+  ;;
+
+warning)
+  # The battery is not critical, so we can remove the critical alert flag.
+  rm -f "$NOTIFICATION_CRITICAL_FLAG"
+  if [[ ! -f "$NOTIFICATION_WARNING_FLAG" ]]; then
+    send_notification "normal" "Battery Low" "Time to find a charger. (${BATTERY_LEVEL}%)" "battery-caution"
+    touch "$NOTIFICATION_WARNING_FLAG"
+  fi
+  ;;
+
+charging | ok)
+  # If charging or discharging safely, clear all flags to reset alerts.
+  rm -f "$NOTIFICATION_WARNING_FLAG" "$NOTIFICATION_CRITICAL_FLAG"
+  ;;
+esac


### PR DESCRIPTION
This is a response to https://github.com/basecamp/omarchy/issues/392. 

1. send warning at 30%
2. as before, send critical at 10%

Possible  TODO
move thresholds config to ~/.config 
Better notificatoin, as a comment mentioned notification is not noticed, in #392 
 - already trying
    batsignal - an issue with "Battery fully charged" notificatoin staying. https://github.com/electrickite/batsignal
    hyprctl notify, with larger font and colour, has notificatoin timer which disappers, and does not stay. https://wiki.hypr.land/Configuring/Using-hyprctl/