### PR TITLE
Omarchy is exclusively for vanilla Arch without Gnome or KDE installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ show_subtext() {
 }
 
 # Install prerequisites
+source $OMARCHY_INSTALL/preflight/guard.sh
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh
 source $OMARCHY_INSTALL/preflight/migrations.sh

--- a/install/preflight/guard.rb
+++ b/install/preflight/guard.rb
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+abort() {
+  echo -e "\e[31mOmarchy is only designed for a fresh Arch install!\e[0m"
+  exit 1
+}
+
+# Must be an Arch distro
+[[ -f /etc/arch-release ]] || abort
+
+# Must not be an Arch derivative distro
+for marker in /etc/cachyos-release /etc/eos-release /etc/garuda-release /etc/manjaro-release; do
+  [[ -f "$marker" ]] && abort
+done
+
+# Must not have Gnome or KDE already install
+pacman -Qe gnome-shell &>/dev/null && abort
+pacman -Qe plasma-desktop &>/dev/null && abort


### PR DESCRIPTION
We keep having folks trying to install Omarchy on something else than a fresh Arch installation.