### PR TITLE
Add noscreenshare windowrule to 1password

### DIFF
--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -6,3 +6,4 @@ source = ~/.local/share/omarchy/default/hypr/apps/retroarch.conf
 source = ~/.local/share/omarchy/default/hypr/apps/steam.conf
 source = ~/.local/share/omarchy/default/hypr/apps/system.conf
 source = ~/.local/share/omarchy/default/hypr/apps/walker.conf
+source = ~/.local/share/omarchy/default/hypr/apps/1password.conf

--- a/default/hypr/apps/1password.conf
+++ b/default/hypr/apps/1password.conf
@@ -1,0 +1,1 @@
+windowrule = noscreenshare, class:^(1Password)$


### PR DESCRIPTION
This PR adds the ```noscreenshare``` windowrule to 1Password.

This windowrule blacks out the window when screen sharing, preventing accidentals leaks.

From Hyprland wiki:
<img width="1328" height="88" alt="image" src="https://github.com/user-attachments/assets/418fe57c-8a09-4682-93c9-bd1e32cbbcc3" />
