### PR TITLE
Handle installing in chroot and fix shellcheck issues

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,249 @@
+# Omarchy Development Guide
+
+This document provides guidance for developers contributing to Omarchy, an Arch Linux desktop environment installer based on Hyprland.
+
+## Overview
+
+Omarchy is a shell-based configuration system that transforms a fresh Arch installation into a fully-configured, beautiful, and modern web development system. The codebase is primarily bash scripts organized into modular components with a robust migration system for updates.
+
+## Architecture Overview
+
+### Directory Structure
+
+- **`install/`** - Modular installation scripts organized by category:
+  - `preflight/` - Pre-installation checks and setup
+  - `config/` - System configuration (network, timezones, login, etc.)
+  - `development/` - Development tools (terminal, nvim, docker, etc.)
+  - `desktop/` - Desktop environment setup (Hyprland, themes, fonts, etc.)
+  - `apps/` - Application installation and configuration
+
+- **`config/`** - User configuration files that get copied to ~/.config/
+  - Contains configs for alacritty, hypr, nvim, waybar, etc.
+
+- **`default/`** - Default/template configuration files
+  - `bash/` - Bash configuration (aliases, functions, prompt, etc.)
+  - `hypr/` - Default Hyprland configuration modules
+  - `walker/` - Application launcher themes
+
+- **`themes/`** - Complete theme definitions
+  - Each theme directory contains configs for all themed applications
+  - Themes include: catppuccin, gruvbox, nord, tokyo-night, etc.
+
+- **`bin/`** - Utility scripts (prefixed with `omarchy-`)
+  - System management, theme switching, configuration refresh tools
+  - These scripts are automatically added to `$PATH` during installation
+  - Available system-wide after installation for user and system management
+  - Examples: `omarchy-theme-set`, `omarchy-refresh-config`, `omarchy-migrate`
+
+- **`migrations/`** - Timestamped migration scripts for system updates
+  - Named with Unix timestamps (e.g., `1751134560.sh`)
+
+### Key Concepts
+
+**Modular Installation**: The installation process is broken into logical phases (preflight, config, development, desktop, apps) with each phase containing multiple focused scripts.
+
+**Theme System**: Themes are complete configuration sets that override configs for alacritty, hyprland, waybar, etc. The theme system allows switching entire visual configurations atomically.
+
+**Configuration Management**: The system uses a layered approach where default configs are copied and then overridden by theme-specific configs.
+
+**Migration System**: Database-style migrations allow the system to evolve while maintaining user installations through incremental update scripts.
+
+## Migration System
+
+### Purpose
+Migrations in Omarchy are **incremental update scripts** that handle breaking changes, new features, or system adjustments that need to be applied when users update their Omarchy installation. They ensure that existing installations can evolve smoothly without manual intervention.
+
+### How Migrations Work
+
+1. **Naming Convention**: Migration files are named with **Unix timestamps** (e.g., `1751134560.sh`, `1754922805.sh`). This ensures they run in chronological order.
+
+2. **Storage Locations**:
+   - **Migration scripts**: `~/.local/share/omarchy/migrations/*.sh`
+   - **State tracking**: `~/.local/state/omarchy/migrations/` (empty files marking completed migrations)
+
+3. **Execution Flow**:
+   - `omarchy-migrate` iterates through all migration files in timestamp order
+   - For each migration file, it checks if a corresponding state file exists
+   - If no state file exists → migration hasn't run → execute it and create state file
+   - If state file exists → migration already completed → skip it
+
+4. **Integration Points**:
+   - **Fresh installs**: `install/preflight/migrations.sh` creates state files for ALL existing migrations (marking them as "already completed" since fresh installs don't need them)
+   - **Updates**: `omarchy-update` calls `omarchy-migrate` after pulling git changes
+
+### Types of Migration Tasks
+
+Looking at examples:
+- **Environment setup**: Adding UWSM environment variables and relaunching Hyprland
+- **File updates**: Copying missing application launcher icons
+- **Configuration changes**: Updating config files for new features
+- **System adjustments**: Installing new packages or changing system settings
+
+### Developer Workflow
+
+- **Creating migrations**: `omarchy-dev-add-migration` creates a new migration file with the current git commit timestamp and opens it in nvim
+- **Testing**: Developers can test migrations locally before committing
+
+### Key Benefits
+
+1. **Incremental updates**: Only new changes get applied
+2. **Idempotent**: Running migrations multiple times is safe
+3. **Chronological order**: Timestamp naming ensures proper sequencing
+4. **Fresh install optimization**: New installations skip all historical migrations
+5. **Rollback protection**: Once a migration runs, it won't run again
+
+This is essentially a **database-style migration system applied to system configuration**, allowing Omarchy to evolve over time while maintaining existing user installations seamlessly.
+
+## Development Workflow
+
+### Making Changes
+
+1. **Edit files** in their respective directories (config/, default/, themes/, etc.)
+2. **Test locally** using `omarchy-refresh-*` commands to reload configurations without restarting
+3. **Add migrations** using `omarchy-dev-add-migration` for breaking changes that affect existing installations
+4. **Test migrations** by running `omarchy-migrate` locally
+5. **Commit changes** following the project's git workflow
+
+### Code Quality Standards
+
+#### Shell Script Best Practices
+
+- **Use shellcheck**: All shell scripts should pass `shellcheck` analysis
+  ```bash
+  shellcheck install/**/*.sh bin/omarchy-* migrations/*.sh
+  ```
+- **Set error handling**: Use `set -e` for scripts that should fail fast
+- **Quote variables**: Always quote variables to prevent word splitting
+- **Use proper shebangs**: Start scripts with `#!/bin/bash`
+
+#### Chroot Compatibility
+
+The install scripts are designed to work in chroot environments (for automated system building). Key considerations:
+
+- **Centralized chroot detection**: The `is_chroot()` function is available from the main `install.sh` script
+  - Detects chroot via `CHROOT` environment variable, `/proc/1/root` accessibility, or filesystem comparison
+- **Conditional execution patterns**:
+  - For `systemctl`: Remove `--now` flag in chroot (services can't start)
+  - For `ufw`: Skip firewall configuration entirely in chroot
+  - For `reboot`: Show completion message instead of rebooting in chroot
+- **Implementation example**:
+  ```bash
+  if is_chroot; then
+    echo "⚠️  [CHROOT] Enabling service (without --now flag)"
+    sudo systemctl enable service-name
+  else
+    sudo systemctl enable --now service-name
+  fi
+  ```
+- **Test in chroot**: Set `CHROOT=1` environment variable to simulate chroot behavior
+
+#### Configuration Files
+
+The system manages configuration for:
+- **Hyprland** (window manager)
+- **Waybar** (status bar)
+- **Alacritty** (terminal)
+- **Walker** (application launcher)
+- **Mako** (notifications)
+- **Neovim** (editor)
+- **Bash** (shell environment)
+
+Most configs support theming and can be refreshed without restarting the desktop session.
+
+### Theme Development
+
+1. **Create theme directory** in `themes/` with descriptive name
+2. **Include all application configs** that should change with the theme
+3. **Follow naming conventions** used by existing themes
+4. **Test theme switching** using `omarchy-theme-set <theme-name>`
+5. **Update theme list** if adding new themes
+
+### Testing
+
+#### Local Testing
+- Use `omarchy-refresh-*` commands to reload configurations
+- Test theme switching with `omarchy-theme-set`
+- Verify migrations run correctly with `omarchy-migrate`
+
+#### Chroot Testing
+```bash
+# Simulate chroot environment
+CHROOT=1 bash install.sh
+
+# Test chroot detection
+CHROOT=1 bash -c 'source install.sh && is_chroot && echo "Chroot detected" || echo "Not in chroot"'
+
+# Test individual installation scripts in chroot mode
+CHROOT=1 bash install/config/network.sh
+CHROOT=1 bash install/development/firewall.sh
+```
+
+### Key Commands for Developers
+
+#### Installation and Updates
+- `bash install.sh` - Main installation script
+- `omarchy-update` - Update Omarchy (git pull, migrations, system packages, restart services)
+- `omarchy-migrate` - Run pending migrations
+
+#### Development Tools
+- `omarchy-dev-add-migration` - Add a new migration script
+- `omarchy-install-dev-env` - Install development environment tools
+
+#### Configuration Management
+- `omarchy-refresh-config` - Refresh all configuration files
+- `omarchy-refresh-hyprland` - Refresh Hyprland config
+- `omarchy-refresh-waybar` - Refresh Waybar config
+
+#### Theme Management
+- `omarchy-theme-list` - List available themes
+- `omarchy-theme-set <theme-name>` - Set the active theme
+- `omarchy-theme-current` - Show current theme
+
+## Contributing Guidelines
+
+1. **Follow existing patterns**: Study how similar functionality is implemented
+2. **Use existing utilities**: Leverage the bin/ scripts and helper functions
+3. **Test thoroughly**: Verify changes work in both normal and chroot environments
+4. **Document breaking changes**: Create migrations for changes that affect existing installations
+5. **Run shellcheck**: Ensure all shell scripts pass static analysis
+6. **Keep changes atomic**: Each commit should represent a single logical change
+
+## Security Considerations
+
+- **Never commit secrets**: Use environment variables or user prompts for sensitive data
+- **Validate user input**: Sanitize any user-provided data in scripts
+- **Use sudo judiciously**: Only elevate privileges when necessary
+- **Follow principle of least privilege**: Scripts should only modify what they need to
+
+## Dependencies
+
+### Runtime Dependencies
+- Arch Linux base system
+- `yay` (AUR helper)
+- `git` for updates and version control
+- Standard shell utilities (`bash`, `awk`, `sed`, etc.)
+
+### Development Dependencies
+- `shellcheck` for script analysis
+- `nvim` for editing (used by development scripts)
+- `gum` for interactive prompts in some utilities
+
+## Troubleshooting
+
+### Common Issues
+- **Permission errors**: Ensure proper sudo usage in install scripts
+- **Missing dependencies**: Check that required packages are installed before use
+- **Chroot failures**: Verify chroot detection is working with `CHROOT=1` testing
+- **Migration failures**: Check migration state files in `~/.local/state/omarchy/migrations/`
+
+### Debugging
+- **Verbose output**: Add `set -x` to scripts for detailed execution tracing
+- **Check logs**: Many operations log to system journals
+- **Test incrementally**: Run individual install scripts rather than full installation
+
+## Resources
+
+- **Community Discord**: https://discord.gg/tXFUdasqhY
+- **Manual**: https://manuals.omamix.org/2/the-omarchy-manual
+- **Hyprland Wiki**: https://wiki.hypr.land/
+- **Arch Wiki**: https://wiki.archlinux.org/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,6 +96,13 @@ This is essentially a **database-style migration system applied to system config
 
 ## Development Workflow
 
+### Branch Strategy
+
+**Development happens on the `dev` branch.** All pull requests should be opened against the `dev` branch, not `master`. The `master` branch contains stable releases.
+
+- **`master`** - Stable releases
+- **`dev`** - Active development branch
+
 ### Making Changes
 
 1. **Edit files** in their respective directories (config/, default/, themes/, etc.)
@@ -109,13 +116,27 @@ This is essentially a **database-style migration system applied to system config
 #### Shell Script Best Practices
 
 - **Use shellcheck**: All shell scripts should pass `shellcheck` analysis
-  ```bash
-  shellcheck install/**/*.sh bin/omarchy-* migrations/*.sh
-  ```
 - **Set error handling**: Use `set -e` for scripts that should fail fast
 - **Quote variables**: Always quote variables to prevent word splitting
 - **Use proper shebangs**: Start scripts with `#!/bin/bash`
 - **Handle cd failures**: Always check that `cd` commands succeed (see SC2164 below)
+
+#### Running Shellcheck
+
+To check shell scripts for common issues and best practices:
+
+**Check bin scripts:**
+```bash
+shellcheck -a -x boot.sh bin/*
+```
+
+**Check installer scripts:**
+```bash
+cd install/
+shellcheck -a -x ../install.sh
+```
+
+The `-a` flag enables all optional checks, and `-x` enables cross-file analysis to properly resolve sourced files and relative paths.
 
 #### Shellcheck Warning Suppressions
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,7 +131,7 @@ When shellcheck warnings are false positives or intentional, suppress them with 
 
 - **SC1090** - Dynamic source files that can't be statically analyzed:
   ```bash
-  # shellcheck source=/dev/null
+  # shellcheck source=/dev/null  # This is okay because $file is dynamically generated
   source "$file"
   ```
 
@@ -157,12 +157,12 @@ cd /some/directory
 rm -rf *  # Could delete files in wrong location!
 
 # CORRECT - safe error handling
-cd /some/directory || exit
+cd /some/directory || exit 1
 rm -rf *
 
 # ALTERNATIVE - use subshell to avoid changing working directory
 (
-  cd /some/directory || exit
+  cd /some/directory || exit 1
   rm -rf *
 )
 ```

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -6,11 +6,11 @@ BATTERY_THRESHOLD=10
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
 
 get_battery_percentage() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
+  upower -i "$(upower -e | grep 'BAT')" | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
 }
 
 get_battery_state() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}'
+  upower -i "$(upower -e | grep 'BAT')" | grep -E "state" | awk '{print $2}'
 }
 
 send_notification() {

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -17,8 +17,8 @@ send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
 }
 
-BATTERY_LEVEL=$(get_battery_percentage)
-BATTERY_STATE=$(get_battery_state)
+BATTERY_LEVEL="$(get_battery_percentage)"
+BATTERY_STATE="$(get_battery_state)"
 
 if [[ "$BATTERY_STATE" == "discharging" && "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
   if [[ ! -f "$NOTIFICATION_FLAG" ]]; then

--- a/bin/omarchy-cmd-apple-display-brightness
+++ b/bin/omarchy-cmd-apple-display-brightness
@@ -3,5 +3,5 @@
 if [[ $# -eq 0 ]]; then
   echo "Adjust Apple Display Brightness by passing +5000 or -5000 (or any range from 0-60000)"
 else
-  sudo asdcontrol $(sudo asdcontrol --detect /dev/usb/hiddev* | grep ^/dev/usb/hiddev | cut -d: -f1) -- "$1"
+  sudo asdcontrol "$(sudo asdcontrol --detect /dev/usb/hiddev* | grep ^/dev/usb/hiddev | cut -d: -f1)" -- "$1"
 fi

--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=/dev/null
+# shellcheck source=/dev/null  # user-dirs.dirs is a runtime config file
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
 
@@ -28,6 +28,6 @@ if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
 elif [[ "$1" == "output" ]]; then
   screenrecording
 else
-  region=$(slurp) || exit 1
+  region="$(slurp)" || exit 1
   screenrecording -g "$region"
 fi

--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck source=/dev/null
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
 

--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -8,7 +8,7 @@ if command -v tte &>/dev/null; then
       "$effect" &
 
     while pgrep -x tte >/dev/null; do
-      if read -n 1 -t 0.01; then
+      if read -r -n 1 -t 0.01; then
         pkill -x tte 2>/dev/null
         pkill -f "alacritty --class Screensaver" 2>/dev/null
         exit 0

--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=/dev/null
+# shellcheck source=/dev/null  # user-dirs.dirs is a runtime config file
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}}"
 

--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck source=/dev/null
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}}"
 
@@ -8,7 +9,7 @@ if [[ ! -d "$OUTPUT_DIR" ]]; then
   exit 1
 fi
 
-pkill slurp || hyprshot -m ${1:-region} --raw |
+pkill slurp || hyprshot -m "${1:-region}" --raw |
   satty --filename - \
     --output-filename "$OUTPUT_DIR/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png" \
     --early-exit \

--- a/bin/omarchy-cmd-tzupdate
+++ b/bin/omarchy-cmd-tzupdate
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 sudo tzupdate
-new_timezone=$(timedatectl show -p Timezone --value)
+new_timezone="$(timedatectl show -p Timezone --value)"
 omarchy-restart-waybar
 notify-send "Timezone has been set to $new_timezone"

--- a/bin/omarchy-dev-add-migration
+++ b/bin/omarchy-dev-add-migration
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/.local/share/omarchy || exit
+cd ~/.local/share/omarchy || exit 1
 migration_file="$HOME/.local/share/omarchy/migrations/$(git log -1 --format=%cd --date=unix).sh"
 touch "$migration_file"
 nvim "$migration_file"

--- a/bin/omarchy-dev-add-migration
+++ b/bin/omarchy-dev-add-migration
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/.local/share/omarchy
+cd ~/.local/share/omarchy || exit
 migration_file="$HOME/.local/share/omarchy/migrations/$(git log -1 --format=%cd --date=unix).sh"
-touch $migration_file
-nvim $migration_file
+touch "$migration_file"
+nvim "$migration_file"

--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -12,7 +12,7 @@ install_php() {
   if [[ ":$PATH:" != *":$HOME/.config/composer/vendor/bin:"* ]]; then
     # shellcheck disable=SC2016  # We want literal $HOME and $PATH in the output
     echo 'export PATH="$HOME/.config/composer/vendor/bin:$PATH"' >>"$HOME/.bashrc"
-    # shellcheck source=/dev/null
+    # shellcheck source=/dev/null  # .bashrc content varies by user
     source "$HOME/.bashrc"
     echo "Added Composer global bin directory to PATH."
   else

--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -10,7 +10,9 @@ install_php() {
 
   # Install Path for Composer
   if [[ ":$PATH:" != *":$HOME/.config/composer/vendor/bin:"* ]]; then
+    # shellcheck disable=SC2016  # We want literal $HOME and $PATH in the output
     echo 'export PATH="$HOME/.config/composer/vendor/bin:$PATH"' >>"$HOME/.bashrc"
+    # shellcheck source=/dev/null
     source "$HOME/.bashrc"
     echo "Added Composer global bin directory to PATH."
   else

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -6,11 +6,11 @@ pgrep -f "alacritty --class Screensaver" && exit 0
 focused=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')
 
 for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
-  hyprctl dispatch focusmonitor $m
+  hyprctl dispatch focusmonitor "$m"
   hyprctl dispatch exec -- \
     alacritty --class Screensaver \
     --config-file ~/.local/share/omarchy/default/alacritty/screensaver.toml \
     -e omarchy-cmd-screensaver
 done
 
-hyprctl dispatch focusmonitor $focused
+hyprctl dispatch focusmonitor "$focused"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -22,7 +22,7 @@ menu() {
 }
 
 terminal() {
-  alacritty --class Omarchy -e $1
+  alacritty --class Omarchy -e "$1"
 }
 
 present_terminal() {

--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -8,11 +8,11 @@ mkdir -p "$STATE_DIR"
 
 # Run any pending migrations
 for file in ~/.local/share/omarchy/migrations/*.sh; do
-  filename=$(basename "$file")
+  filename="$(basename "$file")"
 
   if [[ ! -f "$STATE_DIR/$filename" ]]; then
     echo -e "\e[32m\nRunning migration (${filename%.sh})\e[0m"
-    # shellcheck source=/dev/null
+    # shellcheck source=/dev/null  # Migration files are dynamically sourced
     source "$file"
     touch "$STATE_DIR/$filename"
   fi

--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -12,7 +12,8 @@ for file in ~/.local/share/omarchy/migrations/*.sh; do
 
   if [[ ! -f "$STATE_DIR/$filename" ]]; then
     echo -e "\e[32m\nRunning migration (${filename%.sh})\e[0m"
-    source $file
+    # shellcheck source=/dev/null
+    source "$file"
     touch "$STATE_DIR/$filename"
   fi
 done

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -10,7 +10,7 @@ fzf_args=(
   --color 'pointer:green,marker:green'
 )
 
-pkg_name=$(yay -Slq | fzf "${fzf_args[@]}")
+pkg_name="$(yay -Slq | fzf "${fzf_args[@]}")"
 
 if [[ -n "$pkg_name" ]]; then
   yay -Sy --noconfirm "$pkg_name"

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -10,7 +10,7 @@ fzf_args=(
   --color 'pointer:red,marker:red'
 )
 
-pkg_name=$(yay -Qqe | fzf "${fzf_args[@]}")
+pkg_name="$(yay -Qqe | fzf "${fzf_args[@]}")"
 
 if [[ -n "$pkg_name" ]]; then
   yay -Rns --noconfirm "$pkg_name"

--- a/bin/omarchy-restart-app
+++ b/bin/omarchy-restart-app
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pkill -x $1
-setsid uwsm app -- $1 >/dev/null 2>&1 &
+pkill -x "$1"
+setsid uwsm app -- "$1" >/dev/null 2>&1 &

--- a/bin/omarchy-setup-fido2
+++ b/bin/omarchy-setup-fido2
@@ -19,8 +19,7 @@ else
     if [ ! -f /etc/fido2/fido2 ]; then
       sudo mkdir -p /etc/fido2
       echo -e "\e[32m\nLet's setup your device by confirming on the device now.\e[0m"
-      pamu2fcfg >/tmp/fido2 # This needs to run as the user
-      if [ $? -ne 0 ]; then
+      if ! pamu2fcfg >/tmp/fido2; then # This needs to run as the user
         echo -e "\e[31m\nSomething went wrong. Maybe try again?\e[0m"
         exit 1
       fi

--- a/bin/omarchy-setup-fido2
+++ b/bin/omarchy-setup-fido2
@@ -10,7 +10,7 @@ else
   echo -e "\e[32mLet's setup your Fido2 device for sudo authentication.\n\e[0m"
   yay -S --noconfirm --needed libfido2 pam-u2f
 
-  tokens=$(fido2-token -L)
+  tokens="$(fido2-token -L)"
 
   if [ -z "$tokens" ]; then
     echo -e "\e[31m\nNo fido2 device detected. Plug it in, you may have to unlock it as well\e[0m"

--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -32,7 +32,7 @@ EOF
 
     # Enroll the first finger
     echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\nKeep moving the finger around on sensor until the process completes.\n\e[0m"
-    sudo fprintd-enroll $USER
+    sudo fprintd-enroll "$USER"
 
     echo -e "\e[32m\nNow let's verify that it's working correctly.\e[0m\n"
 

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-echo
+printf '\n'
 gum spin --spinner "globe" --title "Done! Press any key to close..." -- bash -c 'read -n 1 -s'

--- a/bin/omarchy-theme-bg-next
+++ b/bin/omarchy-theme-bg-next
@@ -15,7 +15,7 @@ if [[ $TOTAL -eq 0 ]]; then
 else
   # Get current background from symlink
   if [[ -L "$CURRENT_BACKGROUND_LINK" ]]; then
-    CURRENT_BACKGROUND=$(readlink "$CURRENT_BACKGROUND_LINK")
+    CURRENT_BACKGROUND="$(readlink "$CURRENT_BACKGROUND_LINK")"
   else
     # Default to first background if no symlink exists
     CURRENT_BACKGROUND=""
@@ -35,7 +35,7 @@ else
     # Use the first background when no match was found
     NEW_BACKGROUND="${BACKGROUNDS[0]}"
   else
-    NEXT_INDEX=$(((INDEX + 1) % TOTAL))
+    NEXT_INDEX="$(((INDEX + 1) % TOTAL))"
     NEW_BACKGROUND="${BACKGROUNDS[$NEXT_INDEX]}"
   fi
 

--- a/bin/omarchy-theme-install
+++ b/bin/omarchy-theme-install
@@ -30,4 +30,4 @@ if ! git clone "$REPO_URL" "$THEME_PATH"; then
 fi
 
 # Apply the new theme with omarchy-theme-set
-omarchy-theme-set $THEME_NAME
+omarchy-theme-set "$THEME_NAME"

--- a/bin/omarchy-theme-list
+++ b/bin/omarchy-theme-list
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 find ~/.config/omarchy/themes/ -mindepth 1 -maxdepth 1 \( -type d -o -type l \) | sort | while read -r path; do
-  echo "$(basename "$path" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g')"
+  basename "$path" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g'
 done

--- a/bin/omarchy-theme-list
+++ b/bin/omarchy-theme-list
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Define pattern for converting kebab-case to Title Case
+FORMAT_PATTERN='s/(^|-)([a-z])/\1\u\2/g; s/-/ /g'
+
 find ~/.config/omarchy/themes/ -mindepth 1 -maxdepth 1 \( -type d -o -type l \) | sort | while read -r path; do
-  basename "$path" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g'
+  basename "$path" | sed -E "$FORMAT_PATTERN"
 done

--- a/bin/omarchy-theme-next
+++ b/bin/omarchy-theme-next
@@ -8,16 +8,16 @@ TOTAL=${#THEMES[@]}
 
 # Get current theme from symlink
 if [[ -L "$CURRENT_THEME_LINK" ]]; then
-  CURRENT_THEME=$(realpath "$CURRENT_THEME_LINK")
+  CURRENT_THEME="$(realpath "$CURRENT_THEME_LINK")"
 else
   # Default to first theme if no symlink exists
-  CURRENT_THEME=$(realpath "${THEMES[0]}")
+  CURRENT_THEME="$(realpath "${THEMES[0]}")"
 fi
 
 # Find current theme index
 INDEX=0
 for i in "${!THEMES[@]}"; do
-  THEMES[i]=$(realpath "${THEMES[$i]}")
+  THEMES[i]="$(realpath "${THEMES[$i]}")"
 
   if [[ "${THEMES[$i]}" == "$CURRENT_THEME" ]]; then
     INDEX=$i
@@ -26,9 +26,9 @@ for i in "${!THEMES[@]}"; do
 done
 
 # Get next theme (wrap around)
-NEXT_INDEX=$(((INDEX + 1) % TOTAL))
+NEXT_INDEX="$(((INDEX + 1) % TOTAL))"
 NEW_THEME=${THEMES[$NEXT_INDEX]}
-NEW_THEME_NAME=$(basename "$NEW_THEME")
+NEW_THEME_NAME="$(basename "$NEW_THEME")"
 
 omarchy-theme-set "$NEW_THEME_NAME"
 notify-send "Theme changed to $NEW_THEME_NAME" -t 2000

--- a/bin/omarchy-theme-next
+++ b/bin/omarchy-theme-next
@@ -3,7 +3,7 @@
 THEMES_DIR="$HOME/.config/omarchy/themes/"
 CURRENT_THEME_LINK="$HOME/.config/omarchy/current/theme"
 
-THEMES=($(find "$THEMES_DIR" -mindepth 1 -maxdepth 1 | sort))
+mapfile -t THEMES < <(find "$THEMES_DIR" -mindepth 1 -maxdepth 1 | sort)
 TOTAL=${#THEMES[@]}
 
 # Get current theme from symlink
@@ -17,7 +17,7 @@ fi
 # Find current theme index
 INDEX=0
 for i in "${!THEMES[@]}"; do
-  THEMES[$i]=$(realpath "${THEMES[$i]}")
+  THEMES[i]=$(realpath "${THEMES[$i]}")
 
   if [[ "${THEMES[$i]}" == "$CURRENT_THEME" ]]; then
     INDEX=$i
@@ -30,5 +30,5 @@ NEXT_INDEX=$(((INDEX + 1) % TOTAL))
 NEW_THEME=${THEMES[$NEXT_INDEX]}
 NEW_THEME_NAME=$(basename "$NEW_THEME")
 
-omarchy-theme-set $NEW_THEME_NAME
+omarchy-theme-set "$NEW_THEME_NAME"
 notify-send "Theme changed to $NEW_THEME_NAME" -t 2000

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -11,7 +11,7 @@ fi
 THEMES_DIR="$HOME/.config/omarchy/themes/"
 CURRENT_THEME_DIR="$HOME/.config/omarchy/current/theme"
 
-THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+THEME_NAME="$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
 THEME_PATH="$THEMES_DIR/$THEME_NAME"
 
 # Check if the theme entered exists

--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -11,7 +11,7 @@ if ! pgrep -x hyprsunset; then
 fi
 
 # Query the current temperature
-CURRENT_TEMP=$(hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+')
+CURRENT_TEMP="$(hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+')"
 
 restart_nightlighted_waybar() {
   if grep -q "custom/nightlight" ~/.config/waybar/config.jsonc; then

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -7,7 +7,7 @@ if ! git -C "$OMARCHY_PATH" ls-remote &>/dev/null; then
 fi
 
 latest_tag=$(git -C "$OMARCHY_PATH" ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
-current_tag=$(git -C "$OMARCHY_PATH" describe --tags $(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1))
+current_tag=$(git -C "$OMARCHY_PATH" describe --tags "$(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1)")
 
 if [[ "$current_tag" != "$latest_tag" ]]; then
   echo "Omarchy update available ($latest_tag)"

--- a/bin/omarchy-update-git
+++ b/bin/omarchy-update-git
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo -e "\e[32mUpdate Omarchy\e[0m"
-git -C $OMARCHY_PATH pull --autostash
-git -C $OMARCHY_PATH diff --check || git -C $OMARCHY_PATH reset --merge
+git -C "$OMARCHY_PATH" pull --autostash
+git -C "$OMARCHY_PATH" diff --check || git -C "$OMARCHY_PATH" reset --merge

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -16,7 +16,8 @@ fi
 for file in "$HOME"/.local/state/omarchy/restart-*-required; do
   if [ -f "$file" ]; then
     filename=$(basename "$file")
-    service=$(echo "$filename" | sed 's/restart-\(.*\)-required/\1/')
+    service=${filename#restart-}
+    service=${service%-required}
     echo "Restarting $service"
     omarchy-state clear "$filename"
     omarchy-restart-"$service"

--- a/bin/omarchy-version
+++ b/bin/omarchy-version
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git -C "$OMARCHY_PATH" describe --tags $(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1)
+git -C "$OMARCHY_PATH" describe --tags "$(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1)"

--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -2,9 +2,9 @@
 
 if [ "$#" -ne 3 ]; then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
-  APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
-  APP_URL=$(gum input --prompt "URL> " --placeholder "https://example.com")
-  ICON_URL=$(gum input --prompt "Icon URL> " --placeholder "See https://dashboardicons.com (must use PNG!)")
+  APP_NAME="$(gum input --prompt "Name> " --placeholder "My favorite web app")"
+  APP_URL="$(gum input --prompt "URL> " --placeholder "https://example.com")"
+  ICON_URL="$(gum input --prompt "Icon URL> " --placeholder "See https://dashboardicons.com (must use PNG!)")"
 else
   APP_NAME="$1"
   APP_URL="$2"

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -12,8 +12,7 @@ if [ "$#" -ne 1 ]; then
   done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0)
 
   if ((${#WEB_APPS[@]})); then
-    IFS=$'\n' SORTED_WEB_APPS=($(sort <<<"${WEB_APPS[*]}"))
-    unset IFS
+    mapfile -t SORTED_WEB_APPS < <(printf '%s\n' "${WEB_APPS[@]}" | sort)
     APP_NAME=$(gum choose --header "Select web app to remove..." "${SORTED_WEB_APPS[@]}")
   else
     echo "No web apps to remove."

--- a/boot.sh
+++ b/boot.sh
@@ -27,11 +27,11 @@ git clone "https://github.com/${OMARCHY_REPO}.git" ~/.local/share/omarchy >/dev/
 if [[ -n "$OMARCHY_REF" ]]; then
   echo -e "\eUsing branch: $OMARCHY_REF"
   (
-    cd ~/.local/share/omarchy || exit
+    cd ~/.local/share/omarchy || exit 1
     git fetch origin "${OMARCHY_REF}" && git checkout "${OMARCHY_REF}"
   )
 fi
 
 echo -e "\nInstallation starting..."
-# shellcheck source=/dev/null
+# shellcheck source=/dev/null  # install.sh is dynamically generated
 source ~/.local/share/omarchy/install.sh

--- a/boot.sh
+++ b/boot.sh
@@ -26,10 +26,12 @@ git clone "https://github.com/${OMARCHY_REPO}.git" ~/.local/share/omarchy >/dev/
 # Use custom branch if instructed
 if [[ -n "$OMARCHY_REF" ]]; then
   echo -e "\eUsing branch: $OMARCHY_REF"
-  cd ~/.local/share/omarchy
-  git fetch origin "${OMARCHY_REF}" && git checkout "${OMARCHY_REF}"
-  cd -
+  (
+    cd ~/.local/share/omarchy || exit
+    git fetch origin "${OMARCHY_REF}" && git checkout "${OMARCHY_REF}"
+  )
 fi
 
 echo -e "\nInstallation starting..."
+# shellcheck source=/dev/null
 source ~/.local/share/omarchy/install.sh

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,11 @@ set -e
 export PATH="$HOME/.local/share/omarchy/bin:$PATH"
 OMARCHY_INSTALL=~/.local/share/omarchy/install
 
+# Simple chroot detection function
+is_chroot() {
+  [ -n "${CHROOT:-}" ] || [ ! -r /proc/1/root ] || ! cmp -s /proc/1/root/ / 2>/dev/null
+}
+
 # Give people a chance to retry running the installation
 catch_errors() {
   echo -e "\n\e[31mOmarchy installation failed!\e[0m"
@@ -87,6 +92,12 @@ fi
 
 # Reboot
 show_logo laseretch 920
-show_subtext "You're done! So we'll be rebooting now..."
-sleep 2
-reboot
+if is_chroot; then
+  show_subtext "🎉 Omarchy installation completed successfully!"
+  echo "    Installation finished in chroot environment."
+  echo "    Please exit the chroot and reboot your system manually."
+else
+  show_subtext "You're done! So we'll be rebooting now..."
+  sleep 2
+  sudo reboot
+fi

--- a/install.sh
+++ b/install.sh
@@ -93,11 +93,10 @@ fi
 # Reboot
 show_logo laseretch 920
 if is_chroot; then
-  show_subtext "🎉 Omarchy installation completed successfully!"
-  echo "    Installation finished in chroot environment."
-  echo "    Please exit the chroot and reboot your system manually."
+  show_subtext "⚠️ 🎉 Omarchy installation completed successfully!"
+  echo "    Installation finished. Please exit the chroot environment manually and reboot."
 else
-  show_subtext "You're done! So we'll be rebooting now..."
+  show_subtext "🎉 Omarchy installation completed successfully! Rebooting now..."
   sleep 2
   sudo reboot
 fi

--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -3,8 +3,8 @@
 conf="/etc/vconsole.conf"
 hyprconf="$HOME/.config/hypr/hyprland.conf"
 
-layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
-variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
+layout="$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')"
+variant="$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')"
 
 if [[ -n "$layout" ]]; then
   sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $layout" "$hyprconf"

--- a/install/config/identification.sh
+++ b/install/config/identification.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 [ -z "$OMARCHY_USER_NAME" ] &&
-  export OMARCHY_USER_NAME=$(gum input --placeholder "Enter full name" --prompt "Name> ")
+  OMARCHY_USER_NAME=$(gum input --placeholder "Enter full name" --prompt "Name> ") &&
+  export OMARCHY_USER_NAME
 
 [ -z "$OMARCHY_USER_EMAIL" ] &&
-  export OMARCHY_USER_EMAIL=$(gum input --placeholder "Enter email address" --prompt "Email> ")
+  OMARCHY_USER_EMAIL=$(gum input --placeholder "Enter email address" --prompt "Email> ") &&
+  export OMARCHY_USER_NAME

--- a/install/config/identification.sh
+++ b/install/config/identification.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 [ -z "$OMARCHY_USER_NAME" ] &&
-  OMARCHY_USER_NAME=$(gum input --placeholder "Enter full name" --prompt "Name> ") &&
+  OMARCHY_USER_NAME="$(gum input --placeholder "Enter full name" --prompt "Name> ")" &&
   export OMARCHY_USER_NAME
 
 [ -z "$OMARCHY_USER_EMAIL" ] &&
-  OMARCHY_USER_EMAIL=$(gum input --placeholder "Enter email address" --prompt "Email> ") &&
+  OMARCHY_USER_EMAIL="$(gum input --placeholder "Enter email address" --prompt "Email> ")" &&
   export OMARCHY_USER_NAME

--- a/install/config/login.sh
+++ b/install/config/login.sh
@@ -12,7 +12,7 @@ fi
 
 if ! grep -Eq '^HOOKS=.*plymouth' /etc/mkinitcpio.conf; then
   # Backup original mkinitcpio.conf just in case
-  backup_timestamp=$(date +"%Y%m%d%H%M%S")
+  backup_timestamp="$(date +"%Y%m%d%H%M%S")"
   sudo cp /etc/mkinitcpio.conf "/etc/mkinitcpio.conf.bak.${backup_timestamp}"
 
   # Add plymouth to HOOKS array after 'base udev' or 'base systemd'
@@ -52,13 +52,13 @@ elif [ -f "/etc/default/grub" ]; then # Grub
   echo "Detected grub"
 
   # Backup GRUB config before modifying
-  backup_timestamp=$(date +"%Y%m%d%H%M%S")
+  backup_timestamp="$(date +"%Y%m%d%H%M%S")"
   sudo cp /etc/default/grub "/etc/default/grub.bak.${backup_timestamp}"
 
   # Check if splash is already in GRUB_CMDLINE_LINUX_DEFAULT
   if ! grep -q "GRUB_CMDLINE_LINUX_DEFAULT.*splash" /etc/default/grub; then
     # Get current GRUB_CMDLINE_LINUX_DEFAULT value
-    current_cmdline=$(grep "^GRUB_CMDLINE_LINUX_DEFAULT=" /etc/default/grub | cut -d'"' -f2)
+    current_cmdline="$(grep "^GRUB_CMDLINE_LINUX_DEFAULT=" /etc/default/grub | cut -d'"' -f2)"
 
     # Add splash and quiet if not present
     new_cmdline="$current_cmdline"
@@ -70,7 +70,7 @@ elif [ -f "/etc/default/grub" ]; then # Grub
     fi
 
     # Trim any leading/trailing spaces
-    new_cmdline=$(echo "$new_cmdline" | xargs)
+    new_cmdline="$(echo "$new_cmdline" | xargs)"
 
     sudo sed -i "s/^GRUB_CMDLINE_LINUX_DEFAULT=\".*\"/GRUB_CMDLINE_LINUX_DEFAULT=\"$new_cmdline\"/" /etc/default/grub
 
@@ -96,10 +96,10 @@ elif [ -f "/etc/kernel/cmdline" ]; then # UKI Alternate
   echo "Detected a UKI setup"
 
   # Backup kernel cmdline config before modifying
-  backup_timestamp=$(date +"%Y%m%d%H%M%S")
+  backup_timestamp="$(date +"%Y%m%d%H%M%S")"
   sudo cp /etc/kernel/cmdline "/etc/kernel/cmdline.bak.${backup_timestamp}"
 
-  current_cmdline=$(cat /etc/kernel/cmdline)
+  current_cmdline="$(cat /etc/kernel/cmdline)"
 
   # Add splash and quiet if not present
   new_cmdline="$current_cmdline"
@@ -111,16 +111,16 @@ elif [ -f "/etc/kernel/cmdline" ]; then # UKI Alternate
   fi
 
   # Trim any leading/trailing spaces
-  new_cmdline=$(echo "$new_cmdline" | xargs)
+  new_cmdline="$(echo "$new_cmdline" | xargs)"
 
   # Write new file
   echo "$new_cmdline" | sudo tee /etc/kernel/cmdline
 else
-  echo ""
+  printf '\n'
   echo " None of systemd-boot, GRUB, or UKI detected. Please manually add these kernel parameters:"
   echo "  - splash (to see the graphical splash screen)"
   echo "  - quiet (for silent boot)"
-  echo ""
+  printf '\n'
 fi
 
 if [ "$(plymouth-set-default-theme)" != "omarchy" ]; then

--- a/install/config/login.sh
+++ b/install/config/login.sh
@@ -114,7 +114,7 @@ elif [ -f "/etc/kernel/cmdline" ]; then # UKI Alternate
   new_cmdline=$(echo "$new_cmdline" | xargs)
 
   # Write new file
-  echo $new_cmdline | sudo tee /etc/kernel/cmdline
+  echo "$new_cmdline" | sudo tee /etc/kernel/cmdline
 else
   echo ""
   echo " None of systemd-boot, GRUB, or UKI detected. Please manually add these kernel parameters:"
@@ -261,7 +261,7 @@ fi
 
 # Enable omarchy-seamless-login.service only if not already enabled
 if ! systemctl is-enabled omarchy-seamless-login.service | grep -q enabled; then
-  sudo systemctl enable omarchy-seamless-login.service
+    sudo systemctl enable omarchy-seamless-login.service
 fi
 
 # Disable getty@tty1.service only if not already disabled

--- a/install/config/network.sh
+++ b/install/config/network.sh
@@ -4,7 +4,12 @@
 # This can happen if archinstall used ethernet
 if ! command -v iwctl &>/dev/null; then
   yay -S --noconfirm --needed iwd
-  sudo systemctl enable --now iwd.service
+  if is_chroot; then
+    echo "⚠️  [CHROOT] Enabling iwd.service (without --now flag)"
+    sudo systemctl enable iwd.service
+  else
+    sudo systemctl enable --now iwd.service
+  fi
 fi
 
 # Prevent systemd-networkd-wait-online timeout on boot

--- a/install/config/nvidia.sh
+++ b/install/config/nvidia.sh
@@ -17,7 +17,8 @@ if lspci | grep -q -i 'nvidia'; then
 
   # --- Driver Selection ---
   # Turing (16xx, 20xx), Ampere (30xx), Ada (40xx), and newer recommend the open-source kernel modules
-  if lspci | grep -i 'nvidia' | grep -q -E "RTX [2-9][0-9]|GTX 16"; then
+  MODERN_GPU_PATTERN="RTX [2-9][0-9]|GTX 16"
+  if lspci | grep -i 'nvidia' | grep -q -E "$MODERN_GPU_PATTERN"; then
     NVIDIA_DRIVER_PACKAGE="nvidia-open-dkms"
   else
     NVIDIA_DRIVER_PACKAGE="nvidia-dkms"

--- a/install/config/nvidia.sh
+++ b/install/config/nvidia.sh
@@ -11,13 +11,13 @@
 # ==============================================================================
 
 # --- GPU Detection ---
-if [ -n "$(lspci | grep -i 'nvidia')" ]; then
+if lspci | grep -q -i 'nvidia'; then
   show_logo
   show_subtext "Install NVIDIA drivers..."
 
   # --- Driver Selection ---
   # Turing (16xx, 20xx), Ampere (30xx), Ada (40xx), and newer recommend the open-source kernel modules
-  if echo "$(lspci | grep -i 'nvidia')" | grep -q -E "RTX [2-9][0-9]|GTX 16"; then
+  if lspci | grep -i 'nvidia' | grep -q -E "RTX [2-9][0-9]|GTX 16"; then
     NVIDIA_DRIVER_PACKAGE="nvidia-open-dkms"
   else
     NVIDIA_DRIVER_PACKAGE="nvidia-dkms"

--- a/install/config/power.sh
+++ b/install/config/power.sh
@@ -9,7 +9,12 @@ if ls /sys/class/power_supply/BAT* &>/dev/null; then
   powerprofilesctl set balanced || true
 
   # Enable battery monitoring timer for low battery notifications
-  systemctl --user enable --now omarchy-battery-monitor.timer || true
+  if is_chroot; then
+    echo "⚠️  [CHROOT] Enabling omarchy-battery-monitor.timer (without --now flag)"
+    systemctl --user enable omarchy-battery-monitor.timer || true
+  else
+    systemctl --user enable --now omarchy-battery-monitor.timer || true
+  fi
 else
   # This computer runs on power outlet
   powerprofilesctl set performance || true

--- a/install/desktop/bluetooth.sh
+++ b/install/desktop/bluetooth.sh
@@ -4,4 +4,9 @@
 yay -S --noconfirm --needed blueberry
 
 # Turn on bluetooth by default
-sudo systemctl enable --now bluetooth.service
+if is_chroot; then
+  echo "⚠️  [CHROOT] Enabling bluetooth.service (without --now flag)"
+  sudo systemctl enable bluetooth.service
+else
+  sudo systemctl enable --now bluetooth.service
+fi

--- a/install/desktop/printer.sh
+++ b/install/desktop/printer.sh
@@ -1,16 +1,31 @@
 #!/bin/bash
 
 sudo pacman -S --noconfirm cups cups-pdf cups-filters cups-browsed system-config-printer avahi nss-mdns
-sudo systemctl enable --now cups.service
+if is_chroot; then
+  echo "⚠️  [CHROOT] Enabling cups.service (without --now flag)"
+  sudo systemctl enable cups.service
+else
+  sudo systemctl enable --now cups.service
+fi
 
 # Disable multicast dns in resolved. Avahi will provide this for better network printer discovery
 sudo mkdir -p /etc/systemd/resolved.conf.d
 echo -e "[Resolve]\nMulticastDNS=no" | sudo tee /etc/systemd/resolved.conf.d/10-disable-multicast.conf
-sudo systemctl enable --now avahi-daemon.service
+if is_chroot; then
+  echo "⚠️  [CHROOT] Enabling avahi-daemon.service (without --now flag)"
+  sudo systemctl enable avahi-daemon.service
+else
+  sudo systemctl enable --now avahi-daemon.service
+fi
 
 # Enable automatically adding remote printers
 if ! grep -q '^CreateRemotePrinters Yes' /etc/cups/cups-browsed.conf; then
   echo 'CreateRemotePrinters Yes' | sudo tee -a /etc/cups/cups-browsed.conf
 fi
 
-sudo systemctl enable --now cups-browsed.service
+if is_chroot; then
+  echo "⚠️  [CHROOT] Enabling cups-browsed.service (without --now flag)"
+  sudo systemctl enable cups-browsed.service
+else
+  sudo systemctl enable --now cups-browsed.service
+fi

--- a/install/development/docker.sh
+++ b/install/development/docker.sh
@@ -24,7 +24,7 @@ sudo systemctl restart systemd-resolved
 sudo systemctl enable docker
 
 # Give this user privileged Docker access
-sudo usermod -aG docker ${USER}
+sudo usermod -aG docker "${USER}"
 
 # Prevent Docker from preventing boot for network-online.target
 sudo mkdir -p /etc/systemd/system/docker.service.d

--- a/install/development/firewall.sh
+++ b/install/development/firewall.sh
@@ -3,24 +3,29 @@
 if ! command -v ufw &>/dev/null; then
   yay -S --noconfirm --needed ufw ufw-docker
 
-  # Allow nothing in, everything out
-  sudo ufw default deny incoming
-  sudo ufw default allow outgoing
+  if is_chroot; then
+    echo "⚠️  [CHROOT] Skipping firewall configuration in chroot environment"
+    echo "    You will need to configure the firewall after booting into the installed system."
+  else
+    # Allow nothing in, everything out
+    sudo ufw default deny incoming
+    sudo ufw default allow outgoing
 
-  # Allow ports for LocalSend
-  sudo ufw allow 53317/udp
-  sudo ufw allow 53317/tcp
+    # Allow ports for LocalSend
+    sudo ufw allow 53317/udp
+    sudo ufw allow 53317/tcp
 
-  # Allow SSH in
-  sudo ufw allow 22/tcp
+    # Allow SSH in
+    sudo ufw allow 22/tcp
 
-  # Allow Docker containers to use DNS on host
-  sudo ufw allow in on docker0 to any port 53
+    # Allow Docker containers to use DNS on host
+    sudo ufw allow in on docker0 to any port 53
 
-  # Turn on the firewall
-  sudo ufw --force enable
+    # Turn on the firewall
+    sudo ufw --force enable
 
-  # Turn on Docker protections
-  sudo ufw-docker install
-  sudo ufw reload
+    # Turn on Docker protections
+    sudo ufw-docker install
+    sudo ufw reload
+  fi
 fi


### PR DESCRIPTION
We add conditional checks for:
- systemctl enable - to skip --now which fails in the chroot
- ufw - the ufw configuration cannot run without ufw running, so this is
  skipped in the chroot
- reboot - we do not reboot when installing in a chroot

Also added DEVELOPMENT.md covering the main concepts for developers to contribute to Omarchy, and fixed current shellcheck errors.

Note installing in a chroot is used for installing with alma-nv - https://github.com/jamesmcm/alma-nv - see issue #756 