### PR TITLE
add workspace switching keyboard shortcuts

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -56,6 +56,9 @@ bindd = SUPER SHIFT, equal, Expand window down, resizeactive, 0 100
 # Scroll through existing workspaces with SUPER + scroll
 bindd = SUPER, mouse_down, Scroll active workspace forward, workspace, e+1
 bindd = SUPER, mouse_up, Scroll active workspace backward, workspace, e-1
+bindd = SUPER, bracketright, Scroll active workspace forward, workspace, e+1
+bindd = SUPER, bracketleft, Scroll active workspace backward, workspace, e-1
+bindd = SUPER, backslash, Switch to the previous workspace, workspace, previous
 
 # Move/resize windows with mainMod + LMB/RMB and dragging
 bindmd = SUPER, mouse:272, Move window, movewindow


### PR DESCRIPTION
This change introduces keyboard shortcuts that allow for keyboard-based workspace navigation.

I think the shortcut `SUPER + \` binding for switching to the previous workspace, i think it is very useful when switching between workspaces (e.g., IDE workspace and browser workspace).

While workspace switching with `e+1` and `e-1` is already available through mouse scroll, this functionality doesn't work with touchpads. 