### PR TITLE
Idle toggle without losing suspend lock

### DIFF
--- a/bin/omarchy-toggle-idle
+++ b/bin/omarchy-toggle-idle
@@ -1,9 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# This script uses 'systemd-run' to reliably create a transient service
+# that holds a persistent idle inhibit lock.
 
-if pgrep -x hypridle >/dev/null; then
-  pkill -x hypridle
-  notify-send "Stop locking computer when idle"
-else
-  uwsm app -- hypridle >/dev/null 2>&1 &
+# The predictable systemd unit name we will assign and control.
+UNIT_NAME="hypridle-inhibit-toggle.service"
+
+# Check if the systemd unit is currently active.
+if systemctl --user is-active --quiet "$UNIT_NAME"; then
+  # The unit is active, so we stop it to release the lock.
+  systemctl --user stop "$UNIT_NAME"
   notify-send "Now locking computer when idle"
+else
+  # The unit is not active, so we use systemd-run to create and start it.
+  systemd-run \
+    --user \
+    --unit="$UNIT_NAME" \
+    --description="Persistent hypridle inhibit lock" \
+    /usr/bin/systemd-inhibit --what=idle --who='Toggle Script' --why='User Requested' sleep infinity
+  notify-send "Stop locking computer when idle"
 fi


### PR DESCRIPTION
With the current implementation, when you disable locking on idle we also lose locking on suspend.
This means if you forget to re-enable idle locking before closing your laptop, it won't be locked at all.  

We make use of the inhibition logic that hypridle already supports, to just stop the auto-lock on idle
while maintaining lock on suspend.

We need a running process to "own" the inhibition, so we launch a transient systemd unit that sleeps forever.
When we want to re-enable locking, we simply stop that process again.

This keeps the whole implementation contained to a single file without any additional dependencies.


---

This was part of an earlier merge request, where I also changed the way we launch hypridle and
I didn't do a good job of conveying the benefits of this approach.

I hope this more focused PR with a better description does a better job at that. 