### PR TITLE
Add 60 second inactivity timeout to Walker launcher

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -4,6 +4,7 @@ theme_base = []
 theme_location = ["~/.local/share/omarchy/default/walker/themes/"]
 hotreload_theme = true
 force_keyboard_focus = true
+timeout = 60
 
 [keys.ai]
 run_last_response = ["ctrl e"]

--- a/migrations/1754929737.sh
+++ b/migrations/1754929737.sh
@@ -1,0 +1,2 @@
+echo "Update Walker config"
+omarchy-refresh-walker

--- a/migrations/1754929737.sh
+++ b/migrations/1754929737.sh
@@ -1,2 +1,2 @@
-echo "Update Walker config"
+echo "Update Walker config to add 60s timeout such that it won't conflict with screensaver"
 omarchy-refresh-walker


### PR DESCRIPTION
This will close the launcher after 60 seconds of inactivity.  

Found that if the launcher was left open the screensaver would open in a new terminal window rather than the entire screen.  

I chose 60 seconds as that seems reasonable (and needs to be under the 150 seconds before the screensaver kicks in)

Fixes https://github.com/basecamp/omarchy/issues/680

There was some timeout bugs upstream I found and fixed to help with this https://github.com/abenz1267/walker/pull/396
https://github.com/abenz1267/walker/issues/393