### PR TITLE
Add option to launch webapps as new browser tabs

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -1,7 +1,9 @@
 # Application bindings
 $terminal = uwsm app -- alacritty
 $browser = uwsm app -- chromium --new-window --ozone-platform=wayland
+$browserTab = chromium --ozone-platform=wayland
 $webapp = $browser --app
+$tabapp = $browserTab --app
 
 bindd = SUPER, return, Terminal, exec, $terminal
 bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window
@@ -23,6 +25,9 @@ bindd = SUPER SHIFT, G, WhatsApp, exec, $webapp="https://web.whatsapp.com/"
 bindd = SUPER ALT, G, Google Messages, exec, $webapp="https://messages.google.com/web/conversations"
 bindd = SUPER, X, X, exec, $webapp="https://x.com/"
 bindd = SUPER SHIFT, X, X Post, exec, $webapp="https://x.com/compose/post"
+
+# Example tabapp (remember to never use '=' in $tabapp="url")
+bindd = SUPER, O, Omarchy Manual, exec, $tabapp "https://manuals.omamix.org/2/the-omarchy-manual"
 
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, Space


### PR DESCRIPTION
This PR adds `$tabapp` to `omarchy/config/hypr/bindings.conf` to allow users to decide whether they want to have shortcuts to URLs that are opened in a new window the omarchy (`$webapp`) way or they want to open them in a new existing browsert tab.