### PR TITLE
Add Discord

### DIFF
--- a/install/apps/xtras.sh
+++ b/install/apps/xtras.sh
@@ -2,7 +2,7 @@
 
 if [ -z "$OMARCHY_BARE" ]; then
   yay -S --noconfirm --needed \
-    gnome-calculator gnome-keyring signal-desktop \
+    gnome-calculator gnome-keyring signal-desktop discord \
     obsidian-bin libreoffice obs-studio kdenlive \
     xournalpp localsend-bin
 


### PR DESCRIPTION
Discord is the official support/community for Omarchy and takes center stage on the homepage.  However it is not installed on Omarchy by default so its a few extra steps for new users.  

This PR adds it as an application along side Signal, Obsidian, OBS and the like.

Alternatively - if this is not the right path forward we should perhaps put a section in the manual about how to install and use it (best channels for questions etc).  

Just trying to make the path for new people to get help if needed much simpler.