### PR TITLE
Add Phoenix Framework install option.

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "$1" ]]; then
-  echo "Usage: omarchy-install-dev-env <ruby|node|bun|go|laravel|symfony|php|python|elixir|rust|java|ocaml|dotnet>" >&2
+  echo "Usage: omarchy-install-dev-env <ruby|node|bun|go|laravel|symfony|php|python|elixir|phoenix|rust|java|ocaml|dotnet>" >&2
   exit 1
 fi
 
@@ -84,6 +84,19 @@ elixir)
   mise use --global erlang@latest
   mise use --global elixir@latest
   mise x elixir -- mix local.hex --force
+  ;;
+phoenix)
+  echo -e "Installing Phoenix Framework...\n"
+  # Ensure Erlang/Elixir first
+  mise use --global erlang@latest
+  mise use --global elixir@latest
+  # Hex & Rebar
+  mise x elixir -- mix local.hex --force
+  mise x elixir -- mix local.rebar --force
+  # Phoenix project (phx_new)
+  mise x elixir -- mix archive.install hex phx_new --force
+  echo -e "\n Phoenix installed. Create a project with:\n   mix phx.new my_app\n"
+  echo -e "Tip: Inside the project you can run:\n   mix deps.get\n   mix ecto.create   # if using a DB\n   mix phx.server\n"
   ;;
 rust)
   echo -e "Installing Rust...\n"


### PR DESCRIPTION
### Summary
This PR adds support for installing the Phoenix Framework via the existing `omarchy-install-dev-env` script.

### Changes
- Added `phoenix)` case to install Erlang, Elixir, Hex, Rebar, and the Phoenix project generator (`phx_new`).
- Updated usage instructions to include `phoenix` as an option.