### PR TITLE
add: helix themes for every default omarchy theme

### DIFF
--- a/themes/catppuccin-latte/helix.toml
+++ b/themes/catppuccin-latte/helix.toml
@@ -1,0 +1,161 @@
+# NOTE: This is just a copy of the default helix catppuchin-latte theme with transparent bg to fit in omarchy
+# -------------------
+"attribute" = "yellow"
+
+"type" = "yellow"
+"type.enum.variant" = "teal"
+
+"constructor" = "sapphire"
+
+"constant" = "peach"
+"constant.character" = "teal"
+"constant.character.escape" = "pink"
+
+"string" = "green"
+"string.regexp" = "pink"
+"string.special" = "blue"
+"string.special.symbol" = "red"
+
+"comment" = { fg = "overlay2", modifiers = ["italic"] }
+
+"variable" = "text"
+"variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
+"variable.builtin" = "red"
+"variable.other.member" = "blue"
+
+"label" = "sapphire" # used for lifetimes
+
+"punctuation" = "overlay2"
+"punctuation.special" = "sky"
+
+"keyword" = "mauve"
+"keyword.control.conditional" = { fg = "mauve", modifiers = ["italic"] }
+
+"operator" = "sky"
+
+"function" = "blue"
+"function.macro" = "mauve"
+
+"tag" = "blue"
+
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
+
+"special" = "blue" # fuzzy highlight
+
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "sapphire"
+"markup.heading.6" = "lavender"
+"markup.list" = "teal"
+"markup.list.unchecked" = "overlay2"
+"markup.list.checked" = "green"
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
+"markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
+"markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
+"markup.raw" = "green"
+"markup.quote" = "pink"
+
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "blue"
+
+# User Interface
+# --------------
+"ui.background" = {  fg = "text" }
+
+"ui.linenr" = { fg = "surface1" }
+"ui.linenr.selected" = { fg = "lavender" }
+
+"ui.statusline" = { fg = "subtext1", bg = "mantle" }
+"ui.statusline.inactive" = { fg = "surface2", bg = "mantle" }
+"ui.statusline.normal" = { fg = "base", bg = "rosewater", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "base", bg = "green", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "base", bg = "lavender", modifiers = ["bold"] }
+
+"ui.popup" = { fg = "text", bg = "surface0" }
+"ui.window" = { fg = "crust" }
+"ui.help" = { fg = "overlay2", bg = "surface0" }
+
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "mauve", bg = "base", underline = { color = "mauve", style = "line" } }
+"ui.bufferline.background" = { bg = "crust" }
+
+"ui.text" = "text"
+"ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
+"ui.text.inactive" = { fg = "overlay1" }
+"ui.text.directory" = { fg = "blue" }
+
+"ui.virtual" = "overlay0"
+"ui.virtual.ruler" = { bg = "surface0" }
+"ui.virtual.indent-guide" = "surface0"
+"ui.virtual.inlay-hint" = { fg = "surface1", bg = "mantle" }
+"ui.virtual.jump-label" = { fg = "rosewater", modifiers = ["bold"] }
+
+"ui.selection" = { bg = "surface1" }
+
+"ui.cursor" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.primary" = { fg = "base", bg = "rosewater" }
+"ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
+
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
+"ui.cursor.primary.insert" = { fg = "base", bg = "green" }
+"ui.cursor.primary.select" = { fg = "base", bg = "lavender" }
+
+"ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
+"ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
+
+"ui.cursorline.primary" = { bg = "cursorline" }
+
+"ui.highlight" = { bg = "surface1", modifiers = ["bold"] }
+
+"ui.menu" = { fg = "overlay2", bg = "surface0" }
+"ui.menu.selected" = { fg = "text", bg = "surface1", modifiers = ["bold"] }
+
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.info" = { underline = { color = "sky", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+
+error = "red"
+warning = "yellow"
+info = "sky"
+hint = "teal"
+
+[palette]
+rosewater = "#dc8a78"
+flamingo = "#dd7878"
+pink = "#ea76cb"
+mauve = "#8839ef"
+red = "#d20f39"
+maroon = "#e64553"
+peach = "#fe640b"
+yellow = "#df8e1d"
+green = "#40a02b"
+teal = "#179299"
+sky = "#04a5e5"
+sapphire = "#209fb5"
+blue = "#1e66f5"
+lavender = "#7287fd"
+text = "#4c4f69"
+subtext1 = "#5c5f77"
+subtext0 = "#6c6f85"
+overlay2 = "#7c7f93"
+overlay1 = "#8c8fa1"
+overlay0 = "#9ca0b0"
+surface2 = "#acb0be"
+surface1 = "#bcc0cc"
+surface0 = "#ccd0da"
+base = "#eff1f5"
+mantle = "#e6e9ef"
+crust = "#dce0e8"
+
+cursorline = "#e8ecf1"
+secondary_cursor = "#e1a99d"
+secondary_cursor_normal = "#97a7fb"
+secondary_cursor_insert = "#74b867"

--- a/themes/catppuccin/helix.toml
+++ b/themes/catppuccin/helix.toml
@@ -1,0 +1,162 @@
+# NOTE: This is just a copy of the default helix catppuchin theme with transparent bg to fit in omarchy
+# -------------------
+"attribute" = "yellow"
+
+"type" = "yellow"
+"type.enum.variant" = "teal"
+
+"constructor" = "sapphire"
+
+"constant" = "peach"
+"constant.character" = "teal"
+"constant.character.escape" = "pink"
+
+"string" = "green"
+"string.regexp" = "pink"
+"string.special" = "blue"
+"string.special.symbol" = "red"
+
+"comment" = { fg = "overlay2", modifiers = ["italic"] }
+
+"variable" = "text"
+"variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
+"variable.builtin" = "red"
+"variable.other.member" = "blue"
+
+"label" = "sapphire" # used for lifetimes
+
+"punctuation" = "overlay2"
+"punctuation.special" = "sky"
+
+"keyword" = "mauve"
+"keyword.control.conditional" = { fg = "mauve", modifiers = ["italic"] }
+
+"operator" = "sky"
+
+"function" = "blue"
+"function.macro" = "mauve"
+
+"tag" = "blue"
+
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
+
+"special" = "blue" # fuzzy highlight
+
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "sapphire"
+"markup.heading.6" = "lavender"
+"markup.list" = "teal"
+"markup.list.unchecked" = "overlay2"
+"markup.list.checked" = "green"
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
+"markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
+"markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
+"markup.raw" = "green"
+"markup.quote" = "pink"
+
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "blue"
+
+# User Interface
+# --------------
+"ui.background" = { fg = "text" }
+
+"ui.linenr" = { fg = "surface1" }
+"ui.linenr.selected" = { fg = "lavender" }
+
+"ui.statusline" = { fg = "subtext1", bg = "mantle" }
+"ui.statusline.inactive" = { fg = "surface2", bg = "mantle" }
+"ui.statusline.normal" = { fg = "base", bg = "rosewater", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "base", bg = "green", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "base", bg = "lavender", modifiers = ["bold"] }
+
+"ui.popup" = { fg = "text", bg = "surface0" }
+"ui.window" = { fg = "crust" }
+"ui.help" = { fg = "overlay2", bg = "surface0" }
+
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "mauve", bg = "base", underline = { color = "mauve", style = "line" } }
+"ui.bufferline.background" = { bg = "crust" }
+
+"ui.text" = "text"
+"ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
+"ui.text.inactive" = { fg = "overlay1" }
+"ui.text.directory" = { fg = "blue" }
+
+"ui.virtual" = "overlay0"
+"ui.virtual.ruler" = { bg = "surface0" }
+"ui.virtual.indent-guide" = "surface0"
+"ui.virtual.inlay-hint" = { fg = "surface1", bg = "mantle" }
+"ui.virtual.jump-label" = { fg = "rosewater", modifiers = ["bold"] }
+
+"ui.selection" = { bg = "surface1" }
+
+"ui.cursor" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.primary" = { fg = "base", bg = "rosewater" }
+"ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
+
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
+"ui.cursor.primary.insert" = { fg = "base", bg = "green" }
+"ui.cursor.primary.select" = { fg = "base", bg = "lavender" }
+
+"ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
+"ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
+
+"ui.cursorline.primary" = { bg = "cursorline" }
+
+"ui.highlight" = { bg = "surface1", modifiers = ["bold"] }
+
+"ui.menu" = { fg = "overlay2", bg = "surface0" }
+"ui.menu.selected" = { fg = "text", bg = "surface1", modifiers = ["bold"] }
+
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.info" = { underline = { color = "sky", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+
+error = "red"
+warning = "yellow"
+info = "sky"
+hint = "teal"
+
+[palette]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"
+
+cursorline = "#2a2b3c"
+secondary_cursor = "#b5a6a8"
+secondary_cursor_select = "#878ec0"
+secondary_cursor_normal = "#b5a6a8"
+secondary_cursor_insert = "#7ea87f"

--- a/themes/everforest/helix.toml
+++ b/themes/everforest/helix.toml
@@ -1,0 +1,151 @@
+# Everforest (Dark Medium)
+# Authors: CptPotato, basbebe
+
+# Original Author:
+# URL: https://github.com/sainnhe/everforest
+# Filename: colors/everforest.vim
+# Author: sainnhe
+# Email: sainnhe@gmail.com
+# License: MIT License
+#
+# NOTE: This is just a copy of the default helix everforest theme with transparent bg to fit in omarchy
+
+"type" = "yellow"
+"constant" = "fg"
+"constant.builtin" = { fg = "purple", modifiers = ["italic"] }
+"constant.builtin.boolean" = "purple"
+"constant.numeric" = "purple"
+"constant.character.escape" = "green"
+"string" = "aqua"
+"string.regexp" = "green"
+"string.special" = "yellow"
+"comment" = { fg = "grey1", modifiers = ["italic"] }
+"variable" = "fg"
+"variable.builtin" = { fg = "purple", modifiers = ["italic"] }
+"variable.parameter" = "fg"
+"variable.other.member" = "blue"
+"label" = "orange"
+"punctuation" = "grey2"
+"punctuation.delimiter" = "grey1"
+"punctuation.bracket" = "fg"
+"punctuation.special" = "blue"
+"keyword" = "red"
+"keyword.operator" = "orange"
+"keyword.directive" = "purple"
+"keyword.storage" = "red"
+"operator" = "orange"
+"function" = "green"
+"function.macro" = "green"
+"tag" = "orange"
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
+"attribute" = { fg = "purple", modifiers = ["italic"] }
+"constructor" = "green"
+"module" = "yellow"
+"special" = "blue"
+"ui.virtual.jump-label" = { fg = "#00dfff", modifiers = ["bold"] }
+
+"markup.heading.marker" = "grey1"
+"markup.heading.1" = { fg = "red", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "orange", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "yellow", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "blue", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "purple", modifiers = ["bold"] }
+"markup.list" = "red"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "blue", underline = { style = "line" } }
+"markup.link.label" = "orange"
+"markup.link.text" = "purple"
+"markup.quote" = "grey1"
+"markup.raw.inline" = "green"
+"markup.raw.block" = "aqua"
+
+"diff.plus" = "green"
+"diff.delta" = "blue"
+"diff.minus" = "red"
+
+"ui.background" = { }
+"ui.background.separator" = "grey0"
+"ui.cursor" = { fg = "bg1", bg = "grey2" }
+"ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
+"ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursor.match" = { fg = "orange", bg = "bg_yellow" }
+"ui.cursor.primary" = { fg = "bg0", bg = "fg" }
+"ui.cursorline.primary" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg2" }
+"ui.selection" = { bg = "bg3" }
+"ui.linenr" = "grey0"
+"ui.linenr.selected" = "grey2"
+"ui.statusline" = { fg = "grey2", bg = "bg3" }
+"ui.statusline.inactive" = { fg = "grey0", bg = "bg1" }
+"ui.statusline.normal" = { fg = "bg0", bg = "statusline1", modifiers = [
+  "bold",
+] }
+"ui.statusline.insert" = { fg = "bg0", bg = "statusline2", modifiers = [
+  "bold",
+] }
+"ui.statusline.select" = { fg = "bg0", bg = "blue", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "grey2", bg = "bg3" }
+"ui.bufferline.active" = { fg = "bg0", bg = "statusline1", modifiers = [
+  "bold",
+] }
+"ui.popup" = { fg = "grey2", bg = "bg2" }
+"ui.picker.header" = { modifiers = ["bold", "underlined"] }
+"ui.window" = { fg = "bg4", bg = "bg_dim" }
+"ui.help" = { fg = "fg", bg = "bg2" }
+"ui.text" = "fg"
+"ui.text.directory" = { fg = "green" }
+"ui.text.focus" = "fg"
+"ui.menu" = { fg = "fg", bg = "bg3" }
+"ui.menu.selected" = { fg = "bg0", bg = "green" }
+"ui.virtual.ruler" = { bg = "bg3" }
+"ui.virtual.whitespace" = { fg = "bg4" }
+"ui.virtual.indent-guide" = { fg = "bg4" }
+"ui.virtual.inlay-hint" = { fg = "grey0" }
+"ui.virtual.wrap" = { fg = "grey0" }
+
+"hint" = "green"
+"info" = "blue"
+"warning" = "yellow"
+"error" = "red"
+
+"diagnostic.hint" = { underline = { color = "green", style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+[palette]
+
+bg_dim = "#232a2e"
+bg0 = "#2d353b"
+bg1 = "#343f44"
+bg2 = "#3d484d"
+bg3 = "#475258"
+bg4 = "#4f585e"
+bg5 = "#56635f"
+bg_visual = "#543a48"
+bg_red = "#514045"
+bg_green = "#425047"
+bg_blue = "#3a515d"
+bg_yellow = "#4d4c43"
+
+fg = "#d3c6aa"
+red = "#e67e80"
+orange = "#e69875"
+yellow = "#dbbc7f"
+green = "#a7c080"
+aqua = "#83c092"
+blue = "#7fbbb3"
+purple = "#d699b6"
+
+grey0 = "#7a8478"
+grey1 = "#859289"
+grey2 = "#9da9a0"
+
+statusline1 = "#a7c080"
+statusline2 = "#d3c6aa"
+statusline3 = "#e67e80"

--- a/themes/gruvbox/helix.toml
+++ b/themes/gruvbox/helix.toml
@@ -1,0 +1,154 @@
+# Author : Jakub Bartodziej <kubabartodziej@gmail.com>
+# The theme uses the gruvbox dark palette with standard contrast: github.com/morhetz/gruvbox
+# NOTE: This is just a copy of the default helix gruvbox theme with transparent bg to fit in omarchy
+
+"annotation" = { fg = "fg1" }
+
+"attribute" = { fg = "aqua1", modifiers = ["italic"] }
+
+"comment" = { fg = "gray", modifiers = ["italic"] }
+
+"constant" = { fg = "purple1" }
+"constant.character" = { fg = "aqua1" }
+"constant.character.escape" = { fg = "orange1" }
+"constant.macro" = { fg = "aqua1" }
+"constructor" = { fg = "purple1" }
+
+"definition" = { underline = { color = "aqua1" } }
+
+"diagnostic" = { underline = { color = "orange1", style = "curl" } }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+"diagnostic.error" = { underline = { color = "red1", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "blue1", style = "curl" } }
+"diagnostic.info" = { underline = { color = "aqua1", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow1", style = "curl" } }
+# "diagnostic.unnecessary" = { modifiers = ["dim"] }  # do not remove this for future resolving
+
+"error" = { fg = "red1" }
+"hint" = { fg = "blue1" }
+"info" = { fg = "aqua1" }
+"warning" = { fg = "yellow1" }
+
+"diff.delta" = { fg = "yellow1" }
+"diff.minus" = { fg = "red1" }
+"diff.plus" = { fg = "green1" }
+
+"function" = { fg = "green1" }
+"function.builtin" = { fg = "yellow1" }
+"function.macro" = { fg = "blue1" }
+
+"keyword" = { fg = "red1" }
+"keyword.control.import" = { fg = "aqua1" }
+
+"label" = { fg = "red1" }
+
+"markup.bold" = { modifiers = ["bold"] }
+"markup.heading" = "aqua1"
+"markup.italic" = { modifiers = ["italic"] }
+"markup.link.text" = "red1"
+"markup.link.url" = { fg = "green1", modifiers = ["underlined"] }
+"markup.raw" = "red1"
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+
+"module" = { fg = "aqua1" }
+
+"namespace" = { fg = "fg1" }
+
+"operator" = { fg = "purple1" }
+
+"punctuation" = { fg = "orange1" }
+
+"special" = { fg = "purple0" }
+
+"string" = { fg = "green1" }
+"string.regexp" = { fg = "orange1" }
+"string.special" = { fg = "orange1" }
+"string.symbol" = { fg = "yellow1" }
+
+"tag" = { fg = "aqua1" }
+
+"type" = { fg = "yellow1" }
+"type.enum.variant" = { modifiers = ["italic"] }
+
+"ui.background" = { }
+"ui.bufferline" = { fg = "fg1", bg = "bg1" }
+"ui.bufferline.active" = { fg = "bg0", bg = "yellow0" }
+"ui.bufferline.background" = { bg = "bg2" }
+
+"ui.cursor" = { fg = "bg1", bg = "bg2" }
+"ui.cursor.insert" = { fg = "bg1", bg = "blue0" }
+"ui.cursor.normal" = { fg = "bg1", bg = "gray" }
+"ui.cursor.select" = { fg = "bg1", bg = "orange0" }
+"ui.cursor.match" = { fg = "fg3", bg = "bg3" }
+
+"ui.cursor.primary" = { bg = "fg3", fg = "bg1" }
+"ui.cursor.primary.insert" = { fg = "bg1", bg = "blue1" }
+"ui.cursor.primary.normal" = { fg = "bg1", bg = "fg3" }
+"ui.cursor.primary.select" = { fg = "bg1", bg = "orange1" }
+
+"ui.cursorline" = { bg = "bg0_s" }
+"ui.cursorline.primary" = { bg = "bg1" }
+
+"ui.help" = { bg = "bg1", fg = "fg1" }
+"ui.linenr" = { fg = "bg3" }
+"ui.linenr.selected" = { fg = "yellow1" }
+"ui.menu" = { fg = "fg1", bg = "bg2" }
+"ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
+"ui.popup" = { bg = "bg1" }
+"ui.picker.header.column" = { underline.style = "line" }
+"ui.picker.header.column.active" = { modifiers = ["bold"], underline.style = "line" }
+"ui.selection" = { bg = "bg2" }
+"ui.selection.primary" = { bg = "bg3" }
+
+"ui.statusline" = { fg = "fg1", bg = "bg2" }
+"ui.statusline.inactive" = { fg = "fg4", bg = "bg2" }
+"ui.statusline.insert" = { fg = "bg1", bg = "blue1", modifiers = ["bold"] }
+"ui.statusline.normal" = { fg = "bg1", bg = "fg3", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "bg1", bg = "orange1", modifiers = ["bold"] }
+
+"ui.text" = { fg = "fg1" }
+"ui.text.focus" = { fg = "green1" }
+"ui.text.directory" = { fg = "blue1" }
+"ui.virtual.inlay-hint" = { fg = "gray" }
+"ui.virtual.jump-label" = { fg = "purple0", modifiers = ["bold"] }
+"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.whitespace" = "bg2"
+"ui.virtual.wrap" = { fg = "bg2" }
+"ui.window" = { bg = "bg1" }
+
+"variable" = { fg = "fg1" }
+"variable.builtin" = { fg = "orange1", modifiers = ["italic"] }
+"variable.other.member" = { fg = "blue1" }
+"variable.parameter" = { fg = "blue1", modifiers = ["italic"] }
+
+
+[palette]
+bg0 = "#282828"   # main background
+bg0_s = "#32302f"
+bg1 = "#3c3836"
+bg2 = "#504945"
+bg3 = "#665c54"
+bg4 = "#7c6f64"
+
+fg0 = "#fbf1c7"
+fg1 = "#ebdbb2" # main foreground
+fg2 = "#d5c4a1"
+fg3 = "#bdae93"
+fg4 = "#a89984"
+
+gray = "#928374"
+
+red0 = "#cc241d"    # neutral
+red1 = "#fb4934"    # bright
+green0 = "#98971a"
+green1 = "#b8bb26"
+yellow0 = "#d79921"
+yellow1 = "#fabd2f"
+blue0 = "#458588"
+blue1 = "#83a598"
+purple0 = "#b16286"
+purple1 = "#d3869b"
+aqua0 = "#689d6a"
+aqua1 = "#8ec07c"
+orange0 = "#d65d0e"
+orange1 = "#fe8019"

--- a/themes/kanagawa/helix.toml
+++ b/themes/kanagawa/helix.toml
@@ -1,0 +1,162 @@
+# Kanagawa
+# Author: zetashift
+
+# Adaptation of https://github.com/rebelot/kanagawa.nvim
+# Original author: rebelot
+# All credits to the original author, the palette is taken from the README
+# because of some theming differences, it's not an exact copy of the original.
+
+# NOTE: This is just a copy of the default helix kanagawa theme with transparent bg to fit in omarchy
+# 
+## User interface
+"ui.selection" = { bg = "waveBlue2" }
+"ui.selection.primary" = { bg = "waveBlue2" }
+"ui.background" = { fg = "fujiWhite" }
+
+"ui.linenr" = { fg = "sumiInk6" }
+"ui.linenr.selected" = { fg = "roninYellow", modifiers = ["bold"] }
+"ui.gutter" = { fg = "sumiInk6" }
+
+"ui.virtual" = "sumiInk6"
+"ui.virtual.ruler" = { bg = "sumiInk4" }
+"ui.virtual.inlay-hint" = "sumiInk6"
+"ui.virtual.jump-label" = { fg = "peachRed", modifiers = ["bold"] }
+
+"ui.statusline" = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.statusline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }
+"ui.statusline.normal" = { fg = "sumiInk0", bg = "crystalBlue", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "sumiInk0", bg = "autumnGreen", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "sumiInk0", bg = "oniViolet", modifiers = ["bold"] }
+
+"ui.bufferline" = { fg = "fujiGray", bg = "sumiInk0" }
+"ui.bufferline.active" = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.bufferline.background" = { bg = "sumiInk0" }
+
+"ui.popup" = { fg = "fujiWhite", bg = "sumiInk0" }
+"ui.window" = { fg = "sumiInk0" }
+"ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
+"ui.text" = "fujiWhite"
+"ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
+
+"ui.cursor" = { fg = "waveBlue1", bg = "waveAqua2" }
+"ui.cursor.primary" = { fg = "waveBlue1", bg = "fujiWhite" }
+"ui.cursor.match" = { fg = "waveRed", modifiers = ["bold"] }
+"ui.highlight" = { fg = "fujiWhite", bg = "waveBlue2" }
+"ui.menu" = { fg = "fujiWhite", bg = "waveBlue1" }
+"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "oldWhite", bg = "waveBlue1" }
+
+"ui.cursorline.primary" = { bg = "sumiInk5" }
+"ui.cursorcolumn.primary" = { bg = "sumiInk5" }
+
+"ui.debug.breakpoint" = "springBlue"
+"ui.debug.active" = "winterRed"
+
+"diagnostic.error" = { underline = { color = "samuraiRed", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "roninYellow", style = "curl" } }
+"diagnostic.info" = { underline = { color = "dragonBlue", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "waveAqua1", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+error = "samuraiRed"
+warning = "roninYellow"
+info = "dragonBlue"
+hint = "waveAqua1"
+
+## Diff
+"diff.plus" = "autumnGreen"
+"diff.minus" = "autumnRed"
+"diff.delta" = "autumnYellow"
+
+## Syntax highlighting
+"attribute" = "waveRed"
+"type" = "waveAqua2"
+"type.builtin" = "springBlue"
+"constructor" = "springBlue"
+"constant" = "surimiOrange"
+"constant.numeric" = "sakuraPink"
+"constant.character.escape" = { fg = "boatYellow2", modifiers = ["bold"] }
+"string" = "springGreen"
+"string.regexp" = "boatYellow2"
+"string.special.url" = "springBlue"
+"string.special.symbol" = "oniViolet"
+"comment" = "fujiGray"
+"variable" = "fujiWhite"
+"variable.builtin" = "waveRed"
+"variable.parameter" = "oniViolet2"
+"variable.other.member" = "carpYellow"
+"label" = "springBlue"
+"punctuation" = "springViolet2"
+"keyword" = { fg = "oniViolet", modifiers = ["italic"] }
+"keyword.control.return" = "peachRed"
+"keyword.control.exception" = "peachRed"
+"keyword.directive" = "waveRed"
+"operator" = "boatYellow2"
+"function" = "crystalBlue"
+"function.builtin" = "springBlue"
+"function.macro" = "waveRed"
+"tag" = "waveAqua2"
+"namespace" = "surimiOrange"
+"special" = "peachRed"
+
+## Markup modifiers
+"markup.heading" = { fg = "springViolet2", modifiers = ["bold"] }
+"markup.heading.marker" = "springViolet2"
+"markup.heading.1" = { fg = "carpYellow", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "crystalBlue", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "waveAqua2", modifiers = ["bold"] }
+"markup.list" = "sakuraPink"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.text" = { fg = "springBlue" }
+"markup.link.url" = { fg = "lightBlue" }
+"markup.link.label" = "surimiOrange"
+"markup.quote" = "oniViolet2"
+"markup.raw" = "springGreen"
+
+[palette]
+oldWhite = "#C8C093"       # dark foreground, e.g. statuslines
+fujiWhite = "#DCD7BA"      # default foreground
+fujiGray = "#727169"       # comments
+sumiInk0 = "#16161D"       # dark background, e.g. statuslines, floating windows
+sumiInk1 = "#181820"       # unused
+sumiInk2 = "#1A1A22"       # unused
+sumiInk3 = "#1F1F28"       # default background
+sumiInk4 = "#2A2A37"       # lighter background, e.g. colorcolumns, folds
+sumiInk5 = "#363646"       # lighter background, e.g. cursorline
+sumiInk6 = "#54546D"       # inlay hints
+waveBlue1 = "#223249"      # popup background, visual selection background
+waveBlue2 = "#2D4F67"      # popup selection background, search background
+winterGreen = "#2B3328"    # diff add background
+winterYellow = "#49443C"   # diff change background
+winterRed = "#43242B"      # diff delete background
+winterBlue = "#252535"     # diff line background
+autumnGreen = "#76946A"    # git add
+autumnRed = "#C34043"      # git delete
+autumnYellow = "#DCA561"   # git change
+samuraiRed = "#E82424"     # diagnostic error
+roninYellow = "#FF9E3B"    # diagnostic warning
+waveAqua1 = "#6A9589"      # diagnostic info
+dragonBlue = "#658594"     # diagnostic hint
+oniViolet = "#957FB8"      # statements and keywords
+oniViolet2 = "#B8B4D0"     # parameters
+crystalBlue = "#7E9CD8"    # functions and titles
+springViolet1 = "#938AA9"  # unused
+springViolet2 = "#9CABCA"  # brackets and punctuation
+springBlue = "#7FB4CA"     # specials and builtins
+lightBlue = "#A3D4D5"      # URLs
+waveAqua2 = "#7AA89F"      # types
+waveAqua3  = "#68AD99"     # unused
+waveAqua4  = "#7AA880"     # unused
+waveAqua5  = "#6CAF95"     # unused
+springGreen = "#98BB6C"    # strings
+boatYellow1 = "#938056"    # unused
+boatYellow2 = "#C0A36E"    # operators, regex
+carpYellow = "#E6C384"     # identifiers
+sakuraPink = "#D27E99"     # numbers
+waveRed = "#E46876"        # standout specials 1, e.g. builtin variables
+peachRed = "#FF5D62"       # standout specials 2, e.g. exception handling, returns
+surimiOrange = "#FFA066"   # constants, imports, booleans
+katanaGray = "#717C7C"     # unused

--- a/themes/matte-black/helix.toml
+++ b/themes/matte-black/helix.toml
@@ -1,0 +1,194 @@
+# Matte Black theme for Helix
+# Inspired by tahayvr/matteblack.nvim - A matte black colorscheme
+# Converted from Neovim to Helix by Claude AI
+# Deep black background with subtle contrasts and elegant accents
+
+# UI Colors
+"ui.background" = { }
+"ui.background.separator" = "bg2"
+"ui.cursor" = { fg = "bg0", bg = "fg" }
+"ui.cursor.insert" = { fg = "bg0", bg = "green" }
+"ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursor.match" = { fg = "yellow", bg = "bg2" }
+"ui.cursor.primary" = { fg = "bg0", bg = "fg" }
+"ui.cursor.secondary" = { fg = "bg0", bg = "grey" }
+"ui.cursorline.primary" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.selection" = { bg = "bg2" }
+"ui.selection.primary" = { bg = "bg3" }
+"ui.linenr" = "grey"
+"ui.linenr.selected" = "fg"
+"ui.statusline" = { fg = "fg", bg = "bg2" }
+"ui.statusline.inactive" = { fg = "grey", bg = "bg1" }
+"ui.statusline.normal" = { fg = "bg0", bg = "cyan" }
+"ui.statusline.insert" = { fg = "bg0", bg = "green" }
+"ui.statusline.select" = { fg = "bg0", bg = "purple" }
+"ui.popup" = { bg = "bg1" }
+"ui.window" = { bg = "bg1" }
+"ui.help" = { bg = "bg1", fg = "fg" }
+"ui.text" = "fg"
+"ui.text.focus" = "cyan"
+"ui.text.inactive" = "grey"
+"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.whitespace" = "dark_grey"
+"ui.virtual.indent-guide" = "bg3"
+"ui.virtual.inlay-hint" = { fg = "dark_grey", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "yellow", modifiers = ["bold"] }
+
+# Menu and completion
+"ui.menu" = { fg = "fg", bg = "bg1" }
+"ui.menu.selected" = { fg = "bg0", bg = "cyan" }
+"ui.menu.scroll" = { fg = "fg", bg = "bg2" }
+
+# Gutter
+"ui.gutter" = { }
+"ui.gutter.selected" = { bg = "bg1" }
+
+# Debug
+"ui.debug.breakpoint" = "red"
+"ui.debug.active" = "yellow"
+
+# Diagnostics
+"warning" = "yellow"
+"error" = "red"
+"info" = "blue"
+"hint" = "green"
+"diagnostic.hint" = { underline = { color = "green", style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+
+# Syntax highlighting
+"type" = "cyan"
+"type.builtin" = "cyan"
+"type.parameter" = "fg"
+"type.enum" = "cyan"
+"constructor" = "cyan"
+"constant" = "orange"
+"constant.builtin" = "orange"
+"constant.builtin.boolean" = "purple"
+"constant.character" = "green"
+"constant.character.escape" = "yellow"
+"constant.numeric" = "orange"
+"constant.numeric.integer" = "orange"
+"constant.numeric.float" = "orange"
+"string" = "green"
+"string.regexp" = "red"
+"string.special" = "yellow"
+"string.special.path" = "green"
+"string.special.url" = "blue"
+"string.special.symbol" = "yellow"
+"comment" = { fg = "grey", modifiers = ["italic"] }
+"comment.line" = { fg = "grey", modifiers = ["italic"] }
+"comment.block" = { fg = "grey", modifiers = ["italic"] }
+"comment.block.documentation" = { fg = "grey", modifiers = ["italic"] }
+
+# Variables
+"variable" = "fg"
+"variable.builtin" = "purple"
+"variable.parameter" = { fg = "orange", modifiers = ["italic"] }
+"variable.other.member" = "fg"
+
+# Keywords
+"keyword" = "purple"
+"keyword.control" = "purple"
+"keyword.control.conditional" = "purple"
+"keyword.control.repeat" = "purple"
+"keyword.control.import" = "purple"
+"keyword.control.return" = "purple"
+"keyword.control.exception" = "purple"
+"keyword.operator" = "purple"
+"keyword.directive" = "purple"
+"keyword.function" = "purple"
+"keyword.storage" = "purple"
+"keyword.storage.modifier" = "purple"
+
+# Operators
+"operator" = "purple"
+
+# Functions
+"function" = "blue"
+"function.builtin" = "blue"
+"function.method" = "blue"
+"function.macro" = "red"
+"function.special" = "yellow"
+
+# Namespaces
+"namespace" = "cyan"
+
+# Tags (for markup languages)
+"tag" = "red"
+"tag.builtin" = "red"
+
+# Attributes
+"attribute" = "yellow"
+"attribute.builtin" = "yellow"
+
+# Labels
+"label" = "red"
+
+# Punctuation
+"punctuation" = "light_grey"
+"punctuation.delimiter" = "light_grey"
+"punctuation.bracket" = "light_grey"
+"punctuation.special" = "yellow"
+
+# Special
+"special" = "yellow"
+
+# Markup (for markdown, etc.)
+"markup.heading" = { fg = "cyan", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "cyan", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "blue", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "purple", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "yellow", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "orange", modifiers = ["bold"] }
+"markup.heading.marker" = "grey"
+"markup.list" = "purple"
+"markup.list.numbered" = "purple"
+"markup.list.unnumbered" = "purple"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
+"markup.link.text" = "cyan"
+"markup.quote" = "grey"
+"markup.raw" = "green"
+"markup.raw.inline" = "green"
+"markup.raw.block" = "green"
+
+# Diff
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "yellow"
+"diff.delta.moved" = "purple"
+
+# Git
+"git.delta.moved" = "purple"
+
+[palette]
+# True matte black backgrounds
+bg0 = "#0a0a0a"      # Deep matte black
+bg1 = "#121212"      # Slightly lighter black
+bg2 = "#1a1a1a"      # Lighter black for selections
+bg3 = "#262626"      # Light black for visual elements
+
+# Foreground colors
+fg = "#e4e4e4"       # Light grey text
+white = "#ffffff"    # Pure white
+light_grey = "#b4b4b4"  # Light grey for punctuation
+grey = "#6c6c6c"     # Medium grey for comments
+dark_grey = "#3a3a3a"   # Dark grey for subtle elements
+
+# Accent colors - carefully chosen for matte black aesthetic
+red = "#ff6b6b"      # Soft red
+green = "#51cf66"    # Soft green
+yellow = "#ffd43b"   # Soft yellow
+blue = "#74c0fc"     # Soft blue
+purple = "#c084fc"   # Soft purple
+cyan = "#22d3ee"     # Soft cyan
+orange = "#ff922b"   # Soft orange
+
+# Additional shades
+black = "#000000"    # Pure black

--- a/themes/nord/helix.toml
+++ b/themes/nord/helix.toml
@@ -1,0 +1,196 @@
+# Nord (Dark Ambiance) port for Helix (https://helix-editor.com/)
+# https://docs.helix-editor.com/themes.html
+# https://www.nordtheme.com/docs/colors-and-palettes
+
+# NOTE: This is just a copy of the default helix nord theme with transparent bg to fit in omarchy
+
+## SYNTAX HIGHLIGHTING
+
+# Constants
+"constant" = "nord4" 
+"constant.builtin" = "nord9"
+"constant.builtin.boolean" = "nord9"
+"constant.builtin.character" = "nord15"
+"constant.character.escape" = "nord13"
+"constant.macro" = "nord9"
+"constant.numeric" = "nord15"
+"constructor" = "nord8"
+
+# Diagnostics
+"diagnostic" = { underline = { color = "nord13", style = "curl" } }
+"diagnostic.error" = { underline = { color = "nord11", style = "curl" } }
+"error" = "nord11"
+"diagnostic.hint" = { underline = { color = "nord10", style = "curl" } }
+"hint" = "nord10"
+"diagnostic.info" = { underline = { color = "nord8", style = "curl" } }
+"info" = "nord8"
+"diagnostic.warning" = { underline = { color = "nord13", style = "curl" } }
+"warning" = "nord13"
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+# Diffs
+"diff.delta" = "nord13"
+"diff.minus" = "nord11"
+"diff.plus" = "nord14"
+
+# Functions
+"function" = "nord8"
+"function.builtin" = "nord7"
+"function.method" = "nord8"
+"function.macro" = "nord9"
+"function.special" = "nord9"
+
+# Git
+"git.delta.moved" = "nord12"
+
+# Keywords
+"keyword" = "nord9"
+"keyword.control.conditional" = "nord9"
+"keyword.control.exception" = "nord9"
+"keyword.control.repeat" = "nord9"
+"keyword.directive" = "nord9"
+"keyword.function" = "nord9"
+"keyword.operator" = "nord9"
+"keyword.return" = "nord9"
+"keyword.storage.modifier" = "nord9"
+"keyword.storage.type" = "nord9"
+
+# Punctuation
+"punctuation" = "nord6"
+"punctuation.bracket" = "nord6"
+"punctuation.delimiter" = "nord6"
+"punctuation.special" = "nord9"
+
+# Strings
+"string" = "nord14"
+"string.escape" = "nord13"
+"string.regex" = "nord13"
+"string.special" = "nord13"
+
+# Types
+"type" = "nord7"
+"type.builtin" = "nord7"
+
+# Variables
+"variable" = "nord4"
+"variable.builtin" = "nord9"
+"variable.other.member" = "nord4"
+"variable.parameter" = "nord8"
+"attribute" = "nord9"
+
+# Misc.
+"label" = "nord7"
+"namespace" = "nord4"
+"operator" = "nord9"
+"special" = "nord9"
+"tag" = "nord7"
+"comment" = { fg = "nord3_bright", modifiers = ["italic"] }
+
+## EDITOR UI COLORS
+
+"ui.background" = { }
+"ui.text" = "nord4"
+"ui.window" = "nord1"
+
+# Debug
+"ui.debug.active" = "nord13"
+"ui.debug.breakpoint" = "nord11"
+
+# Popus and menus
+"ui.menu" = { bg = "nord1" }
+"ui.menu.scroll" = { fg = "nord4", bg = "nord3" }
+"ui.menu.selected" = { fg = "nord8", bg = "nord2" }
+"ui.popup" = { bg = "nord1" }
+"ui.popup.info" = { bg = "nord1" }
+"ui.help" = { bg = "nord1" }
+"ui.text.focus" = { fg = "nord8", bg = "nord2" }
+
+# Gutter
+"ui.gutter" = "nord5"
+"ui.linenr" = "nord3"
+"ui.linenr.selected" = "nord5"
+
+# Cursor
+"ui.cursor" = { fg = "nord4", modifiers = [ "reversed" ] }
+"ui.cursorcolumn.primary" = { bg = "nord1" }
+"ui.cursorline.primary" = { bg = "nord1" }
+"ui.cursor.match" = { bg = "nord3" }
+
+"ui.selection" = { bg = "nord3" }
+"ui.highlight" = { fg = "nord8", bg = "nord2" }
+
+# Statusline
+"ui.statusline" = {  bg = "nord1" }
+"ui.statusline.inactive" = { fg = "nord8", bg = "nord1" }
+"ui.statusline.insert" = { fg = "nord1", bg = "nord6" }
+"ui.statusline.normal" = { fg = "nord1", bg = "nord8" }
+"ui.statusline.select" = { fg = "nord1", bg = "nord7" }
+"ui.statusline.separator" = "nord3"
+
+# Virtual/invisible text
+"ui.virtual.indent-guide" = "nord3"
+"ui.virtual.inlay-hint" = { fg = "nord3", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "nord11", modifiers = ["bold"] }
+"ui.virtual.ruler" = { bg = "nord1" }
+"ui.virtual.whitespace" = "nord3"
+"ui.virtual.wrap" = "nord3"
+
+# Bufferline
+"ui.bufferline" = { fg = "nord5", bg = "nord1" }
+"ui.bufferline.active" = { fg = "nord6", bg = "nord2", underline = { color = "nord8", style = "line" }, modifiers = [ "italic" ] }
+
+# Markup
+"markup.heading" = "nord8"
+"markup.list" = "nord9"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.text" = "nord8"
+"markup.raw" = "nord7"
+
+[palette]
+# Polar Night is made up of four darker colors that are commonly used for base elements like backgrounds or text color in bright ambiance designs.
+#
+# The origin color or the Polar Night palette
+nord0 = "#2e3440" 
+# A brighter shade color based on nord0
+nord1 = "#3B4252" 
+# An even more brighter shade color of nord0
+nord2 = "#434C5E" 
+# The brightest shade color based on nord0
+nord3 = "#4C566A" 
+# 10% brighter for comments, see https://github.com/nordtheme/nord/issues/94
+nord3_bright = "#616e88" 
+
+# Snow Storm is made up of three bright colors that are commonly used for text colors or base UI elements in bright ambiance designs.
+# The origin color or the Snow Storm palette
+nord4 = "#D8DEE9" 
+# A brighter shade color of nord4
+nord5 = "#E5E9F0" 
+# The brightest shade color based on nord4
+nord6 = "#ECEFF4" 
+
+# Frost can be described as the heart palette of Nord, a group of four bluish colors that are commonly used for primary UI component and text highlighting and essential code syntax elements.
+#
+# A calm and highly contrasted color reminiscent of frozen polar water
+nord7 = "#8FBCBB" 
+# The bright and shiny primary accent color reminiscent of pure and clear ice
+nord8 = "#88C0D0" 
+# A more darkened and less saturated color reminiscent of arctic waters
+nord9 = "#81A1C1" 
+# A dark and intensive color reminiscent of the deep arctic ocean
+nord10 = "#5E81AC" 
+
+# Aurora consists of five colorful components reminiscent of the "Aurora borealis", sometimes referred to as polar lights or northern lights.
+#
+# Red
+nord11 = "#BF616A" 
+# Orange
+nord12 = "#D08770" 
+# Yellow
+nord13 = "#EBCB8B" 
+# Green
+nord14 = "#A3BE8C" 
+# Purple
+nord15 = "#B48EAD" 

--- a/themes/osaka-jade/helix.toml
+++ b/themes/osaka-jade/helix.toml
@@ -1,0 +1,189 @@
+# Bamboo theme for Helix
+# Inspired by ribru17/bamboo.nvim - A warm green theme
+# Prioritizes green, yellow, and red colors while minimizing blue/purple for reduced eye strain
+# NOTE: Converted from Neovim to Helix by Claude AI
+
+# UI Colors
+"ui.background" = {}
+"ui.background.separator" = "bg2"
+"ui.cursor" = { fg = "bg0", bg = "fg" }
+"ui.cursor.insert" = { fg = "bg0", bg = "green" }
+"ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursor.match" = { fg = "orange", bg = "bg2" }
+"ui.cursor.primary" = { fg = "bg0", bg = "fg" }
+"ui.cursor.secondary" = { fg = "bg0", bg = "grey" }
+"ui.cursorline.primary" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.selection" = { bg = "bg2" }
+"ui.selection.primary" = { bg = "bg3" }
+"ui.linenr" = "grey"
+"ui.linenr.selected" = "fg"
+"ui.statusline" = { fg = "fg", bg = "bg2" }
+"ui.statusline.inactive" = { fg = "grey", bg = "bg1" }
+"ui.statusline.normal" = { fg = "bg0", bg = "green" }
+"ui.statusline.insert" = { fg = "bg0", bg = "yellow" }
+"ui.statusline.select" = { fg = "bg0", bg = "blue" }
+"ui.popup" = { bg = "bg1" }
+"ui.window" = { bg = "bg1" }
+"ui.help" = { bg = "bg1", fg = "fg" }
+"ui.text" = "fg"
+"ui.text.focus" = "yellow"
+"ui.text.inactive" = "grey"
+"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.whitespace" = "grey"
+"ui.virtual.indent-guide" = "bg3"
+"ui.virtual.inlay-hint" = { fg = "grey", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
+
+# Menu and completion
+"ui.menu" = { fg = "fg", bg = "bg1" }
+"ui.menu.selected" = { fg = "bg0", bg = "green" }
+"ui.menu.scroll" = { fg = "fg", bg = "bg2" }
+
+# Gutter
+"ui.gutter" = { }
+"ui.gutter.selected" = { bg = "bg1" }
+
+# Debug
+"ui.debug.breakpoint" = "red"
+"ui.debug.active" = "yellow"
+
+# Diagnostics
+"warning" = "yellow"
+"error" = "red"
+"info" = "blue"
+"hint" = "green"
+"diagnostic.hint" = { underline = { color = "green", style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+
+# Syntax highlighting
+"type" = "green"
+"type.builtin" = "green"
+"type.parameter" = "fg"
+"type.enum" = "green"
+"constructor" = "green"
+"constant" = "orange"
+"constant.builtin" = "orange"
+"constant.builtin.boolean" = "orange"
+"constant.character" = "yellow"
+"constant.character.escape" = "red"
+"constant.numeric" = "orange"
+"constant.numeric.integer" = "orange"
+"constant.numeric.float" = "orange"
+"string" = "yellow"
+"string.regexp" = "red"
+"string.special" = "red"
+"string.special.path" = "yellow"
+"string.special.url" = "blue"
+"string.special.symbol" = "red"
+"comment" = { fg = "grey", modifiers = ["italic"] }
+"comment.line" = { fg = "grey", modifiers = ["italic"] }
+"comment.block" = { fg = "grey", modifiers = ["italic"] }
+"comment.block.documentation" = { fg = "grey", modifiers = ["italic"] }
+
+# Variables
+"variable" = "fg"
+"variable.builtin" = "red"
+"variable.parameter" = { fg = "fg", modifiers = ["italic"] }
+"variable.other.member" = "fg"
+
+# Keywords
+"keyword" = { fg = "red", modifiers = ["italic"] }
+"keyword.control" = { fg = "red", modifiers = ["italic"] }
+"keyword.control.conditional" = { fg = "red", modifiers = ["italic"] }
+"keyword.control.repeat" = { fg = "red", modifiers = ["italic"] }
+"keyword.control.import" = { fg = "red", modifiers = ["italic"] }
+"keyword.control.return" = { fg = "red", modifiers = ["italic"] }
+"keyword.control.exception" = { fg = "red", modifiers = ["italic"] }
+"keyword.operator" = "red"
+"keyword.directive" = "red"
+"keyword.function" = "red"
+"keyword.storage" = "red"
+"keyword.storage.modifier" = "red"
+
+# Operators
+"operator" = "red"
+
+# Functions
+"function" = "blue"
+"function.builtin" = "blue"
+"function.method" = "blue"
+"function.macro" = "red"
+"function.special" = "red"
+
+# Namespaces
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
+
+# Tags (for markup languages)
+"tag" = "red"
+"tag.builtin" = "red"
+
+# Attributes
+"attribute" = "yellow"
+"attribute.builtin" = "yellow"
+
+# Labels
+"label" = "red"
+
+# Punctuation
+"punctuation" = "fg"
+"punctuation.delimiter" = "fg"
+"punctuation.bracket" = "fg"
+"punctuation.special" = "red"
+
+# Special
+"special" = "red"
+
+# Markup (for markdown, etc.)
+"markup.heading" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "green", modifiers = ["bold"] }
+"markup.heading.marker" = "grey"
+"markup.list" = "red"
+"markup.list.numbered" = "red"
+"markup.list.unnumbered" = "red"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
+"markup.link.text" = "yellow"
+"markup.quote" = "grey"
+"markup.raw" = "yellow"
+"markup.raw.inline" = "yellow"
+"markup.raw.block" = "yellow"
+
+# Diff
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "yellow"
+"diff.delta.moved" = "blue"
+
+# Git
+"git.delta.moved" = "blue"
+
+[palette]
+# Main background and foreground
+bg0 = "#252623"  # Dark green background
+bg1 = "#2a2d2a"  # Slightly lighter background
+bg2 = "#313431"  # Even lighter background for selections
+bg3 = "#3a3d3a"  # Light background for visual elements
+fg = "#e0dcc7"   # Light foreground text
+
+# Core colors - prioritizing green, yellow, red as per bamboo.nvim philosophy
+green = "#8db573"    # Bamboo green - primary accent
+yellow = "#e3c78a"   # Warm yellow for strings
+red = "#e07d61"      # Warm red for keywords
+orange = "#dba76d"   # Orange for constants
+blue = "#7fa8d6"     # Muted blue - used sparingly
+purple = "#ad7fa8"   # Muted purple - used sparingly
+
+# Neutral colors
+grey = "#6a7364"     # Comments and secondary text
+white = "#f4f1e8"    # Bright white
+black = "#1b1d1a"    # Deep dark

--- a/themes/ristretto/helix.toml
+++ b/themes/ristretto/helix.toml
@@ -1,0 +1,133 @@
+# Author : WindSoilder<WindSoilder@outlook.com>
+# The unofficial Monokai Pro theme, simply migrate from jetbrains monokai pro theme: https://github.com/subtheme-dev/monokai-pro
+# Credit goes to the original creator: https://monokai.pro
+
+# NOTE: This is just a copy of the default helix monkai_pro_ristretto theme with transparent bg to fit in omarchy
+
+"ui.linenr.selected" = { bg = "base3" }
+"ui.text.focus" = { fg = "yellow", modifiers= ["bold"] }
+"ui.menu" = { fg = "base8", bg = "base3" }
+"ui.menu.selected" = { fg = "base2", bg = "yellow" }
+"ui.virtual.whitespace" = "base5"
+"ui.virtual.ruler" = { bg = "base1" }
+"ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
+
+"info" = "base8"
+"hint" = "base8"
+
+# background color
+"ui.background" = { }
+"ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
+
+# status bars, panels, modals, autocompletion
+"ui.statusline" = { fg = "base8", bg = "base4" }
+"ui.popup" = { bg = "base3" }
+"ui.window" = { bg = "base3" }
+"ui.help" = { fg = "base8", bg = "base3" }
+
+# active line, highlighting
+"ui.selection" = { bg = "base4" }
+"ui.cursor.match" = { bg = "base4" }
+"ui.cursorline" = { bg = "base1" }
+
+# bufferline, inlay hints
+"ui.bufferline" = { fg = "base6", bg = "base8x0c" }
+"ui.bufferline.active" = { fg = "base8", bg = "base4" }
+"ui.virtual.inlay-hint" = { fg = "base6" }
+
+# comments, nord3 based lighter color
+"comment" = { fg = "base5", modifiers = ["italic"] }
+"ui.linenr" = { fg = "base5" }
+
+# cursor, variables, constants, attributes, fields
+"ui.cursor.primary" = { fg = "base7", modifiers = ["reversed"] }
+"attribute" = "blue"
+"variable"  = "base8"
+"constant"  = "orange"
+"variable.builtin" = "red"
+"constant.builtin" = "red"
+"namespace" = "base8"
+
+# base text, punctuation
+"ui.text" = { fg = "base8" }
+"punctuation" = "base6"
+
+# classes, types, primitives
+"type" = "green"
+"type.builtin" = { fg = "red"}
+"label" = "base8"
+
+# declaration, methods, routines
+"constructor" = "blue"
+"function" = "green"
+"function.macro" = { fg = "blue" }
+"function.builtin" = { fg = "cyan" }
+
+# operator, tags, units, punctuations
+"operator" = "red"
+"variable.other.member" = "base8"
+
+# keywords, special
+"keyword" = { fg = "red" }
+"keyword.directive" = "blue"
+"variable.parameter" = "#f59762"
+
+# error
+"error" = "red"
+
+# annotations, decorators
+"special" = "#f59762"
+"module" = "#f59762"
+
+# warnings, escape characters, regex
+"warning" = "orange"
+"constant.character.escape" = { fg = "base8" }
+
+# strings
+"string" = "yellow"
+
+# integer, floating point
+"constant.numeric" = "purple"
+
+# vcs
+"diff.plus" = "green"
+"diff.delta" = "orange"
+"diff.minus" = "red"
+
+# make diagnostic underlined, to distinguish with selection text.
+"diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.info" = { underline = { color = "base8", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "base8", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+# markup highlight, no need for `markup.raw` and `markup.list`, make them to be default
+"markup.heading" = "green"
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "orange", modifiers = ["underlined"] }
+"markup.link.text" = "yellow"
+"markup.quote" = "green"
+
+[palette]
+# primary colors
+"red" = "#fd6883"
+"orange" = "#f38d70"
+"yellow" = "#f9cc6c"
+"green" = "#adda78"
+"blue" = "#85dacc"
+"purple" = "#a8a9eb"
+# base colors
+"base0" = "#191515"
+"base1" = "#211c1c"
+"base2" = "#2c2525"
+"base3" = "#403838"
+"base4" = "#5b5353"
+"base5" = "#72696a"
+"base6" = "#8c8384"
+"base7" = "#c3b7b8"
+"base8" = "#fff1f3"
+# variants
+"base8x0c" = "#352e2e"

--- a/themes/rose-pine/helix.toml
+++ b/themes/rose-pine/helix.toml
@@ -1,0 +1,198 @@
+# Author: Rosé Pine <hi@rosepinetheme.com>
+# Upstream: https://github.com/rose-pine/helix
+# Contributing:
+#   Please submit changes to https://github.com/rose-pine/helix.
+#   The Rosé Pine team will update Helix, including you as a co-author.
+# NOTE: This is just a copy of the default helix rose-pine theme with transparent bg to fit in omarchy
+
+"ui.background" = { }
+"ui.background.separator" = { bg = "base" }
+
+"ui.cursor" = { fg = "text", bg = "highlight_high" }
+# "ui.cursor.select" = {}
+"ui.cursor.match" = { fg = "text", bg = "highlight_med" }
+"ui.cursor.primary" = { fg = "text", bg = "muted" }
+
+# "ui.gutter" = {}
+# "ui.gutter.selected" = {}
+
+"ui.linenr" = { fg = "muted" }
+"ui.linenr.selected" = { fg = "text" }
+
+"ui.bufferline" = { fg = "muted", bg = "base" }
+"ui.bufferline.active" = { fg = "text", bg = "overlay" }
+"ui.statusline" = { fg = "subtle", bg = "surface" }
+"ui.statusline.inactive" = { fg = "muted", bg = "surface" }
+"ui.statusline.normal" = { fg = "rose", bg = "rose_10" }
+"ui.statusline.insert" = { fg = "foam", bg = "foam_10" }
+"ui.statusline.select" = { fg = "iris", bg = "iris_10" }
+# "ui.statusline.separator" = {}
+
+"ui.popup" = { bg = "surface" }
+"ui.popup.info" = { bg = "surface" }
+
+"ui.window" = { fg = "overlay", bg = "base" }
+"ui.help" = { fg = "subtle", bg = "overlay" }
+
+"ui.text" = { fg = "text" }
+"ui.text.focus" = { bg = "overlay" }
+"ui.text.info" = { fg = "subtle" }
+"ui.text.directory" = { fg = "iris" }
+
+"ui.virtual.jump-label" = { fg = "love", modifiers = ["bold"] }
+"ui.virtual.ruler" = { bg = "overlay" }
+"ui.virtual.whitespace" = { fg = "highlight_high" }
+"ui.virtual.indent-guide" = { fg = "muted" }
+"ui.virtual.inlay-hint" = { fg = "subtle" }
+
+"ui.menu" = { fg = "subtle", bg = "surface" }
+"ui.menu.selected" = { fg = "text", bg = "overlay" }
+"ui.menu.scroll" = { fg = "muted", bg = "highlight_med" }
+
+"ui.selection" = { bg = "overlay" }
+"ui.selection.primary" = { bg = "highlight_med" }
+
+"ui.cursorline.primary" = { bg = "highlight_low" }
+"ui.cursorline.secondary" = { bg = "surface" }
+
+"warning" = "gold"
+"error" = "love"
+"info" = "foam"
+"hint" = "iris"
+"debug" = "rose"
+
+"diagnostic" = { underline = { color = "subtle", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "iris", style = "curl" } }
+"diagnostic.info" = { underline = { color = "foam", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "gold", style = "curl" } }
+"diagnostic.error" = { underline = { color = "love", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+"special" = "rose"
+
+"attribute" = "iris"
+
+"type" = "foam"
+# "type.builtin" = ""
+
+"constructor" = "foam"
+
+"constant" = "foam"
+"constant.builtin" = "love"
+"constant.builtin.boolean" = "rose"
+"constant.character" = "gold"
+"constant.character.escape" = "pine"
+"constant.numeric" = "gold"
+# "constant.numeric.integer" = ""
+# "constant.numeric.float" = ""
+
+"string" = "gold"
+# "string.regexp" = ""
+# "string.special" = ""
+# "string.special.path" = ""
+# "string.special.url" = ""
+# "string.special.symbol" = ""
+
+"comment" = { fg = "muted", modifiers = ["italic"] }
+# "comment.line" = ""
+# "comment.line.documentation" = ""
+# "comment.block" = ""
+# "comment.block.documentation" = ""
+
+"variable" = "text"
+"variable.builtin" = "love"
+"variable.parameter" = "iris"
+# "variable.other" = ""
+"variable.other.member" = "foam"
+
+"label" = "foam"
+
+"punctuation" = "subtle"
+# "punctuation.delimiter" = ""
+# "punctuation.bracket" = ""
+# "punctuation.special" = ""
+
+"keyword" = "pine"
+# "keyword.control" = ""
+# "keyword.control.conditional" = ""
+# "keyword.control.repeat" = ""
+# "keyword.control.import" = ""
+# "keyword.control.return" = ""
+# "keyword.control.exception" = ""
+"keyword.operator" = "subtle"
+# "keyword.directive" = ""
+# "keyword.function" = ""
+# "keyword.storage" = ""
+# "keyword.storage.type" = ""
+# "keyword.storage.modifier" = ""
+
+"operator" = "subtle"
+
+"function" = "rose"         # maybe pine
+"function.builtin" = "love"
+# "function.method" = ""
+# "function.macro" = ""
+# "function.special" = ""
+
+"tag" = "foam"
+
+"namespace" = "text"
+
+"markup.heading.marker" = "muted"
+"markup.heading" = { fg = "iris", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "iris", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "foam", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "rose", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "gold", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "pine", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "foam", modifiers = ["bold"] }
+# "markup.heading.completion" = ""
+# "markup.heading.hover" = ""
+"markup.list" = "muted"
+# "markup.list.unnumbered" = ""
+# "markup.list.numbered" = ""
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = "iris"
+"markup.link.url" = { fg = "iris", underline = { color = "iris", style = "line" } }
+"markup.link.label" = "subtle"
+"markup.link.text" = "text"
+"markup.quote" = "subtle"
+"markup.raw" = "subtle"
+# "markup.raw.inline" = {}
+# "markup.raw.inline.completion" = {}
+# "markup.raw.inline.hover" = {}
+# "markup.raw.block" = {}
+# "markup.normal" = ""
+# "markup.normal.completion" = ""
+# "markup.normal.hover" = ""
+
+"diff" = "overlay"
+"diff.plus" = "foam"
+"diff.minus" = "love"
+"diff.delta" = "highlight_high"
+# "diff.delta.moved" = ""
+
+[palette]
+base           = "#faf4ed" 
+surface        = "#fffaf3" 
+overlay        = "#f2e9e1"
+muted          = "#9893a5"
+subtle         = "#797593"
+text           = "#575279"
+love           = "#b4637a"
+love_10        = "#f6e4e0"
+gold           = "#ea9d34"
+gold_10        = "#fbead8"
+rose           = "#d7827e"
+rose_10        = "#fae8e1"
+pine           = "#286983"
+pine_10        = "#e5e6e2"
+foam           = "#56949f"
+foam_10        = "#eaeae5"
+iris           = "#907aa9"
+iris_10        = "#f1e8e6"
+highlight_low  = "#f4ede8"
+highlight_med  = "#dfdad9"
+highlight_high = "#cecacd"

--- a/themes/tokyo-night/helix.toml
+++ b/themes/tokyo-night/helix.toml
@@ -1,0 +1,137 @@
+# Author: Paul Graydon <untimely.creation97@proton.me>
+# NOTE: This is just a copy of the default helix tokyo-night theme with transparent bg to fit in omarchy
+
+attribute = { fg = "cyan" }
+comment = { fg = "comment", modifiers = ["italic"] }
+"comment.block.documentation" = { fg = "yellow" }
+"comment.line.documentation" = { fg = "yellow" }
+constant = { fg = "orange" }
+"constant.builtin" = { fg = "aqua" }
+"constant.character" = { fg = "light-green" }
+"constant.character.escape" = { fg = "magenta" }
+constructor = { fg = "aqua" }
+function = { fg = "blue", modifiers = ["italic"] }
+"function.builtin" = { fg = "aqua" }
+"function.macro" = { fg = "cyan" }
+"function.special" = { fg = "cyan" }
+keyword = { fg = "purple", modifiers = ["italic"] }
+"keyword.control" = { fg = "magenta" }
+"keyword.control.import" = { fg = "cyan" }
+"keyword.control.return" = { fg = "purple", modifiers = ["italic"] }
+"keyword.directive" = { fg = "cyan" }
+"keyword.function" = { fg = "magenta" }
+"keyword.operator" = { fg = "magenta" }
+label = { fg = "blue" }
+namespace = { fg = "cyan" }
+operator = { fg = "turquoise" }
+punctuation = { fg = "turquoise" }
+special = { fg = "aqua" }
+string = { fg = "light-green" }
+"string.regexp" = { fg = "light-cyan" }
+"string.special" = { fg = "aqua" }
+tag = { fg = "magenta" }
+type = { fg = "aqua" }
+"type.builtin" = { fg = "aqua" }
+"type.enum.variant" = { fg = "orange" }
+variable = { fg = "fg" }
+"variable.builtin" = { fg = "red" }
+"variable.other.member" = { fg = "green" }
+"variable.parameter" = { fg = "yellow", modifiers = ["italic"] }
+
+"markup.bold" = { modifiers = ["bold"] }
+"markup.heading" = { fg = "blue", modifiers = ["bold"] }
+"markup.heading.completion" = { bg = "bg-menu", fg = "fg" }
+"markup.heading.hover" = { bg = "fg-selected" }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.link" = { fg = "blue", underline = { style = "line" } }
+"markup.link.label" = { fg = "teal" }
+"markup.link.text" = { fg = "teal" }
+"markup.link.url" = { underline = { style = "line" } }
+"markup.list" = { fg = "orange", modifiers = ["bold"] }
+"markup.normal.completion" = { fg = "comment" }
+"markup.normal.hover" = { fg = "fg-dark" }
+"markup.raw" = { fg = "teal" }
+"markup.raw.inline" = { bg = "black", fg = "blue" }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+
+"diff.delta" = { fg = "change" }
+"diff.delta.moved" = { fg = "blue" }
+"diff.minus" = { fg = "delete" }
+"diff.plus" = { fg = "add" }
+
+error = { fg = "error" }
+warning = { fg = "yellow" }
+info = { fg = "info" }
+hint = { fg = "hint" }
+"diagnostic.error" = { underline = { style = "curl", color = "error" } }
+"diagnostic.warning" = { underline = { style = "curl", color = "yellow"} }
+"diagnostic.info" = { underline = { style = "curl", color = "info"} }
+"diagnostic.hint" = { underline = { style = "curl", color = "hint" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+"ui.background" = { fg = "fg" }
+"ui.cursor" = { modifiers = ["reversed"] }
+"ui.cursor.match" = { fg = "orange", modifiers = ["bold"] }
+"ui.cursorline.primary" = { bg = "bg-menu" }
+"ui.help" = { bg = "bg-menu", fg = "fg" }
+"ui.linenr" = { fg = "fg-gutter" }
+"ui.linenr.selected" = { fg = "fg-linenr" }
+"ui.menu" = { bg = "bg-menu", fg = "fg" }
+"ui.menu.selected" = { bg = "fg-selected" }
+"ui.popup" = { bg = "bg-menu", fg = "border-highlight" }
+"ui.selection" = { bg = "bg-selection" }
+"ui.selection.primary" = { bg = "bg-selection" }
+"ui.statusline" = { bg = "bg-menu", fg = "fg-dark" }
+"ui.statusline.inactive" = { bg = "bg-menu", fg = "fg-gutter" }
+"ui.statusline.normal" = { bg = "blue", fg = "bg", modifiers = ["bold"] }
+"ui.statusline.insert" = { bg = "light-green", fg = "bg", modifiers = ["bold"] }
+"ui.statusline.select" = { bg = "magenta", fg = "bg", modifiers = ["bold"] }
+"ui.text" = { fg = "fg" }
+"ui.text.focus" = { bg = "bg-focus" }
+"ui.text.inactive" = { fg = "comment", modifiers = ["italic"] }
+"ui.text.info" = { bg = "bg-menu", fg = "fg" }
+"ui.text.directory" = { fg = "cyan" }
+"ui.virtual.ruler" = { bg = "fg-gutter" }
+"ui.virtual.whitespace" = { fg = "fg-gutter" }
+"ui.virtual.inlay-hint" = {  bg = "bg-inlay", fg = "teal" }
+"ui.virtual.jump-label" = {  fg = "orange", modifiers = ["bold"] }
+"ui.window" = { fg = "border", modifiers = ["bold"] }
+
+[palette]
+red = "#f7768e"
+orange = "#ff9e64"
+yellow = "#e0af68"
+light-green = "#9ece6a"
+green = "#73daca"
+aqua = "#2ac3de"
+teal = "#1abc9c"
+turquoise = "#89ddff"
+light-cyan = "#b4f9f8"
+cyan = "#7dcfff"
+blue = "#7aa2f7"
+purple = "#9d7cd8"
+magenta = "#bb9af7"
+comment = "#565f89"
+black = "#414868"
+
+add = "#449dab"
+change = "#6183bb"
+delete = "#914c54"
+
+error = "#db4b4b"
+info = "#0db9d7"
+hint = "#1abc9c"
+
+fg = "#c0caf5"
+fg-dark = "#a9b1d6"
+fg-gutter = "#3b4261"
+fg-linenr = "#737aa2"
+fg-selected = "#343a55"
+border = "#15161e"
+border-highlight = "#27a1b9"
+bg = "#1a1b26"
+bg-inlay = "#1a2b32"
+bg-selection = "#283457"
+bg-menu = "#16161e"
+bg-focus = "#292e42"


### PR DESCRIPTION
# Add Helix editor support for Omarchy themes

This PR adds a `helix.toml` theme file for all default Omarchy themes to work with the Helix editor.

## Setup Instructions

Since Helix is not included in the default installation, users need to create a symlink:

```bash
ln -s ~/.config/omarchy/current/theme/helix.toml ~/.config/helix/themes/omarchy.toml
```

Then specify Omarchy as their theme in the Helix config `config.toml`:

```toml
theme = "omarchy"
```

## Theme Details

- **9 out of 11 themes** are sourced directly from Helix's built-in default themes
- **2 custom themes** were created specifically for this integration (using Claude AI assistance) to provide alternatives where no equivalent Helix themes existed
