### PR TITLE
 Fix kernel update detection for alternative kernel variants

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $2}')" ]; then
-  gum confirm "New Linux kernel requires reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
+# Check for kernel package updates since last boot
+boot_time=$(date -d "$(uptime -s)" '+%Y-%m-%d %H:%M')
+recent_kernel_updates=$(awk -v boot_time="$boot_time" '$0 >="["boot_time' /var/log/pacman.log | grep -E "\[ALPM\] (upgraded|installed) (linux|linux-zen|linux-lts|linux-hardened)\b" || true)
+if [ -n "$recent_kernel_updates" ]; then
+  gum confirm "Linux kernel has been updated. Reboot?" && omarchy-state clear re*-required && sudo reboot now
+
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
   gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
+
 elif [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
   gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
 fi


### PR DESCRIPTION
# Pull Request Summary
## Fix kernel update detection for alternative kernel variants
### Issue Description
The original kernel update detection in `omarchy-update` used a version comparison method that only worked with the standard `linux` package:
```bash
if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $2}')" ]; then
```

This approach had several problems:
- **Failed with alternative kernels**: Users running `linux-zen`, `linux-lts`, `linux-hardened`, or other kernel variants would never get reboot prompts after kernel updates
- **Unreliable detection**: The version string manipulation was fragile and could miss legitimate kernel updates
- **Package assumption**: Hardcoded to only check the `linux` package, ignoring other kernel variants

This meant users with alternative kernels would unknowingly run outdated kernels after system updates, potentially missing important security fixes and stability improvements.

Screenshot:
<img width="437" height="385" alt="screenshot-2025-08-09_08-36-01" src="https://github.com/user-attachments/assets/63189d14-96cd-4427-b53b-1d556527f135" />

### Fix Summary
• Replaces unreliable kernel version comparison with pacman log parsing to properly detect kernel updates
• Fixes reboot prompts not working with alternative kernels like linux-zen, linux-lts, and linux-hardened

### Test Evidence
Tested the kernel update detection by simulating pacman log entries:

**Test 1: Standard linux kernel update**
- Added to `/var/log/pacman.log`: `[2025-08-09 08:26] [ALPM] upgraded linux (6.8.1.arch1-1 -> 6.8.2.arch1-1)`
- Simulates a main kernel update
- Screenshot: 
<img width="460" height="400" alt="screenshot-2025-08-09_08-29-37" src="https://github.com/user-attachments/assets/131545ef-865b-4612-ac01-8e90f44c2d92" />

**Test 2: Alternative kernel (linux-zen) update**  
- Added to `/var/log/pacman.log`: `[2025-08-09T08:29:31-0500] [ALPM] upgraded linux-zen (6.15.8.zen1-2 -> 6.15.9.zen1-1)`
- Simulates a linux-zen kernel update
- Screenshot: 
<img width="462" height="382" alt="screenshot-2025-08-09_08-34-56" src="https://github.com/user-attachments/assets/99d75e35-3feb-448e-b796-2d6855e35a04" />

** Test 3: Running `omarchy-update all` on `linux-zen` kernel with no kernel updates available 
- Shows no kernel reboot message.
- Screenshot:
<img width="626" height="961" alt="screenshot-2025-08-09_11-44-35" src="https://github.com/user-attachments/assets/c2ab712f-698b-43d0-893f-917afdfb44a9" />


Both tests successfully detected kernel updates and prompted for reboot, confirming the fix works for both standard and alternative kernel variants. When running `linux-zen` kernel and no kernels were updated, the kernel update reboot message is not displayed.

