### PR TITLE
Waybar: show battery percentage by default for laptop users

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -82,8 +82,8 @@
   },
   "battery": {
     "format": "{capacity}% {icon}",
-    "format-discharging": "{icon}",
-    "format-charging":    "{icon}",
+    "format-discharging": "{capacity}% {icon}",
+    "format-charging":    "{capacity}% {icon}",
     "format-plugged":     "",
     "format-icons": {
       "charging": [
@@ -93,7 +93,7 @@
         "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"
       ]
     },
-    "format-full": "󰂅",
+    "format-full": "{capacity}% 󰂅",
     "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
     "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
     "interval": 5,


### PR DESCRIPTION
This PR updates the default Waybar battery module config to display the battery percentage next to the icon.

Before: only battery icon shown
After: 85% icon (percentage + icon)

Added {capacity}% to battery formats so percentage is always visible on laptops.