### PR TITLE
fix: move zoxide init to end of bashrc

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -2,10 +2,6 @@ if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 
-if command -v zoxide &> /dev/null; then
-  eval "$(zoxide init bash)"
-fi
-
 if command -v fzf &> /dev/null; then
   if [[ -f /usr/share/fzf/completion.bash ]]; then
     source /usr/share/fzf/completion.bash

--- a/default/bash/init-late
+++ b/default/bash/init-late
@@ -1,0 +1,5 @@
+# Tools that need to be initialized at the end of shell configuration
+
+if command -v zoxide &> /dev/null; then
+  eval "$(zoxide init bash)"
+fi

--- a/default/bashrc
+++ b/default/bashrc
@@ -12,3 +12,6 @@ source ~/.local/share/omarchy/default/bash/rc
 #
 # Set a custom prompt with the directory revealed (alternatively use https://starship.rs)
 # PS1="\W \[\e]0;\w\a\]$PS1"
+
+# Source late initialization (must be at the end)
+source ~/.local/share/omarchy/default/bash/init-late


### PR DESCRIPTION
Zoxide requires initialization at the very end of the shell configuration to avoid conflicts with other shell customizations like starship. Split bash initialization into early (init) and late (init-late) stages.

This would silence the follwing warning:
```
zoxide: detected a possible configuration issue.
Please ensure that zoxide is initialized right at the end of your shell configuration file (usually ~/.bashrc).

If the issue persists, consider filing an issue at:
https://github.com/ajeetdsouza/zoxide/issues

Disable this message by setting _ZO_DOCTOR=0.
```