### PR TITLE
Show estimated battery charge and discharge time in the tooltip

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -93,8 +93,8 @@
       ]
     },
     "format-full": "󰂅",
-    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
-    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%\n{time}",
+    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%\n{time}",
     "interval": 5,
     "states": {
       "warning": 20,


### PR DESCRIPTION
Small QOL improvement I hope :)

<img width="180" height="104" alt="20250808_14h05m29s_grim" src="https://github.com/user-attachments/assets/cd6c017f-c12e-4787-9def-ebd37eeab505" />
