### PR TITLE
fix pgrep and pkill

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -7,9 +7,9 @@ if command -v tte &>/dev/null; then
       --frame-rate 240 --canvas-width 0 --canvas-height $(($(tput lines) - 2)) --anchor-canvas c --anchor-text c \
       "$effect" &
 
-    while pgrep tte >/dev/null; do
+    while pgrep -x tte >/dev/null; do
       if read -n 1 -t 0.01; then
-        pkill tte 2>/dev/null
+        pkill -x tte 2>/dev/null
         pkill -f "alacritty --class Screensaver" 2>/dev/null
         exit 0
       fi


### PR DESCRIPTION
Using `pgrep`/`pkill` without the `-x` parameter will return any process that contains the string `"tte"`, which can cause `pkill` to terminate the wrong process.
