### PR TITLE
Update migration script to suppress errors when removing old Omarchy TUI app

### DIFF
--- a/migrations/1754332200.sh
+++ b/migrations/1754332200.sh
@@ -1,2 +1,2 @@
 echo "Remove old Omarchy TUI app now that we have the Omarchy Menu"
-rm ~/.local/share/applications/omarchy.desktop
+rm ~/.local/share/applications/omarchy.desktop 2> /dev/null


### PR DESCRIPTION
This error occurs when updating omarchy.

``` bash
Running migration (1754332200)
Remove old Omarchy TUI app now that we have the Omarchy Menu
rm: cannot remove '/home/omar/.local/share/applications/omarchy.desktop': No such file or directory
```