### PR TITLE
fixed font-size for Impala waybar widget

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -71,7 +71,7 @@
     "tooltip-format-disconnected": "Disconnected",
     "interval": 3,
     "nospacing": 1,
-    "on-click": "alacritty --class=Impala -e impala"
+    "on-click": "alacritty --option='font.size=9' --class=Impala -e impala"
   },
   "battery": {
     "format": "{capacity}% {icon}",


### PR DESCRIPTION
I changed the font-size of my terminal in `~/.config/alacritty/alacritty.toml` ot `12`. After that the Impala network widget in the waybar stopped working - or so I thought. Specifically, I thought it didn't show any "New Networks":

<img width="3366" height="1168" alt="screenshot-2025-08-05_10-39-26" src="https://github.com/user-attachments/assets/dc227f20-ea40-4b08-b72d-eb86811dc020" />

It runs out to be an issue with the Impala tui. The networks are there and can be selected but they are not visible because the "New networks" section is to small. Changing the height of the terminal (or decreasing the font-size) makes the new networks visible again:

<img width="1918" height="2318" alt="screenshot-2025-08-05_10-39-59" src="https://github.com/user-attachments/assets/338f30f7-2f04-492d-a7e4-2da0f62dc729" />

I opened an issue with Impala:
https://github.com/pythops/impala/issues/46

An immediate fix is the overwrite to font-size option of alacritty in the call to impala in the waybar which this PR implements.
