### PR TITLE
Explicitly add python-object to make power profile work

### DIFF
--- a/install/config/power.sh
+++ b/install/config/power.sh
@@ -2,7 +2,7 @@
 
 # Setting the performance profile can make a big difference. By default, most systems seem to start in balanced mode,
 # even if they're not running off a battery. So let's make sure that's changed to performance.
-yay -S --noconfirm power-profiles-daemon
+yay -S --noconfirm python-gobject power-profiles-daemon
 
 if ls /sys/class/power_supply/BAT* &>/dev/null; then
   # This computer runs on a battery


### PR DESCRIPTION
Users reported power-profile daemon not working at install, and found python-gobject package is missing. 

I thought i would be a dependency, and installed,  but to be sure, explicitly install it. 

User repoted , after installing python-gobject, remaining install works. 

