### PR TITLE
Fix git usage in migration script

### DIFF
--- a/migrations/1754566681.sh
+++ b/migrations/1754566681.sh
@@ -2,6 +2,6 @@ echo "Make new Osaka Jade theme available as new default"
 
 if [[ ! -L ~/.config/omarchy/themes/osaka-jade ]]; then
   rm -rf ~/.config/omarchy/themes/osaka-jade
-  git -C ~/.local/share/omarchy co -f themes/osaka-jade
+  git -C ~/.local/share/omarchy checkout -f themes/osaka-jade
   ln -nfs ~/.local/share/omarchy/themes/osaka-jade ~/.config/omarchy/themes/osaka-jade
 fi


### PR DESCRIPTION
A user may not have `co` aliased to `checkout` and then will have errors running the migration script.