### PR TITLE
add reverse window cycling with cycleprev

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -45,6 +45,7 @@ bindd = SUPER SHIFT, down, Swap window down, swapwindow, d
 
 # Cycle through applications on active workspace
 bindd = ALT, Tab, Cycle to next window, cyclenext
+bindd = ALT SHIFT, Tab, Cycle to prev window, cyclenext, prev
 bindd = ALT, Tab, Reveal active window on top, bringactivetotop
 
 # Resize active window

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -47,6 +47,7 @@ bindd = SUPER SHIFT, down, Swap window down, swapwindow, d
 bindd = ALT, Tab, Cycle to next window, cyclenext
 bindd = ALT SHIFT, Tab, Cycle to prev window, cyclenext, prev
 bindd = ALT, Tab, Reveal active window on top, bringactivetotop
+bindd = ALT SHIFT, Tab, Reveal active window on top, bringactivetotop
 
 # Resize active window
 bindd = SUPER, minus, Expand window left, resizeactive, -100 0


### PR DESCRIPTION
Adds binding for the "reverse" action of window cyclenext for active workspace. Shortcut for when many windows are in view.