### PR TITLE
Change Obsidian package from AUR to Extra

### DIFF
--- a/install/apps/xtras.sh
+++ b/install/apps/xtras.sh
@@ -3,7 +3,7 @@
 if [ -z "$OMARCHY_BARE" ]; then
   yay -S --noconfirm --needed \
     gnome-calculator gnome-keyring signal-desktop \
-    obsidian-bin libreoffice obs-studio kdenlive \
+    obsidian libreoffice obs-studio kdenlive \
     xournalpp localsend-bin
 
   # Packages known to be flaky or having key signing issues are run one-by-one


### PR DESCRIPTION
This pull request updates the package installation script by replacing the AUR obsidian-bin package with the officially maintained obsidian package in install/apps/xtras.sh.

### Changes
Replaced: obsidian-bin ➝ obsidian

File: install/apps/xtras.sh

### Rationale
Switching to the official obsidian package aligns with a preference to reduce reliance on AUR packages. AUR helpers can introduce potential safety, stability, and maintenance concerns. Where possible, using officially supported packages or scripted installations improves reproducibility and reduces system complexity.

### Personal Consideration
In my view, opting out of the AUR when official packages are available is the safer and more maintainable choice. Over time, the few AUR packages preinstalled could be replaced with custom installation scripts, further minimizing external dependencies and safety concerns.