### PR TITLE
Add eu Keyboard layout

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -2,7 +2,7 @@
 # See https://wiki.hypr.land/Configuring/Variables/#input
 input {
   # Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
-  # kb_layout = us,dk
+  # kb_layout = us,dk,eu
   kb_options = compose:caps # ,grp:alts_toggle
 
   # Change speed of keyboard repeat
@@ -11,6 +11,8 @@ input {
 
   # Increase sensitity for mouse/trackpack (default: 0)
   # sensitivity = 0.35
+
+  # natural_scroll = true
 
   touchpad {
     # Use natural (inverse) scrolling


### PR DESCRIPTION
It might be helpful for those europoors like me, who use e.g. lofree keyboards without ISO layout, to use eu layout. Thats why I added it to the options https://eurkey.steffen.bruentjen.eu

Also, i find myself using natural scroll for mouse as well. Added it to the block as helpful reminder for new users, that it can be added to to the non-touchpad section as well.