### PR TITLE
Add notes about web app url containing hash

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -27,3 +27,6 @@ bindd = SUPER SHIFT, X, X Post, exec, $webapp="https://x.com/compose/post"
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, Space
 # bindd = SUPER, SPACE, Omarchy menu, exec, omarchy-menu
+#
+# If your web app url contains #, type it as ## to prevent hyperland treat it as comments
+# e.g. $webapp="https://example.com/##home" instead of #home


### PR DESCRIPTION
I have encountered this problem and spent some time to figure it out. It's quite common that web apps have # in the url for web app routing, hyperland will treat the hash part as comment and the binding will fail silently. 