### PR TITLE
Add state based app restarts for migrations

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -5,5 +5,15 @@ if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
   gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
 elif [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
-  gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear relaunch-required && uwsm stop
+  gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
 fi
+
+for file in "$HOME"/.local/state/omarchy/restart-*-required; do
+  if [ -f "$file" ]; then
+    filename=$(basename "$file")
+    service=$(echo "$filename" | sed 's/restart-\(.*\)-required/\1/')
+    echo "Restarting $service"
+    omarchy-state clear "$filename"
+    omarchy-restart-"$service"
+  fi
+done

--- a/migrations/1751225707.sh
+++ b/migrations/1751225707.sh
@@ -2,5 +2,5 @@ echo "Fixing persistent workspaces in waybar config"
 
 if [[ -f ~/.config/waybar/config ]]; then
   sed -i 's/"persistent_workspaces":/"persistent-workspaces":/' ~/.config/waybar/config
-  omarchy-restart-waybar
+  omarchy-state set restart-waybar-required
 fi

--- a/migrations/1754113760.sh
+++ b/migrations/1754113760.sh
@@ -6,5 +6,5 @@ if ! grep -q 'on_unlock_cmd *= *omarchy-restart-waybar' ~/.config/hypr/hypridle.
     on_unlock_cmd = omarchy-restart-waybar  # prevent stacking of waybar when waking' \
     ~/.config/hypr/hypridle.conf
 
-  omarchy-restart-waybar
+  omarchy-state set restart-waybar-required
 fi

--- a/migrations/1754133148.sh
+++ b/migrations/1754133148.sh
@@ -2,5 +2,5 @@ echo "Update Waybar CSS to dim unused workspaces"
 
 if ! grep -q "#workspaces button\.empty" ~/.config/waybar/style.css; then
   omarchy-refresh-config waybar/style.css
-  omarchy-restart-waybar
+  omarchy-state set restart-waybar-required
 fi

--- a/migrations/1754305112.sh
+++ b/migrations/1754305112.sh
@@ -1,2 +1,2 @@
 echo "Restart Walker to pick up menu selections"
-omarchy-restart-walker
+omarchy-state set restart-walker-required

--- a/migrations/1754390772.sh
+++ b/migrations/1754390772.sh
@@ -2,5 +2,5 @@ echo "Set SwayOSD max volume back to 100"
 
 if ! grep -q "max_volume = 100" ~/.config/swayosd/config.toml; then
   sed -i 's/max_volume = 150/max_volume = 100/' ~/.config/swayosd/config.toml
-  omarchy-restart-swayosd
+  omarchy-state set restart-swayosd-required
 fi

--- a/migrations/1754515289.sh
+++ b/migrations/1754515289.sh
@@ -1,4 +1,4 @@
 echo "Update and restart Walker to resolve stuck Omarchy menu"
 
 yay -Sy --noconfirm walker-bin
-omarchy-restart-walker
+omarchy-state set restart-walker-required

--- a/migrations/1754568612.sh
+++ b/migrations/1754568612.sh
@@ -2,5 +2,5 @@ echo "Update Waybar config to fix path issue with update-available icon click"
 
 if grep -q "alacritty --class Omarchy --title Omarchy -e omarchy-update" ~/.config/waybar/config.jsonc; then
   sed -i 's|\("on-click": "alacritty --class Omarchy --title Omarchy -e \)omarchy-update"|\1omarchy-update"|' ~/.config/waybar/config.jsonc
-  omarchy-restart-waybar
+  omarchy-state set restart-waybar-required
 fi


### PR DESCRIPTION
Builds upon the same restart logic we have. We have a lot of repetitive restarts that can start to stack up in migrations, particularly for Waybar. This will prevent having to deal with multiple restarts, as well as give us the ability to easily flag things that need restarted down the line.

Also means we don't waste time restarting apps when we're going to reboot anyway in other instances.