### PR TITLE
Add SUPER PGUP/PGDOWN to slide between workspaces.

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -27,3 +27,5 @@ bindd = SUPER SHIFT, X, X Post, exec, $webapp="https://x.com/compose/post"
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, Space
 # bindd = SUPER, SPACE, Omarchy menu, exec, omarchy-menu
+bind = SUPER, Page_Up, workspace, -1
+bind = SUPER, Page_Down, workspace, +1

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -27,5 +27,9 @@ bindd = SUPER SHIFT, X, X Post, exec, $webapp="https://x.com/compose/post"
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, Space
 # bindd = SUPER, SPACE, Omarchy menu, exec, omarchy-menu
+
+# Workspace navigation
 bind = SUPER, Page_Up, workspace, -1
 bind = SUPER, Page_Down, workspace, +1
+bind = SUPER SHIFT, Page_Up, movetoworkspace, r-1
+bind = SUPER SHIFT, Page_Down, movetoworkspace, r+1


### PR DESCRIPTION
I am not 100% sure if this is the right place to add keybinds for Omarchy, but I would like to suggest 4 additional keybinds to do with workspace navigation / window management, these are:

1. SUPER + PG UP (scroll left/up workspaces)
2. SUPER + PG DOWN (scroll right/down workspaces)
3. SUPER + SHIFT + PG UP (move current window left/up workspace)
4. SUPER + SHIFT + PG DOWN (move current window right/down workspace)

I'm new to Omarchy and I found that these were some keybinds that I was missing when moving around the environment.