### PR TITLE
[omarchy-cmd-screenshot] - Set LIBGL_ALWAYS_SOFTWARE=1 for satty

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -9,7 +9,7 @@ if [[ ! -d "$OUTPUT_DIR" ]]; then
 fi
 
 pkill slurp || hyprshot -m ${1:-region} --raw |
-  satty --filename - \
+  LIBGL_ALWAYS_SOFTWARE=1 satty --filename - \
     --output-filename "$OUTPUT_DIR/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png" \
     --early-exit \
     --actions-on-enter save-to-clipboard \


### PR DESCRIPTION
Attempt to mitigate visual bugs in satty with Intel Arc graphics as seen below (with Intel Arc Graphics 130V / 140V). If anyone has a suggestion for a more proper fix (not just setting `LIBGL_ALWAYS_SOFTWARE=1`) I am open for suggestions.

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/d1227059-cb18-4472-a42f-4c31b36abb22" />
