### PR TITLE
Install gum before trying to use it

### DIFF
--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+sudo pacman -S --noconfirm --needed gum
+
 abort() {
   echo -e "\e[31mOmarchy install requires: $1\e[0m"
   echo

--- a/install/preflight/presentation.sh
+++ b/install/preflight/presentation.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yay -S --noconfirm --needed gum python-terminaltexteffects
+yay -S --noconfirm --needed python-terminaltexteffects


### PR DESCRIPTION
`gum` is not yet available when tried to be used here: https://github.com/basecamp/omarchy/blob/3d283eac180933e1381508a3ab775c91cda1affc/install/preflight/guard.sh#L6

Currently being installed here: https://github.com/basecamp/omarchy/blob/3d283eac180933e1381508a3ab775c91cda1affc/install/preflight/presentation.sh#L3