### PR TITLE
style: Improve steam hyprland config

### DIFF
--- a/default/hypr/apps/steam.conf
+++ b/default/hypr/apps/steam.conf
@@ -1,6 +1,4 @@
-# Float Steam, fullscreen RetroArch
-windowrule = float, class:steam
-windowrule = center, class:steam, title:Steam
-windowrule = opacity 1 1, class:steam
-windowrule = size 1100 700, class:steam, title:Steam
-windowrule = size 460 800, class:steam, title:Friends List
+# Steam: float by default; tile the main client
+windowrulev2 = float, class:^(steam)$
+windowrulev2 = tile, class:^(steam)$, title:^Steam$
+windowrulev2 = opacity 1 1, class:^(steam)$


### PR DESCRIPTION
This pull request updates the window management rules for Steam in the `steam.conf` configuration file, switching from the older `windowrule` syntax to the newer `windowrulev2` for improved matching and behavior.

Window rule improvements for Steam:

* Replaced legacy `windowrule` entries with `windowrulev2` for more precise class and title matching using regular expressions.
* Updated rules so that the main client window is tiled by default, and other windows float. Removed static sizing, allowing all floating content to dynamically size based on content
* Simplified opacity handling for Steam windows using the new syntax.