### PR TITLE
Add themes support for Zed Editor

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -39,6 +39,41 @@ else
   gsettings set org.gnome.desktop.interface icon-theme "Yaru-blue"
 fi
 
+# Set Zed theme if installed (check for both zed and zeditor commands)
+if (command -v zed &>/dev/null || command -v zeditor &>/dev/null) && [[ -f "$THEME_PATH/zed.json" ]]; then
+  mkdir -p ~/.config/zed/themes
+  ln -nsf "$THEME_PATH/zed.json" ~/.config/zed/themes/omarchy-current.json
+  
+  # Update Zed's settings.json to trigger theme reload
+  ZED_SETTINGS="$HOME/.config/zed/settings.json"
+  if [[ -f "$ZED_SETTINGS" ]]; then
+    # Use Python to safely update the JSON
+    python3 -c "
+import json
+import sys
+
+settings_file = '$ZED_SETTINGS'
+try:
+    with open(settings_file, 'r') as f:
+        settings = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    settings = {}
+
+# Update theme setting
+settings['theme'] = 'Omarchy Current'
+
+# Write back with nice formatting
+with open(settings_file, 'w') as f:
+    json.dump(settings, f, indent=2)
+" 2>/dev/null || true
+  else
+    # Create new settings.json with theme
+    echo '{
+  "theme": "Omarchy Current"
+}' > "$ZED_SETTINGS"
+  fi
+fi
+
 # Trigger alacritty config reload
 touch "$HOME/.config/alacritty/alacritty.toml"
 

--- a/install/desktop/theme.sh
+++ b/install/desktop/theme.sh
@@ -36,3 +36,9 @@ ln -snf ~/.config/omarchy/current/theme/btop.theme ~/.config/btop/themes/current
 
 mkdir -p ~/.config/mako
 ln -snf ~/.config/omarchy/current/theme/mako.ini ~/.config/mako/config
+
+# Setup Zed theme link if Zed is installed (check for both zed and zeditor commands)
+if command -v zed &>/dev/null || command -v zeditor &>/dev/null; then
+  mkdir -p ~/.config/zed/themes
+  ln -snf ~/.config/omarchy/current/theme/zed.json ~/.config/zed/themes/omarchy-current.json
+fi

--- a/migrations/1754959324.sh
+++ b/migrations/1754959324.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Migration: Add Zed editor theme support
+# This migration sets up Zed theme integration with pre-generated theme files
+
+echo "🎨 Adding Zed editor theme support..."
+
+# Setup Zed theme link if Zed is installed
+if command -v zed &>/dev/null || command -v zeditor &>/dev/null; then
+  echo "  Setting up Zed theme integration..."
+  
+  # Create Zed themes directory
+  mkdir -p ~/.config/zed/themes
+  
+  # Link current theme if it exists
+  if [[ -f ~/.config/omarchy/current/theme/zed.json ]]; then
+    ln -snf ~/.config/omarchy/current/theme/zed.json ~/.config/zed/themes/omarchy-current.json
+    
+    # Update Zed settings to use the theme
+    ZED_SETTINGS="$HOME/.config/zed/settings.json"
+    if [[ -f "$ZED_SETTINGS" ]]; then
+      # Use Python to safely update the JSON
+      python3 -c "
+import json
+import sys
+
+settings_file = '$ZED_SETTINGS'
+try:
+    with open(settings_file, 'r') as f:
+        settings = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    settings = {}
+
+# Update theme setting
+settings['theme'] = 'Omarchy Current'
+
+# Write back with nice formatting
+with open(settings_file, 'w') as f:
+    json.dump(settings, f, indent=2)
+" 2>/dev/null || true
+    else
+      # Create new settings.json with theme
+      echo '{
+  "theme": "Omarchy Current"
+}' > "$ZED_SETTINGS"
+    fi
+    
+    echo "  ✅ Zed theme integration complete"
+  fi
+else
+  echo "  ℹ️  Zed not installed, skipping Zed theme setup"
+fi
+
+echo "✨ Zed editor theme support migration complete!"

--- a/themes/catppuccin-latte/zed.json
+++ b/themes/catppuccin-latte/zed.json
@@ -1,0 +1,2823 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Catppuccin <releases@catppuccin.com>",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "light",
+      "style": {
+        "accents": [
+          "#7c3ed466",
+          "#6a7cdf66",
+          "#298fa666",
+          "#42903766",
+          "#c1822c66",
+          "#da601e66",
+          "#b71c4366"
+        ],
+        "background.appearance": "opaque",
+        "border": "#ccd0da",
+        "border.variant": "#9658eb",
+        "border.focused": "#7287fd",
+        "border.selected": "#8839ef",
+        "border.transparent": "#40a02b",
+        "border.disabled": "#9ca0b0",
+        "elevated_surface.background": "#e6e9ef",
+        "surface.background": "#e6e9ef",
+        "background": "#d7dce5",
+        "element.background": "#dce0e8",
+        "element.hover": "#ccd0da",
+        "element.active": "#acb0be4d",
+        "element.selected": "#ccd0da4d",
+        "element.disabled": "#9ca0b0",
+        "drop_target.background": "#ccd0da66",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#bcc0cc4d",
+        "ghost_element.active": "#acb0be99",
+        "ghost_element.selected": "#8f94a766",
+        "ghost_element.disabled": "#9ca0b0",
+        "text": "#4c4f69",
+        "text.muted": "#5c5f77",
+        "text.placeholder": "#acb0be",
+        "text.disabled": "#bcc0cc",
+        "text.accent": "#8839ef",
+        "icon": "#4c4f69",
+        "icon.muted": "#8c8fa1",
+        "icon.disabled": "#9ca0b0",
+        "icon.placeholder": "#acb0be",
+        "icon.accent": "#8839ef",
+        "status_bar.background": "#dce0e8",
+        "title_bar.background": "#dce0e8",
+        "title_bar.inactive_background": "#dce0e8d9",
+        "toolbar.background": "#eff1f5",
+        "tab_bar.background": "#dce0e8",
+        "tab.inactive_background": "#d2d7e2",
+        "tab.active_background": "#eff1f5",
+        "search.match_background": "#17929933",
+        "panel.background": "#e6e9ef",
+        "panel.focused_border": "#4c4f69",
+        "panel.indent_guide": "#ccd0da99",
+        "panel.indent_guide_active": "#acb0be",
+        "panel.indent_guide_hover": "#8839ef",
+        "panel.overlay_background": "#dce0e8",
+        "pane.focused_border": "#4c4f69",
+        "pane_group.border": "#ccd0da",
+        "scrollbar.thumb.background": "#8839ef33",
+        "scrollbar.thumb.hover_background": "#9ca0b0",
+        "scrollbar.thumb.border": "#8839ef",
+        "scrollbar.track.background": null,
+        "scrollbar.track.border": "#4c4f6912",
+        "editor.foreground": "#4c4f69",
+        "editor.background": "#eff1f5",
+        "editor.gutter.background": "#eff1f5",
+        "editor.subheader.background": "#e6e9ef",
+        "editor.active_line.background": "#4c4f690f",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#8c8fa1",
+        "editor.active_line_number": "#8839ef",
+        "editor.invisible": "#7c7f9333",
+        "editor.wrap_guide": "#acb0be",
+        "editor.active_wrap_guide": "#acb0be",
+        "editor.document_highlight.bracket_background": "#8839ef17",
+        "editor.document_highlight.read_background": "#6c6f8529",
+        "editor.document_highlight.write_background": "#6c6f8529",
+        "editor.indent_guide": "#ccd0da99",
+        "editor.indent_guide_active": "#acb0be",
+        "terminal.background": "#eff1f5",
+        "terminal.ansi.background": "#eff1f5",
+        "terminal.foreground": "#4c4f69",
+        "terminal.dim_foreground": "#8c8fa1",
+        "terminal.bright_foreground": "#4c4f69",
+        "terminal.ansi.black": "#bcc0cc",
+        "terminal.ansi.red": "#d20f39",
+        "terminal.ansi.green": "#40a02b",
+        "terminal.ansi.yellow": "#df8e1d",
+        "terminal.ansi.blue": "#1e66f5",
+        "terminal.ansi.magenta": "#ea76cb",
+        "terminal.ansi.cyan": "#179299",
+        "terminal.ansi.white": "#5c5f77",
+        "terminal.ansi.bright_black": "#acb0be",
+        "terminal.ansi.bright_red": "#d20f39",
+        "terminal.ansi.bright_green": "#40a02b",
+        "terminal.ansi.bright_yellow": "#df8e1d",
+        "terminal.ansi.bright_blue": "#1e66f5",
+        "terminal.ansi.bright_magenta": "#ea76cb",
+        "terminal.ansi.bright_cyan": "#179299",
+        "terminal.ansi.bright_white": "#6c6f85",
+        "terminal.ansi.dim_black": "#bcc0cc",
+        "terminal.ansi.dim_red": "#d20f39",
+        "terminal.ansi.dim_green": "#40a02b",
+        "terminal.ansi.dim_yellow": "#df8e1d",
+        "terminal.ansi.dim_blue": "#1e66f5",
+        "terminal.ansi.dim_magenta": "#ea76cb",
+        "terminal.ansi.dim_cyan": "#179299",
+        "terminal.ansi.dim_white": "#5c5f77",
+        "link_text.hover": "#04a5e5",
+        "conflict": "#fe640b",
+        "conflict.border": "#fe640b",
+        "conflict.background": "#fe640b26",
+        "created": "#40a02b",
+        "created.border": "#40a02b",
+        "created.background": "#40a02b26",
+        "deleted": "#d20f39",
+        "deleted.border": "#d20f39",
+        "deleted.background": "#d20f3926",
+        "hidden": "#9ca0b0",
+        "hidden.border": "#9ca0b0",
+        "hidden.background": "#e6e9ef",
+        "hint": "#81879d",
+        "hint.border": "#acb0be",
+        "hint.background": "#e6e9ef",
+        "ignored": "#9ca0b0",
+        "ignored.border": "#9ca0b0",
+        "ignored.background": "#9ca0b026",
+        "modified": "#df8e1d",
+        "modified.border": "#df8e1d",
+        "modified.background": "#df8e1d26",
+        "predictive": "#9ca0b0",
+        "predictive.border": "#7287fd",
+        "predictive.background": "#e6e9ef",
+        "renamed": "#209fb5",
+        "renamed.border": "#209fb5",
+        "renamed.background": "#209fb526",
+        "info": "#179299",
+        "info.border": "#179299",
+        "info.background": "#7c7f9333",
+        "warning": "#df8e1d",
+        "warning.border": "#df8e1d",
+        "warning.background": "#df8e1d1f",
+        "error": "#d20f39",
+        "error.border": "#d20f39",
+        "error.background": "#d20f391f",
+        "success": "#40a02b",
+        "success.border": "#40a02b",
+        "success.background": "#40a02b1f",
+        "unreachable": "#d20f39",
+        "unreachable.border": "#d20f39",
+        "unreachable.background": "#d20f391f",
+        "players": [
+          {
+            "cursor": "#dc8a78",
+            "selection": "#acb0be80",
+            "background": "#dc8a78"
+          },
+          {
+            "cursor": "#7c3ed4",
+            "selection": "#7c3ed433",
+            "background": "#7c3ed4"
+          },
+          {
+            "cursor": "#6a7cdf",
+            "selection": "#6a7cdf33",
+            "background": "#6a7cdf"
+          },
+          {
+            "cursor": "#298fa6",
+            "selection": "#298fa633",
+            "background": "#298fa6"
+          },
+          {
+            "cursor": "#429037",
+            "selection": "#42903733",
+            "background": "#429037"
+          },
+          {
+            "cursor": "#c1822c",
+            "selection": "#c1822c33",
+            "background": "#c1822c"
+          },
+          {
+            "cursor": "#da601e",
+            "selection": "#da601e33",
+            "background": "#da601e"
+          },
+          {
+            "cursor": "#b71c43",
+            "selection": "#b71c4333",
+            "background": "#b71c43"
+          }
+        ],
+        "version_control.added": "#40a02b",
+        "version_control.added_background": "#40a02b26",
+        "version_control.deleted": "#d20f39",
+        "version_control.deleted_background": "#d20f3926",
+        "version_control.modified": "#df8e1d",
+        "version_control.modified_background": "#df8e1d26",
+        "version_control.renamed": "#209fb5",
+        "version_control.conflict": "#fe640b",
+        "version_control.conflict_background": "#fe640b26",
+        "version_control.ignored": "#9ca0b0",
+        "syntax": {
+          "variable": {
+            "color": "#4c4f69",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#d20f39",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#e64553",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#1e66f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#d20f39",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#df8e1d",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "label": {
+            "color": "#209fb5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#40a02b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#179299",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#dd7878",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#dc8a78",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "character": {
+            "color": "#179299",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#df8e1d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#8839ef",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#df8e1d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#df8e1d",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#df8e1d",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "attribute": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#1e66f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#1e66f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#1e66f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#179299",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#1e66f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#1e66f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#dd7878",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#04a5e5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#04a5e5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#7c7f93",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#7c7f93",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#7c7f93",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special.symbol": {
+            "color": "#dd7878",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#179299",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#7c7f93",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#7c7f93",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#7c7f93",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#d20f39",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#df8e1d",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#1e66f5",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#dd7878",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#dc8a78",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#40a02b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#d20f39",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#1e66f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#df8e1d",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#179299",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#e64553",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#7287fd",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#df8e1d",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "float": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#ea76cb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text": {
+            "color": "#4c4f69",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#e64553",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "emphasis": {
+            "color": "#e64553",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#e64553",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#40a02b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#209fb5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#179299",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function.decorator": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#df8e1d",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "hint": {
+            "color": "#acb0be",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#7287fd",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#1e66f5",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#fe640b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#9ca0b0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#d20f39",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#e64553",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#8839ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#179299",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "title": {
+            "color": "#4c4f69",
+            "font_style": null,
+            "font_weight": 800
+          },
+          "variant": {
+            "color": "#d20f39",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Omarchy Current Variant 1",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#caa8e966",
+          "#bdc0f266",
+          "#92c4e166",
+          "#add19f66",
+          "#dfcaa466",
+          "#e7a98f66",
+          "#e1929b66"
+        ],
+        "background.appearance": "opaque",
+        "border": "#414559",
+        "border.variant": "#af8cca",
+        "border.focused": "#babbf1",
+        "border.selected": "#ca9ee6",
+        "border.transparent": "#a6d189",
+        "border.disabled": "#737994",
+        "elevated_surface.background": "#292c3c",
+        "surface.background": "#292c3c",
+        "background": "#383c52",
+        "element.background": "#232634",
+        "element.hover": "#414559",
+        "element.active": "#6268804d",
+        "element.selected": "#4145594d",
+        "element.disabled": "#737994",
+        "drop_target.background": "#41455966",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#51576d4d",
+        "ghost_element.active": "#62688099",
+        "ghost_element.selected": "#7c829a66",
+        "ghost_element.disabled": "#737994",
+        "text": "#c6d0f5",
+        "text.muted": "#b5bfe2",
+        "text.placeholder": "#626880",
+        "text.disabled": "#51576d",
+        "text.accent": "#ca9ee6",
+        "icon": "#c6d0f5",
+        "icon.muted": "#838ba7",
+        "icon.disabled": "#737994",
+        "icon.placeholder": "#626880",
+        "icon.accent": "#ca9ee6",
+        "status_bar.background": "#232634",
+        "title_bar.background": "#232634",
+        "title_bar.inactive_background": "#232634d9",
+        "toolbar.background": "#303446",
+        "tab_bar.background": "#232634",
+        "tab.inactive_background": "#1d202b",
+        "tab.active_background": "#303446",
+        "search.match_background": "#81c8be33",
+        "panel.background": "#292c3c",
+        "panel.focused_border": "#c6d0f5",
+        "panel.indent_guide": "#41455999",
+        "panel.indent_guide_active": "#626880",
+        "panel.indent_guide_hover": "#ca9ee6",
+        "panel.overlay_background": "#232634",
+        "pane.focused_border": "#c6d0f5",
+        "pane_group.border": "#414559",
+        "scrollbar.thumb.background": "#ca9ee633",
+        "scrollbar.thumb.hover_background": "#737994",
+        "scrollbar.thumb.border": "#ca9ee6",
+        "scrollbar.track.background": null,
+        "scrollbar.track.border": "#c6d0f512",
+        "editor.foreground": "#c6d0f5",
+        "editor.background": "#303446",
+        "editor.gutter.background": "#303446",
+        "editor.subheader.background": "#292c3c",
+        "editor.active_line.background": "#c6d0f50f",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#838ba7",
+        "editor.active_line_number": "#ca9ee6",
+        "editor.invisible": "#949cbb33",
+        "editor.wrap_guide": "#626880",
+        "editor.active_wrap_guide": "#626880",
+        "editor.document_highlight.bracket_background": "#ca9ee617",
+        "editor.document_highlight.read_background": "#a5adce29",
+        "editor.document_highlight.write_background": "#a5adce29",
+        "editor.indent_guide": "#41455999",
+        "editor.indent_guide_active": "#626880",
+        "terminal.background": "#303446",
+        "terminal.ansi.background": "#303446",
+        "terminal.foreground": "#c6d0f5",
+        "terminal.dim_foreground": "#838ba7",
+        "terminal.bright_foreground": "#c6d0f5",
+        "terminal.ansi.black": "#51576d",
+        "terminal.ansi.red": "#e78284",
+        "terminal.ansi.green": "#a6d189",
+        "terminal.ansi.yellow": "#e5c890",
+        "terminal.ansi.blue": "#8caaee",
+        "terminal.ansi.magenta": "#f4b8e4",
+        "terminal.ansi.cyan": "#81c8be",
+        "terminal.ansi.white": "#b5bfe2",
+        "terminal.ansi.bright_black": "#626880",
+        "terminal.ansi.bright_red": "#e78284",
+        "terminal.ansi.bright_green": "#a6d189",
+        "terminal.ansi.bright_yellow": "#e5c890",
+        "terminal.ansi.bright_blue": "#8caaee",
+        "terminal.ansi.bright_magenta": "#f4b8e4",
+        "terminal.ansi.bright_cyan": "#81c8be",
+        "terminal.ansi.bright_white": "#a5adce",
+        "terminal.ansi.dim_black": "#51576d",
+        "terminal.ansi.dim_red": "#e78284",
+        "terminal.ansi.dim_green": "#a6d189",
+        "terminal.ansi.dim_yellow": "#e5c890",
+        "terminal.ansi.dim_blue": "#8caaee",
+        "terminal.ansi.dim_magenta": "#f4b8e4",
+        "terminal.ansi.dim_cyan": "#81c8be",
+        "terminal.ansi.dim_white": "#b5bfe2",
+        "link_text.hover": "#99d1db",
+        "conflict": "#ef9f76",
+        "conflict.border": "#ef9f76",
+        "conflict.background": "#ef9f7626",
+        "created": "#a6d189",
+        "created.border": "#a6d189",
+        "created.background": "#a6d18926",
+        "deleted": "#e78284",
+        "deleted.border": "#e78284",
+        "deleted.background": "#e7828426",
+        "hidden": "#737994",
+        "hidden.border": "#737994",
+        "hidden.background": "#292c3c",
+        "hint": "#898fa5",
+        "hint.border": "#626880",
+        "hint.background": "#292c3c",
+        "ignored": "#737994",
+        "ignored.border": "#737994",
+        "ignored.background": "#73799426",
+        "modified": "#e5c890",
+        "modified.border": "#e5c890",
+        "modified.background": "#e5c89026",
+        "predictive": "#737994",
+        "predictive.border": "#babbf1",
+        "predictive.background": "#292c3c",
+        "renamed": "#85c1dc",
+        "renamed.border": "#85c1dc",
+        "renamed.background": "#85c1dc26",
+        "info": "#81c8be",
+        "info.border": "#81c8be",
+        "info.background": "#949cbb33",
+        "warning": "#e5c890",
+        "warning.border": "#e5c890",
+        "warning.background": "#e5c8901f",
+        "error": "#e78284",
+        "error.border": "#e78284",
+        "error.background": "#e782841f",
+        "success": "#a6d189",
+        "success.border": "#a6d189",
+        "success.background": "#a6d1891f",
+        "unreachable": "#e78284",
+        "unreachable.border": "#e78284",
+        "unreachable.background": "#e782841f",
+        "players": [
+          {
+            "cursor": "#f2d5cf",
+            "selection": "#62688080",
+            "background": "#f2d5cf"
+          },
+          {
+            "cursor": "#caa8e9",
+            "selection": "#caa8e933",
+            "background": "#caa8e9"
+          },
+          {
+            "cursor": "#bdc0f2",
+            "selection": "#bdc0f233",
+            "background": "#bdc0f2"
+          },
+          {
+            "cursor": "#92c4e1",
+            "selection": "#92c4e133",
+            "background": "#92c4e1"
+          },
+          {
+            "cursor": "#add19f",
+            "selection": "#add19f33",
+            "background": "#add19f"
+          },
+          {
+            "cursor": "#dfcaa4",
+            "selection": "#dfcaa433",
+            "background": "#dfcaa4"
+          },
+          {
+            "cursor": "#e7a98f",
+            "selection": "#e7a98f33",
+            "background": "#e7a98f"
+          },
+          {
+            "cursor": "#e1929b",
+            "selection": "#e1929b33",
+            "background": "#e1929b"
+          }
+        ],
+        "version_control.added": "#a6d189",
+        "version_control.added_background": "#a6d18926",
+        "version_control.deleted": "#e78284",
+        "version_control.deleted_background": "#e7828426",
+        "version_control.modified": "#e5c890",
+        "version_control.modified_background": "#e5c89026",
+        "version_control.renamed": "#85c1dc",
+        "version_control.conflict": "#ef9f76",
+        "version_control.conflict_background": "#ef9f7626",
+        "version_control.ignored": "#737994",
+        "syntax": {
+          "variable": {
+            "color": "#c6d0f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#e78284",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ea999c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#8caaee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#e78284",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#e5c890",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "label": {
+            "color": "#85c1dc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a6d189",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#81c8be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#eebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#f2d5cf",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "character": {
+            "color": "#81c8be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#e5c890",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#ca9ee6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#e5c890",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#e5c890",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#e5c890",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "attribute": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#8caaee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#8caaee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#8caaee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#81c8be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8caaee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#8caaee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#eebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#99d1db",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#99d1db",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#949cbb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#949cbb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#949cbb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special.symbol": {
+            "color": "#eebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#81c8be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#949cbb",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#949cbb",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#949cbb",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#e78284",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#e5c890",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#8caaee",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#eebebe",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#f2d5cf",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#a6d189",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#e78284",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8caaee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#e5c890",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#81c8be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#ea999c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#babbf1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#e5c890",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "float": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#f4b8e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text": {
+            "color": "#c6d0f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ea999c",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "emphasis": {
+            "color": "#ea999c",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ea999c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a6d189",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#85c1dc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#81c8be",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function.decorator": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#e5c890",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "hint": {
+            "color": "#626880",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#babbf1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8caaee",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#ef9f76",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#737994",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#e78284",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#ea999c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#ca9ee6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#81c8be",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "title": {
+            "color": "#c6d0f5",
+            "font_style": null,
+            "font_weight": 800
+          },
+          "variant": {
+            "color": "#e78284",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Omarchy Current Variant 2",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#c6aaf666",
+          "#bac1f766",
+          "#8cc7e766",
+          "#add8a866",
+          "#e6d4b066",
+          "#ecb19766",
+          "#e696a966"
+        ],
+        "background.appearance": "opaque",
+        "border": "#363a4f",
+        "border.variant": "#a98cd5",
+        "border.focused": "#b7bdf8",
+        "border.selected": "#c6a0f6",
+        "border.transparent": "#a6da95",
+        "border.disabled": "#6e738d",
+        "elevated_surface.background": "#1e2030",
+        "surface.background": "#1e2030",
+        "background": "#2c2f46",
+        "element.background": "#181926",
+        "element.hover": "#363a4f",
+        "element.active": "#5b60784d",
+        "element.selected": "#363a4f4d",
+        "element.disabled": "#6e738d",
+        "drop_target.background": "#363a4f66",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#494d644d",
+        "ghost_element.active": "#5b607899",
+        "ghost_element.selected": "#73799566",
+        "ghost_element.disabled": "#6e738d",
+        "text": "#cad3f5",
+        "text.muted": "#b8c0e0",
+        "text.placeholder": "#5b6078",
+        "text.disabled": "#494d64",
+        "text.accent": "#c6a0f6",
+        "icon": "#cad3f5",
+        "icon.muted": "#8087a2",
+        "icon.disabled": "#6e738d",
+        "icon.placeholder": "#5b6078",
+        "icon.accent": "#c6a0f6",
+        "status_bar.background": "#181926",
+        "title_bar.background": "#181926",
+        "title_bar.inactive_background": "#181926d9",
+        "toolbar.background": "#24273a",
+        "tab_bar.background": "#181926",
+        "tab.inactive_background": "#12121c",
+        "tab.active_background": "#24273a",
+        "search.match_background": "#8bd5ca33",
+        "panel.background": "#1e2030",
+        "panel.focused_border": "#cad3f5",
+        "panel.indent_guide": "#363a4f99",
+        "panel.indent_guide_active": "#5b6078",
+        "panel.indent_guide_hover": "#c6a0f6",
+        "panel.overlay_background": "#181926",
+        "pane.focused_border": "#cad3f5",
+        "pane_group.border": "#363a4f",
+        "scrollbar.thumb.background": "#c6a0f633",
+        "scrollbar.thumb.hover_background": "#6e738d",
+        "scrollbar.thumb.border": "#c6a0f6",
+        "scrollbar.track.background": null,
+        "scrollbar.track.border": "#cad3f512",
+        "editor.foreground": "#cad3f5",
+        "editor.background": "#24273a",
+        "editor.gutter.background": "#24273a",
+        "editor.subheader.background": "#1e2030",
+        "editor.active_line.background": "#cad3f50f",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#8087a2",
+        "editor.active_line_number": "#c6a0f6",
+        "editor.invisible": "#939ab733",
+        "editor.wrap_guide": "#5b6078",
+        "editor.active_wrap_guide": "#5b6078",
+        "editor.document_highlight.bracket_background": "#c6a0f617",
+        "editor.document_highlight.read_background": "#a5adcb29",
+        "editor.document_highlight.write_background": "#a5adcb29",
+        "editor.indent_guide": "#363a4f99",
+        "editor.indent_guide_active": "#5b6078",
+        "terminal.background": "#24273a",
+        "terminal.ansi.background": "#24273a",
+        "terminal.foreground": "#cad3f5",
+        "terminal.dim_foreground": "#8087a2",
+        "terminal.bright_foreground": "#cad3f5",
+        "terminal.ansi.black": "#494d64",
+        "terminal.ansi.red": "#ed8796",
+        "terminal.ansi.green": "#a6da95",
+        "terminal.ansi.yellow": "#eed49f",
+        "terminal.ansi.blue": "#8aadf4",
+        "terminal.ansi.magenta": "#f5bde6",
+        "terminal.ansi.cyan": "#8bd5ca",
+        "terminal.ansi.white": "#b8c0e0",
+        "terminal.ansi.bright_black": "#5b6078",
+        "terminal.ansi.bright_red": "#ed8796",
+        "terminal.ansi.bright_green": "#a6da95",
+        "terminal.ansi.bright_yellow": "#eed49f",
+        "terminal.ansi.bright_blue": "#8aadf4",
+        "terminal.ansi.bright_magenta": "#f5bde6",
+        "terminal.ansi.bright_cyan": "#8bd5ca",
+        "terminal.ansi.bright_white": "#a5adcb",
+        "terminal.ansi.dim_black": "#494d64",
+        "terminal.ansi.dim_red": "#ed8796",
+        "terminal.ansi.dim_green": "#a6da95",
+        "terminal.ansi.dim_yellow": "#eed49f",
+        "terminal.ansi.dim_blue": "#8aadf4",
+        "terminal.ansi.dim_magenta": "#f5bde6",
+        "terminal.ansi.dim_cyan": "#8bd5ca",
+        "terminal.ansi.dim_white": "#b8c0e0",
+        "link_text.hover": "#91d7e3",
+        "conflict": "#f5a97f",
+        "conflict.border": "#f5a97f",
+        "conflict.background": "#f5a97f26",
+        "created": "#a6da95",
+        "created.border": "#a6da95",
+        "created.background": "#a6da9526",
+        "deleted": "#ed8796",
+        "deleted.border": "#ed8796",
+        "deleted.background": "#ed879626",
+        "hidden": "#6e738d",
+        "hidden.border": "#6e738d",
+        "hidden.background": "#1e2030",
+        "hint": "#81869f",
+        "hint.border": "#5b6078",
+        "hint.background": "#1e2030",
+        "ignored": "#6e738d",
+        "ignored.border": "#6e738d",
+        "ignored.background": "#6e738d26",
+        "modified": "#eed49f",
+        "modified.border": "#eed49f",
+        "modified.background": "#eed49f26",
+        "predictive": "#6e738d",
+        "predictive.border": "#b7bdf8",
+        "predictive.background": "#1e2030",
+        "renamed": "#7dc4e4",
+        "renamed.border": "#7dc4e4",
+        "renamed.background": "#7dc4e426",
+        "info": "#8bd5ca",
+        "info.border": "#8bd5ca",
+        "info.background": "#939ab733",
+        "warning": "#eed49f",
+        "warning.border": "#eed49f",
+        "warning.background": "#eed49f1f",
+        "error": "#ed8796",
+        "error.border": "#ed8796",
+        "error.background": "#ed87961f",
+        "success": "#a6da95",
+        "success.border": "#a6da95",
+        "success.background": "#a6da951f",
+        "unreachable": "#ed8796",
+        "unreachable.border": "#ed8796",
+        "unreachable.background": "#ed87961f",
+        "players": [
+          {
+            "cursor": "#f4dbd6",
+            "selection": "#5b607880",
+            "background": "#f4dbd6"
+          },
+          {
+            "cursor": "#c6aaf6",
+            "selection": "#c6aaf633",
+            "background": "#c6aaf6"
+          },
+          {
+            "cursor": "#bac1f7",
+            "selection": "#bac1f733",
+            "background": "#bac1f7"
+          },
+          {
+            "cursor": "#8cc7e7",
+            "selection": "#8cc7e733",
+            "background": "#8cc7e7"
+          },
+          {
+            "cursor": "#add8a8",
+            "selection": "#add8a833",
+            "background": "#add8a8"
+          },
+          {
+            "cursor": "#e6d4b0",
+            "selection": "#e6d4b033",
+            "background": "#e6d4b0"
+          },
+          {
+            "cursor": "#ecb197",
+            "selection": "#ecb19733",
+            "background": "#ecb197"
+          },
+          {
+            "cursor": "#e696a9",
+            "selection": "#e696a933",
+            "background": "#e696a9"
+          }
+        ],
+        "version_control.added": "#a6da95",
+        "version_control.added_background": "#a6da9526",
+        "version_control.deleted": "#ed8796",
+        "version_control.deleted_background": "#ed879626",
+        "version_control.modified": "#eed49f",
+        "version_control.modified_background": "#eed49f26",
+        "version_control.renamed": "#7dc4e4",
+        "version_control.conflict": "#f5a97f",
+        "version_control.conflict_background": "#f5a97f26",
+        "version_control.ignored": "#6e738d",
+        "syntax": {
+          "variable": {
+            "color": "#cad3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ed8796",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "label": {
+            "color": "#7dc4e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a6da95",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#f0c6c6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#f4dbd6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "character": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#c6a0f6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "attribute": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f0c6c6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#91d7e3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#91d7e3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#939ab7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#939ab7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#939ab7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special.symbol": {
+            "color": "#f0c6c6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#939ab7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#939ab7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#939ab7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#ed8796",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#8aadf4",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#f0c6c6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#f4dbd6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#a6da95",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#b7bdf8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "float": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text": {
+            "color": "#cad3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "emphasis": {
+            "color": "#ee99a0",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a6da95",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#7dc4e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function.decorator": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "hint": {
+            "color": "#5b6078",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#b7bdf8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8aadf4",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#6e738d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#8bd5ca",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "title": {
+            "color": "#cad3f5",
+            "font_style": null,
+            "font_weight": 800
+          },
+          "variant": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Omarchy Current Variant 3",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#cbb0f766",
+          "#b9c3fc66",
+          "#86caee66",
+          "#aee1b266",
+          "#f0e0bd66",
+          "#f1ba9d66",
+          "#eb9ab766"
+        ],
+        "background.appearance": "opaque",
+        "border": "#313244",
+        "border.variant": "#ac8fd4",
+        "border.focused": "#b4befe",
+        "border.selected": "#cba6f7",
+        "border.transparent": "#a6e3a1",
+        "border.disabled": "#6c7086",
+        "elevated_surface.background": "#181825",
+        "surface.background": "#181825",
+        "background": "#27273b",
+        "element.background": "#11111b",
+        "element.hover": "#313244",
+        "element.active": "#585b704d",
+        "element.selected": "#3132444d",
+        "element.disabled": "#6c7086",
+        "drop_target.background": "#31324466",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#45475a4d",
+        "ghost_element.active": "#585b7099",
+        "ghost_element.selected": "#6f728d66",
+        "ghost_element.disabled": "#6c7086",
+        "text": "#cdd6f4",
+        "text.muted": "#bac2de",
+        "text.placeholder": "#585b70",
+        "text.disabled": "#45475a",
+        "text.accent": "#cba6f7",
+        "icon": "#cdd6f4",
+        "icon.muted": "#7f849c",
+        "icon.disabled": "#6c7086",
+        "icon.placeholder": "#585b70",
+        "icon.accent": "#cba6f7",
+        "status_bar.background": "#11111b",
+        "title_bar.background": "#11111b",
+        "title_bar.inactive_background": "#11111bd9",
+        "toolbar.background": "#1e1e2e",
+        "tab_bar.background": "#11111b",
+        "tab.inactive_background": "#0b0b11",
+        "tab.active_background": "#1e1e2e",
+        "search.match_background": "#94e2d533",
+        "panel.background": "#181825",
+        "panel.focused_border": "#cdd6f4",
+        "panel.indent_guide": "#31324499",
+        "panel.indent_guide_active": "#585b70",
+        "panel.indent_guide_hover": "#cba6f7",
+        "panel.overlay_background": "#11111b",
+        "pane.focused_border": "#cdd6f4",
+        "pane_group.border": "#313244",
+        "scrollbar.thumb.background": "#cba6f733",
+        "scrollbar.thumb.hover_background": "#6c7086",
+        "scrollbar.thumb.border": "#cba6f7",
+        "scrollbar.track.background": null,
+        "scrollbar.track.border": "#cdd6f412",
+        "editor.foreground": "#cdd6f4",
+        "editor.background": "#1e1e2e",
+        "editor.gutter.background": "#1e1e2e",
+        "editor.subheader.background": "#181825",
+        "editor.active_line.background": "#cdd6f40f",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#7f849c",
+        "editor.active_line_number": "#cba6f7",
+        "editor.invisible": "#9399b233",
+        "editor.wrap_guide": "#585b70",
+        "editor.active_wrap_guide": "#585b70",
+        "editor.document_highlight.bracket_background": "#cba6f717",
+        "editor.document_highlight.read_background": "#a6adc829",
+        "editor.document_highlight.write_background": "#a6adc829",
+        "editor.indent_guide": "#31324499",
+        "editor.indent_guide_active": "#585b70",
+        "terminal.background": "#1e1e2e",
+        "terminal.ansi.background": "#1e1e2e",
+        "terminal.foreground": "#cdd6f4",
+        "terminal.dim_foreground": "#7f849c",
+        "terminal.bright_foreground": "#cdd6f4",
+        "terminal.ansi.black": "#45475a",
+        "terminal.ansi.red": "#f38ba8",
+        "terminal.ansi.green": "#a6e3a1",
+        "terminal.ansi.yellow": "#f9e2af",
+        "terminal.ansi.blue": "#89b4fa",
+        "terminal.ansi.magenta": "#f5c2e7",
+        "terminal.ansi.cyan": "#94e2d5",
+        "terminal.ansi.white": "#bac2de",
+        "terminal.ansi.bright_black": "#585b70",
+        "terminal.ansi.bright_red": "#f38ba8",
+        "terminal.ansi.bright_green": "#a6e3a1",
+        "terminal.ansi.bright_yellow": "#f9e2af",
+        "terminal.ansi.bright_blue": "#89b4fa",
+        "terminal.ansi.bright_magenta": "#f5c2e7",
+        "terminal.ansi.bright_cyan": "#94e2d5",
+        "terminal.ansi.bright_white": "#a6adc8",
+        "terminal.ansi.dim_black": "#45475a",
+        "terminal.ansi.dim_red": "#f38ba8",
+        "terminal.ansi.dim_green": "#a6e3a1",
+        "terminal.ansi.dim_yellow": "#f9e2af",
+        "terminal.ansi.dim_blue": "#89b4fa",
+        "terminal.ansi.dim_magenta": "#f5c2e7",
+        "terminal.ansi.dim_cyan": "#94e2d5",
+        "terminal.ansi.dim_white": "#bac2de",
+        "link_text.hover": "#89dceb",
+        "conflict": "#fab387",
+        "conflict.border": "#fab387",
+        "conflict.background": "#fab38726",
+        "created": "#a6e3a1",
+        "created.border": "#a6e3a1",
+        "created.background": "#a6e3a126",
+        "deleted": "#f38ba8",
+        "deleted.border": "#f38ba8",
+        "deleted.background": "#f38ba826",
+        "hidden": "#6c7086",
+        "hidden.border": "#6c7086",
+        "hidden.background": "#181825",
+        "hint": "#7c7f98",
+        "hint.border": "#585b70",
+        "hint.background": "#181825",
+        "ignored": "#6c7086",
+        "ignored.border": "#6c7086",
+        "ignored.background": "#6c708626",
+        "modified": "#f9e2af",
+        "modified.border": "#f9e2af",
+        "modified.background": "#f9e2af26",
+        "predictive": "#6c7086",
+        "predictive.border": "#b4befe",
+        "predictive.background": "#181825",
+        "renamed": "#74c7ec",
+        "renamed.border": "#74c7ec",
+        "renamed.background": "#74c7ec26",
+        "info": "#94e2d5",
+        "info.border": "#94e2d5",
+        "info.background": "#9399b233",
+        "warning": "#f9e2af",
+        "warning.border": "#f9e2af",
+        "warning.background": "#f9e2af1f",
+        "error": "#f38ba8",
+        "error.border": "#f38ba8",
+        "error.background": "#f38ba81f",
+        "success": "#a6e3a1",
+        "success.border": "#a6e3a1",
+        "success.background": "#a6e3a11f",
+        "unreachable": "#f38ba8",
+        "unreachable.border": "#f38ba8",
+        "unreachable.background": "#f38ba81f",
+        "players": [
+          {
+            "cursor": "#f5e0dc",
+            "selection": "#585b7080",
+            "background": "#f5e0dc"
+          },
+          {
+            "cursor": "#cbb0f7",
+            "selection": "#cbb0f733",
+            "background": "#cbb0f7"
+          },
+          {
+            "cursor": "#b9c3fc",
+            "selection": "#b9c3fc33",
+            "background": "#b9c3fc"
+          },
+          {
+            "cursor": "#86caee",
+            "selection": "#86caee33",
+            "background": "#86caee"
+          },
+          {
+            "cursor": "#aee1b2",
+            "selection": "#aee1b233",
+            "background": "#aee1b2"
+          },
+          {
+            "cursor": "#f0e0bd",
+            "selection": "#f0e0bd33",
+            "background": "#f0e0bd"
+          },
+          {
+            "cursor": "#f1ba9d",
+            "selection": "#f1ba9d33",
+            "background": "#f1ba9d"
+          },
+          {
+            "cursor": "#eb9ab7",
+            "selection": "#eb9ab733",
+            "background": "#eb9ab7"
+          }
+        ],
+        "version_control.added": "#a6e3a1",
+        "version_control.added_background": "#a6e3a126",
+        "version_control.deleted": "#f38ba8",
+        "version_control.deleted_background": "#f38ba826",
+        "version_control.modified": "#f9e2af",
+        "version_control.modified_background": "#f9e2af26",
+        "version_control.renamed": "#74c7ec",
+        "version_control.conflict": "#fab387",
+        "version_control.conflict_background": "#fab38726",
+        "version_control.ignored": "#6c7086",
+        "syntax": {
+          "variable": {
+            "color": "#cdd6f4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#f38ba8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#eba0ac",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#89b4fa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#f38ba8",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#f9e2af",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "label": {
+            "color": "#74c7ec",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a6e3a1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#94e2d5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#f2cdcd",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#f5e0dc",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "character": {
+            "color": "#94e2d5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#f9e2af",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#cba6f7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#f9e2af",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#f9e2af",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#f9e2af",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "attribute": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#89b4fa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#89b4fa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#89b4fa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#94e2d5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#89b4fa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#89b4fa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f2cdcd",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89dceb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#89dceb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#9399b2",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#9399b2",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#9399b2",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special.symbol": {
+            "color": "#f2cdcd",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#94e2d5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9399b2",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9399b2",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#9399b2",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#f38ba8",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#f9e2af",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#89b4fa",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#f2cdcd",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#f5e0dc",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#a6e3a1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#f38ba8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#89b4fa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#f9e2af",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#94e2d5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#eba0ac",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#b4befe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#f9e2af",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "float": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#f5c2e7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text": {
+            "color": "#cdd6f4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#eba0ac",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "emphasis": {
+            "color": "#eba0ac",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#eba0ac",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a6e3a1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#74c7ec",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#94e2d5",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function.decorator": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#f9e2af",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "hint": {
+            "color": "#585b70",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#b4befe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#89b4fa",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#fab387",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#6c7086",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#f38ba8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#eba0ac",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#cba6f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#94e2d5",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "title": {
+            "color": "#cdd6f4",
+            "font_style": null,
+            "font_weight": 800
+          },
+          "variant": {
+            "color": "#f38ba8",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/catppuccin/zed.json
+++ b/themes/catppuccin/zed.json
@@ -1,0 +1,711 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Catppuccin",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#c6aaf666",
+          "#bac1f766",
+          "#8cc7e766",
+          "#add8a866",
+          "#e6d4b066",
+          "#ecb19766",
+          "#e696a966"
+        ],
+        "background.appearance": "opaque",
+        "border": "#363a4f",
+        "border.variant": "#a98cd5",
+        "border.focused": "#b7bdf8",
+        "border.selected": "#c6a0f6",
+        "border.transparent": "#a6da95",
+        "border.disabled": "#6e738d",
+        "elevated_surface.background": "#1e2030",
+        "surface.background": "#1e2030",
+        "background": "#2c2f46",
+        "element.background": "#181926",
+        "element.hover": "#363a4f",
+        "element.active": "#5b60784d",
+        "element.selected": "#363a4f4d",
+        "element.disabled": "#6e738d",
+        "drop_target.background": "#363a4f66",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#494d644d",
+        "ghost_element.active": "#5b607899",
+        "ghost_element.selected": "#73799566",
+        "ghost_element.disabled": "#6e738d",
+        "text": "#cad3f5",
+        "text.muted": "#b8c0e0",
+        "text.placeholder": "#5b6078",
+        "text.disabled": "#494d64",
+        "text.accent": "#c6a0f6",
+        "icon": "#cad3f5",
+        "icon.muted": "#8087a2",
+        "icon.disabled": "#6e738d",
+        "icon.placeholder": "#5b6078",
+        "icon.accent": "#c6a0f6",
+        "status_bar.background": "#181926",
+        "title_bar.background": "#181926",
+        "title_bar.inactive_background": "#181926d9",
+        "toolbar.background": "#24273a",
+        "tab_bar.background": "#181926",
+        "tab.inactive_background": "#12121c",
+        "tab.active_background": "#24273a",
+        "search.match_background": "#8bd5ca33",
+        "panel.background": "#1e2030",
+        "panel.focused_border": "#cad3f5",
+        "panel.indent_guide": "#363a4f99",
+        "panel.indent_guide_active": "#5b6078",
+        "panel.indent_guide_hover": "#c6a0f6",
+        "panel.overlay_background": "#181926",
+        "pane.focused_border": "#cad3f5",
+        "pane_group.border": "#363a4f",
+        "scrollbar.thumb.background": "#c6a0f633",
+        "scrollbar.thumb.hover_background": "#6e738d",
+        "scrollbar.thumb.border": "#c6a0f6",
+        "scrollbar.track.background": null,
+        "scrollbar.track.border": "#cad3f512",
+        "editor.foreground": "#cad3f5",
+        "editor.background": "#24273a",
+        "editor.gutter.background": "#24273a",
+        "editor.subheader.background": "#1e2030",
+        "editor.active_line.background": "#cad3f50f",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#8087a2",
+        "editor.active_line_number": "#c6a0f6",
+        "editor.invisible": "#939ab733",
+        "editor.wrap_guide": "#5b6078",
+        "editor.active_wrap_guide": "#5b6078",
+        "editor.document_highlight.bracket_background": "#c6a0f617",
+        "editor.document_highlight.read_background": "#a5adcb29",
+        "editor.document_highlight.write_background": "#a5adcb29",
+        "editor.indent_guide": "#363a4f99",
+        "editor.indent_guide_active": "#5b6078",
+        "terminal.background": "#24273a",
+        "terminal.ansi.background": "#24273a",
+        "terminal.foreground": "#cad3f5",
+        "terminal.dim_foreground": "#8087a2",
+        "terminal.bright_foreground": "#cad3f5",
+        "terminal.ansi.black": "#494d64",
+        "terminal.ansi.red": "#ed8796",
+        "terminal.ansi.green": "#a6da95",
+        "terminal.ansi.yellow": "#eed49f",
+        "terminal.ansi.blue": "#8aadf4",
+        "terminal.ansi.magenta": "#f5bde6",
+        "terminal.ansi.cyan": "#8bd5ca",
+        "terminal.ansi.white": "#b8c0e0",
+        "terminal.ansi.bright_black": "#5b6078",
+        "terminal.ansi.bright_red": "#ed8796",
+        "terminal.ansi.bright_green": "#a6da95",
+        "terminal.ansi.bright_yellow": "#eed49f",
+        "terminal.ansi.bright_blue": "#8aadf4",
+        "terminal.ansi.bright_magenta": "#f5bde6",
+        "terminal.ansi.bright_cyan": "#8bd5ca",
+        "terminal.ansi.bright_white": "#a5adcb",
+        "terminal.ansi.dim_black": "#494d64",
+        "terminal.ansi.dim_red": "#ed8796",
+        "terminal.ansi.dim_green": "#a6da95",
+        "terminal.ansi.dim_yellow": "#eed49f",
+        "terminal.ansi.dim_blue": "#8aadf4",
+        "terminal.ansi.dim_magenta": "#f5bde6",
+        "terminal.ansi.dim_cyan": "#8bd5ca",
+        "terminal.ansi.dim_white": "#b8c0e0",
+        "link_text.hover": "#91d7e3",
+        "conflict": "#f5a97f",
+        "conflict.border": "#f5a97f",
+        "conflict.background": "#f5a97f26",
+        "created": "#a6da95",
+        "created.border": "#a6da95",
+        "created.background": "#a6da9526",
+        "deleted": "#ed8796",
+        "deleted.border": "#ed8796",
+        "deleted.background": "#ed879626",
+        "hidden": "#6e738d",
+        "hidden.border": "#6e738d",
+        "hidden.background": "#1e2030",
+        "hint": "#81869f",
+        "hint.border": "#5b6078",
+        "hint.background": "#1e2030",
+        "ignored": "#6e738d",
+        "ignored.border": "#6e738d",
+        "ignored.background": "#6e738d26",
+        "modified": "#eed49f",
+        "modified.border": "#eed49f",
+        "modified.background": "#eed49f26",
+        "predictive": "#6e738d",
+        "predictive.border": "#b7bdf8",
+        "predictive.background": "#1e2030",
+        "renamed": "#7dc4e4",
+        "renamed.border": "#7dc4e4",
+        "renamed.background": "#7dc4e426",
+        "info": "#8bd5ca",
+        "info.border": "#8bd5ca",
+        "info.background": "#939ab733",
+        "warning": "#eed49f",
+        "warning.border": "#eed49f",
+        "warning.background": "#eed49f1f",
+        "error": "#ed8796",
+        "error.border": "#ed8796",
+        "error.background": "#ed87961f",
+        "success": "#a6da95",
+        "success.border": "#a6da95",
+        "success.background": "#a6da951f",
+        "unreachable": "#ed8796",
+        "unreachable.border": "#ed8796",
+        "unreachable.background": "#ed87961f",
+        "players": [
+          {
+            "cursor": "#f4dbd6",
+            "selection": "#5b607880",
+            "background": "#f4dbd6"
+          },
+          {
+            "cursor": "#c6aaf6",
+            "selection": "#c6aaf633",
+            "background": "#c6aaf6"
+          },
+          {
+            "cursor": "#bac1f7",
+            "selection": "#bac1f733",
+            "background": "#bac1f7"
+          },
+          {
+            "cursor": "#8cc7e7",
+            "selection": "#8cc7e733",
+            "background": "#8cc7e7"
+          },
+          {
+            "cursor": "#add8a8",
+            "selection": "#add8a833",
+            "background": "#add8a8"
+          },
+          {
+            "cursor": "#e6d4b0",
+            "selection": "#e6d4b033",
+            "background": "#e6d4b0"
+          },
+          {
+            "cursor": "#ecb197",
+            "selection": "#ecb19733",
+            "background": "#ecb197"
+          },
+          {
+            "cursor": "#e696a9",
+            "selection": "#e696a933",
+            "background": "#e696a9"
+          }
+        ],
+        "version_control.added": "#a6da95",
+        "version_control.added_background": "#a6da9526",
+        "version_control.deleted": "#ed8796",
+        "version_control.deleted_background": "#ed879626",
+        "version_control.modified": "#eed49f",
+        "version_control.modified_background": "#eed49f26",
+        "version_control.renamed": "#7dc4e4",
+        "version_control.conflict": "#f5a97f",
+        "version_control.conflict_background": "#f5a97f26",
+        "version_control.ignored": "#6e738d",
+        "syntax": {
+          "variable": {
+            "color": "#cad3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ed8796",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "label": {
+            "color": "#7dc4e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a6da95",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#f0c6c6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#f4dbd6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "character": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#c6a0f6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "attribute": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f0c6c6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#91d7e3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#91d7e3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#939ab7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#939ab7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#939ab7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special.symbol": {
+            "color": "#f0c6c6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#939ab7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#939ab7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#939ab7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#ed8796",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#8aadf4",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#f0c6c6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#f4dbd6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#a6da95",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8aadf4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#b7bdf8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#eed49f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "float": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#f5bde6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text": {
+            "color": "#cad3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "emphasis": {
+            "color": "#ee99a0",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a6da95",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#7dc4e4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#8bd5ca",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function.decorator": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "hint": {
+            "color": "#5b6078",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#b7bdf8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8aadf4",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#f5a97f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#6e738d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#ee99a0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#c6a0f6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#8bd5ca",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "title": {
+            "color": "#cad3f5",
+            "font_style": null,
+            "font_weight": 800
+          },
+          "variant": {
+            "color": "#ed8796",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/everforest/zed.json
+++ b/themes/everforest/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "background": "#2d353b",
+        "foreground": "#d3c6aa",
+        "border": "#1f2529",
+        "border.variant": "#282f35",
+        "border.focused": "#7fbbb3",
+        "border.selected": "#7fbbb3",
+        "border.transparent": "#00000000",
+        "border.disabled": "#282f35",
+        "elevated_surface.background": "#1f2529",
+        "surface.background": "#2d353b",
+        "drop_target.background": "#282f3580",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#363f46",
+        "ghost_element.active": "#3e4a52",
+        "ghost_element.selected": "#3e4a52",
+        "ghost_element.disabled": "#282f35",
+        "text": "#d3c6aa",
+        "text.muted": "#a19a88",
+        "text.placeholder": "#a19a88",
+        "text.disabled": "#a19a88",
+        "text.accent": "#7fbbb3",
+        "icon": "#d3c6aa",
+        "icon.muted": "#a19a88",
+        "icon.disabled": "#a19a88",
+        "icon.placeholder": "#a19a88",
+        "icon.accent": "#7fbbb3",
+        "status_bar.background": "#1f2529",
+        "title_bar.background": "#1f2529",
+        "toolbar.background": "#2d353b",
+        "tab_bar.background": "#1f2529",
+        "tab.inactive_background": "#1f2529",
+        "tab.active_background": "#2d353b",
+        "search.match_background": "#282f35",
+        "panel.background": "#1f2529",
+        "panel.focused_border": "#7fbbb3",
+        "pane.focused_border": "#7fbbb3",
+        "scrollbar.thumb.background": "#282f3588",
+        "scrollbar.thumb.hover_background": "#363f46",
+        "scrollbar.thumb.border": "#282f3544",
+        "scrollbar.track.background": "#1f2529",
+        "scrollbar.track.border": "#181d20",
+        "editor.foreground": "#d3c6aa",
+        "editor.background": "#2d353b",
+        "editor.gutter.background": "#2d353b",
+        "editor.subheader.background": "#1f2529",
+        "editor.active_line.background": "#282f35",
+        "editor.highlighted_line.background": "#282f35",
+        "editor.line_number": "#a19a88",
+        "editor.active_line_number": "#d3c6aa",
+        "editor.invisible": "#a19a88",
+        "editor.wrap_guide": "#282f35",
+        "editor.active_wrap_guide": "#a19a88",
+        "editor.document_highlight.read_background": "#282f3544",
+        "editor.document_highlight.write_background": "#282f3566",
+        "terminal.background": "#2d353b",
+        "terminal.foreground": "#d3c6aa",
+        "terminal.bright_foreground": "#d3c6aa",
+        "terminal.dim_foreground": "#d3c6aa",
+        "terminal.ansi.black": "#475258",
+        "terminal.ansi.bright_black": "#475258",
+        "terminal.ansi.dim_black": "#475258",
+        "terminal.ansi.red": "#e67e80",
+        "terminal.ansi.bright_red": "#e67e80",
+        "terminal.ansi.dim_red": "#e67e80",
+        "terminal.ansi.green": "#a7c080",
+        "terminal.ansi.bright_green": "#a7c080",
+        "terminal.ansi.dim_green": "#a7c080",
+        "terminal.ansi.yellow": "#dbbc7f",
+        "terminal.ansi.bright_yellow": "#dbbc7f",
+        "terminal.ansi.dim_yellow": "#dbbc7f",
+        "terminal.ansi.blue": "#7fbbb3",
+        "terminal.ansi.bright_blue": "#7fbbb3",
+        "terminal.ansi.dim_blue": "#7fbbb3",
+        "terminal.ansi.magenta": "#d699b6",
+        "terminal.ansi.bright_magenta": "#d699b6",
+        "terminal.ansi.dim_magenta": "#d699b6",
+        "terminal.ansi.cyan": "#83c092",
+        "terminal.ansi.bright_cyan": "#83c092",
+        "terminal.ansi.dim_cyan": "#83c092",
+        "terminal.ansi.white": "#d3c6aa",
+        "terminal.ansi.bright_white": "#d3c6aa",
+        "terminal.ansi.dim_white": "#d3c6aa",
+        "link_text.hover": "#7fbbb3",
+        "conflict": "#dbbc7f",
+        "conflict.background": "#dbbc7f20",
+        "conflict.border": "#dbbc7f",
+        "created": "#a7c080",
+        "created.background": "#a7c08020",
+        "created.border": "#a7c080",
+        "deleted": "#e67e80",
+        "deleted.background": "#e67e8020",
+        "deleted.border": "#e67e80",
+        "error": "#e67e80",
+        "error.background": "#e67e8020",
+        "error.border": "#e67e80",
+        "hidden": "#a19a88",
+        "hidden.background": "#2d353b",
+        "hidden.border": "#282f35",
+        "hint": "#a19a88",
+        "hint.background": "#7fbbb320",
+        "hint.border": "#7fbbb3",
+        "ignored": "#a19a88",
+        "ignored.background": "#2d353b",
+        "ignored.border": "#282f35",
+        "info": "#7fbbb3",
+        "info.background": "#7fbbb320",
+        "info.border": "#7fbbb3",
+        "modified": "#dbbc7f",
+        "modified.background": "#dbbc7f20",
+        "modified.border": "#dbbc7f",
+        "predictive": "#a19a88",
+        "predictive.background": "#a19a8820",
+        "predictive.border": "#a19a88",
+        "renamed": "#7fbbb3",
+        "renamed.background": "#7fbbb320",
+        "renamed.border": "#7fbbb3",
+        "success": "#a7c080",
+        "success.background": "#a7c08020",
+        "success.border": "#a7c080",
+        "unreachable": "#a19a88",
+        "unreachable.background": "#2d353b",
+        "unreachable.border": "#282f35",
+        "warning": "#dbbc7f",
+        "warning.background": "#dbbc7f20",
+        "warning.border": "#dbbc7f",
+        "players": [
+          {
+            "cursor": "#dbbc7f",
+            "background": "#dbbc7f",
+            "selection": "#dbbc7f20"
+          },
+          {
+            "cursor": "#d699b6",
+            "background": "#d699b6",
+            "selection": "#d699b620"
+          },
+          {
+            "cursor": "#83c092",
+            "background": "#83c092",
+            "selection": "#83c09220"
+          },
+          {
+            "cursor": "#dbbc7f",
+            "background": "#dbbc7f",
+            "selection": "#dbbc7f20"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#dbbc7f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#e67e80",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a19a88",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#a19a88",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#e67e80",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#d699b6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#d3c6aa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#e67e80",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#e67e80",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#83c092",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#7fbbb3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#83c092",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#d699b6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#7fbbb3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#7fbbb3",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#d699b6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#e67e80",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#83c092",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#a19a88",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#d3c6aa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#d3c6aa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#7fbbb3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#a19a88",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a19a88",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#a19a88",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#a19a88",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#83c092",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a7c080",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#d699b6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#83c092",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#d699b6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#a7c080",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7fbbb3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a7c080",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#7fbbb3",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#dbbc7f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#d3c6aa",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#e67e80",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#7fbbb3",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/gruvbox/zed.json
+++ b/themes/gruvbox/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "background": "#282828",
+        "foreground": "#d4be98",
+        "border": "#1c1c1c",
+        "border.variant": "#242424",
+        "border.focused": "#7daea3",
+        "border.selected": "#7daea3",
+        "border.transparent": "#00000000",
+        "border.disabled": "#242424",
+        "elevated_surface.background": "#1c1c1c",
+        "surface.background": "#282828",
+        "drop_target.background": "#24242480",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#303030",
+        "ghost_element.active": "#383838",
+        "ghost_element.selected": "#383838",
+        "ghost_element.disabled": "#242424",
+        "text": "#d4be98",
+        "text.muted": "#a09176",
+        "text.placeholder": "#a09176",
+        "text.disabled": "#a09176",
+        "text.accent": "#7daea3",
+        "icon": "#d4be98",
+        "icon.muted": "#a09176",
+        "icon.disabled": "#a09176",
+        "icon.placeholder": "#a09176",
+        "icon.accent": "#7daea3",
+        "status_bar.background": "#1c1c1c",
+        "title_bar.background": "#1c1c1c",
+        "toolbar.background": "#282828",
+        "tab_bar.background": "#1c1c1c",
+        "tab.inactive_background": "#1c1c1c",
+        "tab.active_background": "#282828",
+        "search.match_background": "#242424",
+        "panel.background": "#1c1c1c",
+        "panel.focused_border": "#7daea3",
+        "pane.focused_border": "#7daea3",
+        "scrollbar.thumb.background": "#24242488",
+        "scrollbar.thumb.hover_background": "#303030",
+        "scrollbar.thumb.border": "#24242444",
+        "scrollbar.track.background": "#1c1c1c",
+        "scrollbar.track.border": "#161616",
+        "editor.foreground": "#d4be98",
+        "editor.background": "#282828",
+        "editor.gutter.background": "#282828",
+        "editor.subheader.background": "#1c1c1c",
+        "editor.active_line.background": "#242424",
+        "editor.highlighted_line.background": "#242424",
+        "editor.line_number": "#a09176",
+        "editor.active_line_number": "#d4be98",
+        "editor.invisible": "#a09176",
+        "editor.wrap_guide": "#242424",
+        "editor.active_wrap_guide": "#a09176",
+        "editor.document_highlight.read_background": "#24242444",
+        "editor.document_highlight.write_background": "#24242466",
+        "terminal.background": "#282828",
+        "terminal.foreground": "#d4be98",
+        "terminal.bright_foreground": "#d4be98",
+        "terminal.dim_foreground": "#d4be98",
+        "terminal.ansi.black": "#3c3836",
+        "terminal.ansi.bright_black": "#3c3836",
+        "terminal.ansi.dim_black": "#3c3836",
+        "terminal.ansi.red": "#ea6962",
+        "terminal.ansi.bright_red": "#ea6962",
+        "terminal.ansi.dim_red": "#ea6962",
+        "terminal.ansi.green": "#a9b665",
+        "terminal.ansi.bright_green": "#a9b665",
+        "terminal.ansi.dim_green": "#a9b665",
+        "terminal.ansi.yellow": "#d8a657",
+        "terminal.ansi.bright_yellow": "#d8a657",
+        "terminal.ansi.dim_yellow": "#d8a657",
+        "terminal.ansi.blue": "#7daea3",
+        "terminal.ansi.bright_blue": "#7daea3",
+        "terminal.ansi.dim_blue": "#7daea3",
+        "terminal.ansi.magenta": "#d3869b",
+        "terminal.ansi.bright_magenta": "#d3869b",
+        "terminal.ansi.dim_magenta": "#d3869b",
+        "terminal.ansi.cyan": "#89b482",
+        "terminal.ansi.bright_cyan": "#89b482",
+        "terminal.ansi.dim_cyan": "#89b482",
+        "terminal.ansi.white": "#d4be98",
+        "terminal.ansi.bright_white": "#d4be98",
+        "terminal.ansi.dim_white": "#d4be98",
+        "link_text.hover": "#7daea3",
+        "conflict": "#d8a657",
+        "conflict.background": "#d8a65720",
+        "conflict.border": "#d8a657",
+        "created": "#a9b665",
+        "created.background": "#a9b66520",
+        "created.border": "#a9b665",
+        "deleted": "#ea6962",
+        "deleted.background": "#ea696220",
+        "deleted.border": "#ea6962",
+        "error": "#ea6962",
+        "error.background": "#ea696220",
+        "error.border": "#ea6962",
+        "hidden": "#a09176",
+        "hidden.background": "#282828",
+        "hidden.border": "#242424",
+        "hint": "#a09176",
+        "hint.background": "#7daea320",
+        "hint.border": "#7daea3",
+        "ignored": "#a09176",
+        "ignored.background": "#282828",
+        "ignored.border": "#242424",
+        "info": "#7daea3",
+        "info.background": "#7daea320",
+        "info.border": "#7daea3",
+        "modified": "#d8a657",
+        "modified.background": "#d8a65720",
+        "modified.border": "#d8a657",
+        "predictive": "#a09176",
+        "predictive.background": "#a0917620",
+        "predictive.border": "#a09176",
+        "renamed": "#7daea3",
+        "renamed.background": "#7daea320",
+        "renamed.border": "#7daea3",
+        "success": "#a9b665",
+        "success.background": "#a9b66520",
+        "success.border": "#a9b665",
+        "unreachable": "#a09176",
+        "unreachable.background": "#282828",
+        "unreachable.border": "#242424",
+        "warning": "#d8a657",
+        "warning.background": "#d8a65720",
+        "warning.border": "#d8a657",
+        "players": [
+          {
+            "cursor": "#d8a657",
+            "background": "#d8a657",
+            "selection": "#d8a65720"
+          },
+          {
+            "cursor": "#d3869b",
+            "background": "#d3869b",
+            "selection": "#d3869b20"
+          },
+          {
+            "cursor": "#89b482",
+            "background": "#89b482",
+            "selection": "#89b48220"
+          },
+          {
+            "cursor": "#d8a657",
+            "background": "#d8a657",
+            "selection": "#d8a65720"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#d8a657",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ea6962",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a09176",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#a09176",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ea6962",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#d3869b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#d4be98",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#ea6962",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ea6962",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#89b482",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#7daea3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#89b482",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#d3869b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#7daea3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#7daea3",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#d3869b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ea6962",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89b482",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#a09176",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#d4be98",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#d4be98",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#7daea3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#a09176",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a09176",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#a09176",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#a09176",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#89b482",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a9b665",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#d3869b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#89b482",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#d3869b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#a9b665",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7daea3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a9b665",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#7daea3",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#d8a657",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#d4be98",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ea6962",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#7daea3",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/kanagawa/zed.json
+++ b/themes/kanagawa/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "background": "#1f1f28",
+        "foreground": "#dcd7ba",
+        "border": "#15151c",
+        "border.variant": "#1b1b24",
+        "border.focused": "#7e9cd8",
+        "border.selected": "#7e9cd8",
+        "border.transparent": "#00000000",
+        "border.disabled": "#1b1b24",
+        "elevated_surface.background": "#15151c",
+        "surface.background": "#1f1f28",
+        "drop_target.background": "#1b1b2480",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#252530",
+        "ghost_element.active": "#2b2b38",
+        "ghost_element.selected": "#2b2b38",
+        "ghost_element.disabled": "#1b1b24",
+        "text": "#dcd7ba",
+        "text.muted": "#a39f8e",
+        "text.placeholder": "#a39f8e",
+        "text.disabled": "#a39f8e",
+        "text.accent": "#7e9cd8",
+        "icon": "#dcd7ba",
+        "icon.muted": "#a39f8e",
+        "icon.disabled": "#a39f8e",
+        "icon.placeholder": "#a39f8e",
+        "icon.accent": "#7e9cd8",
+        "status_bar.background": "#15151c",
+        "title_bar.background": "#15151c",
+        "toolbar.background": "#1f1f28",
+        "tab_bar.background": "#15151c",
+        "tab.inactive_background": "#15151c",
+        "tab.active_background": "#1f1f28",
+        "search.match_background": "#1b1b24",
+        "panel.background": "#15151c",
+        "panel.focused_border": "#7e9cd8",
+        "pane.focused_border": "#7e9cd8",
+        "scrollbar.thumb.background": "#1b1b2488",
+        "scrollbar.thumb.hover_background": "#252530",
+        "scrollbar.thumb.border": "#1b1b2444",
+        "scrollbar.track.background": "#15151c",
+        "scrollbar.track.border": "#101016",
+        "editor.foreground": "#dcd7ba",
+        "editor.background": "#1f1f28",
+        "editor.gutter.background": "#1f1f28",
+        "editor.subheader.background": "#15151c",
+        "editor.active_line.background": "#1b1b24",
+        "editor.highlighted_line.background": "#1b1b24",
+        "editor.line_number": "#a39f8e",
+        "editor.active_line_number": "#dcd7ba",
+        "editor.invisible": "#a39f8e",
+        "editor.wrap_guide": "#1b1b24",
+        "editor.active_wrap_guide": "#a39f8e",
+        "editor.document_highlight.read_background": "#1b1b2444",
+        "editor.document_highlight.write_background": "#1b1b2466",
+        "terminal.background": "#1f1f28",
+        "terminal.foreground": "#dcd7ba",
+        "terminal.bright_foreground": "#dcd7ba",
+        "terminal.dim_foreground": "#dcd7ba",
+        "terminal.ansi.black": "#090618",
+        "terminal.ansi.bright_black": "#727169",
+        "terminal.ansi.dim_black": "#090618",
+        "terminal.ansi.red": "#c34043",
+        "terminal.ansi.bright_red": "#e82424",
+        "terminal.ansi.dim_red": "#c34043",
+        "terminal.ansi.green": "#76946a",
+        "terminal.ansi.bright_green": "#98bb6c",
+        "terminal.ansi.dim_green": "#76946a",
+        "terminal.ansi.yellow": "#c0a36e",
+        "terminal.ansi.bright_yellow": "#e6c384",
+        "terminal.ansi.dim_yellow": "#c0a36e",
+        "terminal.ansi.blue": "#7e9cd8",
+        "terminal.ansi.bright_blue": "#7fb4ca",
+        "terminal.ansi.dim_blue": "#7e9cd8",
+        "terminal.ansi.magenta": "#957fb8",
+        "terminal.ansi.bright_magenta": "#938aa9",
+        "terminal.ansi.dim_magenta": "#957fb8",
+        "terminal.ansi.cyan": "#6a9589",
+        "terminal.ansi.bright_cyan": "#7aa89f",
+        "terminal.ansi.dim_cyan": "#6a9589",
+        "terminal.ansi.white": "#c8c093",
+        "terminal.ansi.bright_white": "#dcd7ba",
+        "terminal.ansi.dim_white": "#c8c093",
+        "link_text.hover": "#7e9cd8",
+        "conflict": "#c0a36e",
+        "conflict.background": "#c0a36e20",
+        "conflict.border": "#c0a36e",
+        "created": "#76946a",
+        "created.background": "#76946a20",
+        "created.border": "#76946a",
+        "deleted": "#c34043",
+        "deleted.background": "#c3404320",
+        "deleted.border": "#c34043",
+        "error": "#c34043",
+        "error.background": "#c3404320",
+        "error.border": "#c34043",
+        "hidden": "#a39f8e",
+        "hidden.background": "#1f1f28",
+        "hidden.border": "#1b1b24",
+        "hint": "#a39f8e",
+        "hint.background": "#7e9cd820",
+        "hint.border": "#7e9cd8",
+        "ignored": "#a39f8e",
+        "ignored.background": "#1f1f28",
+        "ignored.border": "#1b1b24",
+        "info": "#7e9cd8",
+        "info.background": "#7e9cd820",
+        "info.border": "#7e9cd8",
+        "modified": "#c0a36e",
+        "modified.background": "#c0a36e20",
+        "modified.border": "#c0a36e",
+        "predictive": "#a39f8e",
+        "predictive.background": "#a39f8e20",
+        "predictive.border": "#a39f8e",
+        "renamed": "#7e9cd8",
+        "renamed.background": "#7e9cd820",
+        "renamed.border": "#7e9cd8",
+        "success": "#76946a",
+        "success.background": "#76946a20",
+        "success.border": "#76946a",
+        "unreachable": "#a39f8e",
+        "unreachable.background": "#1f1f28",
+        "unreachable.border": "#1b1b24",
+        "warning": "#c0a36e",
+        "warning.background": "#c0a36e20",
+        "warning.border": "#c0a36e",
+        "players": [
+          {
+            "cursor": "#c0a36e",
+            "background": "#c0a36e",
+            "selection": "#c0a36e20"
+          },
+          {
+            "cursor": "#957fb8",
+            "background": "#957fb8",
+            "selection": "#957fb820"
+          },
+          {
+            "cursor": "#6a9589",
+            "background": "#6a9589",
+            "selection": "#6a958920"
+          },
+          {
+            "cursor": "#c0a36e",
+            "background": "#c0a36e",
+            "selection": "#c0a36e20"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#c0a36e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#e82424",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a39f8e",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#a39f8e",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#e82424",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#957fb8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#dcd7ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#c34043",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#c34043",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#6a9589",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#7e9cd8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#6a9589",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#957fb8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#7e9cd8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#7e9cd8",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#957fb8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#e82424",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#6a9589",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#a39f8e",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#dcd7ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#dcd7ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#7e9cd8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#a39f8e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a39f8e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#a39f8e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#a39f8e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#6a9589",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#76946a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#957fb8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#6a9589",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#957fb8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#76946a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7e9cd8",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#76946a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#7e9cd8",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#c0a36e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#dcd7ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#c34043",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#7e9cd8",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/matte-black/zed.json
+++ b/themes/matte-black/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "background": "#121212",
+        "foreground": "#bebebe",
+        "border": "#0c0c0c",
+        "border.variant": "#101010",
+        "border.focused": "#e68e0d",
+        "border.selected": "#e68e0d",
+        "border.transparent": "#00000000",
+        "border.disabled": "#101010",
+        "elevated_surface.background": "#0c0c0c",
+        "surface.background": "#121212",
+        "drop_target.background": "#10101080",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#151515",
+        "ghost_element.active": "#191919",
+        "ghost_element.selected": "#191919",
+        "ghost_element.disabled": "#101010",
+        "text": "#bebebe",
+        "text.muted": "#8a8a8a",
+        "text.placeholder": "#8a8a8a",
+        "text.disabled": "#8a8a8a",
+        "text.accent": "#e68e0d",
+        "icon": "#bebebe",
+        "icon.muted": "#8a8a8a",
+        "icon.disabled": "#8a8a8a",
+        "icon.placeholder": "#8a8a8a",
+        "icon.accent": "#e68e0d",
+        "status_bar.background": "#0c0c0c",
+        "title_bar.background": "#0c0c0c",
+        "toolbar.background": "#121212",
+        "tab_bar.background": "#0c0c0c",
+        "tab.inactive_background": "#0c0c0c",
+        "tab.active_background": "#121212",
+        "search.match_background": "#101010",
+        "panel.background": "#0c0c0c",
+        "panel.focused_border": "#e68e0d",
+        "pane.focused_border": "#e68e0d",
+        "scrollbar.thumb.background": "#10101088",
+        "scrollbar.thumb.hover_background": "#151515",
+        "scrollbar.thumb.border": "#10101044",
+        "scrollbar.track.background": "#0c0c0c",
+        "scrollbar.track.border": "#090909",
+        "editor.foreground": "#bebebe",
+        "editor.background": "#121212",
+        "editor.gutter.background": "#121212",
+        "editor.subheader.background": "#0c0c0c",
+        "editor.active_line.background": "#101010",
+        "editor.highlighted_line.background": "#101010",
+        "editor.line_number": "#8a8a8a",
+        "editor.active_line_number": "#bebebe",
+        "editor.invisible": "#8a8a8a",
+        "editor.wrap_guide": "#101010",
+        "editor.active_wrap_guide": "#8a8a8a",
+        "editor.document_highlight.read_background": "#10101044",
+        "editor.document_highlight.write_background": "#10101066",
+        "terminal.background": "#121212",
+        "terminal.foreground": "#bebebe",
+        "terminal.bright_foreground": "#bebebe",
+        "terminal.dim_foreground": "#bebebe",
+        "terminal.ansi.black": "#333333",
+        "terminal.ansi.bright_black": "#8a8a8d",
+        "terminal.ansi.dim_black": "#333333",
+        "terminal.ansi.red": "#D35F5F",
+        "terminal.ansi.bright_red": "#B91C1C",
+        "terminal.ansi.dim_red": "#D35F5F",
+        "terminal.ansi.green": "#FFC107",
+        "terminal.ansi.bright_green": "#FFC107",
+        "terminal.ansi.dim_green": "#FFC107",
+        "terminal.ansi.yellow": "#b91c1c",
+        "terminal.ansi.bright_yellow": "#b90a0a",
+        "terminal.ansi.dim_yellow": "#b91c1c",
+        "terminal.ansi.blue": "#e68e0d",
+        "terminal.ansi.bright_blue": "#f59e0b",
+        "terminal.ansi.dim_blue": "#e68e0d",
+        "terminal.ansi.magenta": "#D35F5F",
+        "terminal.ansi.bright_magenta": "#B91C1C",
+        "terminal.ansi.dim_magenta": "#D35F5F",
+        "terminal.ansi.cyan": "#bebebe",
+        "terminal.ansi.bright_cyan": "#eaeaea",
+        "terminal.ansi.dim_cyan": "#bebebe",
+        "terminal.ansi.white": "#bebebe",
+        "terminal.ansi.bright_white": "#ffffff",
+        "terminal.ansi.dim_white": "#bebebe",
+        "link_text.hover": "#e68e0d",
+        "conflict": "#b91c1c",
+        "conflict.background": "#b91c1c20",
+        "conflict.border": "#b91c1c",
+        "created": "#FFC107",
+        "created.background": "#FFC10720",
+        "created.border": "#FFC107",
+        "deleted": "#D35F5F",
+        "deleted.background": "#D35F5F20",
+        "deleted.border": "#D35F5F",
+        "error": "#D35F5F",
+        "error.background": "#D35F5F20",
+        "error.border": "#D35F5F",
+        "hidden": "#8a8a8a",
+        "hidden.background": "#121212",
+        "hidden.border": "#101010",
+        "hint": "#8a8a8a",
+        "hint.background": "#e68e0d20",
+        "hint.border": "#e68e0d",
+        "ignored": "#8a8a8a",
+        "ignored.background": "#121212",
+        "ignored.border": "#101010",
+        "info": "#e68e0d",
+        "info.background": "#e68e0d20",
+        "info.border": "#e68e0d",
+        "modified": "#b91c1c",
+        "modified.background": "#b91c1c20",
+        "modified.border": "#b91c1c",
+        "predictive": "#8a8a8a",
+        "predictive.background": "#8a8a8a20",
+        "predictive.border": "#8a8a8a",
+        "renamed": "#e68e0d",
+        "renamed.background": "#e68e0d20",
+        "renamed.border": "#e68e0d",
+        "success": "#FFC107",
+        "success.background": "#FFC10720",
+        "success.border": "#FFC107",
+        "unreachable": "#8a8a8a",
+        "unreachable.background": "#121212",
+        "unreachable.border": "#101010",
+        "warning": "#b91c1c",
+        "warning.background": "#b91c1c20",
+        "warning.border": "#b91c1c",
+        "players": [
+          {
+            "cursor": "#eaeaea",
+            "background": "#eaeaea",
+            "selection": "#eaeaea20"
+          },
+          {
+            "cursor": "#D35F5F",
+            "background": "#D35F5F",
+            "selection": "#D35F5F20"
+          },
+          {
+            "cursor": "#bebebe",
+            "background": "#bebebe",
+            "selection": "#bebebe20"
+          },
+          {
+            "cursor": "#b91c1c",
+            "background": "#b91c1c",
+            "selection": "#b91c1c20"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#b91c1c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#B91C1C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#8a8a8a",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#8a8a8a",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#B91C1C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#D35F5F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#D35F5F",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#D35F5F",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#e68e0d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#D35F5F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#e68e0d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#e68e0d",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#D35F5F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#B91C1C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#8a8a8a",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#e68e0d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#8a8a8a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#8a8a8a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#8a8a8a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#8a8a8a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#FFC107",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#D35F5F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#D35F5F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#FFC107",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#e68e0d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#FFC107",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#e68e0d",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#b91c1c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#bebebe",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#D35F5F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#e68e0d",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/nord/zed.json
+++ b/themes/nord/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "background": "#2e3440",
+        "foreground": "#d8dee9",
+        "border": "#20242c",
+        "border.variant": "#292e39",
+        "border.focused": "#81a1c1",
+        "border.selected": "#81a1c1",
+        "border.transparent": "#00000000",
+        "border.disabled": "#292e39",
+        "elevated_surface.background": "#20242c",
+        "surface.background": "#2e3440",
+        "drop_target.background": "#292e3980",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#373e4c",
+        "ghost_element.active": "#404859",
+        "ghost_element.selected": "#404859",
+        "ghost_element.disabled": "#292e39",
+        "text": "#d8dee9",
+        "text.muted": "#a5abb6",
+        "text.placeholder": "#a5abb6",
+        "text.disabled": "#a5abb6",
+        "text.accent": "#81a1c1",
+        "icon": "#d8dee9",
+        "icon.muted": "#a5abb6",
+        "icon.disabled": "#a5abb6",
+        "icon.placeholder": "#a5abb6",
+        "icon.accent": "#81a1c1",
+        "status_bar.background": "#20242c",
+        "title_bar.background": "#20242c",
+        "toolbar.background": "#2e3440",
+        "tab_bar.background": "#20242c",
+        "tab.inactive_background": "#20242c",
+        "tab.active_background": "#2e3440",
+        "search.match_background": "#292e39",
+        "panel.background": "#20242c",
+        "panel.focused_border": "#81a1c1",
+        "pane.focused_border": "#81a1c1",
+        "scrollbar.thumb.background": "#292e3988",
+        "scrollbar.thumb.hover_background": "#373e4c",
+        "scrollbar.thumb.border": "#292e3944",
+        "scrollbar.track.background": "#20242c",
+        "scrollbar.track.border": "#191c23",
+        "editor.foreground": "#d8dee9",
+        "editor.background": "#2e3440",
+        "editor.gutter.background": "#2e3440",
+        "editor.subheader.background": "#20242c",
+        "editor.active_line.background": "#292e39",
+        "editor.highlighted_line.background": "#292e39",
+        "editor.line_number": "#a5abb6",
+        "editor.active_line_number": "#d8dee9",
+        "editor.invisible": "#a5abb6",
+        "editor.wrap_guide": "#292e39",
+        "editor.active_wrap_guide": "#a5abb6",
+        "editor.document_highlight.read_background": "#292e3944",
+        "editor.document_highlight.write_background": "#292e3966",
+        "terminal.background": "#2e3440",
+        "terminal.foreground": "#d8dee9",
+        "terminal.bright_foreground": "#d8dee9",
+        "terminal.dim_foreground": "#d8dee9",
+        "terminal.ansi.black": "#3b4252",
+        "terminal.ansi.bright_black": "#4c566a",
+        "terminal.ansi.dim_black": "#3b4252",
+        "terminal.ansi.red": "#bf616a",
+        "terminal.ansi.bright_red": "#bf616a",
+        "terminal.ansi.dim_red": "#bf616a",
+        "terminal.ansi.green": "#a3be8c",
+        "terminal.ansi.bright_green": "#a3be8c",
+        "terminal.ansi.dim_green": "#a3be8c",
+        "terminal.ansi.yellow": "#ebcb8b",
+        "terminal.ansi.bright_yellow": "#ebcb8b",
+        "terminal.ansi.dim_yellow": "#ebcb8b",
+        "terminal.ansi.blue": "#81a1c1",
+        "terminal.ansi.bright_blue": "#81a1c1",
+        "terminal.ansi.dim_blue": "#81a1c1",
+        "terminal.ansi.magenta": "#b48ead",
+        "terminal.ansi.bright_magenta": "#b48ead",
+        "terminal.ansi.dim_magenta": "#b48ead",
+        "terminal.ansi.cyan": "#88c0d0",
+        "terminal.ansi.bright_cyan": "#8fbcbb",
+        "terminal.ansi.dim_cyan": "#88c0d0",
+        "terminal.ansi.white": "#e5e9f0",
+        "terminal.ansi.bright_white": "#eceff4",
+        "terminal.ansi.dim_white": "#e5e9f0",
+        "link_text.hover": "#81a1c1",
+        "conflict": "#ebcb8b",
+        "conflict.background": "#ebcb8b20",
+        "conflict.border": "#ebcb8b",
+        "created": "#a3be8c",
+        "created.background": "#a3be8c20",
+        "created.border": "#a3be8c",
+        "deleted": "#bf616a",
+        "deleted.background": "#bf616a20",
+        "deleted.border": "#bf616a",
+        "error": "#bf616a",
+        "error.background": "#bf616a20",
+        "error.border": "#bf616a",
+        "hidden": "#a5abb6",
+        "hidden.background": "#2e3440",
+        "hidden.border": "#292e39",
+        "hint": "#a5abb6",
+        "hint.background": "#81a1c120",
+        "hint.border": "#81a1c1",
+        "ignored": "#a5abb6",
+        "ignored.background": "#2e3440",
+        "ignored.border": "#292e39",
+        "info": "#81a1c1",
+        "info.background": "#81a1c120",
+        "info.border": "#81a1c1",
+        "modified": "#ebcb8b",
+        "modified.background": "#ebcb8b20",
+        "modified.border": "#ebcb8b",
+        "predictive": "#a5abb6",
+        "predictive.background": "#a5abb620",
+        "predictive.border": "#a5abb6",
+        "renamed": "#81a1c1",
+        "renamed.background": "#81a1c120",
+        "renamed.border": "#81a1c1",
+        "success": "#a3be8c",
+        "success.background": "#a3be8c20",
+        "success.border": "#a3be8c",
+        "unreachable": "#a5abb6",
+        "unreachable.background": "#2e3440",
+        "unreachable.border": "#292e39",
+        "warning": "#ebcb8b",
+        "warning.background": "#ebcb8b20",
+        "warning.border": "#ebcb8b",
+        "players": [
+          {
+            "cursor": "#d8dee9",
+            "background": "#d8dee9",
+            "selection": "#d8dee920"
+          },
+          {
+            "cursor": "#b48ead",
+            "background": "#b48ead",
+            "selection": "#b48ead20"
+          },
+          {
+            "cursor": "#88c0d0",
+            "background": "#88c0d0",
+            "selection": "#88c0d020"
+          },
+          {
+            "cursor": "#ebcb8b",
+            "background": "#ebcb8b",
+            "selection": "#ebcb8b20"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#ebcb8b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#bf616a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a5abb6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#a5abb6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#bf616a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#b48ead",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#d8dee9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#bf616a",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#bf616a",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#88c0d0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#81a1c1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#88c0d0",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#b48ead",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#81a1c1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#81a1c1",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#b48ead",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#bf616a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#88c0d0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#a5abb6",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#d8dee9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#d8dee9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#81a1c1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#a5abb6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a5abb6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#a5abb6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#a5abb6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#88c0d0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a3be8c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#b48ead",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#88c0d0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#b48ead",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#a3be8c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#81a1c1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a3be8c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#81a1c1",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ebcb8b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#d8dee9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#bf616a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#81a1c1",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/osaka-jade/zed.json
+++ b/themes/osaka-jade/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "background": "#111c18",
+        "foreground": "#C1C497",
+        "border": "#0b1310",
+        "border.variant": "#0f1915",
+        "border.focused": "#509475",
+        "border.selected": "#509475",
+        "border.transparent": "#00000000",
+        "border.disabled": "#0f1915",
+        "elevated_surface.background": "#0b1310",
+        "surface.background": "#111c18",
+        "drop_target.background": "#0f191580",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#14211c",
+        "ghost_element.active": "#172721",
+        "ghost_element.selected": "#172721",
+        "ghost_element.disabled": "#0f1915",
+        "text": "#C1C497",
+        "text.muted": "#8c9170",
+        "text.placeholder": "#8c9170",
+        "text.disabled": "#8c9170",
+        "text.accent": "#509475",
+        "icon": "#C1C497",
+        "icon.muted": "#8c9170",
+        "icon.disabled": "#8c9170",
+        "icon.placeholder": "#8c9170",
+        "icon.accent": "#509475",
+        "status_bar.background": "#0b1310",
+        "title_bar.background": "#0b1310",
+        "toolbar.background": "#111c18",
+        "tab_bar.background": "#0b1310",
+        "tab.inactive_background": "#0b1310",
+        "tab.active_background": "#111c18",
+        "search.match_background": "#0f1915",
+        "panel.background": "#0b1310",
+        "panel.focused_border": "#509475",
+        "pane.focused_border": "#509475",
+        "scrollbar.thumb.background": "#0f191588",
+        "scrollbar.thumb.hover_background": "#14211c",
+        "scrollbar.thumb.border": "#0f191544",
+        "scrollbar.track.background": "#0b1310",
+        "scrollbar.track.border": "#080f0c",
+        "editor.foreground": "#C1C497",
+        "editor.background": "#111c18",
+        "editor.gutter.background": "#111c18",
+        "editor.subheader.background": "#0b1310",
+        "editor.active_line.background": "#0f1915",
+        "editor.highlighted_line.background": "#0f1915",
+        "editor.line_number": "#8c9170",
+        "editor.active_line_number": "#C1C497",
+        "editor.invisible": "#8c9170",
+        "editor.wrap_guide": "#0f1915",
+        "editor.active_wrap_guide": "#8c9170",
+        "editor.document_highlight.read_background": "#0f191544",
+        "editor.document_highlight.write_background": "#0f191566",
+        "terminal.background": "#111c18",
+        "terminal.foreground": "#C1C497",
+        "terminal.bright_foreground": "#C1C497",
+        "terminal.dim_foreground": "#C1C497",
+        "terminal.ansi.black": "#23372B",
+        "terminal.ansi.bright_black": "#53685B",
+        "terminal.ansi.dim_black": "#23372B",
+        "terminal.ansi.red": "#FF5345",
+        "terminal.ansi.bright_red": "#db9f9c",
+        "terminal.ansi.dim_red": "#FF5345",
+        "terminal.ansi.green": "#549e6a",
+        "terminal.ansi.bright_green": "#143614",
+        "terminal.ansi.dim_green": "#549e6a",
+        "terminal.ansi.yellow": "#459451",
+        "terminal.ansi.bright_yellow": "#E5C736",
+        "terminal.ansi.dim_yellow": "#459451",
+        "terminal.ansi.blue": "#509475",
+        "terminal.ansi.bright_blue": "#ACD4CF",
+        "terminal.ansi.dim_blue": "#509475",
+        "terminal.ansi.magenta": "#D2689C",
+        "terminal.ansi.bright_magenta": "#75bbb3",
+        "terminal.ansi.dim_magenta": "#D2689C",
+        "terminal.ansi.cyan": "#2DD5B7",
+        "terminal.ansi.bright_cyan": "#8CD3CB",
+        "terminal.ansi.dim_cyan": "#2DD5B7",
+        "terminal.ansi.white": "#F6F5DD",
+        "terminal.ansi.bright_white": "#9eebb3",
+        "terminal.ansi.dim_white": "#F6F5DD",
+        "link_text.hover": "#509475",
+        "conflict": "#459451",
+        "conflict.background": "#45945120",
+        "conflict.border": "#459451",
+        "created": "#549e6a",
+        "created.background": "#549e6a20",
+        "created.border": "#549e6a",
+        "deleted": "#FF5345",
+        "deleted.background": "#FF534520",
+        "deleted.border": "#FF5345",
+        "error": "#FF5345",
+        "error.background": "#FF534520",
+        "error.border": "#FF5345",
+        "hidden": "#8c9170",
+        "hidden.background": "#111c18",
+        "hidden.border": "#0f1915",
+        "hint": "#8c9170",
+        "hint.background": "#50947520",
+        "hint.border": "#509475",
+        "ignored": "#8c9170",
+        "ignored.background": "#111c18",
+        "ignored.border": "#0f1915",
+        "info": "#509475",
+        "info.background": "#50947520",
+        "info.border": "#509475",
+        "modified": "#459451",
+        "modified.background": "#45945120",
+        "modified.border": "#459451",
+        "predictive": "#8c9170",
+        "predictive.background": "#8c917020",
+        "predictive.border": "#8c9170",
+        "renamed": "#509475",
+        "renamed.background": "#50947520",
+        "renamed.border": "#509475",
+        "success": "#549e6a",
+        "success.background": "#549e6a20",
+        "success.border": "#549e6a",
+        "unreachable": "#8c9170",
+        "unreachable.background": "#111c18",
+        "unreachable.border": "#0f1915",
+        "warning": "#459451",
+        "warning.background": "#45945120",
+        "warning.border": "#459451",
+        "players": [
+          {
+            "cursor": "#D7C995",
+            "background": "#D7C995",
+            "selection": "#D7C99520"
+          },
+          {
+            "cursor": "#D2689C",
+            "background": "#D2689C",
+            "selection": "#D2689C20"
+          },
+          {
+            "cursor": "#2DD5B7",
+            "background": "#2DD5B7",
+            "selection": "#2DD5B720"
+          },
+          {
+            "cursor": "#459451",
+            "background": "#459451",
+            "selection": "#45945120"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#459451",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#db9f9c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#8c9170",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#8c9170",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#db9f9c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#D2689C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#C1C497",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#FF5345",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#FF5345",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#2DD5B7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#509475",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#2DD5B7",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#D2689C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#509475",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#509475",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#D2689C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#db9f9c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#2DD5B7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#8c9170",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#C1C497",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#C1C497",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#509475",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#8c9170",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#8c9170",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#8c9170",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#8c9170",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#2DD5B7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#549e6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#D2689C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#2DD5B7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#D2689C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#549e6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#509475",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#549e6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#509475",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#459451",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#C1C497",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#FF5345",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#509475",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/ristretto/zed.json
+++ b/themes/ristretto/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "background": "#2c2525",
+        "foreground": "#e6d9db",
+        "border": "#1e1919",
+        "border.variant": "#272121",
+        "border.focused": "#f38d70",
+        "border.selected": "#f38d70",
+        "border.transparent": "#00000000",
+        "border.disabled": "#272121",
+        "elevated_surface.background": "#1e1919",
+        "surface.background": "#2c2525",
+        "drop_target.background": "#27212180",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#342c2c",
+        "ghost_element.active": "#3d3333",
+        "ghost_element.selected": "#3d3333",
+        "ghost_element.disabled": "#272121",
+        "text": "#e6d9db",
+        "text.muted": "#aea3a4",
+        "text.placeholder": "#aea3a4",
+        "text.disabled": "#aea3a4",
+        "text.accent": "#f38d70",
+        "icon": "#e6d9db",
+        "icon.muted": "#aea3a4",
+        "icon.disabled": "#aea3a4",
+        "icon.placeholder": "#aea3a4",
+        "icon.accent": "#f38d70",
+        "status_bar.background": "#1e1919",
+        "title_bar.background": "#1e1919",
+        "toolbar.background": "#2c2525",
+        "tab_bar.background": "#1e1919",
+        "tab.inactive_background": "#1e1919",
+        "tab.active_background": "#2c2525",
+        "search.match_background": "#272121",
+        "panel.background": "#1e1919",
+        "panel.focused_border": "#f38d70",
+        "pane.focused_border": "#f38d70",
+        "scrollbar.thumb.background": "#27212188",
+        "scrollbar.thumb.hover_background": "#342c2c",
+        "scrollbar.thumb.border": "#27212144",
+        "scrollbar.track.background": "#1e1919",
+        "scrollbar.track.border": "#181414",
+        "editor.foreground": "#e6d9db",
+        "editor.background": "#2c2525",
+        "editor.gutter.background": "#2c2525",
+        "editor.subheader.background": "#1e1919",
+        "editor.active_line.background": "#272121",
+        "editor.highlighted_line.background": "#272121",
+        "editor.line_number": "#aea3a4",
+        "editor.active_line_number": "#e6d9db",
+        "editor.invisible": "#aea3a4",
+        "editor.wrap_guide": "#272121",
+        "editor.active_wrap_guide": "#aea3a4",
+        "editor.document_highlight.read_background": "#27212144",
+        "editor.document_highlight.write_background": "#27212166",
+        "terminal.background": "#2c2525",
+        "terminal.foreground": "#e6d9db",
+        "terminal.bright_foreground": "#e6d9db",
+        "terminal.dim_foreground": "#e6d9db",
+        "terminal.ansi.black": "#2c2525",
+        "terminal.ansi.bright_black": "#463a3a",
+        "terminal.ansi.dim_black": "#2c2525",
+        "terminal.ansi.red": "#fd6883",
+        "terminal.ansi.bright_red": "#ff8297",
+        "terminal.ansi.dim_red": "#fd6883",
+        "terminal.ansi.green": "#adda78",
+        "terminal.ansi.bright_green": "#c8e292",
+        "terminal.ansi.dim_green": "#adda78",
+        "terminal.ansi.yellow": "#f9cc6c",
+        "terminal.ansi.bright_yellow": "#fcd675",
+        "terminal.ansi.dim_yellow": "#f9cc6c",
+        "terminal.ansi.blue": "#f38d70",
+        "terminal.ansi.bright_blue": "#f8a788",
+        "terminal.ansi.dim_blue": "#f38d70",
+        "terminal.ansi.magenta": "#a8a9eb",
+        "terminal.ansi.bright_magenta": "#bebffd",
+        "terminal.ansi.dim_magenta": "#a8a9eb",
+        "terminal.ansi.cyan": "#85dacc",
+        "terminal.ansi.bright_cyan": "#9bf1e1",
+        "terminal.ansi.dim_cyan": "#85dacc",
+        "terminal.ansi.white": "#e6d9db",
+        "terminal.ansi.bright_white": "#f1e5e7",
+        "terminal.ansi.dim_white": "#e6d9db",
+        "link_text.hover": "#f38d70",
+        "conflict": "#f9cc6c",
+        "conflict.background": "#f9cc6c20",
+        "conflict.border": "#f9cc6c",
+        "created": "#adda78",
+        "created.background": "#adda7820",
+        "created.border": "#adda78",
+        "deleted": "#fd6883",
+        "deleted.background": "#fd688320",
+        "deleted.border": "#fd6883",
+        "error": "#fd6883",
+        "error.background": "#fd688320",
+        "error.border": "#fd6883",
+        "hidden": "#aea3a4",
+        "hidden.background": "#2c2525",
+        "hidden.border": "#272121",
+        "hint": "#aea3a4",
+        "hint.background": "#f38d7020",
+        "hint.border": "#f38d70",
+        "ignored": "#aea3a4",
+        "ignored.background": "#2c2525",
+        "ignored.border": "#272121",
+        "info": "#f38d70",
+        "info.background": "#f38d7020",
+        "info.border": "#f38d70",
+        "modified": "#f9cc6c",
+        "modified.background": "#f9cc6c20",
+        "modified.border": "#f9cc6c",
+        "predictive": "#aea3a4",
+        "predictive.background": "#aea3a420",
+        "predictive.border": "#aea3a4",
+        "renamed": "#f38d70",
+        "renamed.background": "#f38d7020",
+        "renamed.border": "#f38d70",
+        "success": "#adda78",
+        "success.background": "#adda7820",
+        "success.border": "#adda78",
+        "unreachable": "#aea3a4",
+        "unreachable.background": "#2c2525",
+        "unreachable.border": "#272121",
+        "warning": "#f9cc6c",
+        "warning.background": "#f9cc6c20",
+        "warning.border": "#f9cc6c",
+        "players": [
+          {
+            "cursor": "#c3b7b8",
+            "background": "#c3b7b8",
+            "selection": "#c3b7b820"
+          },
+          {
+            "cursor": "#a8a9eb",
+            "background": "#a8a9eb",
+            "selection": "#a8a9eb20"
+          },
+          {
+            "cursor": "#85dacc",
+            "background": "#85dacc",
+            "selection": "#85dacc20"
+          },
+          {
+            "cursor": "#f9cc6c",
+            "background": "#f9cc6c",
+            "selection": "#f9cc6c20"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#f9cc6c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff8297",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#aea3a4",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#aea3a4",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ff8297",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#a8a9eb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#e6d9db",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#fd6883",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#fd6883",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#85dacc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#f38d70",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#85dacc",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#a8a9eb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#f38d70",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#f38d70",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#a8a9eb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ff8297",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#85dacc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#aea3a4",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#e6d9db",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#e6d9db",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#f38d70",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#aea3a4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#aea3a4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#aea3a4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#aea3a4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#85dacc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#adda78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#a8a9eb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#85dacc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#a8a9eb",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#adda78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#f38d70",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#adda78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#f38d70",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#f9cc6c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#e6d9db",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#fd6883",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#f38d70",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/rose-pine/zed.json
+++ b/themes/rose-pine/zed.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy Current",
+  "author": "Omarchy",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "light",
+      "style": {
+        "background": "#faf4ed",
+        "foreground": "#575279",
+        "border": "#ffffff",
+        "border.variant": "#fffff8",
+        "border.focused": "#56949f",
+        "border.selected": "#56949f",
+        "border.transparent": "#00000000",
+        "border.disabled": "#fffff8",
+        "elevated_surface.background": "#ffffff",
+        "surface.background": "#faf4ed",
+        "drop_target.background": "#fffff880",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#ede7e1",
+        "ghost_element.active": "#e1dbd5",
+        "ghost_element.selected": "#e1dbd5",
+        "ghost_element.disabled": "#fffff8",
+        "text": "#575279",
+        "text.muted": "#87829b",
+        "text.placeholder": "#87829b",
+        "text.disabled": "#87829b",
+        "text.accent": "#56949f",
+        "icon": "#575279",
+        "icon.muted": "#87829b",
+        "icon.disabled": "#87829b",
+        "icon.placeholder": "#87829b",
+        "icon.accent": "#56949f",
+        "status_bar.background": "#ffffff",
+        "title_bar.background": "#ffffff",
+        "toolbar.background": "#faf4ed",
+        "tab_bar.background": "#ffffff",
+        "tab.inactive_background": "#ffffff",
+        "tab.active_background": "#faf4ed",
+        "search.match_background": "#fffff8",
+        "panel.background": "#ffffff",
+        "panel.focused_border": "#56949f",
+        "pane.focused_border": "#56949f",
+        "scrollbar.thumb.background": "#fffff888",
+        "scrollbar.thumb.hover_background": "#ede7e1",
+        "scrollbar.thumb.border": "#fffff844",
+        "scrollbar.track.background": "#ffffff",
+        "scrollbar.track.border": "#cccccc",
+        "editor.foreground": "#575279",
+        "editor.background": "#faf4ed",
+        "editor.gutter.background": "#faf4ed",
+        "editor.subheader.background": "#ffffff",
+        "editor.active_line.background": "#fffff8",
+        "editor.highlighted_line.background": "#fffff8",
+        "editor.line_number": "#87829b",
+        "editor.active_line_number": "#575279",
+        "editor.invisible": "#87829b",
+        "editor.wrap_guide": "#fffff8",
+        "editor.active_wrap_guide": "#87829b",
+        "editor.document_highlight.read_background": "#fffff844",
+        "editor.document_highlight.write_background": "#fffff866",
+        "terminal.background": "#faf4ed",
+        "terminal.foreground": "#575279",
+        "terminal.bright_foreground": "#575279",
+        "terminal.dim_foreground": "#575279",
+        "terminal.ansi.black": "#f2e9e1",
+        "terminal.ansi.bright_black": "#9893a5",
+        "terminal.ansi.dim_black": "#f2e9e1",
+        "terminal.ansi.red": "#b4637a",
+        "terminal.ansi.bright_red": "#b4637a",
+        "terminal.ansi.dim_red": "#b4637a",
+        "terminal.ansi.green": "#286983",
+        "terminal.ansi.bright_green": "#286983",
+        "terminal.ansi.dim_green": "#286983",
+        "terminal.ansi.yellow": "#ea9d34",
+        "terminal.ansi.bright_yellow": "#ea9d34",
+        "terminal.ansi.dim_yellow": "#ea9d34",
+        "terminal.ansi.blue": "#56949f",
+        "terminal.ansi.bright_blue": "#56949f",
+        "terminal.ansi.dim_blue": "#56949f",
+        "terminal.ansi.magenta": "#907aa9",
+        "terminal.ansi.bright_magenta": "#907aa9",
+        "terminal.ansi.dim_magenta": "#907aa9",
+        "terminal.ansi.cyan": "#d7827e",
+        "terminal.ansi.bright_cyan": "#d7827e",
+        "terminal.ansi.dim_cyan": "#d7827e",
+        "terminal.ansi.white": "#575279",
+        "terminal.ansi.bright_white": "#575279",
+        "terminal.ansi.dim_white": "#575279",
+        "link_text.hover": "#56949f",
+        "conflict": "#ea9d34",
+        "conflict.background": "#ea9d3420",
+        "conflict.border": "#ea9d34",
+        "created": "#286983",
+        "created.background": "#28698320",
+        "created.border": "#286983",
+        "deleted": "#b4637a",
+        "deleted.background": "#b4637a20",
+        "deleted.border": "#b4637a",
+        "error": "#b4637a",
+        "error.background": "#b4637a20",
+        "error.border": "#b4637a",
+        "hidden": "#87829b",
+        "hidden.background": "#faf4ed",
+        "hidden.border": "#fffff8",
+        "hint": "#87829b",
+        "hint.background": "#56949f20",
+        "hint.border": "#56949f",
+        "ignored": "#87829b",
+        "ignored.background": "#faf4ed",
+        "ignored.border": "#fffff8",
+        "info": "#56949f",
+        "info.background": "#56949f20",
+        "info.border": "#56949f",
+        "modified": "#ea9d34",
+        "modified.background": "#ea9d3420",
+        "modified.border": "#ea9d34",
+        "predictive": "#87829b",
+        "predictive.background": "#87829b20",
+        "predictive.border": "#87829b",
+        "renamed": "#56949f",
+        "renamed.background": "#56949f20",
+        "renamed.border": "#56949f",
+        "success": "#286983",
+        "success.background": "#28698320",
+        "success.border": "#286983",
+        "unreachable": "#87829b",
+        "unreachable.background": "#faf4ed",
+        "unreachable.border": "#fffff8",
+        "warning": "#ea9d34",
+        "warning.background": "#ea9d3420",
+        "warning.border": "#ea9d34",
+        "players": [
+          {
+            "cursor": "#cecacd",
+            "background": "#cecacd",
+            "selection": "#cecacd20"
+          },
+          {
+            "cursor": "#907aa9",
+            "background": "#907aa9",
+            "selection": "#907aa920"
+          },
+          {
+            "cursor": "#d7827e",
+            "background": "#d7827e",
+            "selection": "#d7827e20"
+          },
+          {
+            "cursor": "#ea9d34",
+            "background": "#ea9d34",
+            "selection": "#ea9d3420"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#ea9d34",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#b4637a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#87829b",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#87829b",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#b4637a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#907aa9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#575279",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#b4637a",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#b4637a",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#d7827e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#56949f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#d7827e",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#907aa9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#56949f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#56949f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#907aa9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#b4637a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#d7827e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#87829b",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#575279",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#575279",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#56949f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#87829b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#87829b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#87829b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#87829b",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#d7827e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#286983",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#907aa9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#d7827e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#907aa9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#286983",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#56949f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#286983",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#56949f",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ea9d34",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#575279",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#b4637a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#56949f",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/tokyo-night/zed.json
+++ b/themes/tokyo-night/zed.json
@@ -1,0 +1,922 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+  "name": "Omarchy Current",
+  "author": "Tokyo Night: Zed Theme Importer",
+  "themes": [
+    {
+      "name": "Omarchy Current",
+      "appearance": "dark",
+      "style": {
+        "border": "#101014",
+        "border.variant": "#101014",
+        "border.focused": "#545c7e33",
+        "border.selected": "#101014",
+        "border.transparent": "#101014",
+        "border.disabled": "#101014",
+        "elevated_surface.background": "#14141b",
+        "surface.background": "#16161e",
+        "background": "#1a1b26",
+        "element.background": "#1a1b26",
+        "element.hover": "#565f89",
+        "element.active": "#9aa5ce",
+        "element.selected": "#565f89",
+        "element.disabled": "#414868",
+        "drop_target.background": "#1e202e",
+        "ghost_element.background": "#1a1b26",
+        "ghost_element.hover": "#565f89",
+        "ghost_element.active": "#9aa5ce",
+        "ghost_element.selected": "#565f89",
+        "ghost_element.disabled": "#414868",
+        "text": "#a9b1d6",
+        "text.muted": "#787c99",
+        "text.placeholder": "#787c99",
+        "text.disabled": "#414868",
+        "text.accent": "#7dcfff",
+        "icon": "#787c99",
+        "icon.muted": "#787c99",
+        "icon.disabled": "#414868",
+        "icon.placeholder": "#565f89",
+        "icon.accent": "#7dcfff",
+        "status_bar.background": "#16161e",
+        "title_bar.background": "#16161e",
+        "title_bar.inactive_background": "#16161e",
+        "toolbar.background": "#16161e",
+        "tab_bar.background": "#16161e",
+        "tab.inactive_background": "#16161e",
+        "tab.active_background": "#414868",
+        "search.match_background": "#414868",
+        "panel.background": "#16161e",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#41486880",
+        "scrollbar.thumb.hover_background": "#414868",
+        "scrollbar.thumb.border": "#414868",
+        "scrollbar.track.background": "#1a1b2680",
+        "scrollbar.track.border": "#101014",
+        "editor.foreground": "#a9b1d6",
+        "editor.background": "#1a1b26",
+        "editor.gutter.background": "#1a1b26",
+        "editor.subheader.background": "#1a1b26",
+        "editor.active_line.background": "#1e202e",
+        "editor.highlighted_line.background": "#1e202e",
+        "editor.line_number": "#363b54",
+        "editor.active_line_number": "#a9b1d6",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#101014",
+        "editor.active_wrap_guide": "#101014",
+        "editor.document_highlight.read_background": "#363b54",
+        "editor.document_highlight.write_background": "#363b54",
+        "terminal.background": "#16161e",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#363b54",
+        "terminal.ansi.bright_black": "#363b54",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#f7768e",
+        "terminal.ansi.bright_red": "#f7768e",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#73daca",
+        "terminal.ansi.bright_green": "#41a6b5",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#e0af68",
+        "terminal.ansi.bright_yellow": "#e0af68",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#7aa2f7",
+        "terminal.ansi.bright_blue": "#7aa2f7",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#bb9af7",
+        "terminal.ansi.bright_magenta": "#bb9af7",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#7dcfff",
+        "terminal.ansi.bright_cyan": "#7dcfff",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#787c99",
+        "terminal.ansi.bright_white": "#acb0d0",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#7dcfff",
+        "conflict": "#bb9af7",
+        "conflict.background": "#1a1b26",
+        "conflict.border": "#414868",
+        "created": "#9ece6a",
+        "created.background": "#1a1b26",
+        "created.border": "#414868",
+        "deleted": "#f7768e",
+        "deleted.background": "#1a1b26",
+        "deleted.border": "#414868",
+        "error": "#f7768e",
+        "error.background": "#1a1b26",
+        "error.border": "#414868",
+        "hidden": "#787c99",
+        "hidden.background": "#1a1b26",
+        "hidden.border": "#414868",
+        "hint": "#51597d",
+        "hint.background": "#1a1b26",
+        "hint.border": "#414868",
+        "ignored": "#515670",
+        "ignored.background": "#1a1b26",
+        "ignored.border": "#414868",
+        "info": "#0da0ba",
+        "info.background": "#1a1b26",
+        "info.border": "#414868",
+        "modified": "#e0af68",
+        "modified.background": "#1a1b26",
+        "modified.border": "#414868",
+        "predictive": "#51597d",
+        "predictive.background": "#1a1b26",
+        "predictive.border": "#414868",
+        "renamed": "#9ece6a",
+        "renamed.background": "#1a1b26",
+        "renamed.border": "#414868",
+        "success": "#9ece6a",
+        "success.background": "#1a1b26",
+        "success.border": "#414868",
+        "unreachable": "#f7768e",
+        "unreachable.background": "#1a1b26",
+        "unreachable.border": "#414868",
+        "warning": "#e0af68",
+        "warning.background": "#1a1b26",
+        "warning.border": "#414868",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#51597d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#51597d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#f7768e",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Omarchy Current Light",
+      "appearance": "light",
+      "style": {
+        "border": "#c1c2c7",
+        "border.variant": "#c1c2c7",
+        "border.focused": "#82859433",
+        "border.selected": "#c1c2c7",
+        "border.transparent": "#c1c2c7",
+        "border.disabled": "#c1c2c7",
+        "elevated_surface.background": "#d5d6db",
+        "surface.background": "#cbccd1",
+        "background": "#d5d6db",
+        "element.background": "#d5d6db",
+        "element.hover": "#9699a3",
+        "element.active": "#565a6e",
+        "element.selected": "#9699a3",
+        "element.disabled": "#0f0f14",
+        "drop_target.background": "#c1c2c7",
+        "ghost_element.background": "#d5d6db",
+        "ghost_element.hover": "#9699a3",
+        "ghost_element.active": "#565a6e",
+        "ghost_element.selected": "#9699a3",
+        "ghost_element.disabled": "#0f0f14",
+        "text": "#343b58",
+        "text.muted": "#4c505e",
+        "text.placeholder": "#4c505e",
+        "text.disabled": "#0f0f14",
+        "text.accent": "0f4b6e",
+        "icon": "#4c505e",
+        "icon.muted": "#4c505e",
+        "icon.disabled": "#0f0f14",
+        "icon.placeholder": "#9699a3",
+        "icon.accent": "#0f4b6e",
+        "status_bar.background": "#cbccd1",
+        "title_bar.background": "#cbccd1",
+        "title_bar.inactive_background": "#cbccd1",
+        "toolbar.background": "#cbccd1",
+        "tab_bar.background": "#cbccd1",
+        "tab.inactive_background": "#cbccd1",
+        "tab.active_background": "#9699a3",
+        "search.match_background": "#9699a3",
+        "panel.background": "#cbccd1",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#9699a380",
+        "scrollbar.thumb.hover_background": "#9699a3",
+        "scrollbar.thumb.border": "#9699a3",
+        "scrollbar.track.background": "#d5d6db80",
+        "scrollbar.track.border": "#c1c2c7",
+        "editor.foreground": "#343b59",
+        "editor.background": "#d5d6db",
+        "editor.gutter.background": "#d5d6db",
+        "editor.subheader.background": "#d5d6db",
+        "editor.active_line.background": "#dcdee3",
+        "editor.highlighted_line.background": "#dcdee3",
+        "editor.line_number": "#9da0ab",
+        "editor.active_line_number": "#343b59",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#c1c2c7",
+        "editor.active_wrap_guide": "#c1c2c7",
+        "editor.document_highlight.read_background": "#9da0ab",
+        "editor.document_highlight.write_background": "#9da0ab",
+        "terminal.background": "#cbccd1",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#0f0f14",
+        "terminal.ansi.bright_black": "#0f0f14",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#8c4351",
+        "terminal.ansi.bright_red": "#8c4351",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#33635c",
+        "terminal.ansi.bright_green": "#33635c",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#8f5e15",
+        "terminal.ansi.bright_yellow": "#8f5e15",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#34548a",
+        "terminal.ansi.bright_blue": "#34548a",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#5a4a78",
+        "terminal.ansi.bright_magenta": "#5a4a78",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#0f4b6e",
+        "terminal.ansi.bright_cyan": "#0f4b6e",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#828594",
+        "terminal.ansi.bright_white": "#828594",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#4c505e",
+        "conflict": "#5a4a78",
+        "conflict.background": "#d5d6db",
+        "conflict.border": "#343b58",
+        "created": "#485e30",
+        "created.background": "#d5d6db",
+        "created.border": "#343b58",
+        "deleted": "#8c4351",
+        "deleted.background": "#d5d6db",
+        "deleted.border": "#343b58",
+        "error": "#8c4351",
+        "error.background": "#d5d6db",
+        "error.border": "#343b58",
+        "hidden": "#4c505e",
+        "hidden.background": "#d5d6db",
+        "hidden.border": "#343b58",
+        "hint": "#634f30",
+        "hint.background": "#d5d6db",
+        "hint.border": "#343b58",
+        "ignored": "#828594",
+        "ignored.background": "#d5d6db",
+        "ignored.border": "#343b58",
+        "info": "#0da0ba",
+        "info.background": "#d5d6db",
+        "info.border": "#343b58",
+        "modified": "#8f5e15",
+        "modified.background": "#d5d6db",
+        "modified.border": "#343b58",
+        "predictive": "#634f30",
+        "predictive.background": "#d5d6db",
+        "predictive.border": "#343b58",
+        "renamed": "#485e30",
+        "renamed.background": "#d5d6db",
+        "renamed.border": "#343b58",
+        "success": "#485e30",
+        "success.background": "#d5d6db",
+        "success.border": "#343b58",
+        "unreachable": "#8c4351",
+        "unreachable.background": "#d5d6db",
+        "unreachable.border": "#343b58",
+        "warning": "#8f5e15",
+        "warning.background": "#d5d6db",
+        "warning.border": "#343b58",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#8c4351",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#34548a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#33635c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#33635c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#33635c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#166775",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Omarchy Current Storm",
+      "appearance": "dark",
+      "style": {
+        "border": "#1b1e2e",
+        "border.variant": "#1b1e2e",
+        "border.focused": "#545c7e33",
+        "border.selected": "#1b1e2e",
+        "border.transparent": "#1b1e2e",
+        "border.disabled": "#1b1e2e",
+        "elevated_surface.background": "#1b1e2e",
+        "surface.background": "#1f2335",
+        "background": "#24283b",
+        "element.background": "#24283b",
+        "element.hover": "#565f89",
+        "element.active": "#9aa5ce",
+        "element.selected": "#565f89",
+        "element.disabled": "#414868",
+        "drop_target.background": "#1e202e",
+        "ghost_element.background": "#1a1b26",
+        "ghost_element.hover": "#565f89",
+        "ghost_element.active": "#9aa5ce",
+        "ghost_element.selected": "#565f89",
+        "ghost_element.disabled": "#414868",
+        "text": "#a9b1d6",
+        "text.muted": "#7982a9",
+        "text.placeholder": "#787c99",
+        "text.disabled": "#414868",
+        "text.accent": "#7dcfff",
+        "icon": "#787c99",
+        "icon.muted": "#787c99",
+        "icon.disabled": "#414868",
+        "icon.placeholder": "#565f89",
+        "icon.accent": "#7dcfff",
+        "status_bar.background": "#1f2335",
+        "title_bar.background": "#1f2335",
+        "title_bar.inactive_background": "#1f2335",
+        "toolbar.background": "#1f2335",
+        "tab_bar.background": "#1f2335",
+        "tab.inactive_background": "#1f2335",
+        "tab.active_background": "#414868",
+        "search.match_background": "#414868",
+        "panel.background": "#1f2335",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#41486880",
+        "scrollbar.thumb.hover_background": "#414868",
+        "scrollbar.thumb.border": "#414868",
+        "scrollbar.track.background": "#24283b80",
+        "scrollbar.track.border": "#1b1e2e",
+        "editor.foreground": "#a9b1d6",
+        "editor.background": "#24283b",
+        "editor.gutter.background": "#24283b",
+        "editor.subheader.background": "#24283b",
+        "editor.active_line.background": "#292e42",
+        "editor.highlighted_line.background": "#1e202e",
+        "editor.line_number": "#3b4261",
+        "editor.active_line_number": "#a9b1d6",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#1b1e2e",
+        "editor.active_wrap_guide": "#1b1e2e",
+        "editor.document_highlight.read_background": "#363b54",
+        "editor.document_highlight.write_background": "#363b54",
+        "terminal.background": "#1f2335",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#414868",
+        "terminal.ansi.bright_black": "#414868",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#f7768e",
+        "terminal.ansi.bright_red": "#f7768e",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#73daca",
+        "terminal.ansi.bright_green": "#73daca",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#e0af68",
+        "terminal.ansi.bright_yellow": "#e0af68",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#7aa2f7",
+        "terminal.ansi.bright_blue": "#7aa2f7",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#bb9af7",
+        "terminal.ansi.bright_magenta": "#bb9af7",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#7dcfff",
+        "terminal.ansi.bright_cyan": "#7dcfff",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#7982a9",
+        "terminal.ansi.bright_white": "#a9b1d6",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#7dcfff",
+        "conflict": "#bb9af7",
+        "conflict.background": "#24283b",
+        "conflict.border": "#414868",
+        "created": "#9ece6a",
+        "created.background": "#24283b",
+        "created.border": "#414868",
+        "deleted": "#f7768e",
+        "deleted.background": "#24283b",
+        "deleted.border": "#414868",
+        "error": "#f7768e",
+        "error.background": "#24283b",
+        "error.border": "#414868",
+        "hidden": "#787c99",
+        "hidden.background": "#24283b",
+        "hidden.border": "#414868",
+        "hint": "#5f6996",
+        "hint.background": "#24283b",
+        "hint.border": "#414868",
+        "ignored": "#515670",
+        "ignored.background": "#24283b",
+        "ignored.border": "#414868",
+        "info": "#0da0ba",
+        "info.background": "#24283b",
+        "info.border": "#414868",
+        "modified": "#e0af68",
+        "modified.background": "#24283b",
+        "modified.border": "#414868",
+        "predictive": "#5f6996",
+        "predictive.background": "#24283b",
+        "predictive.border": "#414868",
+        "renamed": "#9ece6a",
+        "renamed.background": "#24283b",
+        "renamed.border": "#414868",
+        "success": "#9ece6a",
+        "success.background": "#24283b",
+        "success.border": "#414868",
+        "unreachable": "#f7768e",
+        "unreachable.background": "#24283b",
+        "unreachable.border": "#414868",
+        "warning": "#e0af68",
+        "warning.background": "#24283b",
+        "warning.border": "#414868",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#5f6996",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#5f6996",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#f7768e",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summmary

This PR adds theme support for the Zed editor, allowing Omarchy's theme system to seamlessly integrate with Zed.

## What's Changed

  - 11 Zed theme files added:
    - Catppuccin (using official Macchiato variant)
    - Catppuccin Latte (using official theme)
    - Everforest
    - Gruvbox
    - Kanagawa
    - Matte Black
    - Nord
    - Osaka Jade
    - Ristretto
    - Rose Pine
    - Tokyo Night (using official theme)
  - Theme switching integration - Modified omarchy-theme-set to:
    - Create Zed theme symlinks when switching themes
    - Update Zed's settings.json for live theme reloading
    - Support both zed and zeditor command names
  - Installation support - Updated install/desktop/theme.sh to set up initial Zed theme links
  - Migration script - Added migration for existing installations to enable Zed support

## Technical Details

  - In Zed selected themes use standardized name "Omarchy Current" for consistency
  - Live reloading via settings.json modification
  - Official themes used where available for better quality (Catppuccin Macchiato, Catpuccin Latte Tokyo Night)
  - Other themes generated from Alacritty color definitions using custom converter

## Testing

  - Tested theme switching across all 11 themes
  - Verified live reloading works without restarting Zed
  - Confirmed migration script works for existing installations
  - Created test script for automated screenshot capture

## Screenshots

### Catppuccin
<img width="5120" height="2880" alt="Catppuccin" src="https://github.com/user-attachments/assets/7afdf2da-f407-48ae-a47a-9c3b494fa053" />

### Catppuccin Latte
<img width="5120" height="2880" alt="Catppuccin_Latte" src="https://github.com/user-attachments/assets/00206801-58ff-4f28-8ee1-5fe28f929536" />

### Everforest
<img width="5120" height="2880" alt="Everforest" src="https://github.com/user-attachments/assets/1a6afc01-f9e2-4a97-aff7-b5aef1bdcbca" />

### Gruvbox
<img width="5120" height="2880" alt="Gruvbox" src="https://github.com/user-attachments/assets/95b9b1c0-5fc1-4cda-a05c-adba3ac79e1c" />

### Kanagawa
<img width="5120" height="2880" alt="Kanagawa" src="https://github.com/user-attachments/assets/c85a34fc-01d5-4b3d-8ba2-e55542a7b5cc" />

### Matte Black
<img width="5120" height="2880" alt="Matte_Black" src="https://github.com/user-attachments/assets/2fa64d79-584c-46da-a3a0-5dfd3c7c085f" />

### Nord
<img width="5120" height="2880" alt="Nord" src="https://github.com/user-attachments/assets/32e39026-3b6f-4d00-a4ad-928f575eaf4c" />

### Osaka Jade
<img width="5120" height="2880" alt="Osaka_Jade" src="https://github.com/user-attachments/assets/dd74b792-e7b8-49a3-a4da-c1e4dabc2017" />

### Ristretto
<img width="5120" height="2880" alt="Ristretto" src="https://github.com/user-attachments/assets/0c389b65-4e6b-4b64-80a0-5f89ad88ebaa" />

### Rose Pine
<img width="5120" height="2880" alt="Rose_Pine" src="https://github.com/user-attachments/assets/29b0d493-77ac-4f5a-a3c6-f9d8d6be4433" />

### Tokyo Night
<img width="5120" height="2880" alt="Tokyo_Night" src="https://github.com/user-attachments/assets/73923b5a-018e-4a64-a146-6cc098cf06cc" />
