### PR TITLE
Fix "update-available" waybar icon persisting after update

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -21,4 +21,4 @@ if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $
 fi
 
 # Refresh waybar to remove update-available icon
-~/.local/share/omarchy/bin/omarchy-refresh-waybar
+~/.local/share/omarchy/bin/omarchy-restart-waybar


### PR DESCRIPTION
## Fix: Update icon in Waybar doesn't disappear immediately after update

After running `omarchy-update`, the `custom/update` icon in Waybar remains visible until the next interval (1 hour).  
This can confuse users, as it looks like the update didn’t work.

### Expected Behavior
The icon should disappear immediately after a successful update, providing clear feedback.

#### Current Configuration
```json
"custom/update": {
  "format": "",
  "exec": "~/.local/share/omarchy/bin/omarchy-update-available",
  "on-click": "alacritty --class Omarchy --title Omarchy -e omarchy-update",
  "interval": 3600
}
```

### Solution

Running omarchy-refresh-waybar, after a successful update

Sorry if it's a small pr, been trying to contribute: loving the project so far