### PR TITLE
 improve black contrast in ristretto alacritty theme

### DIFF
--- a/themes/ristretto/alacritty.toml
+++ b/themes/ristretto/alacritty.toml
@@ -1,7 +1,7 @@
 [colors]
 
 [colors.normal]
-black = "#2c2525"
+black   = "#72696a"
 red = "#fd6883"
 green = "#adda78"
 yellow = "#f9cc6c"
@@ -11,7 +11,7 @@ cyan = "#85dacc"
 white = "#e6d9db"
 
 [colors.bright]
-black   = "#463a3a"
+black = "#948a8b"
 red     = "#ff8297"
 green   = "#c8e292"
 yellow  = "#fcd675"


### PR DESCRIPTION
The current version renders black and bright black like so.
Having these colors this close to the background makes them practically unusable. 

<img width="952" height="98" alt="low contrast" src="https://github.com/user-attachments/assets/a30bc442-54e4-4aa1-919a-9265223ac55d" />

I've picked some grays from the monokai pro ristretto nvim colors to make the contrast more pronounced.

<img width="888" height="98" alt="improved contrast" src="https://github.com/user-attachments/assets/668c0db4-ed7e-41f1-a31b-1bfdd279ea2c" />
