### PR TITLE
Unpin uwsm now that 0.23.2 is available in AUR

### DIFF
--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
-yay -Syu --noconfirm --ignore uwsm
+yay -Syu --noconfirm
 echo

--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ source $OMARCHY_INSTALL/apps/mimetypes.sh
 show_logo highlight
 show_subtext "Updating system packages [5/5]"
 sudo updatedb
-yay -Syu --noconfirm --ignore uwsm
+yay -Syu --noconfirm
 
 # Reboot
 show_logo laseretch 920

--- a/install/config/login.sh
+++ b/install/config/login.sh
@@ -2,9 +2,8 @@
 
 # Hyprland launched via UWSM and login directly as user, rely on disk encryption + hyprlock for security
 if ! command -v uwsm &>/dev/null || ! command -v plymouth &>/dev/null; then
-  sudo pacman -U --noconfirm https://archive.archlinux.org/packages/u/uwsm/uwsm-0.23.0-1-any.pkg.tar.zst
-  yay -S --noconfirm --needed plymouth
-fi
+  yay -S --noconfirm --needed uwsm plymouth
+ fi
 
 # ==============================================================================
 # PLYMOUTH SETUP


### PR DESCRIPTION
The new version of uwsm (`0.23.2-1`) is now available: https://archlinux.org/packages/extra/any/uwsm/

<img width="443" height="377" alt="image" src="https://github.com/user-attachments/assets/e419a712-0182-43f9-8ed7-0e7f3b3b0b90" />

Removing the code that was pinning an older version. Also tested locally updating to the latest version and rebooting Omarchy without any issue.

```
~/workspace/omarchy[unpin-uwsm-version] $ uwsm --version
uwsm 0.23.2
```

