### PR TITLE
Lock 1password on screen lock

### DIFF
--- a/bin/omarchy-lock-screen
+++ b/bin/omarchy-lock-screen
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Lock the screen
+pidof hyprlock || hyprlock
+
+# Ensure 1password is locked
+if pgrep -x "1password" >/dev/null; then
+  1password --lock
+fi
+
+# Avoid running screensaver when locked
+pkill -f "alacritty --class Screensaver"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -273,7 +273,7 @@ show_update_config_menu() {
 
 show_system_menu() {
   case $(menu "System" "  Lock\n󰤄  Suspend\n  Relaunch\n󰜉  Restart\n󰐥  Shutdown") in
-  *Lock*) hyprlock ;;
+  *Lock*) $OMARCHY_BIN_PATH/omarchy-lock-screen ;;
   *Suspend*) systemctl suspend ;;
   *Relaunch*) uwsm stop ;;
   *Restart*) systemctl reboot ;;

--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -1,8 +1,7 @@
 general {
-    lock_cmd = pidof hyprlock || hyprlock                  # avoid starting multiple hyprlock instances.
+    lock_cmd = omarchy-lock-screen                         # lock screen and 1password
     before_sleep_cmd = loginctl lock-session               # lock before suspend.
     after_sleep_cmd = hyprctl dispatch dpms on             # to avoid having to press a key twice to turn on the display.
-    on_lock_cmd = pkill -f "alacritty --class Screensaver" # avoid running screensaver when locked
     on_unlock_cmd = omarchy-restart-waybar                 # prevent stacking of waybar when waking
 }
 

--- a/migrations/1754679822.sh
+++ b/migrations/1754679822.sh
@@ -1,0 +1,5 @@
+echo "Lock 1password on screen lock"
+
+if ! grep -q "omarchy-lock-screen" ~/.config/hypr/hypridle.conf; then
+  ~/.local/share/omarchy/bin/omarchy-refresh-hypridle
+fi


### PR DESCRIPTION
Because 1password doesn't integrate well with the hyprland session, it doesn't allow locking on idle.

This script ensures that an open 1password vault will be locked whenever the screen is locked. 