### PR TITLE
Fix prevent multiple Walker instances stacking when opening system menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -2,6 +2,28 @@
 
 OMARCHY_BIN_PATH=~/.local/share/omarchy/bin
 
+ensure_single_instance() {
+  local state_dir="/run/user/$UID"
+  local lock_file="$state_dir/omarchy-menu.lock"
+  local pid_file="$state_dir/omarchy-menu.pid"
+
+  trap 'pkill -f "walker .*(--dmenu|-p)" >/dev/null 2>&1; exit 0' USR1
+
+  exec 9>"$lock_file"
+  if ! flock -n 9; then
+    local prev_pid
+    prev_pid="$(cat "$pid_file" 2>/dev/null || true)"
+    [[ -n "$prev_pid" ]] && kill -USR1 "$prev_pid" 2>/dev/null || true
+    for i in {1..20}; do kill -0 "$prev_pid" 2>/dev/null || break; done
+    flock -n 9 || exit 0
+  fi
+
+  echo "$$" > "$pid_file"; trap "rm -f '$pid_file'" EXIT
+  pkill -f 'walker .*(--dmenu|-p)' >/dev/null 2>&1 || true
+}
+
+ensure_single_instance
+
 menu() {
   local prompt="$1"
   local options="$2"


### PR DESCRIPTION
#577 

Ensures the system menu can only run a single Walker instance at a time.

- Uses `flock` on a per-user lock file to coordinate single-instance execution
- Stores leader PID in /run/user/$UID and sends SIGUSR1 for graceful handoff
- Cleans up stale PID files on exit and clears any lingering Walker UI


PS: It's my first Open Source PR so any feedback is appreciated!