### PR TITLE
Open the chat directly from the menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -338,7 +338,7 @@ show_system_menu() {
 }
 
 show_main_menu() {
-  go_to_menu "$(menu "Go" "󰀻  Apps\n󰧑  Learn\n  Capture\n󰔎  Toggle\n  Style\n  Setup\n󰉉  Install\n󰭌  Remove\n  Update\n  About\n  System")"
+  go_to_menu "$(menu "Go" "󰀻  Apps\n󰧑  Learn\n  Capture\n󰔎  Toggle\n  Style\n  Setup\n󰉉  Install\n󰭌  Remove\n  Update\n  About\n  System\n󰍩  Chat")"
 }
 
 go_to_menu() {
@@ -357,6 +357,7 @@ go_to_menu() {
   *update*) show_update_menu ;;
   *system*) show_system_menu ;;
   *about*) gtk-launch About.desktop ;;
+  *chat*) chromium https://discord.gg/invite/tXFUdasqhY ;;
   esac
 }
 


### PR DESCRIPTION
This will for new users open the invite within discord, and for existing users just redirect them to discord.

I looked into different ways of triggering this through the discord binary, but had no luck. I do think it is possible somehow. Even if it  is using deep linking.

Edit: Seems like it is doing some magic towards a local websocket server to trigger the discord app. Meaning, no easy way of doing it without going through the browser.

<img width="568" height="929" alt="screenshot-2025-08-18_15-12-31" src="https://github.com/user-attachments/assets/74688b09-3cad-4e0b-9ebe-d199b5886d23" />

Feel free to close this PR without any explanation if this is an unwanted feature for Omarchy and the menu system.