### PR TITLE
Fix a misspelled word in the last closed pull request

### DIFF
--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-pkg_name=$(yay -Slq | fzf --multi --preview 'yay -Sii {1}' --preview-window=down:75%)
+fzf_args=(
+  --multi
+  --preview 'yay -Sii {1}'
+  --preview-window 'down:50%:wrap'
+  --bind 'alt-p:toggle-preview'
+  --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
+  --bind 'alt-k:preview-up,alt-j:preview-down'
+  --bind 'ctrl-d:half-page-down,ctrl-u:half-page-up'
+)
+
+pkg_name=$(yay -Slq | fzf "${fzf_args[@]}")
 
 if [[ -n "$pkg_name" ]]; then
   yay -Sy --noconfirm "$pkg_name"

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -2,8 +2,8 @@
 
 fzf_args=(
   --multi
-  --preview 'yay -Sii {1}'
-  --preview-window 'down:50%:wrap'
+  --preview 'echo "alt-p: toggle preview, alt-j/k: scroll, F11: maxime"; echo; yay -Sii {1}'
+  --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -7,7 +7,6 @@ fzf_args=(
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'
-  --bind 'ctrl-d:half-page-down,ctrl-u:half-page-up'
 )
 
 pkg_name=$(yay -Slq | fzf "${fzf_args[@]}")

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -2,7 +2,7 @@
 
 fzf_args=(
   --multi
-  --preview 'echo "alt-p: toggle preview, alt-j/k: scroll, F11: maxime"; echo; yay -Sii {1}'
+  --preview 'echo "alt-p: toggle this, alt-j/k: scroll, F11: fullscreen"; echo; yay -Sii {1}'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -2,7 +2,7 @@
 
 fzf_args=(
   --multi
-  --preview 'echo "alt-p: toggle this, alt-j/k: scroll, F11: fullscreen"; echo; yay -Sii {1}'
+  --preview 'echo "alt-p: toggle, alt-j/k: scroll, F11: fullscreen"; echo; yay -Sii {1}'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -2,7 +2,7 @@
 
 fzf_args=(
   --multi
-  --preview 'echo "alt-p: toggle preview, alt-j/k: scroll, F11: maxime"; echo; yay -Qi {1}'
+  --preview 'echo "alt-p: toggle this, alt-j/k: scroll, F11: fullscreen"; echo; yay -Qi {1}'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -7,7 +7,6 @@ fzf_args=(
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'
-  --bind 'ctrl-d:half-page-down,ctrl-u:half-page-up'
 )
 
 pkg_name=$(yay -Qqe | fzf "${fzf_args[@]}")

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -2,8 +2,8 @@
 
 fzf_args=(
   --multi
-  --preview 'yay -Qi {1}'
-  --preview-window 'down:50%:wrap'
+  --preview 'echo "alt-p: toggle preview, alt-j/k: scroll, F11: maxime"; echo; yay -Qi {1}'
+  --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-pkg_name=$(yay -Qqe | fzf --multi --preview 'yay -Qi {1}' --preview-window=down:75%)
+fzf_args=(
+  --multi
+  --preview 'yay -Qi {1}'
+  --preview-window 'down:50%:wrap'
+  --bind 'alt-p:toggle-preview'
+  --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
+  --bind 'alt-k:preview-up,alt-j:preview-down'
+  --bind 'ctrl-d:half-page-down,ctrl-u:half-page-up'
+)
+
+pkg_name=$(yay -Qqe | fzf "${fzf_args[@]}")
 
 if [[ -n "$pkg_name" ]]; then
   yay -Rns --noconfirm "$pkg_name"

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -2,7 +2,7 @@
 
 fzf_args=(
   --multi
-  --preview 'echo "alt-p: toggle this, alt-j/k: scroll, F11: fullscreen"; echo; yay -Qi {1}'
+  --preview 'echo "alt-p: toggle, alt-j/k: scroll, F11: fullscreen"; echo; yay -Qi {1}'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'

--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -33,27 +33,3 @@ n() { if [ "$#" -eq 0 ]; then nvim .; else nvim "$@"; fi; }
 alias gcm='git commit -m'
 alias gcam='git commit -a -m'
 alias gcad='git commit -a --amend'
-
-# Find packages without leaving the terminal
-# alias yayf="yay -Slq | fzf --multi --preview 'yay -Sii {1}' --preview-window=down:75% | xargs -ro yay -S"
-
-yayf() {
-  local fzf_args=(
-    --multi
-    --preview 'echo "alt-p: toggle preview, alt-j/k: scroll, F11: maxime"; echo; yay -Sii {1}'
-    --preview-window 'down:50%:wrap'
-    --bind 'alt-p:toggle-preview'
-    --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
-    --bind 'alt-k:preview-up,alt-j:preview-down'
-  )
-
-  local selected_pkgs
-  selected_pkgs=$(yay -Slq | fzf "${fzf_args[@]}")
-
-  if [[ -n "$selected_pkgs" ]]; then
-    echo "$selected_pkgs" | xargs -r yay -S
-  else
-    echo "No packages selected."
-  fi
-}
-

--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -40,7 +40,7 @@ alias gcad='git commit -a --amend'
 yayf() {
   local fzf_args=(
     --multi
-    --preview 'yay -Sii {1}'
+    --preview 'echo "alt-p: toggle preview, alt-j/k: scroll, F11: maxime"; echo; yay -Sii {1}'
     --preview-window 'down:50%:wrap'
     --bind 'alt-p:toggle-preview'
     --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'

--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -45,7 +45,6 @@ yayf() {
     --bind 'alt-p:toggle-preview'
     --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
     --bind 'alt-k:preview-up,alt-j:preview-down'
-    --bind 'ctrl-d:half-page-down,ctrl-u:half-page-up'
   )
 
   local selected_pkgs

--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -35,4 +35,26 @@ alias gcam='git commit -a -m'
 alias gcad='git commit -a --amend'
 
 # Find packages without leaving the terminal
-alias yayf="yay -Slq | fzf --multi --preview 'yay -Sii {1}' --preview-window=down:75% | xargs -ro yay -S"
+# alias yayf="yay -Slq | fzf --multi --preview 'yay -Sii {1}' --preview-window=down:75% | xargs -ro yay -S"
+
+yayf() {
+  local fzf_args=(
+    --multi
+    --preview 'yay -Sii {1}'
+    --preview-window 'down:50%:wrap'
+    --bind 'alt-p:toggle-preview'
+    --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
+    --bind 'alt-k:preview-up,alt-j:preview-down'
+    --bind 'ctrl-d:half-page-down,ctrl-u:half-page-up'
+  )
+
+  local selected_pkgs
+  selected_pkgs=$(yay -Slq | fzf "${fzf_args[@]}")
+
+  if [[ -n "$selected_pkgs" ]]; then
+    echo "$selected_pkgs" | xargs -r yay -S
+  else
+    echo "No packages selected."
+  fi
+}
+


### PR DESCRIPTION
On my last pullrequest I misspelled "maximize". 

this changes:

--preview 'echo "alt-p: toggle preview, alt-j/k: scroll, F11: maxime"; echo; yay -Sii {1}'

to 

--preview 'echo "alt-p: toggle, alt-j/k: scroll, F11: fullscreen"; echo; yay -Sii {1}'