### PR TITLE
Add aarch64 support

### DIFF
--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -1,17 +1,30 @@
 # Install guide macbook m-series (m1 & m2)
 
-## Dual boot Asahi-alarm
+⚠️⚠️⚠️**This is experimental and might leave your machine in an unusuable state.**⚠️⚠️⚠️
 
+## before we start
+
+Installation requires a dual boot of your macbook. This means Omarchy will live side by side with your existing macOS.
+
+If you don't have space on your machine I recommend looking at the top comment on this reddit thread: 
+https://www.reddit.com/r/MacOS/comments/154rp99/how_to_do_i_clear_system_data_on_mac_os/
+
+This and removing a bunch of unused files removed about 100gb of data to available space for omarchy.
+
+You should always back up any data or files that you don't want to lose. 
+
+## Dual boot Asahi-alarm
 
 ### installation 
 
-Follow the instructions on how to dual boot your macbook with asahi-alarm here
-
-https://asahi-alarm.org/
+Follow the instructions on how to dual boot your macbook with asahi-alarm
 
 **Choose the minimal installation!**
 
 This will create a new partition on your machine and install arch on it!
+
+Follow these instructions: https://asahi-alarm.org/
+
 
 ### get internet
 Follow these instructions once the installation is complete [manual installation guide](https://github.com/asahi-alarm/asahi-alarm/blob/main/manual-install.md)
@@ -23,9 +36,6 @@ This lets you set up wifi for your laptop.
 Now we are logged in as root, lets create a user 
   
   ```
-
-# Install sudo package
-pacman -S sudo
 
 # Create a new user with home directory
 useradd -m youruser    # Replace 'youruser' with your desired username
@@ -75,9 +85,9 @@ wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boo
 
 This step will take some time.
 
-If you run into problems where the AUR is slow, try to enable mirror repositories by editing  `sudo vim /etc/pacman.d/mirrorlist` and uncomment a couple of lines starting with `# Server = ...`.
+If you run into problems where the AUR is slow, try to enable mirror repositories by editing  `sudo vim /etc/pacman.d/mirrorlist` and uncomment a couple of lines starting with `# Server = ...`. 
 
-**If the installation crashes** just run the suggested command but with the `OMARCHY_ARM` flag set like this `OMARCHY_ARM=true bash ~/.local/share/omarchy/install.sh` until it finishes.
+**If the installation crashes** - just run the suggested command but with the `OMARCHY_ARM` flag set like this `OMARCHY_ARM=true bash ~/.local/share/omarchy/install.sh` until it finishes.
 
 
 # Uninstall

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -74,13 +74,13 @@ now lets install omarchy, run the command
 
 
 ```
-wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boot.sh | OMARCHY_ARM=true bash
+wget -qO- https://githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh | OMARCHY_ARM=true bash
 ```
 
 if nothing happens, check that you typed in the correct url before piping to bash with
 
 ```
-wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boot.sh
+wget -qO- https://githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh
 ```
 
 This step will take some time.

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -1,0 +1,84 @@
+# Install guide macbook m-series (m1 & m2)
+
+## Dual boot Asahi-alarm
+
+
+### installation 
+
+Follow the instructions on how to dual boot your macbook with asahi-alarm here
+
+https://asahi-alarm.org/
+
+**Choose the minimal installation!**
+
+This will create a new partition on your machine and install arch on it!
+
+### get internet
+Follow these instructions once the installation is complete [manual installation guide](https://github.com/asahi-alarm/asahi-alarm/blob/main/manual-install.md)
+
+This lets you set up wifi for your laptop.
+
+### Create a user
+
+Now we are logged in as root, lets create a user 
+  
+  ```
+
+# Install sudo package
+pacman -S sudo
+
+# Create a new user with home directory
+useradd -m youruser    # Replace 'youruser' with your desired username
+
+# Set password for the new user
+passwd youruser
+
+# Add user to the wheel group (for sudo access)
+usermod -aG wheel youruser
+```
+
+run `visudo` and look for the line and uncomment it
+
+
+```
+# %wheel ALL=(ALL:ALL) ALL
+```
+
+
+## Install omarchy 
+
+first we need to install the package wget 
+
+```
+pacman -S wget
+```
+
+to install omarchy we need to run as the user we just created before, run the command
+
+```
+su - youruser
+```
+
+
+now lets install omarchy, run the command
+
+
+```
+wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boot.sh | OMARCHY_BARE=true OMARCHY_ARM=true bash
+```
+
+if nothing happens, check that you typed in the correct url before piping to bash with
+
+```
+wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boot.sh
+```
+
+This step will take some time.
+
+
+
+# Uninstall
+
+Uninstall is super easy, big recommend to this guy
+
+https://youtu.be/nMnWTq2H-N0?si=7RsKKRSC5n9-aboF

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -64,7 +64,7 @@ now lets install omarchy, run the command
 
 
 ```
-wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boot.sh | OMARCHY_BARE=true OMARCHY_ARM=true bash
+wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boot.sh | OMARCHY_ARM=true bash
 ```
 
 if nothing happens, check that you typed in the correct url before piping to bash with

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -75,6 +75,9 @@ wget -qO- https://githubusercontent.com/nilszeion/armarchy/refs/heads/master/boo
 
 This step will take some time.
 
+If you run into problems where the AUR is slow, try to enable mirror repositories by editing  `sudo vim /etc/pacman.d/mirrorlist` and uncomment a couple of lines starting with `# Server = ...`.
+
+**If the installation crashes** just run the suggested command but with the `OMARCHY_ARM` flag set like this `OMARCHY_ARM=true bash ~/.local/share/omarchy/install.sh` until it finishes.
 
 
 # Uninstall

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -74,13 +74,7 @@ now lets install omarchy, run the command
 
 
 ```
-wget -qO- https://raw.githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh | OMARCHY_ARM=true bash
-```
-
-if nothing happens, check that you typed in the correct url before piping to bash with
-
-```
-wget -qO- https://raw.githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh
+wget -qO- https://omarchy.org/install
 ```
 
 This step will take some time.

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -74,13 +74,13 @@ now lets install omarchy, run the command
 
 
 ```
-wget -qO- https://githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh | OMARCHY_ARM=true bash
+wget -qO- https://raw.githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh | OMARCHY_ARM=true bash
 ```
 
 if nothing happens, check that you typed in the correct url before piping to bash with
 
 ```
-wget -qO- https://githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh
+wget -qO- https://raw.githubusercontent.com/nilszeilon/armarchy/refs/heads/master/boot.sh
 ```
 
 This step will take some time.

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
-yay -Syu --noconfirm
+yay -Syu --noconfirm --ignore uwsm
 echo

--- a/boot.sh
+++ b/boot.sh
@@ -17,7 +17,7 @@ echo -e "\n$ansi_art\n"
 sudo pacman -Sy --noconfirm --needed git
 
 # Use custom repo if specified, otherwise default to basecamp/omarchy
-OMARCHY_REPO="${OMARCHY_REPO:-nilszeilon/armarchy}"
+OMARCHY_REPO="${OMARCHY_REPO:-basecamp/omarchy}"
 
 echo -e "\nCloning Omarchy from: https://github.com/${OMARCHY_REPO}.git"
 rm -rf ~/.local/share/omarchy/

--- a/boot.sh
+++ b/boot.sh
@@ -17,7 +17,7 @@ echo -e "\n$ansi_art\n"
 sudo pacman -Sy --noconfirm --needed git
 
 # Use custom repo if specified, otherwise default to basecamp/omarchy
-OMARCHY_REPO="${OMARCHY_REPO:-basecamp/omarchy}"
+OMARCHY_REPO="${OMARCHY_REPO:-nilszeilon/armarchy}"
 
 echo -e "\nCloning Omarchy from: https://github.com/${OMARCHY_REPO}.git"
 rm -rf ~/.local/share/omarchy/

--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -6,4 +6,4 @@ source = ~/.local/share/omarchy/default/hypr/apps/retroarch.conf
 source = ~/.local/share/omarchy/default/hypr/apps/steam.conf
 source = ~/.local/share/omarchy/default/hypr/apps/system.conf
 source = ~/.local/share/omarchy/default/hypr/apps/walker.conf
-source = ~/.local/share/omarchy/default/hypr/apps/1password.conf
+#source = ~/.local/share/omarchy/default/hypr/apps/1password.conf

--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -6,4 +6,7 @@ source = ~/.local/share/omarchy/default/hypr/apps/retroarch.conf
 source = ~/.local/share/omarchy/default/hypr/apps/steam.conf
 source = ~/.local/share/omarchy/default/hypr/apps/system.conf
 source = ~/.local/share/omarchy/default/hypr/apps/walker.conf
-#source = ~/.local/share/omarchy/default/hypr/apps/1password.conf
+
+if [[ ! -f ~/.local/state/omarchy/arm.mode ]]; then
+  source = ~/.local/share/omarchy/default/hypr/apps/1password.conf
+fi

--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ source $OMARCHY_INSTALL/apps/mimetypes.sh
 show_logo highlight
 show_subtext "Updating system packages [5/5]"
 sudo updatedb
-sudo pacman -Syu --noconfirm
+yay -Syu --noconfirm --ignore uwsm
 
 # Reboot
 show_logo laseretch 920

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,7 @@ source $OMARCHY_INSTALL/desktop/hyprlandia.sh
 source $OMARCHY_INSTALL/desktop/theme.sh
 source $OMARCHY_INSTALL/desktop/bluetooth.sh
 source $OMARCHY_INSTALL/desktop/asdcontrol.sh
+source $OMARCHY_INSTALL/desktop/audio.sh
 source $OMARCHY_INSTALL/desktop/fonts.sh
 source $OMARCHY_INSTALL/desktop/printer.sh
 

--- a/install/config/config.sh
+++ b/install/config/config.sh
@@ -15,6 +15,10 @@ if [ -n "$OMARCHY_BARE" ]; then
   touch ~/.local/state/omarchy/bare.mode
 fi
 
+if [ -n "$OMARCHY_ARM" ]; then
+  echo "env = VK_ICD_FILENAMES,/usr/share/vulkan/icd.d/lvp_icd.aarch64.json" >> ~/.config/hypr/envs.conf
+fi 
+
 # Setup GPG configuration with multiple keyservers for better reliability
 sudo mkdir -p /etc/gnupg
 sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/

--- a/install/config/config.sh
+++ b/install/config/config.sh
@@ -15,9 +15,15 @@ if [ -n "$OMARCHY_BARE" ]; then
   touch ~/.local/state/omarchy/bare.mode
 fi
 
+# If arm arch, allow a way for its exclusions to not get added in updates & configs
 if [ -n "$OMARCHY_ARM" ]; then
-  echo "env = VK_ICD_FILENAMES,/usr/share/vulkan/icd.d/lvp_icd.aarch64.json" >> ~/.config/hypr/envs.conf
-fi 
+  mkdir -p ~/.local/state/omarchy
+  touch ~/.local/state/omarchy/arm.mode
+fi
+
+if [ -n "$OMARCHY_ARM" ]; then
+  echo "env = VK_ICD_FILENAMES,/usr/share/vulkan/icd.d/lvp_icd.aarch64.json" >>~/.config/hypr/envs.conf
+fi
 
 # Setup GPG configuration with multiple keyservers for better reliability
 sudo mkdir -p /etc/gnupg

--- a/install/config/login.sh
+++ b/install/config/login.sh
@@ -2,7 +2,8 @@
 
 # Hyprland launched via UWSM and login directly as user, rely on disk encryption + hyprlock for security
 if ! command -v uwsm &>/dev/null || ! command -v plymouth &>/dev/null; then
-  yay -S --noconfirm --needed uwsm plymouth
+  sudo pacman -U --noconfirm https://archive.archlinux.org/packages/u/uwsm/uwsm-0.23.0-1-any.pkg.tar.zst
+  yay -S --noconfirm --needed plymouth
 fi
 
 # ==============================================================================

--- a/install/desktop/audio.sh
+++ b/install/desktop/audio.sh
@@ -2,5 +2,5 @@
 
 # on macbook m-series we need pipewire
 if [ -n "$OMARCHY_ARM" ]; then
-  yay -S --needed pipewire-alsa pipewire-pulse wireplumber pipewire-jack
+  yay -S --needed --noconfirm pipewire-alsa pipewire-pulse wireplumber pipewire-jack asahi-audio
 fi

--- a/install/desktop/audio.sh
+++ b/install/desktop/audio.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# on macbook m-series we need pipewire
+if [ -n "$OMARCHY_ARM" ]; then
+  yay -S --needed pipewire-alsa pipewire-pulse wireplumber pipewire-jack
+fi

--- a/install/development/development.sh
+++ b/install/development/development.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-yay -S --noconfirm --needed \
-  cargo clang llvm mise \
-  imagemagick \
-  mariadb-libs postgresql-libs \
-  github-cli \
-  lazygit lazydocker-bin
+if [ -z "$OMARCHY_ARM" ]; then
+  yay -S --noconfirm --needed \
+    cargo clang llvm mise \
+    imagemagick \
+    mariadb-libs postgresql-libs \
+    github-cli \
+    lazygit lazydocker-bin
+else
+  yay -S --noconfirm --needed \
+    cargo clang llvm mise \
+    imagemagick \
+    mariadb-libs postgresql-libs \
+    github-cli \
+    lazygit lazydocker
+fi

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -25,6 +25,11 @@ else
   [[ "$arch" != "aarch64" && "$arch" != "arm64" ]] && abort "ARM CPU"
 fi
 
+# if we install on m1 or m2 macbook then we should install BARE
+if [ -n "$OMARCHY_ARM"]; then
+  export OMARCHY_BARE=true
+fi
+
 # Must not have Gnome or KDE already install
 pacman -Qe gnome-shell &>/dev/null && abort "Fresh + Vanilla Arch"
 pacman -Qe plasma-desktop &>/dev/null && abort "Fresh + Vanilla Arch"

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -17,17 +17,20 @@ done
 # Must not be runnig as root
 [ "$EUID" -eq 0 ] && abort "Running as user (not root)"
 
-# Must be x86 only to fully work, or ARM if OMARCHY_ARM is set
+# Auto-detect ARM architecture and set flags
+arch=$(uname -m)
+if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+  export OMARCHY_ARM=true
+  export OMARCHY_BARE=true
+  echo "Auto-detected ARM architecture: $arch"
+  echo "Setting OMARCHY_ARM=true and OMARCHY_BARE=true"
+fi
+
+# Must be x86 or ARM architecture
 if [ -z "$OMARCHY_ARM" ]; then
   [ "$(uname -m)" != "x86_64" ] && abort "x86_64 CPU"
 else
-  arch=$(uname -m)
   [[ "$arch" != "aarch64" && "$arch" != "arm64" ]] && abort "ARM CPU"
-fi
-
-# if we install on m1 or m2 macbook then we should install BARE
-if [ -n "$OMARCHY_ARM" ]; then
-  export OMARCHY_BARE=true
 fi
 
 # Must not have Gnome or KDE already install

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -26,7 +26,7 @@ else
 fi
 
 # if we install on m1 or m2 macbook then we should install BARE
-if [ -n "$OMARCHY_ARM"]; then
+if [ -n "$OMARCHY_ARM" ]; then
   export OMARCHY_BARE=true
 fi
 

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -17,8 +17,13 @@ done
 # Must not be runnig as root
 [ "$EUID" -eq 0 ] && abort "Running as user (not root)"
 
-# Must be x86 only to fully work
-[ "$(uname -m)" != "x86_64" ] && abort "x86_64 CPU"
+# Must be x86 only to fully work, or ARM if OMARCHY_ARM is set
+if [ -z "$OMARCHY_ARM" ]; then
+  [ "$(uname -m)" != "x86_64" ] && abort "x86_64 CPU"
+else
+  arch=$(uname -m)
+  [[ "$arch" != "aarch64" && "$arch" != "arm64" ]] && abort "ARM CPU"
+fi
 
 # Must not have Gnome or KDE already install
 pacman -Qe gnome-shell &>/dev/null && abort "Fresh + Vanilla Arch"

--- a/migrations/1755244361.sh
+++ b/migrations/1755244361.sh
@@ -1,0 +1,8 @@
+# Add state for arm achitecture
+if [[ $(uname -m) == "arm"* || $(uname -m) == "aarch64" || -n "$OMARCHY_ARM" ]]; then
+  # Do something for ARM
+  echo "Running on ARM architecture"
+
+  mkdir -p ~/.local/state/omarchy
+  touch ~/.local/state/omarchy/arm.mode
+fi


### PR DESCRIPTION
This will add support for installing Omarchy on aarch64 architecture and let you install on m-series macbooks!

Currently the m1 and m2 macbooks are supported by dual boot with [asahi-alarm](asahi-alarm.org)