### PR TITLE
Check if walker is already launched

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -1,5 +1,5 @@
 # Menus
-bindd = SUPER, SPACE, Launch apps, exec, walker -p "Start…"
+bindd = SUPER, SPACE, Launch apps, exec, pgrep -x walker || walker -p "Start…"
 bindd = SUPER ALT, SPACE, Run commands, exec, ~/.local/share/omarchy/bin/omarchy-menu
 bindd = SUPER, ESCAPE, Power menu, exec, ~/.local/share/omarchy/bin/omarchy-menu system
 bindd = SUPER, K, Show key bindings, exec, ~/.local/share/omarchy/bin/omarchy-menu-keybindings


### PR DESCRIPTION
I have encountered a bug where if you press walker keybind while walker is already launched, it would start again leading to an input grab/focus freeze. Simple check for existing process before trying to launch walker again fixes the issue.

**Steps to reproduce:**
Press walker keybind (default: SUPER + SPACE) at least twice
