### PR TITLE
Update uwsm version in the hope of fixing an issue

### DIFF
--- a/install/config/login.sh
+++ b/install/config/login.sh
@@ -2,7 +2,7 @@
 
 # Hyprland launched via UWSM and login directly as user, rely on disk encryption + hyprlock for security
 if ! command -v uwsm &>/dev/null || ! command -v plymouth &>/dev/null; then
-  sudo pacman -U --noconfirm https://archive.archlinux.org/packages/u/uwsm/uwsm-0.23.0-1-any.pkg.tar.zst
+  sudo pacman -U --noconfirm https://archive.archlinux.org/packages/u/uwsm/uwsm-0.23.1-1-any.pkg.tar.zst
   yay -S --noconfirm --needed plymouth
 fi
 


### PR DESCRIPTION
While working, uwsm will try to generate drop in folder and try to remove a unit called "wayland-wm@.service/timeout.conf". The problem is for some reason this version of uwsm can sometimes mess with the regex (see how it works down below) unit_ext = re.compile(
        r"[a-zA-Z0-9_:.\\-]+@?\.(service|slice|scope|target|socket|d/[a-zA-Z0-9_:.\\-]+.conf)\2",
        re.MULTILINE,
    )

After some searching, the problem comes from the "\2" at the end which makes wayland-wm@.service/timeout.conf not detected as correct. So as uwsm will raise an error because of that and the seamless login will try to restart the process, we will be stuck in an infinite loop of uwsm crashing because of this regex and systemd restarting seamless login.
I'm not sure 0.23.1-1 is fixing this specific issue which occured on me i don't know why (it occured without any specific reason). I tried reinstalling uwsm etc but nothing worked except patching uwsm directly.