### PR TITLE
Add dropdown terminal functionality with Alacritty

### DIFF
--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -6,3 +6,4 @@ source = ~/.local/share/omarchy/default/hypr/apps/retroarch.conf
 source = ~/.local/share/omarchy/default/hypr/apps/steam.conf
 source = ~/.local/share/omarchy/default/hypr/apps/system.conf
 source = ~/.local/share/omarchy/default/hypr/apps/walker.conf
+source = ~/.local/share/omarchy/default/hypr/apps/dropdown-alacritty.conf

--- a/default/hypr/apps/dropdown-alacritty.conf
+++ b/default/hypr/apps/dropdown-alacritty.conf
@@ -1,0 +1,8 @@
+# Open dropdown alacritty in special workspace and make it float and maximized
+windowrulev2 = workspace special, title:^(dropdown-alacritty)$
+windowrulev2 = float, title:^(dropdown-alacritty)$
+windowrulev2 = maximize, title:^(dropdown-alacritty)$
+
+# Toggle dropdown alacritty
+bind = , F12, exec, bash -c '[ -z "$(ps -fC alacritty | grep "dropdown")" ] && alacritty --class Alacritty,dropdown -T dropdown-alacritty'
+bind = , F12, togglespecialworkspace


### PR DESCRIPTION
This is my first PR!

**Description**:
Adds a dropdown terminal that can be quickly accessed from any workspace with F12, eliminating the need to navigate to a workspace with an open terminal.

**Changes Made**
Added window rules to make dropdown terminal float, maximize, and use special workspace.
Added F12 keybind to toggle dropdown terminal.
Includes process detection to prevent duplicate instances.

**Features**
Quick Access: Press F12 from any workspace to instantly access terminal.
No Workspace Switching: No need to navigate to workspaces with existing terminals.
Clean Integration: Uses special workspace to avoid cluttering main workspaces.

Improves workflow efficiency by providing instant terminal access regardless of current workspace.