### PR TITLE
Fix spacing for waybar tray icon

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -42,10 +42,6 @@
   margin: 0 7.5px;
 }
 
-#custom-expand-icon {
-  margin-right: 12px;
-}
-
 tooltip {
   padding: 2px;
 }


### PR DESCRIPTION
Removes the extra margin between the tray expander and other waybar icons. The changes from https://github.com/basecamp/omarchy/pull/156  fixed the original complications with getting the spacing consistent, making this margin hack actually make things worse.

**Before**
<img width="169" height="35" alt="image" src="https://github.com/user-attachments/assets/1729f79b-8947-40db-a083-c7c2ac1fd17b" />

**After**
<img width="179" height="32" alt="image" src="https://github.com/user-attachments/assets/43d3775d-df2c-4a2f-b0bd-d7b91d0cb2b4" />
