### PR TITLE
Always install `base-devel` with `yay`

### DIFF
--- a/install/preflight/aur.sh
+++ b/install/preflight/aur.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install build tools
+sudo pacman -Sy --needed --noconfirm base-devel
+
 # Only add Chaotic-AUR if the architecture is x86_64 so ARM users can build the packages
 if [[ "$(uname -m)" == "x86_64" ]] && ! command -v yay &>/dev/null; then
   # Try installing Chaotic-AUR keyring and mirrorlist
@@ -23,8 +26,6 @@ fi
 
 # Manually install yay from AUR if not already available
 if ! command -v yay &>/dev/null; then
-  # Install build tools
-  sudo pacman -Sy --needed --noconfirm base-devel
   cd /tmp
   rm -rf yay-bin
   git clone https://aur.archlinux.org/yay-bin.git


### PR DESCRIPTION
When installing, `yay` tried to build `tte` and failed because `base-devel` was missing.

Moved the install of `base-devel` to the top of the `aur.sh` stage, so it will be installed both for building `yay`, if needed, and later for any other AUR packages that are not available on Chaotic.