### PR TITLE
Add media controls to waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -6,7 +6,8 @@
   "height": 26,
   "modules-left": [
     "custom/omarchy",
-    "hyprland/workspaces"
+    "hyprland/workspaces",
+    "group/media-controls"
   ],
   "modules-center": [
     "clock",
@@ -138,5 +139,25 @@
   "tray": {
     "icon-size": 12,
     "spacing": 12
+  },
+  "group/media-controls": {
+    "orientation": "horizontal",
+    "modules": [
+      "custom/playpause",
+      "custom/next",
+      "custom/media"
+    ]
+  },
+  "custom/playpause": {
+    "exec": "~/work/omarchy/config/waybar/media-controls/playpause.sh",
+    "return-type": "json",
+    "on-click": "playerctl play-pause",
+    "interval": 1
+  },
+  "custom/media": {
+    "exec": "~/work/omarchy/config/waybar/media-controls/mediaplayer.sh",
+    "return-type": "json",
+    "interval": 1,
+    "max-length": 50
   }
 }

--- a/config/waybar/media-controls/mediaplayer.sh
+++ b/config/waybar/media-controls/mediaplayer.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+trap '' SIGPIPE
+
+# Find active player: prefer Playing, then Paused
+players=$(playerctl -l 2>/dev/null)
+player=""
+
+for p in $players; do
+    status=$(playerctl --player="$p" status 2>/dev/null)
+    if [[ "$status" == "Playing" ]]; then
+        player=$p
+        break
+    fi
+done
+
+if [[ -z "$player" ]]; then
+    for p in $players; do
+        status=$(playerctl --player="$p" status 2>/dev/null)
+        if [[ "$status" == "Paused" ]]; then
+            player=$p
+            break
+        fi
+    done
+fi
+
+# No active player, output empty JSON
+if [[ -z "$player" ]]; then
+    echo '{"text": " ", "tooltip": "", "class": ""}'
+    exit 0
+fi
+
+status=$(playerctl --player="$player" status 2>/dev/null)
+artist=$(playerctl --player="$player" metadata xesam:artist 2>/dev/null | head -n 1)
+title=$(playerctl --player="$player" metadata xesam:title 2>/dev/null)
+
+if [[ -z "$status" || -z "$title" ]]; then
+    echo '{"text": " ", "tooltip": "", "class": ""}'
+    exit 0
+fi
+
+declare -A player_icons=(
+    ["chromium"]=""
+    ["firefox"]=""
+    ["kdeconnect"]=""
+    ["mopidy"]=""
+    ["mpv"]="󰐹"
+    ["spotify"]=""
+    ["vlc"]="󰕼"
+    ["strawberry"]=""
+    ["default"]=""
+)
+
+icon="${player_icons[$player]:-${player_icons["default"]}}"
+
+tooltip="$artist - $title"
+# Escape ampersands and quotes to avoid markup errors
+escaped_tooltip=$(printf '%s' "$tooltip" | sed 's/&/\&amp;/g; s/"/\\"/g')
+
+echo "{\"text\": \"$icon $artist - $title\", \"tooltip\": \"$escaped_tooltip\", \"class\": \"custom-media\"}"

--- a/config/waybar/media-controls/playpause.sh
+++ b/config/waybar/media-controls/playpause.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+players=$(playerctl -l 2>/dev/null)
+player=""
+
+# Prefer Playing, then Paused
+for p in $players; do
+    status=$(playerctl --player="$p" status 2>/dev/null)
+    if [[ "$status" == "Playing" ]]; then
+        player=$p
+        break
+    fi
+done
+
+if [[ -z "$player" ]]; then
+    for p in $players; do
+        status=$(playerctl --player="$p" status 2>/dev/null)
+        if [[ "$status" == "Paused" ]]; then
+            player=$p
+            break
+        fi
+    done
+fi
+
+if [[ -z "$player" ]]; then
+    echo '{"text": " ", "tooltip": "", "class": ""}'
+    exit 0
+fi
+
+status=$(playerctl --player="$player" status 2>/dev/null)
+
+case "$status" in
+Playing)
+    icon="" # pause icon
+    tooltip="Pause"
+    ;;
+Paused)
+    icon="" # play icon
+    tooltip="Play"
+    ;;
+*)
+    echo '{"text": " ", "tooltip": "", "class": ""}'
+    exit 0
+    ;;
+esac
+
+echo "{\"text\": \"$icon\", \"tooltip\": \"$tooltip\"}"

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -30,6 +30,14 @@
   opacity: 0.5;
 }
 
+#workspaces {
+  margin-right: 12px;
+}
+
+#custom-playpause {
+  margin-right: 8px;
+}
+
 #tray,
 #cpu,
 #battery,


### PR DESCRIPTION
I’m still getting comfortable with bash and Linux, so I’d appreciate any feedback on this.

### What
Added a media player widget to the Waybar config enabling users to see and control media playback directly from the status bar.

### Changes
- Integrated media player module into Waybar config.
- Added relevant styling and functionality for media controls.
- Added new helper scripts to manage media playback:
  - `mediaplayer.sh`: fetches current media information such as track title and artist.
  - `playpause.sh`: toggles the play/pause state of the media player.

### Screenshot
<img width="1920" height="1080" alt="screenshot-2025-08-11_21-11-11" src="https://github.com/user-attachments/assets/0a93ba53-84fb-41e8-b110-b2e98e484284" />


### Notes 
- Feedback and suggestions welcome. Always keen to learn, even if changes aren’t merged.
