### PR TITLE
Add yazi as an alternative terminal-based file manager

### DIFF
--- a/bin/omarchy-install-yazi
+++ b/bin/omarchy-install-yazi
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Configure Yazi file manager with plugins and custom settings
+if command -v yazi &>/dev/null; then
+    mkdir -p ~/.config/yazi
+
+    # Install Yazi plugins ya pkg add yazi-rs/plugins:full-border
+    ya pkg add AnirudhG07/plugins-yazi:copy-file-contents
+    ya pkg add yazi-rs/plugins:full-border
+
+    # Create init.lua configuration
+    cat >~/.config/yazi/init.lua <<'EOF'
+  -- Show symlink in status bar
+  Status:children_add(function(self)
+  local h = self._current.hovered
+  if h and h.link_to then
+      return " -> " .. tostring(h.link_to)
+  else
+      return ""
+  end
+end, 3300, Status.LEFT)
+
+-- Show user/group of files in status bar
+Status:children_add(function()
+local h = cx.active.current.hovered
+if not h or ya.target_family() ~= "unix" then
+    return ""
+end
+return ui.Line({
+    ui.Span(ya.user_name(h.cha.uid) or tostring(h.cha.uid)):fg("magenta"),
+    ":",
+    ui.Span(ya.group_name(h.cha.gid) or tostring(h.cha.gid)):fg("magenta"),
+    " ",
+})
+end, 500, Status.RIGHT)
+
+-- Plugins
+-- Copy file content (Use "ya pkg add AnirudhG07/plugins-yazi:copy-file-contents" to install on new environments)
+require("copy-file-contents"):setup({
+    append_char = "\n",
+    notification = true,
+})
+-- Full-border line (Use "ya pkg add yazi-rs/plugins:full-border")
+require("full-border"):setup({
+    type = ui.Border.PLAIN,
+})
+EOF
+
+    # Create keymap.toml configuration
+    cat >~/.config/yazi/keymap.toml <<'EOF'
+  [mgr]
+  prepend_keymap = [
+    { on = [ "<A-y>" ], run = "plugin copy-file-contents", desc = "Copy file contents" },
+    ]
+EOF
+
+    echo "Yazi has been configured with plugins and custom settings"
+else
+    echo "Yazi is not installed. Please install yazi first."
+fi

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -4,6 +4,7 @@ $browser = uwsm app -- chromium --new-window --ozone-platform=wayland
 $webapp = $browser --app
 
 bindd = SUPER, return, Terminal, exec, $terminal
+bindd = SUPER SHIFT, F, File Manager (Yazi), exec, $terminal -e yazi
 bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window
 bindd = SUPER, B, Browser, exec, $browser
 bindd = SUPER, M, Music, exec, uwsm app -- spotify

--- a/install/desktop/desktop.sh
+++ b/install/desktop/desktop.sh
@@ -4,6 +4,7 @@ yay -S --noconfirm --needed \
   brightnessctl playerctl pamixer wiremix wireplumber \
   fcitx5 fcitx5-gtk fcitx5-qt wl-clip-persist \
   nautilus sushi ffmpegthumbnailer gvfs-mtp \
+  yazi \
   slurp satty \
   mpv evince imv \
   chromium
@@ -14,3 +15,5 @@ if lspci | grep -qi 'nvidia'; then
 else
   yay -S --noconfirm --needed wl-screenrec
 fi
+
+omarchy-install-yazi

--- a/install/desktop/desktop.sh
+++ b/install/desktop/desktop.sh
@@ -4,7 +4,7 @@ yay -S --noconfirm --needed \
   brightnessctl playerctl pamixer wiremix wireplumber \
   fcitx5 fcitx5-gtk fcitx5-qt wl-clip-persist \
   nautilus sushi ffmpegthumbnailer gvfs-mtp \
-  yazi \
+  yazi ueberzugpp \
   slurp satty \
   mpv evince imv \
   chromium


### PR DESCRIPTION
# Add Yazi Terminal File Manager as Alternative to Nautilus

## Overview
Adds Yazi, a fast terminal-based file manager, as an alternative to Nautilus. Users can now choose between a GUI file manager (Nautilus) and a terminal-based one (Yazi) with vim-like navigation.

## Changes Made

### New Features
- **New keybinding**: `SUPER + SHIFT + F` opens Yazi in terminal
- **Existing keybinding preserved**: `SUPER + F` still opens Nautilus
- **Automatic configuration**: Yazi comes pre-configured with useful plugins and settings
  - For example press \<Alt-y\> over a file to yank its content to system clipboard without having to open it (useful when you want to paste to LLMs)

### Files Added/Modified

#### Installation & Configuration
- `install/desktop/desktop.sh` - Added yazi package installation
- `bin/omarchy-install-yazi` - New script to configure Yazi with plugins and settings

#### Keybindings
- `config/hypr/bindings.conf` - Added `SUPER + SHIFT + F` binding for Yazi

### Yazi Configuration Includes
- **Plugins**:
  - `full-border` - For better visual separation
  - `copy-file-contents` - Copy file contents with `Alt + Y`
- **Status bar enhancements**:
  - Symlink targets display
  - User/group permissions display
- **Pre-configured keymaps** for common operations

Yazi comes with its own pkg manager called ya, use `ya pkg add "plugin_name"` to install new plugins. The list of all available plugins is here: https://yazi-rs.github.io/docs/resources

## User Experience

### Quick Start
1. Press `SUPER + SHIFT + F` to open Yazi
2. Navigate with `j/k + h/l` (vim-style) or arrow keys
3. Press `Alt + Y` on any text file to copy its contents
4. Press `q` to quit

### Image preview
Yazi can display images on the terminal, the list of supported terminals can be found here: https://yazi-rs.github.io/docs/image-preview

This feature also works for Alacritty even thought it doesn't support displaying images by itself, the explanation on how they achieved this can be found in the previous link.

## Benefits
- **Choice**: Users can pick GUI or terminal-based file management
- **Speed**: Yazi is extremely fast for keyboard-driven workflows
- **Vim-like navigation**: Familiar for developers using vim/neovim
- **Plugin ecosystem**: Extensible with additional Yazi plugins
- **Zero disruption**: Existing Nautilus workflow unchanged

## Testing
Tested on a fresh Omarchy installation in VirtualBox:
- [x] Yazi installs and configures automatically
- [x] Keybindings work correctly
- [x] Plugins function as expected
- [x] No conflicts with existing Nautilus workflow