### PR TITLE
Add Power profiles daemon to waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -10,7 +10,8 @@
   ],
   "modules-center": [
     "clock",
-    "custom/update"
+    "custom/update",
+    "power-profiles-daemon"
   ],
   "modules-right": [
     "group/tray-expander",
@@ -20,6 +21,20 @@
     "cpu",
     "battery"
   ],
+
+  "power-profiles-daemon": {
+    "format": "{icon}",
+    "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
+    "tooltip": true,
+    "format-icons": {
+      "default": "\uf0e7",
+      "performance": "\uf0e7",
+      "balanced": "\uf24e",
+      "power-saver": "\uf06c"
+    },
+    "class": true
+  },
+
   "hyprland/workspaces": {
     "on-click": "activate",
     "format": "{icon}",

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -36,6 +36,7 @@
 #network,
 #bluetooth,
 #pulseaudio,
+#power-profiles-daemon,
 #clock,
 #custom-omarchy {
   min-width: 12px;


### PR DESCRIPTION
Changes to both waybar's config.json and style.css so one can switch power profiles, specially useful for latops.