### PR TITLE
Lucidglyph (alternative fonts rendering)

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -171,7 +171,7 @@ show_setup_config_menu() {
 }
 
 show_install_menu() {
-  case $(menu "Install" "󰣇  Package\n  Web App\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming") in
+  case $(menu "Install" "󰣇  Package\n  Web App\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming\n Utilities") in
   *Package*) terminal omarchy-pkg-install ;;
   *Web*) present_terminal omarchy-webapp-install ;;
   *Service*) show_install_service_menu ;;
@@ -180,6 +180,7 @@ show_install_menu() {
   *Editor*) show_install_editor_menu ;;
   *AI*) show_install_ai_menu ;;
   *Gaming*) show_install_gaming_menu ;;
+  *Utilities*) show_install_utilities_menu ;;
   *) show_main_menu ;;
   esac
 }
@@ -220,6 +221,13 @@ show_install_gaming_menu() {
   *Steam*) present_terminal omarchy-install-steam ;;
   *RetroArch*) install_and_launch "RetroArch" "retroarch retroarch-assets libretro libretro-fbneo" "com.libretro.RetroArch.desktop" ;;
   *Minecraft*) install_and_launch "Minecraft" "minecraft-launcher" "minecraft-launcher" ;;
+  *) show_install_menu ;;
+  esac
+}
+
+show_install_utilities_menu() {
+  case $(menu "Install" "Lucidglyph") in
+  *Lucidglyph*) install "Lucidglyph" "lucidglyph" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
**NOT READY FOR MERGE**

This is the first version of an Install > Utilities > Lucidglyph menu.

Lucidglyph attempts to make text appear bolder, which can be beneficial on certain monitors and/or for people with specific vision impairments.

Installation is done via *yay lucidglyph*, and after installing, arch needs to be restarted.

I created this not ready pull request to gauge interest in continuing with this feature.

https://github.com/maximilionus/lucidglyph

with lucidglyph: 
<img width="863" height="743" alt="screenshot-2025-08-11_20-14-12" src="https://github.com/user-attachments/assets/2ff972e4-a541-49a5-bf48-9bdb50459451" />

without:
<img width="971" height="760" alt="screenshot-2025-08-13_02-11-47" src="https://github.com/user-attachments/assets/d1f32327-1578-4579-b71e-a94516ca9fcc" />

with:
<img width="483" height="1095" alt="screenshot-2025-08-13_02-08-41" src="https://github.com/user-attachments/assets/d11cf384-d14b-48bc-9876-d3075f833e17" />

without:
<img width="488" height="1091" alt="screenshot-2025-08-13_02-11-02" src="https://github.com/user-attachments/assets/21566cc6-aca1-47ee-8229-89e82c417057" />

