### PR TITLE
Disable systemd-networkd-wait-online.service to prevent boot delays

### DIFF
--- a/install/config/network.sh
+++ b/install/config/network.sh
@@ -7,12 +7,6 @@ if ! command -v iwctl &>/dev/null; then
   sudo systemctl enable --now iwd.service
 fi
 
-# Fix systemd-networkd-wait-online timeout for multiple interfaces
-# Wait for any interface to be online rather than all interfaces
-# https://wiki.archlinux.org/title/Systemd-networkd#Multiple_interfaces_that_are_not_connected_all_the_time
-sudo mkdir -p /etc/systemd/system/systemd-networkd-wait-online.service.d
-sudo tee /etc/systemd/system/systemd-networkd-wait-online.service.d/wait-for-only-one-interface.conf >/dev/null <<EOF
-[Service]
-ExecStart=
-ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any
-EOF
+# Prevent systemd-networkd-wait-online timeout on boot
+sudo systemctl disable systemd-networkd-wait-online.service
+sudo systemctl mask systemd-networkd-wait-online.service

--- a/migrations/1754856741.sh
+++ b/migrations/1754856741.sh
@@ -1,0 +1,5 @@
+echo "Disable systemd-networkd-wait-online"
+rm /etc/systemd/system/systemd-networkd-wait-online.service.d/wait-for-only-one-interface.conf
+
+sudo systemctl disable systemd-networkd-wait-online.service
+sudo systemctl mask systemd-networkd-wait-online.service


### PR DESCRIPTION
The default networkd config inserts systemd-networkd-wait-online.service into the critical boot chain. We can see this consistently by analyzing `systemd-analyze critical-chain`. I suspect this is a remnant of networkd being primarily designed for server environments where you would want to ensure network online before proceeding to boot.

While we've resolved anything in the boot chain requiring this as a dependency in the core of Omarchy, we can't control every app so we have a number of users who have encountered the issue recurring.

Eg. Zerotier from someone in Discord https://discord.com/channels/1390012484194275541/1390012487000395859/1404167814947934259.

Some have inserted a lower arbitrary timeout of 30sec vs the default 120sec but I dislike this because if a user is impacted, they're still required to wait an unnecessary amount of time to boot.

After searching about for a while, a common practice is to just disable and mask it so it moves on. This appears to be our ticket. 

In my own testing, with Omarchy + Tailscale, I've not encountered any issue. All systems continue to come online just fine **after** booting to the desktop environment, which is what we want.

Submitting PR to get extra eyes and testing on this one.

Fixes #632 