### PR TITLE
Run omarchy lazyvim install if nvim present without any config

### DIFF
--- a/install/development/nvim.sh
+++ b/install/development/nvim.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! command -v nvim &>/dev/null; then
+if ! command -v nvim &>/dev/null || [ ! -d "$HOME/.config/nvim" ]; then
   yay -S --noconfirm --needed nvim luarocks tree-sitter-cli
 
   # Install LazyVim


### PR DESCRIPTION
On running `archinstall`, users often install nvim as an additional package (so they have an editor for troubleshooting), but later find that after running the omarchy install script, their setup is missing the expected LazyVim configuration because the current installer considers default nvim without any configuration as already setup. 

To fix this, we can include a check for absence of `~/.config/nvim` in addition to the check for absence of nvim, and setup LazyVim in either case. This applies the full config when nvim is present but has no configuration files, thereby avoiding overwriting existing setups.

This should ensure users don't end up with a default neovim environment unexpectedly and have to look through the script to find `~/.local/share/omarchy/config/nvim`, like I did.