### PR TITLE
Fix hyprlock blocking execution

### DIFF
--- a/bin/omarchy-lock-screen
+++ b/bin/omarchy-lock-screen
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Lock the screen
-pidof hyprlock || hyprlock
+pidof hyprlock || hyprlock &
 
 # Ensure 1password is locked
 if pgrep -x "1password" >/dev/null; then


### PR DESCRIPTION
Add "&" to run "hyprlock" in background so cleanup tasks execute immediately

Before: `pidof hyprlock || hyprlock` blocks execution of subsequent lines.
After: Script continues to lock 1password and kill screensaver while hyprlock runs.