### PR TITLE
fix: missing python-poetry-core make Omarchy install fail

### DIFF
--- a/install/preflight/tte.sh
+++ b/install/preflight/tte.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yay -S --noconfirm --needed python-terminaltexteffects
+yay -S --noconfirm --needed python-poetry-core python-terminaltexteffects


### PR DESCRIPTION
Summary
Fixes the Omarchy install fails due to missing python-poetry-core

Fixes: https://github.com/basecamp/omarchy/issues/854

Problem
In Omarchy install.sh, try to install but fails.

Root Cause
The install script uses try to install python-terminaltexteffects, and failes due to missing python-poetry-core.

Solution
Install python-poetry-core withpython-terminaltexteffects .

Testing
During discord chat support, many users asked for help, once python-poetry-core installed, install.sh started to work.