### PR TITLE
Use DNS over TLS when possible with certificate validation

### DIFF
--- a/default/systemd/resolved.conf
+++ b/default/systemd/resolved.conf
@@ -1,4 +1,5 @@
 [Resolve]
-DNS=1.1.1.1
-FallbackDNS=8.8.8.8
+DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com
+FallbackDNS=8.8.8.8#dns.google 8.8.4.4#dns.google
+DNSOverTLS=opportunistic
 DNSStubListener=yes

--- a/migrations/1755058968.sh
+++ b/migrations/1755058968.sh
@@ -1,0 +1,5 @@
+echo "Use DNS over TLS when possible with certificate validation"
+
+# Use DNS over TLS when possible with certificate validation
+sudo cp ~/.local/share/omarchy/default/systemd/resolved.conf /etc/systemd/
+sudo systemctl restart systemd-resolved


### PR DESCRIPTION
Improve DNS configuration to use DNS over TLS for better privacy and security
- Use DNSOverTLS=opportunistic to use DoT when possible without being
blocking
- Add certificate validation for Cloudflare and Google DNS servers
- Add secondary resolvers for both Cloudflare and Google for better
reliability
