### PR TITLE
Add an ssh-agent systemd user service

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -116,11 +116,12 @@ show_screenrecord_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n🔐 SSH Agent") in
   *Screensaver*) omarchy-launch-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
   *Idle*) omarchy-toggle-idle ;;
   *Bar*) pkill -SIGUSR1 waybar ;;
+  *SSH*) omarchy-toggle-ssh-agent ;;
   *) show_main_menu ;;
   esac
 }

--- a/bin/omarchy-toggle-ssh-agent
+++ b/bin/omarchy-toggle-ssh-agent
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Check if ssh-agent.service is active
+if systemctl --user is-active --quiet ssh-agent.service; then
+  notify-send "Stopping ssh-agent"
+  systemctl --user stop ssh-agent.service
+  systemctl --user disable ssh-agent.service
+else
+  # Enable and start the service
+  systemctl --user enable --now ssh-agent.service
+  # Export SSH_AUTH_SOCK for current session
+  export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent.socket"
+  notify-send "Enabling ssh-agent"
+fi
+
+# # Verify the current state
+# echo "Current SSH_AUTH_SOCK: $SSH_AUTH_SOCK"
+# systemctl --user status ssh-agent.service --no-pager

--- a/config/environment.d/ssh-agent.conf
+++ b/config/environment.d/ssh-agent.conf
@@ -1,0 +1,1 @@
+SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/ssh-agent.socket

--- a/config/systemd/user/ssh-agent.service
+++ b/config/systemd/user/ssh-agent.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=SSH key agent
+[Service]
+Type=simple
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+ExecStart=/usr/bin/ssh-agent -D -a $SSH_AUTH_SOCK
+[Install]
+WantedBy=default.target

--- a/migrations/1755025508.sh
+++ b/migrations/1755025508.sh
@@ -1,0 +1,3 @@
+echo "Enable ssh-agent"
+
+systemctl --user enable --now ssh-agent.service


### PR DESCRIPTION
This PR adds an ssh-agent systemd user service and a toggle menu item to easily enable or disable the agent.  It also adds a migration to enable the service by default.