### PR TITLE
added dynamic resize keymaps

### DIFF
--- a/bin/omarchy-refresh-hyprland
+++ b/bin/omarchy-refresh-hyprland
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-omarchy-refresh-keybindings
-
 omarchy-refresh-config hypr/autostart.conf
 omarchy-refresh-config hypr/bindings.conf
 omarchy-refresh-config hypr/envs.conf

--- a/bin/omarchy-refresh-hyprland
+++ b/bin/omarchy-refresh-hyprland
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+omarchy-refresh-keybindings
+
 omarchy-refresh-config hypr/autostart.conf
 omarchy-refresh-config hypr/bindings.conf
 omarchy-refresh-config hypr/envs.conf

--- a/bin/omarchy-refresh-keybindings
+++ b/bin/omarchy-refresh-keybindings
@@ -6,15 +6,14 @@
 # Exit on error
 set -e
 
-# Get the active keyboard layout
-layout=$(hyprctl devices | grep 'at-translated-set-2-keyboard' -A 4 | grep 'active keymap:' | awk '{print $3}')
+layout=$(localectl status | grep 'X11 Layout' | sed 's/.*X11 Layout://' | xargs | cut -d ',' -f 1)
 
 # Default to qwerty
 keymap_name="qwerty"
 
-# Check if the layout is French (AZERTY)
-if [[ "$layout" == "French" ]]; then
-    keymap_name="azerty"
+# Check if the layout is French (azerty)
+if [[ "$layout" == "fr" ]]; then
+  keymap_name="azerty"
 fi
 
 # The source directory for the keymaps

--- a/bin/omarchy-refresh-keybindings
+++ b/bin/omarchy-refresh-keybindings
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Detects the active keyboard layout and updates the keybindings accordingly.
+#
+
+# Exit on error
+set -e
+
+# Get the active keyboard layout
+layout=$(hyprctl devices | grep 'at-translated-set-2-keyboard' -A 4 | grep 'active keymap:' | awk '{print $3}')
+
+# Default to qwerty
+keymap_name="qwerty"
+
+# Check if the layout is French (AZERTY)
+if [[ "$layout" == "French" ]]; then
+    keymap_name="azerty"
+fi
+
+# The source directory for the keymaps
+omarchy_dir="$HOME/.local/share/omarchy"
+keymap_src_dir="$omarchy_dir/default/hypr/resize-keymaps"
+
+# The destination for the keymap config
+config_dest_dir="$HOME/.config/hypr"
+config_dest_file="$config_dest_dir/resize-keymap.conf"
+
+# Ensure the destination directory exists
+mkdir -p "$config_dest_dir"
+
+# Create the symlink
+ln -sf "$keymap_src_dir/$keymap_name.conf" "$config_dest_file"
+
+echo "Keybindings refreshed for $keymap_name layout."

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -1,4 +1,4 @@
-exec-once = omarchy-refresh-hyprland
+exec-once = omarchy-refresh-keybindings
 exec-once = uwsm app -- hypridle
 exec-once = uwsm app -- mako
 exec-once = uwsm app -- waybar

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -1,3 +1,4 @@
+exec-once = omarchy-refresh-hyprland
 exec-once = uwsm app -- hypridle
 exec-once = uwsm app -- mako
 exec-once = uwsm app -- waybar

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -47,12 +47,6 @@ bindd = SUPER SHIFT, down, Swap window down, swapwindow, d
 bindd = ALT, Tab, Cycle to next window, cyclenext
 bindd = ALT, Tab, Reveal active window on top, bringactivetotop
 
-# Resize active window
-bindd = SUPER, minus, Expand window left, resizeactive, -100 0
-bindd = SUPER, equal, Shrink window left, resizeactive, 100 0
-bindd = SUPER SHIFT, minus, Shrink window up, resizeactive, 0 -100
-bindd = SUPER SHIFT, equal, Expand window down, resizeactive, 0 100
-
 # Scroll through existing workspaces with SUPER + scroll
 bindd = SUPER, mouse_down, Scroll active workspace forward, workspace, e+1
 bindd = SUPER, mouse_up, Scroll active workspace backward, workspace, e-1
@@ -60,3 +54,6 @@ bindd = SUPER, mouse_up, Scroll active workspace backward, workspace, e-1
 # Move/resize windows with mainMod + LMB/RMB and dragging
 bindmd = SUPER, mouse:272, Move window, movewindow
 bindmd = SUPER, mouse:273, Resize window, resizewindow
+
+# Resize bindings, automatically selected based on keyboard layout
+source = ~/.config/hypr/resize-keymap.conf

--- a/default/hypr/resize-keymaps/azerty.conf
+++ b/default/hypr/resize-keymaps/azerty.conf
@@ -1,0 +1,5 @@
+# Resize active window
+bindd = SUPER, parenright, Expand window left, resizeactive, -100 0
+bindd = SUPER, equal, Shrink window left, resizeactive, 100 0
+bindd = SUPER SHIFT, parenright, Shrink window up, resizeactive, 0 -100
+bindd = SUPER SHIFT, equal, Expand window down, resizeactive, 0 100

--- a/default/hypr/resize-keymaps/qwerty.conf
+++ b/default/hypr/resize-keymaps/qwerty.conf
@@ -1,0 +1,5 @@
+# Resize active window
+bindd = SUPER, minus, Expand window left, resizeactive, -100 0
+bindd = SUPER, equal, Shrink window left, resizeactive, 100 0
+bindd = SUPER SHIFT, minus, Shrink window up, resizeactive, 0 -100
+bindd = SUPER SHIFT, equal, Expand window down, resizeactive, 0 100


### PR DESCRIPTION
It basically check, in each start of hyprland, the layout of the keyboard used. If it's french it changes the keybinds for resizing windows accordingly (")" to make the windows smaller and "=" for bigger). If it's something else it defaults to qwerty.