### PR TITLE
fix: added mkinitcpio-firmware package to remove "WARNING: Possibly missing firmware" messages on sudo pacman -Syu

### DIFF
--- a/install/desktop/desktop.sh
+++ b/install/desktop/desktop.sh
@@ -6,7 +6,8 @@ yay -S --noconfirm --needed \
   nautilus sushi ffmpegthumbnailer gvfs-mtp \
   slurp satty \
   mpv evince imv \
-  chromium
+  chromium \
+  mkinitcpio-firmware
 
 # Add screen recorder based on GPU
 if lspci | grep -qi 'nvidia'; then


### PR DESCRIPTION
This is a optional firmware package for the linux kernel that removes the annoying 'WARNING: Possibly missing firmware for module:' messages that show up on sudo pacman -Syu. 

Here are the warnings:

![k3ynirfgc4af1](https://github.com/user-attachments/assets/71a84e66-cee0-4da5-896f-5a2e924e4553)
