### PR TITLE
Workspace switches

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -37,6 +37,13 @@ bindd = SUPER SHIFT, code:17, Move window to workspace 8, movetoworkspace, 8
 bindd = SUPER SHIFT, code:18, Move window to workspace 9, movetoworkspace, 9
 bindd = SUPER SHIFT, code:19, Move window to workspace 10, movetoworkspace, 10
 
+# Workspace switches
+bind = SUPER, TAB, workspace, previous
+bind = SUPER ALT, Right, workspace, e+1     # Next active workspace
+bind = SUPER ALT, L, workspace, e+1         # Next active workspace
+bind = SUPER ALT, Left, workspace, e-1      # Previous active workspace
+bind = SUPER ALT, H, workspace, e-1         # Previous active workspace
+
 # Swap active window with the one next to it with SUPER + SHIFT + arrow keys
 bindd = SUPER SHIFT, left, Swap window to the left, swapwindow, l
 bindd = SUPER SHIFT, right, Swap window to the right, swapwindow, r


### PR DESCRIPTION
*Switch to the next/previous available workspace*

Navigate to next or previous workspace. You can use Arrows or VIM-like keys. You can "walk" through workspaces using only one bind.

*Switch between workspaces. The "Alt+Tab" for workspaces*

Switch between two last workspace. Very useful when you are heavily using two workspaces and can use only one bind to switch between them.
