### PR TITLE
Add missing package for Intel Graphics Card based device

### DIFF
--- a/install/desktop/desktop.sh
+++ b/install/desktop/desktop.sh
@@ -9,7 +9,7 @@ yay -S --noconfirm --needed \
   omarchy-chromium-bin
 
 # Add screen recorder based on GPU
-if lspci | grep -qi 'nvidia'; then
+if lspci | grep -Eqi 'nvidia|intel.*graphics'; then
   yay -S --noconfirm --needed wf-recorder
 else
   yay -S --noconfirm --needed wl-screenrec

--- a/migrations/1755548643.sh
+++ b/migrations/1755548643.sh
@@ -1,0 +1,5 @@
+echo "Install wf-recorder for intel based device"
+
+if lspci | grep -Eqi 'nvidia|intel.*graphics'; then
+  yay -S --noconfirm --needed wf-recorder
+fi


### PR DESCRIPTION
Hi,

Last week, a fix was added to make the screen recorder work with Intel GPUs. However, wf-recorder is missing, since there is a check during the initial setup.

This PR adds the missing package.