### PR TITLE
Fix disabling of `resolved` Multicast DNS

### DIFF
--- a/install/desktop/printer.sh
+++ b/install/desktop/printer.sh
@@ -5,7 +5,7 @@ sudo systemctl enable --now cups.service
 
 # Disable multicast dns in resolved. Avahi will provide this for better network printer discovery
 sudo mkdir -p /etc/systemd/resolved.conf.d
-echo "[Resolve]\nMulticastDNS=no" | sudo tee /etc/systemd/resolved.conf.d/10-disable-multicast.conf
+echo -e "[Resolve]\nMulticastDNS=no" | sudo tee /etc/systemd/resolved.conf.d/10-disable-multicast.conf
 sudo systemctl enable --now avahi-daemon.service
 
 # Enable automatically adding remote printers


### PR DESCRIPTION
Prior to this fix, the file `10-disable-multicast.conf` had contents:

```
[Resolve]\nMulticastDNS=no
```

We could also switch from `echo` to `printf` so that escape sequences "just work". The joys of shell scripting! :upside_down_face: 