### PR TITLE
Added SUPER Tab and SUPER SHIFT Tab for cycling through workspaces

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -53,6 +53,10 @@ bindd = SUPER, equal, Shrink window left, resizeactive, 100 0
 bindd = SUPER SHIFT, minus, Shrink window up, resizeactive, 0 -100
 bindd = SUPER SHIFT, equal, Expand window down, resizeactive, 0 100
 
+# Navigate through active workspaces with SUPER + Tab
+bindd = SUPER, Tab, Next active workspace, workspace, m+1
+bindd = SUPER SHIFT, Tab, Previous active workspace, workspace, m-1
+
 # Scroll through existing workspaces with SUPER + scroll
 bindd = SUPER, mouse_down, Scroll active workspace forward, workspace, e+1
 bindd = SUPER, mouse_up, Scroll active workspace backward, workspace, e-1


### PR DESCRIPTION
Motivation:

Needed a keyboard-only way to navigate between active workspaces. SUPER Tab to move forward, and SUPER SHIFT Tab to go backwards, not that different from Windows or Mac or other Linux windowing systems