### PR TITLE
Add preflight check for OS and architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ show_subtext() {
 }
 
 # Install prerequisites
+source $OMARCHY_INSTALL/preflight/prerequisites.sh
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh
 source $OMARCHY_INSTALL/preflight/migrations.sh

--- a/install/preflight/prerequisites.sh
+++ b/install/preflight/prerequisites.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if [ ! -f /etc/os-release ]; then
+  echo "$(tput setaf 1)Error: Unable to determine OS. /etc/os-release file not found."
+  echo "Installation stopped."
+  exit 1
+fi
+
+. /etc/os-release
+
+# Check if running on x86
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "aarch64" ]; then
+  echo "$(tput setaf 1)Error: aarch64 is not supported."
+  echo "Hyprland, a required dependency, does not support this architecture."
+  echo "Installation stopped."
+  exit 1
+fi
+
+if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "i686" ]; then
+  echo "$(tput setaf 1)Error: Unsupported architecture: $ARCH"
+  echo "This installation is only supported on x86_64 or i686."
+  echo "Installation stopped."
+  exit 1
+fi
+
+# Check if running on Arch Linux
+if [ "$ID" != "arch" ]; then
+  echo "$(tput setaf 1)Error: OS requirement not met"
+  echo "You are currently running: $ID"
+  echo "OS required: Arch Linux"
+  echo "Installation stopped."
+  exit 1
+fi

--- a/install/preflight/prerequisites.sh
+++ b/install/preflight/prerequisites.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -f /etc/os-release ]; then
-  echo "$(tput setaf 1)Error: Unable to determine OS. /etc/os-release file not found."
+  echo -e "\e[31mError: Unable to determine OS. /etc/os-release file not found.\e[0m"
   echo "Installation stopped."
   exit 1
 fi
@@ -12,14 +12,14 @@ fi
 ARCH=$(uname -m)
 
 if [ "$ARCH" = "aarch64" ]; then
-  echo "$(tput setaf 1)Error: aarch64 is not supported."
+  echo -e "\e[31mError: aarch64 is not supported.\e[0m"
   echo "Hyprland, a required dependency, does not support this architecture."
   echo "Installation stopped."
   exit 1
 fi
 
 if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "i686" ]; then
-  echo "$(tput setaf 1)Error: Unsupported architecture: $ARCH"
+  echo -e "\e[31mError: Unsupported architecture: $ARCH\e[0m"
   echo "This installation is only supported on x86_64 or i686."
   echo "Installation stopped."
   exit 1
@@ -27,7 +27,7 @@ fi
 
 # Check if running on Arch Linux
 if [ "$ID" != "arch" ]; then
-  echo "$(tput setaf 1)Error: OS requirement not met"
+  echo -e "\e[31mError: OS requirement not met\e[0m"
   echo "You are currently running: $ID"
   echo "OS required: Arch Linux"
   echo "Installation stopped."


### PR DESCRIPTION
This PR prevents installation on unsupported systems by adding a preflight check for the OS and architecture. It copies a similar [check from Omakub](https://github.com/basecamp/omakub/blob/master/install/check-version.sh).

We also double-check that the OS is Arch Linux and the architecture is `x86_64` or `i686`.

This would provide a clear error message that improves the user experience by failing early and preventing a partial, broken installation.

This check would have avoided issues encountered when attempting to install ARM builds of Arch, such as the problems described in [issue #87](https://github.com/basecamp/omarchy/issues/87). I've also spent a day facing similar issues.