### PR TITLE
Make Chaotic-AUR optional during installation

### DIFF
--- a/bin/omarchy-setup-chaotic-aur
+++ b/bin/omarchy-setup-chaotic-aur
@@ -30,14 +30,14 @@ echo -e "Chaotic-AUR is an unofficial, \e[1moptional\e[0m repository that provid
 echo "Using it is not required. Please ensure you understand the potential risks."
 echo "https://aur.chaotic.cx"
 
-echo -ne "\e[33m\nWould you like to setup the Chaotic-AUR repository? [Y/n]\e[0m\n"
+echo -ne "\e[33m\nWould you like to setup the Chaotic-AUR repository? [Y/n]\e[0m"
 
 while true; do
   read -rsn1 choice
   if [[ "$choice" =~ ^[YyNn]$ || -z "$choice" ]]; then
       case "$choice" in
           [Yy] | "" ) setup_chaotic_aur; break ;;
-          [Nn]      ) echo "Chaotic-AUR will not be setup."; break ;;
+          [Nn]      ) echo -e "\nChaotic-AUR will not be setup."; break ;;
       esac
   fi
 done

--- a/bin/omarchy-setup-chaotic-aur
+++ b/bin/omarchy-setup-chaotic-aur
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+setup_chaotic_aur() {
+  if [[ "$(uname -m)" != "x86_64" ]]; then
+    echo "Chaotic-AUR is only supported on x86_64 architecture."
+    return 0
+  fi
+
+  if grep -q "^\[chaotic-aur\]" /etc/pacman.conf; then
+    echo "Chaotic-AUR is already configured."
+    return 0
+  fi
+
+  
+  if ! pacman-key --list-keys 3056513887B78AEB >/dev/null 2>&1 &&
+    sudo pacman-key --recv-key 3056513887B78AEB &&
+    sudo pacman-key --lsign-key 3056513887B78AEB &&
+    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' &&
+    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'; then
+
+    echo -e '\n[chaotic-aur]\nInclude = /etc/pacman.d/chaotic-mirrorlist' | sudo tee -a /etc/pacman.conf >/dev/null
+
+    sudo pacman -Sy --needed --noconfirm yay
+  else
+    echo "Failed to install Chaotic-AUR; skipping update to pacman.conf"
+  fi
+}
+
+echo "Chaotic-AUR is an optional and unofficial repository that provides pre-built packages from the AUR."
+echo "Before proceeding, please make sure you understand its implications."
+echo "https://aur.chaotic.cx"
+
+echo -ne "\e[33m\nWould you like to setup the Chaotic-AUR repository? [Y/n]\e[0m"
+
+while true; do
+  read -rsn1 choice
+  if [[ "$choice" =~ ^[YyNn]$ || -z "$choice" ]]; then
+      case "$choice" in
+          [Yy] | "" ) setup_chaotic_aur; break ;;
+          [Nn]      ) echo "Chaotic-AUR will not be setup."; break ;;
+      esac
+  fi
+done
+echo

--- a/bin/omarchy-setup-chaotic-aur
+++ b/bin/omarchy-setup-chaotic-aur
@@ -36,8 +36,8 @@ while true; do
   read -rsn1 choice
   if [[ "$choice" =~ ^[YyNn]$ || -z "$choice" ]]; then
       case "$choice" in
-          [Yy] | "" ) setup_chaotic_aur; break ;;
-          [Nn]      ) echo -e "\nChaotic-AUR will not be setup."; break ;;
+          [Yy] | "" ) echo; setup_chaotic_aur; break ;;
+          [Nn]      ) echo; echo "Chaotic-AUR will not be setup."; break ;;
       esac
   fi
 done

--- a/bin/omarchy-setup-chaotic-aur
+++ b/bin/omarchy-setup-chaotic-aur
@@ -26,11 +26,11 @@ setup_chaotic_aur() {
   fi
 }
 
-echo "Chaotic-AUR is an optional and unofficial repository that provides pre-built packages from the AUR."
-echo "Before proceeding, please make sure you understand its implications."
+echo -e "Chaotic-AUR is an unofficial, \e[1moptional\e[0m repository that provides pre-built AUR packages."
+echo "Using it is not required. Please ensure you understand the potential risks."
 echo "https://aur.chaotic.cx"
 
-echo -ne "\e[33m\nWould you like to setup the Chaotic-AUR repository? [Y/n]\e[0m"
+echo -ne "\e[33m\nWould you like to setup the Chaotic-AUR repository? [Y/n]\e[0m\n"
 
 while true; do
   read -rsn1 choice

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ show_subtext() {
 }
 
 # Install prerequisites
+echo -e "Installing prerequisites [0/5]"
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh
 source $OMARCHY_INSTALL/preflight/migrations.sh

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ show_subtext() {
 }
 
 # Install prerequisites
+clear
 echo -e "Installing prerequisites [0/5]"
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ show_subtext() {
 
 # Install prerequisites
 clear
-echo -e "Installing prerequisites [0/5]"
+echo -e "\e[1mInstalling prerequisites [0/5]\e[0m"
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh
 source $OMARCHY_INSTALL/preflight/migrations.sh

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ show_subtext() {
 
 # Install prerequisites
 clear
-echo -e "\e[1mInstalling prerequisites [0/5]\e[0m"
+echo -e "\e[1mInstalling prerequisites [0/5]\e[0m\n"
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh
 source $OMARCHY_INSTALL/preflight/migrations.sh

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,6 @@ show_subtext() {
 }
 
 # Install prerequisites
-show_logo blackhole
-show_subtext "Installing prerequisites [0/5]"
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh
 source $OMARCHY_INSTALL/preflight/migrations.sh

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,8 @@ show_subtext() {
 }
 
 # Install prerequisites
+show_logo blackhole
+show_subtext "Installing prerequisites [0/5]"
 source $OMARCHY_INSTALL/preflight/aur.sh
 source $OMARCHY_INSTALL/preflight/presentation.sh
 source $OMARCHY_INSTALL/preflight/migrations.sh

--- a/install/preflight/aur.sh
+++ b/install/preflight/aur.sh
@@ -1,25 +1,6 @@
 #!/bin/bash
 
-# Only add Chaotic-AUR if the architecture is x86_64 so ARM users can build the packages
-if [[ "$(uname -m)" == "x86_64" ]] && ! command -v yay &>/dev/null; then
-  # Try installing Chaotic-AUR keyring and mirrorlist
-  if ! pacman-key --list-keys 3056513887B78AEB >/dev/null 2>&1 &&
-    sudo pacman-key --recv-key 3056513887B78AEB &&
-    sudo pacman-key --lsign-key 3056513887B78AEB &&
-    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' &&
-    sudo pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'; then
-
-    # Add Chaotic-AUR repo to pacman config
-    if ! grep -q "chaotic-aur" /etc/pacman.conf; then
-      echo -e '\n[chaotic-aur]\nInclude = /etc/pacman.d/chaotic-mirrorlist' | sudo tee -a /etc/pacman.conf >/dev/null
-    fi
-
-    # Install yay directly from Chaotic-AUR
-    sudo pacman -Sy --needed --noconfirm yay
-  else
-    echo "Failed to install Chaotic-AUR, so won't include it in pacman config!"
-  fi
-fi
+source ~/.local/share/omarchy/bin/omarchy-setup-chaotic-aur
 
 # Manually install yay from AUR if not already available
 if ! command -v yay &>/dev/null; then


### PR DESCRIPTION
Previously, the installer silently added the unofficial Chaotic-AUR repo by default. This PR changes that by having the installer prompt the user at the very start to decide whether they want to include it.

The prompt currently defaults to `[Y/n]` in order to align with existing user expectations. However, I believe `[y/N]` might be a better default, and I’m happy to update the PR accordingly if preferred.