### PR TITLE
Make Screensaver Background Color Black

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -9,10 +9,7 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
   hyprctl dispatch focusmonitor $m
   hyprctl dispatch exec -- \
     alacritty --class Screensaver \
-    -o 'colors.primary.background="#000000"' \
-    -o 'colors.cursor.cursor="#000000"' \
-    -o 'font.size=18' \
-    -o 'window.opacity=1' \
+    --config-file ~/.config/alacritty/screensaver.toml  \
     -e ~/.local/share/omarchy/bin/omarchy-cmd-screensaver
 done
 

--- a/config/alacritty/screensaver.toml
+++ b/config/alacritty/screensaver.toml
@@ -1,0 +1,11 @@
+[colors.primary]
+background = "0x000000"
+
+[colors.cursor]
+cursor = "0x000000"
+
+[font]
+size = 18.0
+
+[window]
+opacity = 1.0


### PR DESCRIPTION
Resolves: Issue #517 

As the color for the screensaver background was not properly set to black, I created a dedicated alacritty .toml file and changed the command for the screensaver to use this config file. 
This change works on my local Omarchy setup (I don’t have a virtual test environment yet).

ps.: It's my first open source PR