### PR TITLE
Fix screen recording on Intel graphics

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -14,7 +14,6 @@ screenrecording() {
   sleep 1
 
   if lspci | grep -Eqi 'nvidia|intel.*graphics'; then
-    # Use wf-recorder for NVIDIA and Intel graphics (VAAPI issues with wl-screenrec on Intel)
     wf-recorder -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@"
   else
     wl-screenrec -f "$filename" --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart" "$@"

--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -15,6 +15,9 @@ screenrecording() {
 
   if lspci | grep -qi 'nvidia'; then
     wf-recorder -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@"
+  elif lspci | grep -qi 'intel.*graphics'; then
+    # Use wf-recorder for Intel graphics due to wl-screenrec VAAPI issues
+    wf-recorder -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@"
   else
     wl-screenrec -f "$filename" --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart" "$@"
   fi

--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -13,10 +13,8 @@ screenrecording() {
   notify-send "Screen recording starting..." -t 1000
   sleep 1
 
-  if lspci | grep -qi 'nvidia'; then
-    wf-recorder -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@"
-  elif lspci | grep -qi 'intel.*graphics'; then
-    # Use wf-recorder for Intel graphics due to wl-screenrec VAAPI issues
+  if lspci | grep -Eqi 'nvidia|intel.*graphics'; then
+    # Use wf-recorder for NVIDIA and Intel graphics (VAAPI issues with wl-screenrec on Intel)
     wf-recorder -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@"
   else
     wl-screenrec -f "$filename" --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart" "$@"


### PR DESCRIPTION
Screen recording with ALT+PrtScreen was failing on Intel graphics due to VAAPI compatibility issues with wl-screenrec. This change adds Intel graphics detection to use wf-recorder instead, which works properly with Intel hardware.

Changes:
- Add Intel graphics detection in omarchy-cmd-screenrecord  
- Use wf-recorder for Intel graphics instead of wl-screenrec
- Preserve existing behavior for NVIDIA (wf-recorder) and AMD/other (wl-screenrec)