### PR TITLE
Add precise volume/brightness controls with alt modifier

### DIFF
--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -9,6 +9,12 @@ bindeld = ,XF86AudioMicMute, Mute microphone, exec, $osdclient --input-volume mu
 bindeld = ,XF86MonBrightnessUp, Brightness up, exec, $osdclient --brightness raise
 bindeld = ,XF86MonBrightnessDown, Brightness down, exec, $osdclient --brightness lower
 
+# Precise 1% multimedia adjustments with Alt modifier
+bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1
+bindeld = ALT, XF86AudioLowerVolume, Volume down precise, exec, $osdclient --output-volume -1
+bindeld = ALT, XF86MonBrightnessUp, Brightness up precise, exec, $osdclient --brightness +1
+bindeld = ALT, XF86MonBrightnessDown, Brightness down precise, exec, $osdclient --brightness -1
+
 # Requires playerctl
 bindld = , XF86AudioNext, Next track, exec, $osdclient --playerctl next
 bindld = , XF86AudioPause, Pause, exec, $osdclient --playerctl play-pause


### PR DESCRIPTION
This change introduces secondary keybindings that allow for fine-grained control over system volume and screen brightness.

By holding the Alt key while using the standard multimedia keys, adjustments are made in 1% increments instead of the default 5%. This is particularly useful for making small, precise adjustments, especially on laptops where the standard increment can feel too large.