### PR TITLE
fix: Avoid fcitx5 override of xcb keyboard layout

### DIFF
--- a/config/fcitx5/conf/xcb.conf
+++ b/config/fcitx5/conf/xcb.conf
@@ -1,0 +1,2 @@
+# Default config to prevent fcitx5 from overwriting XKB layout
+Allow Overriding System XKB Settings=False

--- a/config/fcitx5/conf/xcb.conf
+++ b/config/fcitx5/conf/xcb.conf
@@ -1,2 +1,1 @@
-# Default config to prevent fcitx5 from overwriting XKB layout
 Allow Overriding System XKB Settings=False

--- a/migrations/1755139080.sh
+++ b/migrations/1755139080.sh
@@ -1,0 +1,12 @@
+echo "Ensure fcitx5 does not overwrite xkb layout."
+
+FCITX5_CONF_DIR="${HOME}/.config/fcitx5/conf"
+FCITX5_XCB_CONF="${FCITX5_CONF_DIR}/xcb.conf"
+
+mkdir -p "${FCITX5_CONF_DIR}"
+
+if [ ! -f "${FCITX5_XCB_CONF}" ]; then
+    touch "${FCITX5_XCB_CONF}"
+    echo "# Default config to prevent fcitx5 from overwriting XKB layout" >> "${FCITX5_XCB_CONF}"
+    echo 'Allow Overriding System XKB Settings=False' >> "${FCITX5_XCB_CONF}"
+fi

--- a/migrations/1755139080.sh
+++ b/migrations/1755139080.sh
@@ -1,12 +1,9 @@
-echo "Ensure fcitx5 does not overwrite xkb layout."
+echo "Ensure fcitx5 does not overwrite xkb layout"
 
-FCITX5_CONF_DIR="${HOME}/.config/fcitx5/conf"
-FCITX5_XCB_CONF="${FCITX5_CONF_DIR}/xcb.conf"
+FCITX5_CONF_DIR="$HOME/.config/fcitx5/conf"
+FCITX5_XCB_CONF="$FCITX5_CONF_DIR/xcb.conf"
 
-mkdir -p "${FCITX5_CONF_DIR}"
-
-if [ ! -f "${FCITX5_XCB_CONF}" ]; then
-    touch "${FCITX5_XCB_CONF}"
-    echo "# Default config to prevent fcitx5 from overwriting XKB layout" >> "${FCITX5_XCB_CONF}"
-    echo 'Allow Overriding System XKB Settings=False' >> "${FCITX5_XCB_CONF}"
+if [[ ! -f $FCITX5_XCB_CONF ]]; then
+  mkdir -p "$FCITX5_CONF_DIR"
+  cp "$OMARCHY_PATH/config/fcitx5/conf/xcb.conf" "$FCITX5_XCB_CONF"
 fi


### PR DESCRIPTION
Solves #483

This avoid the fcitx5 default behaviour that overrides the xkb layout on boot, overriding the layout set by hyprland configs. A explained in [this comment](https://github.com/basecamp/omarchy/issues/483#issuecomment-3186453764).

1. Added a migration to fix the current installations on update
2. Added the fcitx5 config for the new installations

