### PR TITLE
Enable Walker list cycling

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -10,6 +10,7 @@ run_last_response = ["ctrl e"]
 
 [list]
 max_entries = 200
+cycle = true
 
 [search]
 placeholder = " Search..."


### PR DESCRIPTION
## Synopsis

Enable the [`cycle`](https://github.com/abenz1267/walker/wiki/Basic-Configuration) behaviour for Walker lists; this allows one to quickly jump from the default-selected first item in a list, to the last item, simply by pressing the "up" arrow key (or other key sequence bound to "previous").
