### PR TITLE
Use `pacman` instead of `yay` to install `gum`

### DIFF
--- a/install/preflight/gum.sh
+++ b/install/preflight/gum.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yay -S --noconfirm --needed gum
+pacman -S --noconfirm --needed gum


### PR DESCRIPTION
One more minor tweak. `yay` is only available after the `aur.sh` step, so `pacman` must be used to install `gum` at the very beginning of `install.sh` preflight section.