### PR TITLE
Fix About menu option not working

### DIFF
--- a/migrations/1755344726.sh
+++ b/migrations/1755344726.sh
@@ -1,0 +1,4 @@
+echo "Install About.desktop for system information menu"
+
+cp $OMARCHY_PATH/applications/About.desktop ~/.local/share/applications/
+update-desktop-database ~/.local/share/applications/


### PR DESCRIPTION
## Summary
Fixes the About menu option that wasn't responding when clicked for some users.

## Problem
The About.desktop file exists in the source but wasn't being deployed consistently to users. When users click About in the menu, gtk-launch can't find the desktop file, so nothing happens.

## Root Cause
The install script uses `source omarchy-refresh-applications || true` which can fail silently. Some users end up without About.desktop in their applications directory.

## Solution
Added a migration to ensure all users have About.desktop properly installed to ~/.local/share/applications/ where gtk-launch expects to find it.

## Testing
After applying this migration:
- About menu option opens correctly
- Shows system information via fastfetch
- Works for both existing and new installations
- Updates users who have older version of the file

Fixes #845