### PR TITLE
Add tmux configuration with Omarchy theme integration

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -42,6 +42,11 @@ fi
 # Trigger alacritty config reload
 touch "$HOME/.config/alacritty/alacritty.toml"
 
+# Trigger tmux config reload
+if command -v tmux >/dev/null 2>&1 && tmux has-session 2>/dev/null; then
+  tmux source-file ~/.config/tmux/tmux.conf
+fi
+
 # Restart components to apply new theme
 pkill -SIGUSR2 btop
 "$HOME/.local/share/omarchy/bin/omarchy-restart-waybar"

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -1,0 +1,43 @@
+source-file ~/.config/tmux/tmux.reset.conf
+set-option -g default-terminal 'screen-256color'
+set-option -g terminal-overrides ',xterm-256color:RGB'
+
+set -g prefix ^a
+set -g base-index 1              # start indexing windows at 1 instead of 0
+set -g detach-on-destroy off     # don't exit from tmux when closing a session
+set -g escape-time 0             # zero-out escape time delay
+set -g history-limit 1000000     # increase history size (from 2,000)
+set -g renumber-windows on       # renumber all windows when any window is closed
+set -g set-clipboard on          # use system clipboard
+set -g status-position top       # macOS / darwin style
+set -g default-terminal "${TERM}"
+setw -g mode-keys vi
+set -g pane-active-border-style 'fg=magenta,bg=default'
+set -g pane-border-style 'fg=brightblack,bg=default'
+
+# TPM - Tmux Plugin Manager
+set -g @plugin 'tmux-plugins/tpm'
+# Basic tmux settings everyone can agree on
+set -g @plugin 'tmux-plugins/tmux-sensible'
+# Enhanced clipboard integration
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+set -g @resurrect-strategy-nvim 'session'
+
+# Status bar configuration - universal settings
+set -g status-left-length 100
+set -g status-right-length 0
+set -g status-right ''
+set -g window-status-separator ''
+
+# Custom pane resizing
+bind-key M-Up resize-pane -U 300
+bind-key M-Down resize-pane -D 300
+bind-key M-Left resize-pane -L 300
+bind-key M-Right resize-pane -R 300
+
+# theme-specific configuration
+source ~/.config/omarchy/current/theme/tmux.conf
+
+# Initialize TPM (Tmux Plugin Manager)
+run '~/.tmux/plugins/tpm/tpm'

--- a/config/tmux/tmux.reset.conf
+++ b/config/tmux/tmux.reset.conf
@@ -1,0 +1,39 @@
+bind ^X lock-server
+bind n new-window -c "#{pane_current_path}"
+bind ^D detach
+bind * list-clients
+
+bind ^n next-window
+
+bind k kill-session
+
+bind H previous-window
+bind L next-window
+
+bind r command-prompt "rename-window %%"
+bind ^A last-window
+bind ^W list-windows
+bind w list-windows
+bind z resize-pane -Z
+bind ^L refresh-client
+bind l refresh-client
+bind | split-window
+bind s split-window -v -c "#{pane_current_path}"
+bind v split-window -h -c "#{pane_current_path}"
+bind '"' choose-window
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+bind -r -T prefix , resize-pane -L 20
+bind -r -T prefix . resize-pane -R 20
+bind -r -T prefix - resize-pane -D 7
+bind -r -T prefix = resize-pane -U 7
+bind : command-prompt
+bind * setw synchronize-panes
+bind P set pane-border-status
+bind ^c kill-pane
+bind x swap-pane -D
+bind S choose-session
+bind R source-file ~/.config/tmux/tmux.conf \; display-message "tmux config reloaded!"
+bind-key -T copy-mode-vi v send-keys -X begin-selection

--- a/migrations/1754230252.sh
+++ b/migrations/1754230252.sh
@@ -1,0 +1,10 @@
+echo "Install Tmux and tpm (Tmux Package Manager)"
+
+if ! yay -Qe tmux &>/dev/null; then
+  yay -S --noconfirm --needed tmux
+fi
+
+
+if [[ ! -d ~/.tmux/plugins/tpm ]]; then
+  git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+fi

--- a/themes/catppuccin-latte/tmux.conf
+++ b/themes/catppuccin-latte/tmux.conf
@@ -1,0 +1,18 @@
+set -g status-style 'bg=#eff1f5,fg=#4c4f69'
+set -g message-style 'bg=#bcc0cc,fg=#4c4f69'
+set -g message-command-style 'bg=#bcc0cc,fg=#4c4f69'
+set -g pane-border-style 'fg=#acb0be'
+set -g pane-active-border-style 'fg=#1e66f5'
+
+set -g window-status-activity-style 'bg=#eff1f5,fg=#fe640b'
+set -g window-status-style 'bg=#eff1f5,fg=#8c8fa1'
+
+set -g window-status-format '#[fg=#8c8fa1,bg=#eff1f5] #I #[fg=#8c8fa1,bg=#eff1f5] #W '
+set -g window-status-current-format '#[fg=#eff1f5,bg=#ea76cb] #I #[fg=#eff1f5,bg=#ea76cb,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#eff1f5,bg=#1e66f5,bold] #S #[fg=#1e66f5,bg=#eff1f5]'
+
+set -g mode-style 'bg=#ea76cb,fg=#eff1f5'
+
+set -g clock-mode-colour '#1e66f5' 
+

--- a/themes/catppuccin/tmux.conf
+++ b/themes/catppuccin/tmux.conf
@@ -1,0 +1,19 @@
+set -g status-style 'bg=#1e1e2e,fg=#cdd6f4'
+set -g message-style 'bg=#313244,fg=#cdd6f4'
+set -g message-command-style 'bg=#313244,fg=#cdd6f4'
+set -g pane-border-style 'fg=#313244'
+set -g pane-active-border-style 'fg=#89b4fa'
+
+set -g window-status-activity-style 'bg=#1e1e2e,fg=#f9e2af'
+set -g window-status-style 'bg=#1e1e2e,fg=#6c7086'
+
+set -g window-status-format '#[fg=#6c7086,bg=#1e1e2e] #I #[fg=#6c7086,bg=#1e1e2e] #W '
+
+set -g window-status-current-format '#[fg=#1e1e2e,bg=#fab387] #I #[fg=#1e1e2e,bg=#fab387,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#1e1e2e,bg=#eba0ac,bold] #S #[fg=#eba0ac,bg=#1e1e2e]'
+
+set -g mode-style 'bg=#74c7ec,fg=#1e1e2e'
+
+set -g clock-mode-colour '#b4befe'
+

--- a/themes/everforest/tmux.conf
+++ b/themes/everforest/tmux.conf
@@ -1,0 +1,17 @@
+set -g status-style 'bg=#2d353b,fg=#d3c6aa'
+set -g message-style 'bg=#475258,fg=#d3c6aa'
+set -g message-command-style 'bg=#475258,fg=#d3c6aa'
+set -g pane-border-style 'fg=#475258'
+set -g pane-active-border-style 'fg=#a7c080'
+
+set -g window-status-activity-style 'bg=#2d353b,fg=#dbbc7f'
+set -g window-status-style 'bg=#2d353b,fg=#d3c6aa'
+
+set -g window-status-format '#[fg=#d3c6aa,bg=#2d353b] #I #[fg=#d3c6aa,bg=#2d353b] #W '
+set -g window-status-current-format '#[fg=#2d353b,bg=#83c092] #I #[fg=#2d353b,bg=#83c092,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#2d353b,bg=#a7c080,bold] #S #[fg=#a7c080,bg=#2d353b]'
+
+set -g mode-style 'bg=#83c092,fg=#2d353b'
+
+set -g clock-mode-colour '#a7c080' 

--- a/themes/gruvbox/tmux.conf
+++ b/themes/gruvbox/tmux.conf
@@ -1,0 +1,17 @@
+set -g status-style 'bg=#282828,fg=#d4be98'
+set -g message-style 'bg=#3c3836,fg=#d4be98'
+set -g message-command-style 'bg=#3c3836,fg=#d4be98'
+set -g pane-border-style 'fg=#3c3836'
+set -g pane-active-border-style 'fg=#a9b665'
+
+set -g window-status-activity-style 'bg=#282828,fg=#ea6962'
+set -g window-status-style 'bg=#282828,fg=#d4be98'
+
+set -g window-status-format '#[fg=#d4be98,bg=#282828] #I #[fg=#d4be98,bg=#282828] #W '
+set -g window-status-current-format '#[fg=#282828,bg=#d8a657] #I #[fg=#282828,bg=#d8a657,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#282828,bg=#d3869b,bold] #S #[fg=#d3869b,bg=#282828]'
+
+set -g mode-style 'bg=#d8a657,fg=#282828'
+
+set -g clock-mode-colour '#d8a657' 

--- a/themes/kanagawa/tmux.conf
+++ b/themes/kanagawa/tmux.conf
@@ -1,0 +1,17 @@
+set -g status-style 'bg=#1f1f28,fg=#dcd7ba'
+set -g message-style 'bg=#090618,fg=#dcd7ba'
+set -g message-command-style 'bg=#090618,fg=#dcd7ba'
+set -g pane-border-style 'fg=#727169'
+set -g pane-active-border-style 'fg=#7e9cd8'
+
+set -g window-status-activity-style 'bg=#1f1f28,fg=#e6c384'
+set -g window-status-style 'bg=#1f1f28,fg=#c8c093'
+
+set -g window-status-format '#[fg=#c8c093,bg=#1f1f28] #I #[fg=#c8c093,bg=#1f1f28] #W '
+set -g window-status-current-format '#[fg=#1f1f28,bg=#957fb8] #I #[fg=#1f1f28,bg=#957fb8,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#1f1f28,bg=#7e9cd8,bold] #S #[fg=#7e9cd8,bg=#1f1f28]'
+
+set -g mode-style 'bg=#957fb8,fg=#1f1f28'
+
+set -g clock-mode-colour '#7e9cd8' 

--- a/themes/matte-black/tmux.conf
+++ b/themes/matte-black/tmux.conf
@@ -1,0 +1,17 @@
+set -g status-style 'bg=#121212,fg=#bebebe'
+set -g message-style 'bg=#333333,fg=#bebebe'
+set -g message-command-style 'bg=#333333,fg=#bebebe'
+set -g pane-border-style 'fg=#333333'
+set -g pane-active-border-style 'fg=#FFC107'
+
+set -g window-status-activity-style 'bg=#121212,fg=#D35F5F'
+set -g window-status-style 'bg=#121212,fg=#8a8a8d'
+
+set -g window-status-format '#[fg=#8a8a8d,bg=#121212] #I #[fg=#8a8a8d,bg=#121212] #W '
+set -g window-status-current-format '#[fg=#121212,bg=#bebebe] #I #[fg=#121212,bg=#bebebe,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#121212,bg=#FFC107,bold] #S #[fg=#FFC107,bg=#121212]'
+
+set -g mode-style 'bg=#bebebe,fg=#121212'
+
+set -g clock-mode-colour '#FFC107' 

--- a/themes/nord/tmux.conf
+++ b/themes/nord/tmux.conf
@@ -1,0 +1,18 @@
+set -g status-style 'bg=#2e3440,fg=#d8dee9'
+set -g message-style 'bg=#3b4252,fg=#d8dee9'
+set -g message-command-style 'bg=#3b4252,fg=#d8dee9'
+set -g pane-border-style 'fg=#4c566a'
+set -g pane-active-border-style 'fg=#88c0d0'
+
+set -g window-status-activity-style 'bg=#2e3440,fg=#ebcb8b'
+set -g window-status-style 'bg=#2e3440,fg=#6c7086'
+
+set -g window-status-format '#[fg=#6c7086,bg=#2e3440] #I #[fg=#6c7086,bg=#2e3440] #W '
+
+set -g window-status-current-format '#[fg=#2e3440,bg=#ebcb8b] #I #[fg=#2e3440,bg=#ebcb8b,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#2e3440,bg=#d08770,bold] #S #[fg=#d08770,bg=#2e3440]'
+
+set -g mode-style 'bg=#81a1c1,fg=#2e3440'
+
+set -g clock-mode-colour '#b48ead'

--- a/themes/ristretto/tmux.conf
+++ b/themes/ristretto/tmux.conf
@@ -1,0 +1,18 @@
+set -g status-style 'bg=#2c2525,fg=#e6d9db'
+set -g message-style 'bg=#463a3a,fg=#e6d9db'
+set -g message-command-style 'bg=#463a3a,fg=#e6d9db'
+set -g pane-border-style 'fg=#463a3a'
+set -g pane-active-border-style 'fg=#f38d70'
+
+set -g window-status-activity-style 'bg=#2c2525,fg=#f9cc6c'
+set -g window-status-style 'bg=#2c2525,fg=#c3b7b8'
+
+set -g window-status-format '#[fg=#c3b7b8,bg=#2c2525] #I #[fg=#c3b7b8,bg=#2c2525] #W '
+
+set -g window-status-current-format '#[fg=#2c2525,bg=#f38d70] #I #[fg=#2c2525,bg=#f38d70,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#2c2525,bg=#fd6883,bold] #S #[fg=#fd6883,bg=#2c2525]'
+
+set -g mode-style 'bg=#85dacc,fg=#2c2525'
+
+set -g clock-mode-colour '#a8a9eb'

--- a/themes/rose-pine/tmux.conf
+++ b/themes/rose-pine/tmux.conf
@@ -1,0 +1,17 @@
+set -g status-style 'bg=#faf4ed,fg=#575279'
+set -g message-style 'bg=#f2e9e1,fg=#575279'
+set -g message-command-style 'bg=#f2e9e1,fg=#575279'
+set -g pane-border-style 'fg=#dfdad9'
+set -g pane-active-border-style 'fg=#56949f'
+
+set -g window-status-activity-style 'bg=#faf4ed,fg=#ea9d34'
+set -g window-status-style 'bg=#faf4ed,fg=#9893a5'
+
+set -g window-status-format '#[fg=#9893a5,bg=#faf4ed] #I #[fg=#9893a5,bg=#faf4ed] #W '
+set -g window-status-current-format '#[fg=#faf4ed,bg=#907aa9] #I #[fg=#faf4ed,bg=#907aa9,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#faf4ed,bg=#56949f,bold] #S #[fg=#56949f,bg=#faf4ed]'
+
+set -g mode-style 'bg=#907aa9,fg=#faf4ed'
+
+set -g clock-mode-colour '#56949f' 

--- a/themes/tokyo-night/tmux.conf
+++ b/themes/tokyo-night/tmux.conf
@@ -1,0 +1,17 @@
+set -g status-style 'bg=#1a1b26,fg=#a9b1d6'
+set -g message-style 'bg=#32344a,fg=#a9b1d6'
+set -g message-command-style 'bg=#32344a,fg=#a9b1d6'
+set -g pane-border-style 'fg=#444b6a'
+set -g pane-active-border-style 'fg=#7aa2f7'
+
+set -g window-status-activity-style 'bg=#1a1b26,fg=#e0af68'
+set -g window-status-style 'bg=#1a1b26,fg=#787c99'
+
+set -g window-status-format '#[fg=#787c99,bg=#1a1b26] #I #[fg=#787c99,bg=#1a1b26] #W '
+set -g window-status-current-format '#[fg=#1a1b26,bg=#bb9af7] #I #[fg=#1a1b26,bg=#bb9af7,bold] #W#{?window_zoomed_flag, 󰊓,} '
+
+set -g status-left '#[fg=#1a1b26,bg=#7aa2f7,bold] #S #[fg=#7aa2f7,bg=#1a1b26]'
+
+set -g mode-style 'bg=#bb9af7,fg=#1a1b26'
+
+set -g clock-mode-colour '#7aa2f7' 


### PR DESCRIPTION
# Add tmux configuration with Omarchy theme integration

Added a basic tmux configuration that:

- Syncs with all Omarchy themes automatically
- Includes essential tmux functionality out of the box
- Updates theme when Omarchy theme changes
- Simple, no-frills setup for users who need tmux

## What's included

- Basic tmux configuration with sensible defaults
- Automatic theme synchronization with current Omarchy theme
- Installation and update handling integrated with existing theme system

## Configuration

The configuration can be adjusted before merging if preferred. The key components are the theming integration and automatic installation/updates.

## Example Screenshots

### Nord Theme
<img width="1920" height="1200" alt="screenshot-2025-08-03_17-01-08" src="https://github.com/user-attachments/assets/1d539c86-66f0-43b7-82a6-4d6ee2bcafc1" />


### Tokyo Night Theme
<img width="1920" height="1200" alt="screenshot-2025-08-03_17-01-50" src="https://github.com/user-attachments/assets/286f2330-5f07-405c-8753-5b2922ca611f" />

PS: ignore the tmux pane on the top right, it is using starship (btw, if interested in a starship themed configuration, let me know, I can create a pr with that too)

## Usage

Users who need tmux will have it available with proper theming. Users who don't want tmux can simply ignore it - no impact on existing workflows.

Whenever launching tmux for the first time, run leader + i to install all plugins with tpm (`Control-A + i`)
