### PR TITLE
Visual improvements for pkg-install and pkg-remove

### DIFF
--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -2,7 +2,9 @@
 
 fzf_args=(
   --multi
-  --preview 'echo "alt-p: toggle description, alt-j/k: scroll, F11: maximize"; echo; yay -Sii {1}'
+  --preview 'yay -Sii {1}'
+  --preview-label='alt-p: toggle description, alt-j/k: scroll, F11: maximize'
+  --preview-label-pos='bottom'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -2,7 +2,9 @@
 
 fzf_args=(
   --multi
-  --preview 'echo "alt-p: toggle description, alt-j/k: scroll, F11: maximize"; echo; yay -Qi {1}'
+  --preview 'yay -Qi {1}'
+  --preview-label='alt-p: toggle description, alt-j/k: scroll, F11: maximize'
+  --preview-label-pos='bottom'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'


### PR DESCRIPTION
This is a small improvement to the scripts, showing the keybinds in a cleaner way, using fzf's `--preview-label` instead of `echo`. 

<img width="1376" height="1200" alt="new look" src="https://github.com/user-attachments/assets/32f04841-5f3a-4481-9b4f-f78f6edc959b" />
