### PR TITLE
Lock 1password right away, not after unlock

### DIFF
--- a/bin/omarchy-lock-screen
+++ b/bin/omarchy-lock-screen
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Lock the screen
-pidof hyprlock || hyprlock
+pidof hyprlock || hyprlock &
 
 # Ensure 1password is locked
 if pgrep -x "1password" >/dev/null; then
-  1password --lock
+  1password --lock &
 fi
 
 # Avoid running screensaver when locked


### PR DESCRIPTION
My previous script here had an error, it would only lock 1password once the lockscreen was terminated.

We still want to lock the screen first, but we mustn't wait for hyprlock to exit. 

I've also backgrounded the 1password lock call, no need to wait for that either.