### PR TITLE
Add zero-width space to xcompose

### DIFF
--- a/default/xcompose
+++ b/default/xcompose
@@ -4,8 +4,8 @@ include "%L"
 <Multi_key> <m> <s> : "😄" # smile
 <Multi_key> <m> <c> : "😂" # cry
 <Multi_key> <m> <l> : "😍" # love
-<Multi_key> <m> <v> : "✌️"  # victory
-<Multi_key> <m> <h> : "❤️"  # heart
+<Multi_key> <m> <v> : "✌️" # victory
+<Multi_key> <m> <h> : "❤️" # heart
 <Multi_key> <m> <y> : "👍" # yes
 <Multi_key> <m> <n> : "👎" # no
 <Multi_key> <m> <f> : "🖕" # fuck
@@ -27,3 +27,4 @@ include "%L"
 
 # Typography
 <Multi_key> <space> <space> : "—"
+<Multi_key> <space> <z> : "​" # zero-width space


### PR DESCRIPTION
Adds zero-width space (`U+200B`) on `capslock space z` so you can slip invisible breaks into text.
Useful for making links look normal but stay unclickable - which is handy for places like X.com where the algorithm isn’t a fan of links in posts.

`z` made the most sense to me but could be anything else.