### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8


### PR DESCRIPTION
Enforces basic code style in editors.

This is supported out of the box by Neovim, VS Code, and [many others](https://editorconfig.org/).