### PR TITLE
Setting a relative path causes path resolution problems with dkms and potentially opens up a security issue.

### DIFF
--- a/default/bash/shell
+++ b/default/bash/shell
@@ -10,7 +10,7 @@ if [[ ! -v BASH_COMPLETION_VERSINFO && -f /usr/share/bash-completion/bash_comple
 fi
 
 # Set complete path
-export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omarchy/bin:$PATH"
+export PATH="$HOME/bin:$HOME/.local/bin:$HOME/.local/share/omarchy/bin:$PATH"
 set +h
 
 # Omarchy path


### PR DESCRIPTION
I didn't test if this causes issues with the install, but I tracked this down while debugging why DKMS has been failing to install modules.

Using a leading relative path could potentially lead to unintended consequences if someone were to say send you a tarball with a `bin/ls` that just `rm -fr /`.

```
==> dkms install --no-depmod zenpower3/0.2.0 -k 6.15.9-zen1-1-zen
./bin/dkms: line 194: ./bin/date: No such file or directory
./bin/dkms: line 1462: ./bin/mkdir: No such file or directory
mktemp: failed to create directory via template ‘/var/lib/dkms/zenpower3/0.2.0/6.15.9-zen1-1-zen/.tmp_x86_64_XXXXXX’: No such file or directory

Error! Unable to make temporary directory.
./bin/dkms: line 1464: ./bin/mkdir: No such file or directory
./bin/dkms: line 1465: ./bin/cp: No such file or directory
./bin/dkms: line 1468: ./bin/mkdir: No such file or directory
./bin/dkms: line 1470: ./bin/cp: No such file or directory
./bin/dkms: line 1512: ./bin/cp: No such file or directory
```