### PR TITLE
Add missing modifier combinations to omarchy-menu-keybindings

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -31,7 +31,10 @@ dynamic_bindings() {
         -e 's/^65,/SUPER SHIFT,/' \
         -e 's/^68,/SUPER CTRL,/' \
         -e 's/^69,/SUPER SHIFT CTRL,/' \
-        -e 's/^72,/SUPER ALT,/'
+        -e 's/^72,/SUPER ALT,/' \
+        -e 's/^73,/SUPER SHIFT ALT,/' \
+        -e 's/^76,/SUPER CTRL ALT,/' \
+        -e 's/^77,/SUPER SHIFT CTRL ALT,/'
 }
 
 # Parse and format keybindings


### PR DESCRIPTION
This PR adds additional key modifier combinations to the `omarchy-menu-keybindings` script. 

While these aren't currently used directly in the Omarchy code, when the user adds custom bindings they are not properly displayed by the omarchy-menu-keybindings script.

The added combinations are:
```
SUPER + ALT
SUPER + SHIFT + ALT
SUPER + CTRL + ALT
SUPER + SHIFT + CTRL + ALT
```