### PR TITLE
Add omarchy-snapshot

### DIFF
--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# omarchy-snapshot: Create filesystem snapshots using snapper
+# Usage: omarchy-snapshot [pre|post] [description]
+
+SNAPSHOT_TYPE="${1:-pre}"
+DESCRIPTION="${2:-omarchy-$(date +'%Y%m%d-%H%M%S')}"
+
+create_snapshot() {
+  local type="$1"
+  local desc="$2"
+
+  # Check if we're on btrfs
+  # We should be - it is the recommended file system on omarchy manual https://manuals.omamix.org/2/the-omarchy-manual/50/getting-started
+  if ! findmnt -n -o FSTYPE / | grep -q btrfs; then
+    echo "Error: Snapshots require btrfs filesystem"
+    echo "Current root filesystem: $(findmnt -n -o FSTYPE /)"
+    return 1
+  fi
+
+  # Check if snapper is available
+  if ! command -v snapper >/dev/null; then
+    echo "Error: snapper not installed"
+    echo "Install with: sudo pacman -S snapper"
+    return 1
+  fi
+
+  # Check if snapper config exists
+  if ! sudo snapper -c root list-configs >/dev/null 2>&1; then
+    echo "Error: snapper not configured for root"
+    echo "Configure with: sudo snapper -c root create-config /"
+    return 1
+  fi
+
+  # Create snapshot
+  echo "Creating $type snapshot: $desc"
+  if sudo snapper -c root create --description "$desc" --type "$type" --cleanup-algorithm number; then
+    echo -e "\e[32m[PASS]\e[0m Snapshot created successfully"
+
+    # Show recent snapshots
+    echo ""
+    echo "Recent snapshots:"
+    sudo snapper -c root list | tail -5
+
+    return 0
+  else
+    echo -e "\e[31m[FAIL]\e[0m Failed to create snapshot"
+    return 1
+  fi
+}
+
+install_snapper() {
+  echo "Installing and configuring snapper..."
+
+  # Install snapper
+  if ! sudo pacman -S --noconfirm --needed snapper; then
+    echo -e "\e[31m[FAIL]\e[0m Failed to install snapper"
+    return 1
+  fi
+
+  # Create config for root
+  if ! sudo snapper -c root create-config /; then
+    echo -e "\e[31m[FAIL]\e[0m Failed to configure snapper"
+    return 1
+  fi
+
+  # Set up automatic timeline snapshots
+  sudo snapper -c root set-config TIMELINE_CREATE=yes
+  sudo snapper -c root set-config TIMELINE_CLEANUP=yes
+  sudo snapper -c root set-config NUMBER_CLEANUP=yes
+  sudo snapper -c root set-config NUMBER_LIMIT=10
+
+  echo -e "\e[32m[PASS]\e[0m Snapper installed and configured"
+  return 0
+}
+
+case "$1" in
+--install)
+  install_snapper
+  ;;
+--list)
+  if command -v snapper >/dev/null; then
+    sudo snapper -c root list
+  else
+    echo "snapper not installed"
+    exit 1
+  fi
+  ;;
+--help)
+  echo "Usage: omarchy-snapshot [COMMAND] [DESCRIPTION]"
+  echo ""
+  echo "Commands:"
+  echo "  pre [desc]     Create pre-update snapshot (default)"
+  echo "  post [desc]    Create post-update snapshot"
+  echo "  --install      Install and configure snapper"
+  echo "  --list         List all snapshots"
+  echo "  --help         Show this help"
+  echo ""
+  echo "Examples:"
+  echo "  omarchy-snapshot                    # Create pre snapshot"
+  echo "  omarchy-snapshot post               # Create post snapshot"
+  echo "  omarchy-snapshot pre 'before-update' # Custom description"
+  ;;
+pre | post | "")
+  create_snapshot "$SNAPSHOT_TYPE" "$DESCRIPTION"
+  ;;
+*)
+  echo "Unknown option: $1"
+  echo "Use --help for usage information"
+  exit 1
+  ;;
+esac
+

--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -20,16 +20,44 @@ create_snapshot() {
 
   # Check if snapper is available
   if ! command -v snapper >/dev/null; then
-    echo "Error: snapper not installed"
-    echo "Install with: sudo pacman -S snapper"
-    return 1
+    echo -e "\e[33m[WARN]\e[0m snapper not installed"
+    read -p "Install and configure snapper now? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      install_snapper
+      if [ $? -ne 0 ]; then
+        return 1
+      fi
+    else
+      echo "Snapper installation cancelled"
+      return 1
+    fi
   fi
 
   # Check if snapper config exists
-  if ! sudo snapper -c root list-configs >/dev/null 2>&1; then
-    echo "Error: snapper not configured for root"
-    echo "Configure with: sudo snapper -c root create-config /"
-    return 1
+  if ! sudo snapper -c root list-configs | grep -q "root"; then
+    echo -e "\e[33m[WARN]\e[0m snapper not configured for root"
+    read -p "Configure snapper now? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      echo "Configuring snapper for root subvolume..."
+      # Create config for root
+      if ! sudo snapper -c root create-config /; then
+        echo -e "\e[31m[FAIL]\e[0m Failed to configure snapper"
+        return 1
+      fi
+      
+      # Set up reasonable defaults (same as install script)
+      sudo snapper -c root set-config TIMELINE_CREATE=yes
+      sudo snapper -c root set-config TIMELINE_CLEANUP=yes
+      sudo snapper -c root set-config NUMBER_CLEANUP=yes
+      sudo snapper -c root set-config NUMBER_LIMIT=10
+      
+      echo -e "\e[32m[PASS]\e[0m Snapper configured"
+    else
+      echo "Snapper configuration cancelled"
+      return 1
+    fi
   fi
 
   # Create snapshot

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -2,6 +2,8 @@
 
 set -e
 
+# Create pre-update snapshot (will not block rest of update going ahead if user is not running btrfs or does not have snapper installed)
+omarchy-snapshot pre "omarchy-update-$(date +'%Y%m%d-%H%M%S')" || true
 omarchy-update-git
 omarchy-migrate
 omarchy-update-system-pkgs

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,7 @@ source $OMARCHY_INSTALL/config/power.sh
 source $OMARCHY_INSTALL/config/timezones.sh
 source $OMARCHY_INSTALL/config/login.sh
 source $OMARCHY_INSTALL/config/nvidia.sh
+source $OMARCHY_INSTALL/config/snapshots.sh
 source $OMARCHY_INSTALL/config/increase-sudo-tries.sh
 
 # Development

--- a/install/config/snapshots.sh
+++ b/install/config/snapshots.sh
@@ -8,7 +8,7 @@ if findmnt -n -o FSTYPE / | grep -q btrfs; then
   sudo pacman -S --noconfirm --needed snapper
 
   # Configure snapper for root subvolume (only if not already configured)
-  if ! sudo snapper -c root list-configs >/dev/null 2>&1; then
+  if ! sudo snapper -c root list-configs | grep -q "root"; then
     echo "Configuring snapper for root subvolume..."
     sudo snapper -c root create-config /
     

--- a/install/config/snapshots.sh
+++ b/install/config/snapshots.sh
@@ -7,17 +7,22 @@ if findmnt -n -o FSTYPE / | grep -q btrfs; then
 
   sudo pacman -S --noconfirm --needed snapper
 
-  # Configure snapper for root subvolume
-  sudo snapper -c root create-config /
-
-  # Set up reasonable defaults
-  sudo snapper -c root set-config TIMELINE_CREATE=yes
-  sudo snapper -c root set-config TIMELINE_CLEANUP=yes
-  sudo snapper -c root set-config NUMBER_CLEANUP=yes
-  sudo snapper -c root set-config NUMBER_LIMIT=10
-
-  # Create initial snapshot
-  sudo snapper -c root create --description "omarchy-initial-install"
+  # Configure snapper for root subvolume (only if not already configured)
+  if ! sudo snapper -c root list-configs >/dev/null 2>&1; then
+    echo "Configuring snapper for root subvolume..."
+    sudo snapper -c root create-config /
+    
+    # Set up reasonable defaults
+    sudo snapper -c root set-config TIMELINE_CREATE=yes
+    sudo snapper -c root set-config TIMELINE_CLEANUP=yes
+    sudo snapper -c root set-config NUMBER_CLEANUP=yes
+    sudo snapper -c root set-config NUMBER_LIMIT=10
+    
+    # Create initial snapshot
+    sudo snapper -c root create --description "omarchy-initial-install"
+  else
+    echo "Snapper already configured for root - skipping configuration"
+  fi
 
   echo -e "\e[32m[PASS]\e[0m Snapper configured and ready"
 else

--- a/install/config/snapshots.sh
+++ b/install/config/snapshots.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Only install snapper on btrfs systems
+# User should have selected this during arch config based on omarchy manual anyway
+if findmnt -n -o FSTYPE / | grep -q btrfs; then
+  echo "Detected btrfs filesystem - installing snapper..."
+
+  sudo pacman -S --noconfirm --needed snapper
+
+  # Configure snapper for root subvolume
+  sudo snapper -c root create-config /
+
+  # Set up reasonable defaults
+  sudo snapper -c root set-config TIMELINE_CREATE=yes
+  sudo snapper -c root set-config TIMELINE_CLEANUP=yes
+  sudo snapper -c root set-config NUMBER_CLEANUP=yes
+  sudo snapper -c root set-config NUMBER_LIMIT=10
+
+  # Create initial snapshot
+  sudo snapper -c root create --description "omarchy-initial-install"
+
+  echo -e "\e[32m[PASS]\e[0m Snapper configured and ready"
+else
+  echo "Non-btrfs filesystem detected - skipping snapper installation"
+fi
+


### PR DESCRIPTION
The motivation for this PR is to provide a clean way to take system snapshots before `omarchy-update` runs. I currently use my own script https://github.com/JamesShelley/arch-backup/blob/master/update.sh to provide a way to check for updates, then update if necessary (creating a snapshot first). This PR aims to introduce the intermediary snapshot step into `omarchy-update`

This PR adds snapper to the initial omarchy install for btrfs file systems (recommended by omarchy manual during arch setup). omarchy-update will then also use omarchy-snapshot as the first step. This is a soft check, and failures will not prevent the rest of the update from happening.

<img width="1875" height="652" alt="image" src="https://github.com/user-attachments/assets/a48c11df-c9ba-4b93-aa13-1c8be44d57f8" />

Snapper is a very commonly used package to automate snapshots, and works great with btrfs file systems. I think adding a snapshot before the update runs feels like a logical 1st step of the update. 

The install script has been amended to install snapper from the official arch repo using pacman.

I have tested this with the following different scenarios:

New installations:
  - During Omarchy install, `/install/config/snapshots.sh` detects btrfs filesystem and automatically installs snapper
  - Creates root config with timeline cleanup enabled and 10 snapshot limit
  - Creates initial snapshot tagged "omarchy-initial-install"

Existing users without snapper:
  - When `omarchy-update` runs, `omarchy-snapshot` shows warning that snapper isn't installed
  - Prompts user to install and configure (y/N)
  - If accepted, installs snapper and applies same config as new installations
  - Proceeds to create pre-update snapshot
  - If declined, update continues without snapshot

Existing users with snapper installed and root volume configured:
  - `omarchy-snapshot` automatically creates pre-update snapshot with timestamp
  - No user interaction required
  - Update proceeds normally after snapshot creation

Existing users with snapper installed and no root volume configured:
  - `omarchy-snapshot` shows warning that snapper isn't configured for root
  - Prompts user to configure root volume (y/N) - this is done automatically.
  - If accepted, creates root config and proceeds to create pre-update snapshot
  - If declined, update continues without snapshot

This should have everything covered 👍