### PR TITLE
feat: Obsidian theme to use current Omarchy theme

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -225,7 +225,8 @@ show_install_gaming_menu() {
 }
 
 show_install_style_menu() {
-  case $(menu "Install" "󰸌  Theme\n  Background\n  Font") in
+  case $(menu "Install" "󰸌  Theme\n  Background\n  Font\n󰸌  Obsidian Theme") in
+  *Obsidian*) present_terminal omarchy-obsidian-theme-install ;;
   *Theme*) present_terminal omarchy-theme-install ;;
   *Background*) nautilus ~/.config/omarchy/current/theme/backgrounds ;;
   *Font*) show_install_font_menu ;;
@@ -280,9 +281,10 @@ show_install_php_menu() {
 }
 
 show_remove_menu() {
-  case $(menu "Remove" "󰣇  Package\n  Web App\n󰸌  Theme\n󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Remove" "󰣇  Package\n  Web App\n󰸌  Theme\n󰸌   Obsidian Theme\n󰈷  Fingerprint\n  Fido2") in
   *Package*) terminal omarchy-pkg-remove ;;
   *Web*) present_terminal omarchy-webapp-remove ;;
+  *Obsidian*) present_terminal omarchy-obsidian-theme-remove ;;
   *Theme*) present_terminal omarchy-theme-remove ;;
   *Fingerprint*) present_terminal "omarchy-setup-fingerprint --remove" ;;
   *Fido2*) present_terminal "omarchy-setup-fido2 --remove" ;;

--- a/bin/omarchy-obsidian-theme-install
+++ b/bin/omarchy-obsidian-theme-install
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# omarchy-obsidian-theme-install: Install Omarchy theme to a specific Obsidian vault
+# Usage: omarchy-obsidian-theme-install [vault-directory]
+# If no vault directory is provided, it will prompt for one
+
+if [ $# -eq 0 ]; then
+  # Start from home directory
+  START_DIR="$HOME/Documents"
+
+  # Loop until we get a valid vault or user cancels
+  while true; do
+    echo "Select your Obsidian vault directory:"
+    echo "Navigation: ← → to enter/exit folders, ↑ ↓ to move, Enter to select, Esc to cancel"
+    SELECTION=$(gum file "$START_DIR" --directory --height 20)
+
+    # Check if user cancelled (ESC or Ctrl+C)
+    if [ -z "$SELECTION" ]; then
+      echo "❌ Installation cancelled"
+      exit 0
+    fi
+
+    # Check if selected directory is a vault
+    if [ -d "$SELECTION/.obsidian" ]; then
+      VAULT_DIR="$SELECTION"
+      echo "✅ Found Obsidian vault: $(basename "$VAULT_DIR")"
+      break
+    else
+      # Use the selected directory as the new starting point
+      START_DIR="$SELECTION"
+    fi
+  done
+else
+  VAULT_DIR="$1"
+fi
+VAULT_NAME=$(basename "$VAULT_DIR")
+
+# Validate vault directory exists
+if [ ! -d "$VAULT_DIR" ]; then
+  echo "❌ Error: Directory '$VAULT_DIR' does not exist"
+  exit 1
+fi
+
+# Validate it's an Obsidian vault (contains .obsidian folder)
+if [ ! -d "$VAULT_DIR/.obsidian" ]; then
+  echo "❌ Error: '$VAULT_DIR' is not an Obsidian vault"
+  echo "   Missing .obsidian folder. Make sure this is the correct vault directory."
+  exit 1
+fi
+
+THEMES_DIR="$VAULT_DIR/.obsidian/themes/Omarchy"
+
+echo "🎨 Installing Omarchy theme to vault: $VAULT_NAME"
+echo "   Vault path: $VAULT_DIR"
+
+# Create theme directory
+mkdir -p "$THEMES_DIR"
+
+# Create theme manifest
+cat >"$THEMES_DIR/manifest.json" <<'EOF'
+{
+	"name": "Omarchy",
+	"version": "1.0.0",
+	"minAppVersion": "0.16.0",
+	"description": "Automatically syncs with your current Omarchy system theme colors and fonts",
+	"author": "Omarchy",
+	"authorUrl": "https://omarchy.org"
+}
+EOF
+
+echo "✅ Created theme manifest"
+
+# Create empty theme.css placeholder
+touch "$THEMES_DIR/theme.css"
+
+# Register vault first (only if valid)
+VAULTS_FILE="$HOME/.local/state/omarchy/obsidian-vaults"
+mkdir -p "$(dirname "$VAULTS_FILE")"
+
+# Check if already registered
+if [ -f "$VAULTS_FILE" ] && grep -Fxq "$VAULT_DIR" "$VAULTS_FILE"; then
+  echo "ℹ️  Vault already registered for automatic updates"
+else
+  # Add to registry
+  echo "$VAULT_DIR" >>"$VAULTS_FILE"
+  echo "✅ Registered vault for automatic theme updates"
+fi
+
+# Use the update command to populate the theme
+omarchy-obsidian-theme-update >/dev/null 2>&1
+echo "✅ Theme installed with current Omarchy colors and fonts"
+
+# Check if Obsidian is running and offer reload tip
+if pgrep -f "obsidian" >/dev/null; then
+  echo ""
+  echo "ℹ️  Obsidian is running. After activating the theme, you may need to:"
+  echo "   • Reload Obsidian (Ctrl+R / Cmd+R)"
+  echo "   • Or restart Obsidian to see all changes"
+fi
+
+echo ""
+echo "🎉 Omarchy theme installed successfully!"
+
+echo ""
+echo "To activate:"
+echo "1. Open Obsidian"
+echo "2. Go to Settings → Appearance"
+echo "3. Select 'Omarchy' from the theme dropdown"
+echo ""
+echo "✨ The theme will use colors and fonts from your current Omarchy configuration."
+echo "🔄 This vault will automatically update when you change Omarchy themes."
+
+# Show all registered vaults
+echo ""
+echo "📋 Currently registered vaults:"
+if [ -f "$VAULTS_FILE" ]; then
+  while IFS= read -r vault_path; do
+    registered_vault_name=$(basename "$vault_path")
+    if [ -d "$vault_path" ]; then
+      if [ "$vault_path" = "$VAULT_DIR" ]; then
+        echo "  ✅ $registered_vault_name (this vault)"
+      else
+        echo "  ✅ $registered_vault_name"
+      fi
+    fi
+  done <"$VAULTS_FILE"
+else
+  echo "  (none)"
+fi

--- a/bin/omarchy-obsidian-theme-remove
+++ b/bin/omarchy-obsidian-theme-remove
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# omarchy-obsidian-theme-remove: Remove Omarchy theme from an Obsidian vault and unregister it
+# Usage: omarchy-obsidian-theme-remove [vault-directory]
+# If no vault directory is provided, it will show a selection menu
+
+VAULTS_FILE="$HOME/.local/state/omarchy/obsidian-vaults"
+
+# Function to remove theme from a vault
+remove_theme_from_vault() {
+  local vault_path="$1"
+  local vault_name=$(basename "$vault_path")
+
+  if [ ! -d "$vault_path" ]; then
+    echo "❌ Vault directory does not exist: $vault_path"
+    return 1
+  fi
+
+  THEME_DIR="$vault_path/.obsidian/themes/Omarchy"
+
+  if [ -d "$THEME_DIR" ]; then
+    rm -rf "$THEME_DIR"
+    echo "✅ Removed Omarchy theme from: $vault_name"
+  else
+    echo "ℹ️  Theme not installed in: $vault_name"
+  fi
+
+  # Remove from registry
+  if [ -f "$VAULTS_FILE" ]; then
+    # Create temp file without this vault
+    grep -v "^$vault_path$" "$VAULTS_FILE" >"$VAULTS_FILE.tmp" || true
+
+    # Replace original file if temp has content, otherwise remove it
+    if [ -s "$VAULTS_FILE.tmp" ]; then
+      mv "$VAULTS_FILE.tmp" "$VAULTS_FILE"
+    else
+      rm -f "$VAULTS_FILE" "$VAULTS_FILE.tmp"
+    fi
+
+    echo "✅ Unregistered vault from automatic updates"
+  fi
+}
+
+# Main logic
+if [ $# -eq 0 ]; then
+  # No argument provided - show selection menu
+
+  # Check if any vaults are registered
+  if [ ! -f "$VAULTS_FILE" ] || [ ! -s "$VAULTS_FILE" ]; then
+    echo "❌ No Obsidian vaults are registered"
+    echo ""
+    echo "To install the theme first, run:"
+    echo "  omarchy-obsidian-theme-install"
+    exit 1
+  fi
+
+  # Build list of vaults for selection
+  vault_list=""
+  while IFS= read -r vault_path; do
+    if [ -d "$vault_path" ]; then
+      vault_name=$(basename "$vault_path")
+      if [ -z "$vault_list" ]; then
+        vault_list="$vault_name:$vault_path"
+      else
+        vault_list="$vault_list\n$vault_name:$vault_path"
+      fi
+    fi
+  done <"$VAULTS_FILE"
+
+  if [ -z "$vault_list" ]; then
+    echo "❌ No valid vaults found in registry"
+    exit 1
+  fi
+
+  # Show selection menu
+  echo "Select vault to remove Omarchy theme from:"
+  selected=$(echo -e "$vault_list" | cut -d: -f1 | gum choose --header "Select Obsidian Vault:")
+
+  if [ -z "$selected" ]; then
+    echo "❌ No vault selected"
+    exit 0
+  fi
+
+  # Get the full path for selected vault
+  VAULT_DIR=$(echo -e "$vault_list" | grep "^$selected:" | cut -d: -f2-)
+
+  if [ -z "$VAULT_DIR" ]; then
+    echo "❌ Could not find path for selected vault"
+    exit 1
+  fi
+
+  # Confirm removal
+  echo ""
+  echo "This will remove the Omarchy theme from:"
+  echo "  📁 $selected"
+  echo "  📍 $VAULT_DIR"
+  echo ""
+
+  if gum confirm "Remove theme and unregister vault?"; then
+    remove_theme_from_vault "$VAULT_DIR"
+  else
+    echo "❌ Removal cancelled"
+    exit 0
+  fi
+
+else
+  # Vault directory provided as argument
+  VAULT_DIR="$1"
+  remove_theme_from_vault "$VAULT_DIR"
+fi
+
+# Show remaining registered vaults
+echo ""
+if [ -f "$VAULTS_FILE" ] && [ -s "$VAULTS_FILE" ]; then
+  echo "📋 Remaining registered vaults:"
+  while IFS= read -r vault_path; do
+    if [ -d "$vault_path" ]; then
+      echo "  • $(basename "$vault_path")"
+    fi
+  done <"$VAULTS_FILE"
+else
+  echo "ℹ️  No vaults are currently registered"
+fi

--- a/bin/omarchy-obsidian-theme-update
+++ b/bin/omarchy-obsidian-theme-update
@@ -1,0 +1,572 @@
+#!/bin/bash
+
+# omarchy-obsidian-theme-update: Update all registered Obsidian vaults with current Omarchy theme
+# This script reads the vault registry and updates each vault's theme
+
+VAULTS_FILE="$HOME/.local/state/omarchy/obsidian-vaults"
+CURRENT_THEME_DIR="$HOME/.config/omarchy/current/theme"
+
+# Exit early if no vaults registered
+if [ ! -f "$VAULTS_FILE" ] || [ ! -s "$VAULTS_FILE" ]; then
+  exit 0
+fi
+
+# Function to extract hex color from string
+extract_hex_color() {
+  echo "$1" | grep -oE '#[0-9a-fA-F]{6}' | head -1
+}
+
+# Function to convert RGB/RGBA to hex
+rgb_to_hex() {
+  local rgb_string="$1"
+  if [[ $rgb_string =~ rgba?\(([0-9]+),\s*([0-9]+),\s*([0-9]+) ]]; then
+    printf "#%02x%02x%02x\n" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+  fi
+}
+
+# Convert hex to RGB components
+hex_to_rgb() {
+  local hex="${1#\#}"
+  printf "%d %d %d\n" "0x${hex:0:2}" "0x${hex:2:2}" "0x${hex:4:2}"
+}
+
+# Calculate perceived brightness (0-255)
+calculate_brightness() {
+  local hex="$1"
+  read -r r g b <<<"$(hex_to_rgb "$hex")"
+  # Use perceived brightness formula
+  echo $(((r * 299 + g * 587 + b * 114) / 1000))
+}
+
+# Calculate color distance (euclidean in RGB space)
+color_distance() {
+  local hex1="$1"
+  local hex2="$2"
+  read -r r1 g1 b1 <<<"$(hex_to_rgb "$hex1")"
+  read -r r2 g2 b2 <<<"$(hex_to_rgb "$hex2")"
+  echo $(((r1 - r2) * (r1 - r2) + (g1 - g2) * (g1 - g2) + (b1 - b2) * (b1 - b2)))
+}
+
+# Extract all colors with frequency count
+extract_all_colors_with_count() {
+  local -A color_counts
+  local color
+
+  # Extract from Alacritty config
+  if [ -f "$CURRENT_THEME_DIR/alacritty.toml" ]; then
+    # Primary colors
+    while IFS= read -r color; do
+      color=$(echo "$color" | tr '[:upper:]' '[:lower:]') # Lowercase for consistency
+      [ -n "$color" ] && ((color_counts["$color"]++))
+    done < <(grep -E "(background|foreground|cursor|text)" "$CURRENT_THEME_DIR/alacritty.toml" | sed "s/.*[\"']0x/#/;s/.*[\"']#/#/;s/[\"'].*//;s/.*#\([0-9a-fA-F]\{6\}\).*/\#\1/" | grep "^#")
+
+    # Normal colors
+    while IFS= read -r color; do
+      color=$(echo "$color" | tr '[:upper:]' '[:lower:]') # Lowercase for consistency
+      [ -n "$color" ] && ((color_counts["$color"]++))
+    done < <(grep -A 20 "\[colors.normal\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep -E "(black|red|green|yellow|blue|magenta|cyan|white)" | sed "s/.*[\"']0x/#/;s/.*[\"']#/#/;s/[\"'].*//;s/.*#\([0-9a-fA-F]\{6\}\).*/\#\1/" | grep "^#")
+
+    # Bright colors
+    while IFS= read -r color; do
+      # Add # if missing
+      [[ "$color" =~ ^[0-9a-fA-F]{6}$ ]] && color="#$color"
+      color=$(echo "$color" | tr '[:upper:]' '[:lower:]') # Lowercase for consistency
+      [[ "$color" =~ ^#[0-9a-f]{6}$ ]] && ((color_counts["$color"]++))
+    done < <(grep -A 20 "\[colors.bright\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep -E "(black|red|green|yellow|blue|magenta|cyan|white)" | sed "s/.*[\"']//;s/[\"'].*//")
+
+    # Dim colors if present
+    while IFS= read -r color; do
+      # Add # if missing
+      [[ "$color" =~ ^[0-9a-fA-F]{6}$ ]] && color="#$color"
+      color=$(echo "$color" | tr '[:upper:]' '[:lower:]') # Lowercase for consistency
+      [[ "$color" =~ ^#[0-9a-f]{6}$ ]] && ((color_counts["$color"]++))
+    done < <(grep -A 20 "\[colors.dim\]" "$CURRENT_THEME_DIR/alacritty.toml" 2>/dev/null | grep -E "(black|red|green|yellow|blue|magenta|cyan|white)" | sed "s/.*[\"']//;s/[\"'].*//")
+
+    # Selection colors
+    while IFS= read -r color; do
+      color=$(echo "$color" | tr '[:upper:]' '[:lower:]') # Lowercase for consistency
+      [ -n "$color" ] && ((color_counts["$color"]++))
+    done < <(grep -A 5 "\[colors.selection\]" "$CURRENT_THEME_DIR/alacritty.toml" 2>/dev/null | grep -E "(background|text)" | sed "s/.*[\"']0x/#/;s/.*[\"']#/#/;s/[\"'].*//;s/.*#\([0-9a-fA-F]\{6\}\).*/\#\1/" | grep "^#")
+  fi
+
+  # Extract from Waybar CSS
+  if [ -f "$CURRENT_THEME_DIR/waybar.css" ]; then
+    while IFS= read -r color; do
+      color=$(echo "$color" | tr '[:upper:]' '[:lower:]') # Lowercase for consistency
+      [ -n "$color" ] && ((color_counts["$color"]++))
+    done < <(grep -oE '@define-color [a-z_-]+ #[0-9a-fA-F]{6}' "$CURRENT_THEME_DIR/waybar.css" | grep -oE '#[0-9a-fA-F]{6}')
+  fi
+
+  # Extract from Hyprland config
+  if [ -f "$CURRENT_THEME_DIR/hyprland.conf" ]; then
+    while IFS= read -r color; do
+      if [[ $color == rgba* ]] || [[ $color == rgb* ]]; then
+        color=$(rgb_to_hex "$color")
+      fi
+      color=$(echo "$color" | tr '[:upper:]' '[:lower:]') # Lowercase for consistency
+      [ -n "$color" ] && ((color_counts["$color"]++))
+    done < <(grep -E "col\.(active|inactive)_border" "$CURRENT_THEME_DIR/hyprland.conf" | grep -oE 'rgba?\([^)]+\)|#[0-9a-fA-F]{6,8}' | sed 's/ff$//')
+  fi
+
+  # Output colors with their counts
+  for color in "${!color_counts[@]}"; do
+    echo "${color_counts[$color]} $color"
+  done
+}
+
+# Sort colors by frequency
+sort_colors_by_frequency() {
+  # Input is already "count color" format
+  sort -rn | cut -d' ' -f2
+}
+
+# Fill color slots with cycling if needed
+fill_color_slots() {
+  local -a colors=("$@")
+  local -a slots
+  local num_colors=${#colors[@]}
+
+  # Need 13 slots total (code colors are handled separately)
+  local slots_needed=13
+
+  if [ $num_colors -eq 0 ]; then
+    # No colors available, use defaults
+    colors=("#3d3d3d" "#5d5d5d" "#7d7d7d" "#9d9d9d" "#bd93f9" "#50fa7b")
+    num_colors=6
+  fi
+
+  # Fill slots, cycling if necessary
+  for ((i = 0; i < slots_needed; i++)); do
+    slots[$i]="${colors[$((i % num_colors))]}"
+  done
+
+  echo "${slots[@]}"
+}
+
+# Main color extraction and theme generation
+extract_theme_data() {
+  # Get primary colors from Alacritty
+  local bg_color="#1a1b26"
+  local fg_color="#a9b1d6"
+
+  if [ -f "$CURRENT_THEME_DIR/alacritty.toml" ]; then
+    local extracted_bg=$(grep -A 5 "\[colors.primary\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep "^background = " | sed "s/.*[\"']0x/#/;s/.*[\"']#/#/;s/[\"'].*//;s/.*#\([0-9a-fA-F]\{6\}\).*/\#\1/" | head -1 | tr '[:upper:]' '[:lower:]')
+    local extracted_fg=$(grep -A 5 "\[colors.primary\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep "^foreground = " | sed "s/.*[\"']0x/#/;s/.*[\"']#/#/;s/[\"'].*//;s/.*#\([0-9a-fA-F]\{6\}\).*/\#\1/" | head -1 | tr '[:upper:]' '[:lower:]')
+    [ -n "$extracted_bg" ] && bg_color="$extracted_bg"
+    [ -n "$extracted_fg" ] && fg_color="$extracted_fg"
+  fi
+
+  # Determine if light or dark theme
+  local bg_brightness=$(calculate_brightness "$bg_color")
+  local is_light_theme=false
+  [ $bg_brightness -gt 127 ] && is_light_theme=true
+
+  # Extract all colors with counts
+  local color_data=$(extract_all_colors_with_count)
+
+  # Filter out background and foreground colors for the main array
+  local filtered_data=$(echo "$color_data" | grep -v "$bg_color" | grep -v "$fg_color")
+
+  # Get all unique colors (including bg/fg) for distance calculations
+  local -a all_unique_colors
+  readarray -t all_unique_colors < <(echo "$color_data" | cut -d' ' -f2 | sort -u)
+
+  # Find the 3 closest colors to background for background variations
+  local -a bg_distances
+  for color in "${all_unique_colors[@]}"; do
+    if [ "$color" != "$bg_color" ]; then
+      distance=$(color_distance "$color" "$bg_color")
+      bg_distances+=("$distance:$color")
+    fi
+  done
+
+  # Sort by distance and get the closest color for code background
+  local -a closest_to_bg
+  readarray -t closest_to_bg < <(printf '%s\n' "${bg_distances[@]}" | sort -n | head -1 | cut -d: -f2)
+
+  # All background variations use the same as primary background
+  local bg_primary_alt="$bg_color"
+  local bg_secondary="$bg_color"
+  local bg_secondary_alt="$bg_color"
+
+  # Code block background uses the closest different color
+  local code_bg="${closest_to_bg[0]}"
+
+  # If no different color available, create a subtle variant for code blocks
+  if [ -z "$code_bg" ]; then
+    read -r r g b <<<"$(hex_to_rgb "$bg_color")"
+    if [ $bg_brightness -gt 127 ]; then
+      r=$((r - 10))
+      g=$((g - 10))
+      b=$((b - 10))
+    else
+      r=$((r + 15))
+      g=$((g + 15))
+      b=$((b + 15))
+    fi
+    [ $r -lt 0 ] && r=0
+    [ $r -gt 255 ] && r=255
+    [ $g -lt 0 ] && g=0
+    [ $g -gt 255 ] && g=255
+    [ $b -lt 0 ] && b=0
+    [ $b -gt 255 ] && b=255
+    code_bg=$(printf "#%02x%02x%02x" "$r" "$g" "$b")
+  fi
+
+  # Find closest color to foreground for code block text
+  local code_fg=""
+  min_distance=999999999
+  for color in "${all_unique_colors[@]}"; do
+    if [ "$color" != "$fg_color" ]; then
+      distance=$(color_distance "$color" "$fg_color")
+      if [ $distance -lt $min_distance ]; then
+        min_distance=$distance
+        code_fg="$color"
+      fi
+    fi
+  done
+  [ -z "$code_fg" ] && code_fg="#e0e0e0" # Fallback
+
+  # Extract text selection colors from Alacritty
+  local selection_bg=""
+  local selection_fg=""
+  if [ -f "$CURRENT_THEME_DIR/alacritty.toml" ]; then
+    selection_bg=$(grep -A 5 "\[colors.selection\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep "^background = " | sed "s/.*[\"']0x/#/;s/.*[\"']#/#/;s/[\"'].*//;s/.*#\([0-9a-fA-F]\{6\}\).*/\#\1/" | head -1 | tr '[:upper:]' '[:lower:]')
+    local selection_text=$(grep -A 5 "\[colors.selection\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep "^text = " | sed "s/.*[\"']0x/#/;s/.*[\"']#/#/;s/[\"'].*//;s/.*#\([0-9a-fA-F]\{6\}\).*/\#\1/" | head -1 | tr '[:upper:]' '[:lower:]')
+
+    # If text is set to CellForeground/CellBackground, use the appropriate color
+    if [ -z "$selection_text" ] || [[ "$(grep -A 5 "\[colors.selection\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep "^text = ")" == *"CellForeground"* ]]; then
+      selection_fg="$fg_color"
+    elif [[ "$(grep -A 5 "\[colors.selection\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep "^text = ")" == *"CellBackground"* ]]; then
+      selection_fg="$bg_color"
+    else
+      selection_fg="$selection_text"
+    fi
+  fi
+
+  # Fallback if no selection colors found
+  if [ -z "$selection_bg" ]; then
+    read -r r1 g1 b1 <<<"$(hex_to_rgb "$bg_color")"
+    read -r r2 g2 b2 <<<"$(hex_to_rgb "$fg_color")"
+    local r=$(((r1 * 3 + r2) / 4)) # 75% background, 25% foreground
+    local g=$(((g1 * 3 + g2) / 4))
+    local b=$(((b1 * 3 + b2) / 4))
+    selection_bg=$(printf "#%02x%02x%02x" "$r" "$g" "$b")
+  fi
+
+  # Use contrasting color for selection text if not defined
+  if [ -z "$selection_fg" ]; then
+    # Calculate brightness of selection background
+    local sel_brightness=$(calculate_brightness "$selection_bg")
+    if [ $sel_brightness -gt 127 ]; then
+      selection_fg="$bg_color" # Dark text on light selection
+    else
+      selection_fg="$fg_color" # Light text on dark selection
+    fi
+  fi
+
+  # Extract border color from btop theme
+  local border_color=""
+  if [ -f "$CURRENT_THEME_DIR/btop.theme" ]; then
+    # Look for theme[div_line] in btop theme
+    local btop_divline=$(grep 'theme\[div_line\]' "$CURRENT_THEME_DIR/btop.theme" | head -1)
+
+    if [ -n "$btop_divline" ]; then
+      # Extract the color value after the = sign
+      local extracted=$(echo "$btop_divline" | sed 's/.*=//' | xargs)
+
+      # Check if it's a hex color and lowercase it
+      if [[ $extracted =~ ^#[0-9a-fA-F]{6}$ ]]; then
+        border_color=$(echo "$extracted" | tr '[:upper:]' '[:lower:]')
+      elif [[ $extracted =~ ^[0-9a-fA-F]{6}$ ]]; then
+        # Add # if missing and lowercase
+        border_color=$(echo "#$extracted" | tr '[:upper:]' '[:lower:]')
+      fi
+    fi
+  fi
+
+  # Fallback if no border color found
+  if [ -z "$border_color" ]; then
+    # Use a color between bg and fg
+    read -r r1 g1 b1 <<<"$(hex_to_rgb "$bg_color")"
+    read -r r2 g2 b2 <<<"$(hex_to_rgb "$fg_color")"
+    local r=$(((r1 + r2) / 3)) # Closer to background
+    local g=$(((g1 + g2) / 3))
+    local b=$(((b1 + b2) / 3))
+    border_color=$(printf "#%02x%02x%02x" "$r" "$g" "$b")
+  fi
+
+  # Get unique colors array (without bg/fg) sorted by frequency
+  local -a unique_colors
+  readarray -t unique_colors < <(echo "$filtered_data" | sort_colors_by_frequency)
+
+  # Fill the 13 color slots (code colors handled separately)
+  local -a color_slots
+  readarray -t color_slots < <(fill_color_slots "${unique_colors[@]}" | tr ' ' '\n')
+
+  # Extract fonts
+  local monospace_font="CaskaydiaMono Nerd Font"
+  local ui_font="Liberation Sans"
+
+  if [ -f "$CURRENT_THEME_DIR/alacritty.toml" ]; then
+    local alacritty_font=$(grep -A 5 "\[font\]" "$CURRENT_THEME_DIR/alacritty.toml" | grep 'family = ' | head -1 | cut -d'"' -f2)
+    [ -n "$alacritty_font" ] && monospace_font="$alacritty_font"
+  fi
+
+  if [ -f "$HOME/.config/fontconfig/fonts.conf" ]; then
+    local fontconfig_mono=$(xmlstarlet sel -t -v '//match[@target="pattern"][test/string="monospace"]/edit[@name="family"]/string' "$HOME/.config/fontconfig/fonts.conf" 2>/dev/null || true)
+    [ -n "$fontconfig_mono" ] && monospace_font="$fontconfig_mono"
+
+    local fontconfig_sans=$(xmlstarlet sel -t -v '//match[@target="pattern"][test/string="sans-serif"]/edit[@name="family"]/string' "$HOME/.config/fontconfig/fonts.conf" 2>/dev/null || true)
+    [ -n "$fontconfig_sans" ] && ui_font="$fontconfig_sans"
+  fi
+
+  # Generate CSS with 14-slot system
+  cat <<EOF
+/* Omarchy Theme for Obsidian */
+/* Generated on $(date) from theme: $(basename "$(readlink "$CURRENT_THEME_DIR" 2>/dev/null || echo "unknown")") */
+/* Colors sorted by frequency, backgrounds by distance */
+
+.theme-dark, .theme-light {
+  /* Core colors */
+  --background-primary: $bg_color;
+  --text-normal: $fg_color;
+
+  /* Background variations (always distance-based) */
+  --background-primary-alt: $bg_primary_alt;
+  --background-secondary: $bg_secondary;
+  --background-secondary-alt: $bg_secondary_alt;
+
+  /* Code block colors (always distance-based) */
+  --code-background: $code_bg;
+  --code-foreground: $code_fg;
+
+  /* Border color from btop theme */
+  --border-color: $border_color;
+
+  /* Selection colors from Alacritty */
+  --text-selection: $selection_bg;
+  --text-selection-fg: $selection_fg;
+
+  /* 13-slot color system for remaining elements */
+  --text-title-h1: ${color_slots[0]};
+  --text-title-h2: ${color_slots[1]};
+  --text-title-h3: ${color_slots[2]};
+  --text-title-h4: ${color_slots[3]};
+  --text-title-h5: ${color_slots[4]};
+  --text-title-h6: ${color_slots[4]};  /* Same as h5 */
+  --text-link: ${color_slots[5]};
+  --markup-code: ${color_slots[6]};
+  --text-mark: ${color_slots[7]};
+  --interactive-accent: ${color_slots[8]};
+  --blockquote-border: ${color_slots[9]};
+  --text-muted: $border_color;  /* Use border color for muted text */
+  --text-faint: $border_color;  /* Use border color for faint text */
+
+  /* Additional mappings */
+  --text-accent: var(--interactive-accent);
+  --text-accent-hover: var(--interactive-accent);
+  --text-error: var(--text-title-h1);
+  --text-error-hover: var(--text-title-h1);
+  --text-highlight-bg: $fg_color;  /* Use text color as highlight background */
+  --text-on-accent: $bg_color;
+
+  --interactive-normal: var(--code-background);
+  --interactive-hover: var(--interactive-accent);
+  --interactive-accent-hover: var(--interactive-accent);
+  --interactive-success: var(--text-title-h2);
+
+  --scrollbar-bg: var(--background-primary);
+  --scrollbar-thumb-bg: var(--code-background);
+  --scrollbar-active-thumb-bg: var(--interactive-accent);
+
+  --background-modifier-border: var(--border-color);
+  --background-modifier-form-field: var(--code-background);
+  --background-modifier-form-field-highlighted: var(--code-background);
+  --background-modifier-box-shadow: rgba(0, 0, 0, 0.3);
+  --background-modifier-success: var(--interactive-success);
+  --background-modifier-error: var(--text-error);
+  --background-modifier-error-hover: var(--text-error);
+  --background-modifier-cover: rgba(0, 0, 0, 0.8);
+
+  --link-color: var(--text-link);
+  --link-color-hover: var(--text-link);
+  --link-unresolved-color: var(--text-muted);
+  --link-unresolved-opacity: 0.7;
+
+  --tag-color: var(--text-title-h3);
+  --tag-background: var(--code-background);
+
+  --graph-line: var(--text-muted);
+  --graph-node: var(--interactive-accent);
+  --graph-node-unresolved: var(--text-muted);
+  --graph-node-focused: var(--text-link);
+  --graph-node-tag: var(--text-title-h3);
+  --graph-node-attachment: var(--text-title-h2);
+
+  /* Fonts */
+  --font-interface-theme: "$ui_font";
+  --font-text-theme: "$ui_font";
+  --font-monospace-theme: "$monospace_font";
+}
+
+/* Headers */
+.cm-header-1, .markdown-rendered h1 { color: var(--text-title-h1); }
+.cm-header-2, .markdown-rendered h2 { color: var(--text-title-h2); }
+.cm-header-3, .markdown-rendered h3 { color: var(--text-title-h3); }
+.cm-header-4, .markdown-rendered h4 { color: var(--text-title-h4); }
+.cm-header-5, .markdown-rendered h5 { color: var(--text-title-h5); }
+.cm-header-6, .markdown-rendered h6 { color: var(--text-title-h6); }
+
+/* Code blocks */
+.markdown-rendered code {
+  font-family: var(--font-monospace-theme);
+  background-color: var(--code-background);
+  color: var(--markup-code);
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.markdown-rendered pre {
+  background-color: var(--code-background);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 5px;
+}
+
+.markdown-rendered pre code {
+  background-color: transparent;
+  color: var(--code-foreground);
+}
+
+/* Syntax highlighting */
+.cm-s-obsidian span.cm-keyword { color: var(--text-title-h1); }
+.cm-s-obsidian span.cm-string { color: var(--text-title-h2); }
+.cm-s-obsidian span.cm-number { color: var(--text-title-h3); }
+.cm-s-obsidian span.cm-comment { color: var(--text-muted); }
+.cm-s-obsidian span.cm-operator { color: var(--text-link); }
+.cm-s-obsidian span.cm-variable { color: var(--text-normal); }
+.cm-s-obsidian span.cm-def { color: var(--text-link); }
+
+/* Highlighted text */
+.markdown-rendered mark,
+.cm-s-obsidian span.cm-highlight,
+mark {
+  background-color: var(--text-highlight-bg) !important;
+  color: var(--code-background) !important;
+}
+
+/* Links */
+.markdown-rendered a {
+  color: var(--text-link);
+}
+
+/* Blockquotes */
+.markdown-rendered blockquote {
+  border-left: 4px solid var(--blockquote-border);
+  padding-left: 1em;
+}
+
+/* Status bar */
+.status-bar {
+  background-color: var(--code-background);
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+/* Active file */
+.workspace-leaf.mod-active .workspace-leaf-header-title {
+  color: var(--interactive-accent);
+}
+
+.nav-file-title.is-active {
+  background-color: var(--code-background);
+  color: var(--interactive-accent);
+}
+
+/* Text selection */
+::selection {
+  background-color: var(--text-selection);
+  color: var(--text-selection-fg);
+}
+
+/* Search results */
+.search-result-file-title {
+  color: var(--interactive-accent);
+}
+
+.search-result-file-match {
+  background-color: var(--code-background);
+  border-left: 3px solid var(--interactive-accent);
+}
+
+/* Tables */
+.markdown-rendered table {
+  border: 1px solid var(--background-modifier-border);
+}
+
+.markdown-rendered th {
+  background-color: var(--code-background);
+  color: var(--text-accent);
+}
+
+.markdown-rendered td {
+  border: 1px solid var(--background-modifier-border);
+}
+
+/* Callouts */
+.callout {
+  border-left: 4px solid var(--interactive-accent);
+  background-color: var(--code-background);
+}
+.callout * {
+  color: var(--text-normal);
+}
+
+/* Modal dialogs */
+.modal {
+  background-color: var(--background-primary);
+  border: 2px solid var(--background-modifier-border);
+}
+
+/* Settings */
+.vertical-tab-header-group-title {
+  color: var(--interactive-accent);
+}
+
+.vertical-tab-nav-item.is-active {
+  background-color: var(--code-background);
+  color: var(--interactive-accent);
+}
+EOF
+}
+
+# Main update logic
+echo "🔄 Updating Obsidian vaults..."
+
+while IFS= read -r vault_path; do
+  vault_name=$(basename "$vault_path")
+
+  # Skip if vault doesn't exist or is invalid
+  if [ ! -d "$vault_path" ] || [ ! -d "$vault_path/.obsidian" ]; then
+    echo "   ❌ $vault_name (vault no longer exists)"
+    continue
+  fi
+
+  THEME_DIR="$vault_path/.obsidian/themes/Omarchy"
+
+  # Skip if theme not installed in this vault
+  if [ ! -d "$THEME_DIR" ]; then
+    echo "   ⚠️  $vault_name (theme not installed)"
+    continue
+  fi
+
+  # Check if current theme has a custom obsidian.css
+  if [ -f "$CURRENT_THEME_DIR/obsidian.css" ]; then
+    # Use theme-specific CSS
+    cp "$CURRENT_THEME_DIR/obsidian.css" "$THEME_DIR/theme.css"
+    echo "   ✅ $vault_name (custom theme)"
+  else
+    # Extract and generate CSS
+    extract_theme_data >"$THEME_DIR/theme.css"
+    echo "   ✅ $vault_name"
+  fi
+done <"$VAULTS_FILE"

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -42,6 +42,9 @@ fi
 # Trigger alacritty config reload
 touch "$HOME/.config/alacritty/alacritty.toml"
 
+# Update Obsidian themes if any vaults are registered
+omarchy-obsidian-theme-update
+
 # Restart components to apply new theme
 pkill -SIGUSR2 btop
 omarchy-restart-waybar

--- a/bin/omarchy-theme-update
+++ b/bin/omarchy-theme-update
@@ -3,3 +3,6 @@
 for dir in ~/.config/omarchy/themes/*/; do
   [ -d "$dir" ] && [ ! -L "${dir%/}" ] && echo "Updating: $(basename "$dir")" && git -C "$dir" pull
 done
+
+# Update Obsidian themes after updating theme files
+omarchy-obsidian-theme-update


### PR DESCRIPTION
## Overview

Scripts to install, update, and remove Obsidian theme based on Omarchy's current theme.

## New Scripts
```bash
omarchy-obsidian-theme-install
```
* TUI with `gum` for user to navigate and select to Obsidian Vault.
* Registers the vault location in `.local/state/omarchy/obsidian-vaults
* Can register multiple vaults
* Installs `manifest.json` and an empty `theme.css` in `.obsidian/themes/Omarchy/`
* Triggers new script `omarchy-obsidian-theme-update`
* In Obsidian, a new 'Omarchy' theme is installed and available to use

```bash
omarchy-obsidian-theme-update
```
* Looks for `obsidian.css` in current theme, if present, replaces Obsidian theme with this content
* If not present, reads multiple theme files to infer the values for an effective Obsidian theme. (see video, these turn out really good defaults)
* If theme is selected in Obsidian, then the theme is immediately updated with changes.
 
```bash
omarchy-obsidian-theme-remove
```
* TUI to select the registered vault to uninstall

## Omarchy Hooks

* Menu triggers: 
  * Install > Style > Obsidian Theme (wasn't a great spot to stick this, this felt like best place)
  * Remove > Obsidian Theme
* `omarchy-theme-set` this will immediately trigger `omarchy-obsidian-theme-update`
* `omarchy-theme-update` this will immediately trigger `omarchy-obsidian-theme-update`

## Demo
https://github.com/user-attachments/assets/e7efdc45-7d98-4fd3-8da0-b29ae3a12cef