### PR TITLE
Update firewall.sh for non-default docker bridge networks

### DIFF
--- a/install/development/firewall.sh
+++ b/install/development/firewall.sh
@@ -15,7 +15,7 @@ if ! command -v ufw &>/dev/null; then
   sudo ufw allow 22/tcp
 
   # Allow Docker containers to use DNS on host
-  sudo ufw allow in on docker0 to any port 53
+  sudo ufw allow in proto udp from 172.16.0.0/12 to 172.17.0.1 port 53 comment allow-docker-dns
 
   # Turn on the firewall
   sudo ufw enable


### PR DESCRIPTION
Allow DNS from 172.16/12 prefix IPs for docker.

When creating a new bridge network, docker creates a new interface `br-*` and `ufw` will block incoming requests as they are not on the `docker0` interface.

Changing docker config to use a different set of IPs will break this, but that's not omakase.