### PR TITLE
Enable themes to customize Walker

### DIFF
--- a/default/walker/themes/omarchy-default.css
+++ b/default/walker/themes/omarchy-default.css
@@ -1,5 +1,3 @@
-@import url("file://~/.config/omarchy/current/theme/walker.css");
-
 /* Reset all elements */
 #window,
 #box,
@@ -168,3 +166,4 @@ scrollbar {
   opacity: 0;
 }
 
+@import url("file://~/.config/omarchy/current/theme/walker.css");


### PR DESCRIPTION
This little change is enabling the themes to be able to customize Walker by modifying the `walker.css` files.

## Problem

If you use the following code in the `walker.css` of the current theme it won't take effect.

```css
#box {
  border-radius: 8px;
}
```

even if you use `!important` because I think GTK-4 doesn't support it or I couldn't figure it out at least.

## Solution

Moving the @import of the walker css to the buttom of the default css file enables the themes to override each property for the walker. For example I modified the radius of the `#box` and `#search` in the below screenshot

```css
@define-color selected-text #BDE0FE;
@define-color text #F8F8F2;
@define-color base #282A36;
@define-color border #BDE0FE;
@define-color foreground #F8F8F2;
@define-color background #282A36;

/* customize */
#box {
  border-radius: 8px;
}

#search {
  border-radius: 4px;
}
```

<img width="1898" height="1200" alt="image" src="https://github.com/user-attachments/assets/a8dbc394-1859-4167-9248-c43454c90886" />


**Note** that the `@define-color`s in the `walker.css` file of each theme still applies even when the `@import` is at the bottom of the default css file.