### PR TITLE
Add mise to UWSM path

### DIFF
--- a/config/uwsm/env
+++ b/config/uwsm/env
@@ -1,2 +1,6 @@
 export OMARCHY_PATH=$HOME/.local/share/omarchy
 export PATH=$OMARCHY_PATH/bin/:$PATH
+
+if command -v mise &> /dev/null; then
+  eval "$(mise activate bash)"
+fi


### PR DESCRIPTION
Adds global items to UWSM path so they're available for all things that we launch appropriately.

Fixes #458 