### PR TITLE
xtras: add Wayland+IME launchers for Discord and Obsidian

### DIFF
--- a/applications/xtras/discord.desktop
+++ b/applications/xtras/discord.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Discord (Wayland + IME)
+GenericName=Internet Messenger
+Comment=Discord client with native Wayland and IME enabled
+Exec=discord --ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime %U
+Terminal=false
+Type=Application
+Icon=discord
+Categories=Network;Chat;InstantMessaging;
+StartupNotify=true

--- a/applications/xtras/obsidian.desktop
+++ b/applications/xtras/obsidian.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Obsidian (Wayland + IME)
+GenericName=Markdown Knowledge Base
+Comment=Obsidian with native Wayland and IME enabled
+Exec=obsidian --ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime %U
+Terminal=false
+Type=Application
+Icon=obsidian
+Categories=Office;Utility;
+StartupNotify=true


### PR DESCRIPTION
The motivation for this PR is to provide a clean way to run Discord and Obsidian under native Wayland with IME support enabled.

Currently, Electron-based apps like Discord and Obsidian default to XWayland, which prevents proper input method handling (e.g., switching between Greek ↔ English layouts).

This PR introduces .desktop launchers that allow users to opt-in to running these apps with the necessary flags.

**What this PR adds**
Adds two .desktop files under applications/xtras/:
- discord.desktop
- obsidian.desktop

Both use the following flags:
`--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime`
