### PR TITLE
Add optional dep for power-profiles-daemon

### DIFF
--- a/install/config/power.sh
+++ b/install/config/power.sh
@@ -2,7 +2,7 @@
 
 # Setting the performance profile can make a big difference. By default, most systems seem to start in balanced mode,
 # even if they're not running off a battery. So let's make sure that's changed to performance.
-yay -S --noconfirm power-profiles-daemon
+yay -S --noconfirm power-profiles-daemon python-gobject
 
 if ls /sys/class/power_supply/BAT* &>/dev/null; then
   # This computer runs on a battery


### PR DESCRIPTION
While installing Omarchy I ran into this error, which is caused by `install/config/power.sh` when selecting a specific power profile:

```
Traceback (most recent call last):
  File "/usr/bin/powerprofilesctl", line 8, in <module>
    from gi.repository import Gio, GLib
ModuleNotFoundError: No module named 'gi'
```

The issue is that [power-profiles-daemon](https://archlinux.org/packages/extra/x86_64/power-profiles-daemon/) has an optional dependency on `python-gobject`:

`python-gobject (optional) - for powerprofilesctl`

This PR adds this `python-gobject` as a dependency, which resolves the error mentioned above. 