### PR TITLE
improved error handling in fido2 setup

### DIFF
--- a/bin/omarchy-setup-fido2
+++ b/bin/omarchy-setup-fido2
@@ -18,6 +18,10 @@ else
       sudo mkdir -p /etc/fido2
       echo -e "\e[32m\nLet's setup your device by confirming on the device now.\e[0m"
       pamu2fcfg >/tmp/fido2 # This needs to run as the user
+      if [ $? -ne 0 ]; then
+        echo -e "\e[31m\nSomething went wrong. Maybe try again?\e[0m"
+        exit 1
+      fi
       sudo mv /tmp/fido2 /etc/fido2/fido2
     fi
 


### PR DESCRIPTION
Introduced in exit code check for pamu2cfg to fix condition where pin could be typed in incorrectly but still exit with a 0 code making is non-obvious to end user that fido2 setup failed