### PR TITLE
Add `--force` when enabling ufw to bypass prompt

### DIFF
--- a/install/development/firewall.sh
+++ b/install/development/firewall.sh
@@ -18,7 +18,7 @@ if ! command -v ufw &>/dev/null; then
   sudo ufw allow in on docker0 to any port 53
 
   # Turn on the firewall
-  sudo ufw enable
+  sudo ufw --force enable
 
   # Turn on Docker protections
   sudo ufw-docker install


### PR DESCRIPTION
I have been running the installation via `ssh`, but there is currently an error when enabling `ufw`. The issue is that `ufw` prompts whether you are sure, because `ssh` may disconnect, and then aborts because no response is given.

Adding the `--force` flag bypasses the prompt, and allows the entire installation complete via `ssh`. I can also confirm, having tested, that no disconnect occurs.

Details on this flag are [documented here](https://man.archlinux.org/man/ufw.8#REMOTE_MANAGEMENT).