### PR TITLE
Use system wide package manager to install a package and install Laravel for the current user.

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -26,7 +26,12 @@ go)
   ;;
 laravel)
   echo -e "Installing PHP and Laravel...\n"
-  bash -c "$(curl -fsSL https://php.new/install/linux)"
+  yay -S php composer --noconfirm
+  composer global require laravel/installer
+  echo 'export PATH="$HOME/.config/composer/vendor/bin:$PATH"' >> "$HOME/.bashrc"
+  source "$HOME/.bashrc"
+  echo "PHP, Composer, and Laravel have been installed successfully."
+  echo "You can now run: laravel new myproject"
   ;;
 python)
   echo -e "Installing Python...\n"


### PR DESCRIPTION
As discussed on the #594 PR this is the version using Arch packages repository instead of downloading PHP binary on the user home.