### PR TITLE
Update omarchy-update-restart to only reboot if running kernel was updated

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -31,10 +31,12 @@ fi
 
 if [ "$reboot_needed" = true ]; then
   gum confirm "Kernel package $updated_kernel_name has been updated and is currently running. Reboot?" && omarchy-state clear re*-required && sudo reboot now
+
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
-  gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*_required && sudo reboot now
+  gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
+
 elif [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
-  gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*_required && uwsm stop
+  gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
 fi
 
 for file in "$HOME"/.local/state/omarchy/restart-*-required; do

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -7,6 +7,7 @@ recent_kernel_updates=$(awk -v boot_time="$boot_time" '$0 >= "["boot_time' /var/
 
 # Check if any updated kernel matches the running kernel
 reboot_needed=false
+updated_kernel_name=""
 if [ -n "$recent_kernel_updates" ]; then
   while IFS= read -r line; do
     # Extract the kernel package name (e.g., linux, linux-zen) from the log
@@ -22,17 +23,18 @@ if [ -n "$recent_kernel_updates" ]; then
     # Check if the running kernel contains the pattern
     if [[ "$running_kernel" == *"$kernel_pattern"* ]]; then
       reboot_needed=true
+      updated_kernel_name="$updated_kernel"
       break
     fi
   done <<<"$recent_kernel_updates"
 fi
 
 if [ "$reboot_needed" = true ]; then
-  gum confirm "Linux kernel has been updated and is in use. Reboot?" && omarchy-state clear re*-required && sudo reboot now
+  gum confirm "Kernel package $updated_kernel_name has been updated and is currently running. Reboot?" && omarchy-state clear re*-required && sudo reboot now
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
-  gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
+  gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*_required && sudo reboot now
 elif [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
-  gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
+  gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*_required && uwsm stop
 fi
 
 for file in "$HOME"/.local/state/omarchy/restart-*-required; do

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -2,13 +2,35 @@
 
 # Check for kernel package updates since last boot
 boot_time=$(date -d "$(uptime -s)" '+%Y-%m-%d %H:%M')
-recent_kernel_updates=$(awk -v boot_time="$boot_time" '$0 >="["boot_time' /var/log/pacman.log | grep -E "\[ALPM\] (upgraded|installed) (linux|linux-zen|linux-lts|linux-hardened)\b" || true)
-if [ -n "$recent_kernel_updates" ]; then
-  gum confirm "Linux kernel has been updated. Reboot?" && omarchy-state clear re*-required && sudo reboot now
+running_kernel=$(uname -r)
+recent_kernel_updates=$(awk -v boot_time="$boot_time" '$0 >= "["boot_time' /var/log/pacman.log | grep -E "\[ALPM\] (upgraded|installed) (linux|linux-zen|linux-lts|linux-hardened)\b" || true)
 
+# Check if any updated kernel matches the running kernel
+reboot_needed=false
+if [ -n "$recent_kernel_updates" ]; then
+  while IFS= read -r line; do
+    # Extract the kernel package name (e.g., linux, linux-zen) from the log
+    updated_kernel=$(echo "$line" | grep -oE '(linux|linux-zen|linux-lts|linux-hardened)')
+    # Map to a pattern that appears in uname -r for that kernel
+    case "$updated_kernel" in
+    linux) kernel_pattern="arch" ;;
+    linux-zen) kernel_pattern="zen" ;;
+    linux-lts) kernel_pattern="lts" ;;
+    linux-hardened) kernel_pattern="hardened" ;;
+    *) continue ;;
+    esac
+    # Check if the running kernel contains the pattern
+    if [[ "$running_kernel" == *"$kernel_pattern"* ]]; then
+      reboot_needed=true
+      break
+    fi
+  done <<<"$recent_kernel_updates"
+fi
+
+if [ "$reboot_needed" = true ]; then
+  gum confirm "Linux kernel has been updated and is in use. Reboot?" && omarchy-state clear re*-required && sudo reboot now
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
   gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
-
 elif [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
   gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
 fi


### PR DESCRIPTION
This PR updates the kernel update check script to:

- Verify if the updated kernel (e.g., `linux`, `linux-zen`) matches the running kernel (`uname -r`, e.g., `6.15.9-zen1-1-zen`) to prevent unnecessary reboot prompts for inactive kernels.
- Improve the reboot prompt to specify the updated kernel package (e.g., "Kernel package `linux-zen` has been updated and is currently running").

Tested with pacman.log entries for linux and linux-zen updates. Resolves issue of prompting reboots for non-running kernel updates.

Test 1 - `linux` and `linux-zen` installed - currently running `linux-zen` - update installed to `linux-zen`:
<img width="820" height="177" alt="image" src="https://github.com/user-attachments/assets/cf05cb0c-808e-4900-9994-14fee0a4c3d3" />
