### PR TITLE
proposal: omarchy-theme-set hooks/plugins for theming non-default applications

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -51,3 +51,8 @@ hyprctl reload
 
 # Set new background
 omarchy-theme-bg-next
+
+# Run user-defined theme hooks, for styling additional applications
+export THEME_NAME
+USER_HOOKS_DIR="$HOME/.local/share/omarchy/theme-set-hooks"
+find "$USER_HOOKS_DIR" -mindepth 2 -maxdepth 2 -name "hook.sh" -type f -executable -exec {} \;


### PR DESCRIPTION
I was looking into how I'd wire up the theme switcher with Doom Emacs and noticed a few PRs for theming other non-default applications too. Here's a quick proposal, inspired by how custom themes work, that would allow a hooks/plugins system for extending this functionality.

* a directory where hooks can be cloned to: `~/.local/share/omarchy/theme-set-hooks`
* hook directories must have an executable `hook.sh` at root level
* after changing the theme for core applications, `omarchy-theme-set` executes all `hook.sh` files

So for example, to use this to add support for theming Doom Emacs, I could do something like:
1. create a new repository `omarchy-theme-set-hook-doom-emacs`:
   * hook.sh - bash script to basically `(load-theme '$THEME_NAME t)` and update any configuration
   * themes/ - folder with theme files for those not already shipped with doom
2. clone that to `~/.local/share/omarchy/theme-set-hooks/doom-emacs/`
   * could be manual or with a cli helper like installing themes has
3. now when I change themes, `~/.local/share/omarchy/theme-set-hooks/doom-emacs/hook.sh` is ran to change the Doom Emacs theme too

Rather than `theme-set-hooks`, could be less verbose and use `theme-hooks` or similar instead.

Any thoughts on this approach?