### PR TITLE
feat(editor): Add Jetbrains toolbox to editor install menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -193,22 +193,14 @@ show_install_service_menu() {
 }
 
 show_install_editor_menu() {
-  case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  IntelliJ IDEA") in
+  case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Jetbrains Toolbox") in
   *VSCode*) install_and_launch "VSCode" "visual-studio-code-bin" "code" ;;
   *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
   *Zed*) install_and_launch "Zed" "zed" "dev.zed.Zed" ;;
   *Sublime*) install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;
   *Helix*) install "Helix" "helix" ;;
-  *IntelliJ*) show_install_intellij_menu ;;
+  *Jetbrains*) install_and_launch "Jetbrains Toolbox" "jetbrains-toolbox" "jetbrains-toolbox" ;;
   *) show_install_menu ;;
-  esac
-}
-
-show_install_intellij_menu() {
-  case $(menu "IntelliJ IDEA" "  Community Edition\n  Ultimate Edition") in
-  *Community*) install_and_launch "IntelliJ IDEA Community Edition" "intellij-idea-community-edition" "jetbrains-idea-ce.desktop" ;;
-  *Ultimate*) install_and_launch "IntelliJ IDEA Ultimate Edition" "intellij-idea-ultimate-edition" "jetbrains-idea-ultimate.desktop" ;;
-  *) show_install_editor_menu ;;
   esac
 }
 


### PR DESCRIPTION
We might be in the minority on linux compared to the other editors :sweat_smile: but its still a wide commonly used IDE/Editor. It might not fit the 'editor' menu since you could argue its an IDE, but it fits the other popular options.

<details>
<summary>screenshots</summary>
<img width="966" height="1012" alt="screenshot-2025-08-15_09-27-45" src="https://github.com/user-attachments/assets/505e3fb4-df21-4f86-b079-4c4d78cd8929" />
<img width="908" height="596" alt="screenshot-2025-08-15_09-28-11" src="https://github.com/user-attachments/assets/29969b8e-bf4a-42d7-a930-297a9ffba9d9" />
</details>

_Would be fully fine with closing this, just trying to contribute to this awesome project!_