### PR TITLE
Add elan to the keywords used to detect if a fingerprint reader exists

### DIFF
--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -10,7 +10,7 @@ else
   echo -e "\e[32mLet's setup your fingerprint scanner for authentication.\n\e[0m"
   yay -S --noconfirm --needed fprintd usbutils
 
-  if ! lsusb | grep -Eiq 'fingerprint|synaptics|goodix'; then
+  if ! lsusb | grep -Eiq 'fingerprint|synaptics|goodix|elan'; then
     echo -e "\e[31m\nNo fingerprint sensor detected.\e[0m"
   else
     # Add fingerprint authentication as an option for sudo


### PR DESCRIPTION
To fix issues with detecting fingerprint readers in some Lenovo Yoga 7i