### PR TITLE
refactor: battery monitor script

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -1,16 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Designed to be run by systemd timer every 30 seconds and alerts if battery is low
 
 BATTERY_THRESHOLD=10
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
+BATTERY_DEVICE="$(upower -e | grep 'BAT')"
 
 get_battery_percentage() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
+  upower -i "$BATTERY_DEVICE" | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
 }
 
 get_battery_state() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}'
+  upower -i "$BATTERY_DEVICE" | grep -E "state" | awk '{print $2}'
 }
 
 send_notification() {


### PR DESCRIPTION
- Updated the battery monitor script to use an env-based Bash shebang and enabled strict error handling with set -euo pipefail
- Consolidated battery detection into a single BATTERY_DEVICE variable, reusing it for both percentage and state queries