### PR TITLE
Find system links in current theme background

### DIFF
--- a/bin/omarchy-theme-bg-next
+++ b/bin/omarchy-theme-bg-next
@@ -5,7 +5,7 @@
 BACKGROUNDS_DIR="$HOME/.config/omarchy/current/theme/backgrounds/"
 CURRENT_BACKGROUND_LINK="$HOME/.config/omarchy/current/background"
 
-mapfile -d '' -t BACKGROUNDS < <(find "$BACKGROUNDS_DIR" -type f -print0 | sort -z)
+mapfile -d '' -t BACKGROUNDS < <(find "$BACKGROUNDS_DIR" -type l -print0 | sort -z)
 TOTAL=${#BACKGROUNDS[@]}
 
 if [[ $TOTAL -eq 0 ]]; then


### PR DESCRIPTION
I'm currently working on a [fork](https://github.com/ncrmro/omarchy-nix/tree/feat/submodule-omarchy-arch) of @henrysipp omarchy-nix where I've added this repo as a submodule to more easily keep things in sync.

When I call `omarchy-theme-next` it cant find any background files because they are system links and not files. I don't have an arch machine at the moment to test but I wouldn't expect this so be an issue across the two distributions.

