### PR TITLE
Theme Auto Switching based on Sunrise / Sunset

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -116,11 +116,12 @@ show_screenrecord_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n󰔡  Theme Auto-Switch") in
   *Screensaver*) omarchy-launch-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
   *Idle*) omarchy-toggle-idle ;;
   *Bar*) pkill -SIGUSR1 waybar ;;
+  *Theme*) omarchy-toggle-theme-auto-switch ;;
   *) show_main_menu ;;
   esac
 }

--- a/bin/omarchy-toggle-theme-auto-switch
+++ b/bin/omarchy-toggle-theme-auto-switch
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Toggle darkman-based theme auto-switching
+
+CONFIG_FILE="$HOME/.config/omarchy/theme-auto-switch.conf"
+DARKMAN_CONFIG="$HOME/.config/darkman/config.yaml"
+
+# Check if config exists
+if [ ! -f "$CONFIG_FILE" ]; then
+  notify-send "Theme Auto-Switch" "Config file not found. Please run the darkman migration first."
+  exit 1
+fi
+
+# Check current status
+# Always regenerate darkman config from theme-schedule.conf
+
+# Create darkman config directory if it doesn't exist
+mkdir -p "$(dirname "$DARKMAN_CONFIG")"
+
+# Parse theme-schedule.conf and generate config.yaml
+cat >"$DARKMAN_CONFIG" <<'EOF'
+# Darkman configuration
+# Based on darkman(1) manual: https://darkman.whynothugo.nl/
+# This file is auto-generated from config/theme-auto-switch.conf
+
+EOF
+
+# Read configuration values from theme-schedule.conf
+LATITUDE=$(grep "^latitude = " "$CONFIG_FILE" | cut -d' ' -f3)
+LONGITUDE=$(grep "^longitude = " "$CONFIG_FILE" | cut -d' ' -f3)
+
+# Generate location settings
+cat >>"$DARKMAN_CONFIG" <<EOF
+# Location settings
+lat: $LATITUDE
+lng: $LONGITUDE
+
+# Use geoclue for location (set to false to use only manual lat/lng)
+usegeoclue: false
+
+# Enable D-Bus server for API access
+dbusserver: true
+
+# Enable XDG portal for desktop integration
+portal: true
+EOF
+
+echo "Generated darkman config at $DARKMAN_CONFIG"
+
+if systemctl --user is-active --quiet darkman; then
+  # Currently enabled, disable it
+  systemctl --user stop darkman
+  systemctl --user disable darkman
+  notify-send "Theme Auto-Switch" "Disabled"
+else
+  # Currently disabled, enable it
+  systemctl --user enable --now darkman
+  notify-send "Theme Auto-Switch" "Enabled"
+fi
+

--- a/config/theme-auto-switch.conf
+++ b/config/theme-auto-switch.conf
@@ -1,0 +1,14 @@
+# Darkman Configuration for Omarchy
+# Integrates with darkman for automatic light/dark theme switching.
+# The darkman config.yaml is auto-generated from this file.
+
+# Theme settings
+light_theme = "catppuccin-latte"
+dark_theme = "catppuccin"
+
+# Location settings (used by darkman for sunrise/sunset calculations)
+latitude = 25.775080
+longitude = -80.194702
+
+# Hyprsunset settings
+hyprsunset_enabled = false

--- a/migrations/1755702456.sh
+++ b/migrations/1755702456.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+echo "Installing darkman for automatic theme switching"
+
+# Install darkman if not present
+if ! command -v darkman &>/dev/null; then
+  yay -S --noconfirm --needed darkman
+fi
+
+# Create XDG data directories for darkman hooks
+DARK_MODE_DIR="$HOME/.local/share/dark-mode.d"
+LIGHT_MODE_DIR="$HOME/.local/share/light-mode.d"
+
+mkdir -p "$DARK_MODE_DIR"
+mkdir -p "$LIGHT_MODE_DIR"
+
+# Install hook scripts in XDG data directories
+cat >"$DARK_MODE_DIR/omarchy-theme-dark" <<'EOF'
+#!/bin/bash
+# Darkman hook for dark mode
+# Applies the dark theme using Omarchy scripts
+
+# Source Omarchy config to get theme names
+CONFIG_FILE="$HOME/.config/omarchy/theme-auto-switch.conf"
+if [ -f "$CONFIG_FILE" ]; then
+  # Simple key=value parsing
+  DARK_THEME=$(grep "^dark_theme = " "$CONFIG_FILE" | cut -d'"' -f2)
+  ENABLE_HYPRSUNSET=$(grep "^hyprsunset_enabled = " "$CONFIG_FILE" | cut -d' ' -f3)
+
+  # Set defaults if parsing failed
+  DARK_THEME=${DARK_THEME:-"tokyo-night"}
+  ENABLE_HYPRSUNSET=${ENABLE_HYPRSUNSET:-"false"}
+else
+  DARK_THEME="tokyo-night"
+  ENABLE_HYPRSUNSET="false"
+fi
+
+# Apply dark theme
+omarchy-theme-set "$DARK_THEME"
+
+# Optional: Set night temperature for hyprsunset
+if [ "$ENABLE_HYPRSUNSET" = "true" ]; then
+  hyprctl hyprsunset temperature 4000  # Set to nightlight temperature
+fi
+
+echo "Switched to dark theme: $DARK_THEME"
+EOF
+chmod +x "$DARK_MODE_DIR/omarchy-theme-dark"
+echo "Installed dark mode hook to $DARK_MODE_DIR/omarchy-theme-dark"
+
+cat >"$LIGHT_MODE_DIR/omarchy-theme-light" <<'EOF'
+#!/bin/bash
+# Darkman hook for light mode
+# Applies the light theme using Omarchy scripts
+
+# Source Omarchy config to get theme names
+CONFIG_FILE="$HOME/.config/omarchy/theme-auto-switch.conf"
+if [ -f "$CONFIG_FILE" ]; then
+  # Simple key=value parsing
+  LIGHT_THEME=$(grep "^light_theme = " "$CONFIG_FILE" | cut -d'"' -f2)
+  ENABLE_HYPRSUNSET=$(grep "^hyprsunset_enabled = " "$CONFIG_FILE" | cut -d' ' -f3)
+
+  # Set defaults if parsing failed
+  LIGHT_THEME=${LIGHT_THEME:-"catppuccin-latte"}
+  ENABLE_HYPRSUNSET=${ENABLE_HYPRSUNSET:-"false"}
+else
+  LIGHT_THEME="catppuccin-latte"
+  ENABLE_HYPRSUNSET="false"
+fi
+
+# Apply light theme
+omarchy-theme-set "$LIGHT_THEME"
+
+# Optional: Set day temperature for hyprsunset
+if [ "$ENABLE_HYPRSUNSET" = "true" ]; then
+  hyprctl hyprsunset temperature 6000  # Set to daylight temperature
+fi
+
+echo "Switched to light theme: $LIGHT_THEME"
+EOF
+chmod +x "$LIGHT_MODE_DIR/omarchy-theme-light"
+echo "Installed light mode hook to $LIGHT_MODE_DIR/omarchy-theme-light"
+
+# Copy theme-auto-switch.conf if it doesn't exist
+if [ ! -f ~/.config/omarchy/theme-auto-switch.conf ]; then
+  cp config/theme-auto-switch.conf ~/.config/omarchy/
+  echo "Copied theme-auto-switch.conf to ~/.config/omarchy/"
+else
+  echo "Theme auto-switch config already exists at ~/.config/omarchy/theme-auto-switch.conf"
+fi
+
+echo ""
+echo "To activate pick Toggle > Theme Auto Switch from the Omarchy menu."
+echo "Darkman setup complete"


### PR DESCRIPTION
### 🌅 Theme Auto-Switching Based on Sunrise/Sunset

This PR introduces automatic theme switching functionality that seamlessly transitions
between light and dark themes based on sunrise and sunset times using the darkman
service.

✨ **What does it do?**

• Automatic Theme Switching: Integrates with `darkman` to automatically switch between
light and dark themes based on solar position
• Location-Based Configuration: Uses latitude/longitude coordinates for accurate
sunrise/sunset calculations
• Menu Integration: Added "Theme Auto-Switch" option to the Toggle menu for easy
access
• Configurable Themes: Supports custom light and dark theme selection via
`~/.config/omarchy/theme-auto-switch.conf`
• Optional Nightlight: Can integrate with `hyprsunset` for temperature-based nightlight
effects

<img width="584" height="664" alt="screenshot-2025-08-20_18-52-08" src="https://github.com/user-attachments/assets/ed5807b8-93d2-47b4-be52-10729516ac69" />


### 🔧 Implementation Details

• New Script: `omarchy-toggle-theme-auto-switch` - Enables/disables the auto-switching
service
• Configuration File: `theme-auto-switch.conf` - Stores theme preferences and
location settings
• Migration Script: 1755702456.sh - Installs darkman and sets up necessary hooks
• Hook Scripts: Automatic theme switching via XDG data directories (~/.
local/share/dark-mode.d/ and ~/.local/share/light-mode.d/)

