### PR TITLE
Install `gvfs-mtp` to enable Android MTP file transfer support

### DIFF
--- a/install/desktop/desktop.sh
+++ b/install/desktop/desktop.sh
@@ -3,7 +3,7 @@
 yay -S --noconfirm --needed \
   brightnessctl playerctl pamixer wiremix wireplumber \
   fcitx5 fcitx5-gtk fcitx5-qt wl-clip-persist \
-  nautilus sushi ffmpegthumbnailer \
+  nautilus sushi ffmpegthumbnailer gvfs-mtp \
   slurp satty \
   mpv evince imv \
   chromium


### PR DESCRIPTION
## Background

When connecting an Android phone via USB, it's not appearing in Nautilus despite the correct file transfer settings being selected on the device. This prevents users from accessing their phone's storage through the file manager.

## Proposed Solution

To fix this, we should install the `gvfs-mtp` package. This provides the necessary **Media Transfer Protocol (MTP)** support for Nautilus, allowing Android devices to be recognized and mounted properly.

---

See the Arch Wiki for more details: [Media Transfer Protocol](https://wiki.archlinux.org/title/Media_Transfer_Protocol#File_manager_integration)