### PR TITLE
Set sudo max tries to 10, binary for easy lockout reset

### DIFF
--- a/bin/omarchy-reset-sudo
+++ b/bin/omarchy-reset-sudo
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Resetting sudo lockout for user: $USER"
+
+# Use su to get root privileges and run faillock reset
+su -c "faillock --reset --user $USER"
+
+if [ $? -eq 0 ]; then
+    echo "✓ Sudo lockout reset successfully for user: $USER"
+else
+    echo "✗ Failed to reset sudo lockout"
+    exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ source $OMARCHY_INSTALL/config/power.sh
 source $OMARCHY_INSTALL/config/timezones.sh
 source $OMARCHY_INSTALL/config/login.sh
 source $OMARCHY_INSTALL/config/nvidia.sh
+source $OMARCHY_INSTALL/config/sudo-retries.sh
 
 # Development
 show_logo decrypt 920

--- a/install/config/sudo-retries.sh
+++ b/install/config/sudo-retries.sh
@@ -1,0 +1,2 @@
+echo "Defaults passwd_tries=10" > /etc/sudoers.d/00-passwd-tries
+chmod 440 /etc/sudoers.d/00-passwd-tries


### PR DESCRIPTION
Resolves #653 

I looked into this a bit and I saw that changing pam.d lines did not get me to 10 fails until lock out. 

`sudo visudo` gets you there but its not persistent. So I created a file to be read in  /etc/sudoers.d/00-passwd-tries

This file sets the 10 password tries and this works for me locally. I updated the install scripts to reflect this. 
For an easy reset command, I relied on Chatgpt here but it worked locally (still no virtual test setup): binary: omarchy-reset-sudo.
