### PR TITLE
Improve config updates with baseline tracking and safe diffs

### DIFF
--- a/bin/omarchy-refresh-config
+++ b/bin/omarchy-refresh-config
@@ -19,22 +19,68 @@ fi
 user_config_file="${HOME}/.config/$config_file"
 default_config_file="${HOME}/.local/share/omarchy/config/$config_file"
 backup_config_file="$user_config_file.bak.$(date +%s)"
+base_config_file="${user_config_file}.omarchy-last-base"
 
-if [[ -f "$user_config_file" ]]; then
-  # Create preliminary backup
-  cp -f "$user_config_file" "$backup_config_file" 2>/dev/null
+mkdir -p -- "$(dirname "$user_config_file")"
 
-  # Replace config with new default
-  cp -f "$default_config_file" "$user_config_file" 2>/dev/null
-
-  # Compare and delete/inform accordingly
-  if cmp -s "$user_config_file" "$backup_config_file"; then
-    rm "$backup_config_file"
-  else
-    echo -e "\e[31mReplaced $user_config_file with new Omarchy default.\nSaved backup as ${backup_config_file}.\n\n\e[32mChanges:\e[0m"
-    diff "$user_config_file" "$backup_config_file" || true
-  fi
+# Set state based on user config and baseline
+if [[ ! -e "$user_config_file" ]]; then
+  state=no_user_config
+elif [[ ! -e "$base_config_file" ]]; then
+  state=has_user_no_base
+elif cmp -s -- "$user_config_file" "$base_config_file"; then
+  state=has_user_same_as_base
 else
-  # Config file did not exist already
-  cp -f "$default_config_file" "$user_config_file" 2>/dev/null
+  state=has_user_different_from_base
 fi
+
+# Helpers
+apply_default() {
+  # Copies default into user file, refreshes baseline and prints a caller-provided message
+  cp -f -- "$default_config_file" "$user_config_file"
+  cp -f -- "$default_config_file" "$base_config_file"
+  printf "$1\n" "$user_config_file"
+}
+
+backup_user() {
+  cp -f -- "$user_config_file" "$backup_config_file"
+  printf "Saved backup as %s\n" "$backup_config_file"
+}
+
+handle_diff() {
+  printf "%s\n" "${1:-Differences detected:}"
+  printf "Diff (user vs new default):\n"
+  diff -u -- "$user_config_file" "$default_config_file" || true
+  echo
+  read -r -p "Replace user config with new default? [y/N] " ans
+  if [[ "$ans" =~ ^[Yy]$ ]]; then
+    backup_user
+    apply_default "Replaced %s with new Omarchy default."
+  else
+    printf "Kept existing user config.\n"
+    printf "New Omarchy default remains at %s\n" "$default_config_file"
+    exit 3
+  fi  
+}
+
+# Apply changes according to state
+case $state in
+  no_user_config)
+    apply_default "Created %s from Omarchy default."
+  ;;
+  has_user_no_base)
+    cp -f -- "$default_config_file" "$base_config_file"
+    printf "Initialized baseline for %s.\n" "$user_config_file"
+    if cmp -s -- "$user_config_file" "$default_config_file"; then
+      printf "No changes needed (user config matches new default).\n"
+    else
+      handle_diff "Local edits suspected (previous baseline missing, user config differs from new default)"
+    fi
+  ;;
+  has_user_same_as_base)
+    apply_default "Updated %s with new Omarchy default."
+  ;;
+  has_user_different_from_base)
+    handle_diff "Local edits detected (user config differs from baseline)"
+  ;;
+esac


### PR DESCRIPTION
This PR improves the config update process to better deal with user-edited configuration files while keeping Omarchy defaults up to date.

Previously, the process overwrote local edits with defaults and left the user to handle diffs after the fact. With baseline tracking and diffs, users will now have visibility into what changed beforehand and control over whether to accept new defaults or not.

### Motivation
This is an alternative to #619, which proposes a lock-file system. It takes a different route:

- Instead of lock files, it introduces **baseline tracking**, so each config keeps a `.omarchy-last-base` copy of the last applied default.
- On refresh:
  - If the user config matches the baseline -> auto-update and refresh baseline.
  - If it differs -> show a diff and prompt the user to keep their config or replace with the new default.
  
  The main **advantages** over the lock-file system are:
  - Works automatically, even for users who already have local modifications (no need to pre-lock).
  - No new setup options required, assume users want to keep their configs or go with the default flow if no config is touched.
  - Preserves user edits by default without surprise overwrites. Users still see diffs and can choose to adopt new defaults when they want.
 
### How it works
The change is solely a refactoring of the `omarchy-refresh-config` script, which on each run will:
- Determines the state of a config by comparing the user's file against the baseline
- Takes the appropiate action based on that state.

The states and their correspondent actions are:
- **No user config** -> create a fresh config from the default and initialize the baseline.
- **User config exists but no baseline** -> assume this was an older setup, intialize the baseline from the current default and compare. If the user config differs, show a diff to let the user decide.
- **User config matches baseline** -> safe to auto update with the new default and refresh the baseline.
- **User config differs from baseline** -> it means there are local edits, so show a diff against the new default and prompt the user to accept the update or keep their version (a backup is kept if they choose to overwrite).

Two helpers support this new flow:
- `apply_default()`: copies the new default into place, updates the baseline and prints a status message.
- `handle_diff()`: shows a unified diff, prompts the user and ensures a backup is created if they choose to replace.
