### PR TITLE
setup-fingerprint: pam_fprintd should be sufficient

### DIFF
--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -21,8 +21,8 @@ else
     # Add fingerprint authentication as an option for hyprpolkitagent
     if [ ! -f /etc/pam.d/polkit-1 ] || ! grep -q pam_fprintd.so /etc/pam.d/polkit-1; then
       sudo tee /etc/pam.d/polkit-1 >/dev/null <<'EOF'
+auth      sufficient pam_fprintd.so
 auth      required pam_unix.so
-auth      optional pam_fprintd.so
 
 account   required pam_unix.so
 password  required pam_unix.so


### PR DESCRIPTION
Update omarchy-setup-fingerprint so that pam_fprintd is sufficient in pam.d/polkit-1.

This prevents apps like 1Password, using polkit, to prompt for both a password AND fingerprint when using system auth.