### PR TITLE
feat: Add notification status indicator to waybar

### DIFF
--- a/bin/omarchy-notification-status
+++ b/bin/omarchy-notification-status
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Check if notifications are silenced (do-not-disturb mode)
+if makoctl mode | grep -q 'do-not-disturb'; then
+  # Notifications are disabled - show red dot
+  echo '{"text": "•", "tooltip": "Notifications silenced", "class": "notifications-disabled"}'
+else
+  # Notifications are enabled - show dim dot
+  echo '{"text": "•", "tooltip": "Notifications enabled", "class": "notifications-enabled"}'
+fi

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -9,6 +9,7 @@
     "hyprland/workspaces"
   ],
   "modules-center": [
+    "custom/notification-status",
     "clock",
     "custom/update"
   ],
@@ -55,6 +56,13 @@
     "on-click": "alacritty --class Omarchy --title Omarchy -e ~/.local/share/omarchy/bin/omarchy-update",
     "tooltip-format": "Omarchy update available",
     "interval": 3600
+  },
+  "custom/notification-status": {
+    "exec": "~/.local/share/omarchy/bin/omarchy-notification-status",
+    "return-type": "json",
+    "interval": 1,
+    "on-click": "makoctl mode -t do-not-disturb",
+    "tooltip": true
   },
   "cpu": {
     "interval": 5,

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -37,7 +37,8 @@
 #bluetooth,
 #pulseaudio,
 #clock,
-#custom-omarchy {
+#custom-omarchy,
+#custom-notification-status {
   min-width: 12px;
   margin: 0 7.5px;
 }
@@ -48,4 +49,18 @@
 
 tooltip {
   padding: 2px;
+}
+
+#custom-notification-status {
+  font-size: 14px;
+  margin-right: 3px;
+}
+
+#custom-notification-status.notifications-disabled {
+  color: #f38ba8;
+  opacity: 1;
+}
+
+#custom-notification-status.notifications-enabled {
+  opacity: 0.5;
 }


### PR DESCRIPTION
## Summary
- Adds a subtle dot indicator to show notification status in waybar  
- Provides visual feedback when notifications are silenced (do-not-disturb mode)
- Integrates seamlessly with existing keyboard shortcuts

## Implementation
- New script `omarchy-notification-status` that checks mako's do-not-disturb mode
- Waybar module displays a red dot when notifications are disabled, dimmed dot when enabled
- Click action toggles do-not-disturb mode (same as SUPER+CTRL+,)
- Positioned to the left of the clock for minimal layout disruption

## Test plan
- [ ] Toggle notifications with SUPER+CTRL+, and verify dot changes color
- [ ] Click the dot indicator and verify it toggles notification status  
- [ ] Hover over the dot to see the tooltip ("Notifications enabled/silenced")
- [ ] Verify the indicator updates in real-time when toggling via keyboard