### PR TITLE
Fix omarchy-update-available script to work with forks

### DIFF
--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 omarchy_path="$HOME/.local/share/omarchy"
-latest_tag=$(git -C $omarchy_path ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
+
+if git -C $omarchy_path remote | grep -q "^upstream$"; then
+  remote="upstream"
+else
+  remote="origin"
+fi
+
+latest_tag=$(git -C $omarchy_path ls-remote --tags $remote | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
 current_tag=$(git -C $omarchy_path describe --tags $(git -C $omarchy_path rev-list --tags --max-count=1))
 
 if [[ "$current_tag" != "$latest_tag" ]]; then


### PR DESCRIPTION
## Fix omarchy-update-available script to work with forks

Many people fork omarchy, to fine tune their experience

This pr allows people with forks to have the update check script working too

Now the update check script uses the upstream remote if it exists:

- If it is a normal clone, nothing changes (still uses origin)
- If it is a fork, it will now still check if the fork is up to date with upstream (actual omarchy)
