### PR TITLE
Fix hypridle timeout to actually be 2.5min

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -7,7 +7,7 @@ general {
 }
 
 listener {
-    timeout = 180                                             # 2.5min
+    timeout = 150                                             # 2.5min
     on-timeout = pidof hyprlock || omarchy-launch-screensaver # start screensaver (if we haven't locked already)
 }
 


### PR DESCRIPTION
Per the release notes:
> * Fix screensaver should wait 2.5 minutes instead of 1 minute before starting automatically

The intent was for this to be 2.5 minutes but 180s is 3 minutes.