### PR TITLE
Isolate PWAs

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -32,7 +32,7 @@ cat >"$DESKTOP_FILE" <<EOF
 Version=1.0
 Name=$APP_NAME
 Comment=$APP_NAME
-Exec=chromium --new-window --ozone-platform=wayland --app="$APP_URL" --name="$APP_NAME" --class="$APP_NAME"
+Exec=chromium --new-window --ozone-platform=wayland --app="$APP_URL" --name="$APP_NAME" --class="$APP_NAME" --user-data-dir="$HOME/.config/chromium-profiles/$APP_NAME" --no-first-run --no-default-browser-check
 Terminal=false
 Type=Application
 Icon=$ICON_PATH

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -14,14 +14,14 @@ bindd = SUPER, G, Signal, exec, uwsm app -- signal-desktop
 bindd = SUPER, O, Obsidian, exec, uwsm app -- obsidian -disable-gpu
 bindd = SUPER, slash, Passwords, exec, uwsm app -- 1password
 
-bindd = SUPER, A, ChatGPT, exec, $webapp="https://chatgpt.com"
+bindd = SUPER, A, ChatGPT, exec, gtk-launch ChatGPT
 bindd = SUPER SHIFT, A, Grok, exec, $webapp="https://grok.com"
-bindd = SUPER, C, Calendar, exec, $webapp="https://app.hey.com/calendar/weeks/"
-bindd = SUPER, E, Email, exec, $webapp="https://app.hey.com"
-bindd = SUPER, Y, YouTube, exec, $webapp="https://youtube.com/"
-bindd = SUPER SHIFT, G, WhatsApp, exec, $webapp="https://web.whatsapp.com/"
-bindd = SUPER ALT, G, Google Messages, exec, $webapp="https://messages.google.com/web/conversations"
-bindd = SUPER, X, X, exec, $webapp="https://x.com/"
+bindd = SUPER, C, Calendar, exec, gtk-launch HEY
+bindd = SUPER, E, Email, exec, gtk-launch HEY
+bindd = SUPER, Y, YouTube, exec, gtk-launch YouTube
+bindd = SUPER SHIFT, G, WhatsApp, exec, gtk-launch WhatsApp
+bindd = SUPER ALT, G, Google Messages, exec, gtk-launch "Google Messages"
+bindd = SUPER, X, X, exec, gtk-launch X
 bindd = SUPER SHIFT, X, X Post, exec, $webapp="https://x.com/compose/post"
 
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space


### PR DESCRIPTION
It may be opinionated but personally i like PWAs to be isolated e.g. my work google account is unrelated to the Youtube account i use. 
It also allows for an more independent app behavior on browser cache clean etc.

The implementation is quite simple by specifying an per-app chrome profile and using gtk-launch on keybindings to use the .desktop-file.

Of course, a per-app-flag or so would also be an option.
