### PR TITLE
About.desktop fixed font size

### DIFF
--- a/applications/About.desktop
+++ b/applications/About.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=About
 Comment=System information from Fastfetch
-Exec=alacritty --class=About --title=About -e bash -c 'fastfetch; read -n 1 -s'
+Exec=alacritty -o "font.size=9" --class=About --title=About -e bash -c 'fastfetch; read -n 1 -s'
 Terminal=false
 Type=Application
 Icon=Arch

--- a/bin/omarchy-version
+++ b/bin/omarchy-version
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-git -C "$OMARCHY_PATH" describe --tags $(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1)

--- a/bin/omarchy-version
+++ b/bin/omarchy-version
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git -C "$OMARCHY_PATH" describe --tags $(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1)


### PR DESCRIPTION
User changes font and size for terminal, often larger fonts.

This affects styling and font size of About as it uses same terminal. About is something user wants to look or show, so if big logo of OS, and format of spec and versions, looks messy. It is not beautiful.

This will set the size (may vary with different font a bit) of fastfech out put in the float. I have defaulted to size 9 but please changae if you feel somehting else is better.

This was one of the most asked questions how to fix, in the chat, after font change menu introduced.

Now, tried to override float size in ~/.config/hyprland/system-override.conf, with larger float size, and sourced in hyprland.conf. It did not work. Manually fixed missing " ," (already fixed in v1.12.1) in default hypr config (system.conf),  and override did not take effect in override, neither. I had to change default itself to make float bigger.

It is cumbersome to change the float size w.r.t. font and size, and some of the output is longer than expected, by each users PC, and font, font size choices. 

another option: resize About float size, with script,  seems too complex , so opted just fix font size. 

please take a look.
Thank you. 