### PR TITLE
add bindings to move the active workspace to another monitor

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -25,6 +25,12 @@ bindd = SUPER, code:17, Switch to workspace 8, workspace, 8
 bindd = SUPER, code:18, Switch to workspace 9, workspace, 9
 bindd = SUPER, code:19, Switch to workspace 10, workspace, 10
 
+# Move active workspace to another monitor with SUPER + CTRL + SHIFT + arrow keys
+bindd = SUPER CTRL SHIFT, left, Move workspace to the left, movecurrentworkspacetomonitor, l
+bindd = SUPER CTRL SHIFT, right, Move workspace to the right, movecurrentworkspacetomonitor, r
+bindd = SUPER CTRL SHIFT, up, Move workspace to the left, movecurrentworkspacetomonitor, u
+bindd = SUPER CTRL SHIFT, down, Move workspace to the right, movecurrentworkspacetomonitor, d
+
 # Move active window to a workspace with SUPER + SHIFT + [0-9]
 bindd = SUPER SHIFT, code:10, Move window to workspace 1, movetoworkspace, 1
 bindd = SUPER SHIFT, code:11, Move window to workspace 2, movetoworkspace, 2


### PR DESCRIPTION
for folks with multiple monitors, right now there is no convenient way to move workspaces around

my proposal:
Move active workspace to another monitor with SUPER + CTRL + SHIFT + arrow keys

bindings are quite personal, and if everyone's preferences were included, the Omakase would quickly bloat
still, I think this is a common enough use case to warrant addition


