### PR TITLE
Use `bat` instead of `cat`

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -24,6 +24,7 @@ alias ...='cd ../..'
 alias ....='cd ../../..'
 
 # Tools
+alias cat='bat'
 alias g='git'
 alias d='docker'
 alias r='rails'


### PR DESCRIPTION
Get syntax highlighting and paging when using `cat`.

No need for a migration because `aliases` is sourced directly from Omarchy, and `bat` is already installed for use with `ff`.