### PR TITLE
Update omarchy-pkg-install/remove scripts

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -4,7 +4,7 @@ set -e
 
 if ! omarchy-pkg-aur-accessible; then
   echo -e "\e[31m\nAUR is unavailable\e[0m"
-  echo
+  omarchy-show-done
   exit 1
 fi
 

--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -2,7 +2,17 @@
 
 set -e
 
+if ! omarchy-pkg-aur-accessible; then
+  echo -e "\e[31m\nAUR is unavailable\e[0m"
+  echo
+  exit 1
+fi
+
 fzf_args=(
+  --prompt=' '
+  --ansi
+  --no-sort
+  --exact
   --multi
   --preview 'yay -Sii {1}'
   --preview-label='alt-p: toggle description, alt-j/k: scroll, tab: multi-select, F11: maximize'
@@ -14,7 +24,7 @@ fzf_args=(
   --color 'pointer:green,marker:green'
 )
 
-pkg_names=$(yay -Slqa | fzf "${fzf_args[@]}")
+pkg_names=$(yay -Sla --color=never | awk '{print "\033[0m" $2 " \033[1;36m" $4 }' | fzf "${fzf_args[@]}" | awk '{print $1}')
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 set -e
+
 fzf_args=(
+  --prompt=' '
   --ansi
-  --delimiter=$'\t'
-  --with-nth=2..
   --no-sort
   --exact
   --multi
@@ -19,7 +19,7 @@ fzf_args=(
 )
 
 sudo pacman -Sy
-pkg_names=$(pacman -Sl --color=always | awk '{printf "%s\t%s\n", $2, $0}' | fzf "${fzf_args[@]}")
+pkg_names=$(pacman -Sl --color=always | awk '{print $2 " " $3 " " $1 " " $4}' | fzf "${fzf_args[@]}" | awk '{print $1}')
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 set -e
-
 fzf_args=(
+  --ansi
+  --delimiter=$'\t'
+  --with-nth=2..
+  --no-sort
+  --exact
   --multi
   --preview 'pacman -Sii {1}'
   --preview-label='alt-p: toggle description, alt-j/k: scroll, tab: multi-select, F11: maximize'
@@ -15,7 +19,7 @@ fzf_args=(
 )
 
 sudo pacman -Sy
-pkg_names=$(pacman -Slq | fzf "${fzf_args[@]}")
+pkg_names=$(pacman -Sl --color=always | awk '{printf "%s\t%s\n", $2, $0}' | fzf "${fzf_args[@]}")
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 fzf_args=(
+  --ansi
+  --prompt=' '
   --multi
   --preview 'yay -Qi {1}'
   --preview-label='alt-p: toggle description, alt-j/k: scroll, tab: multi-select, F11: maximize'
@@ -12,7 +14,7 @@ fzf_args=(
   --color 'pointer:red,marker:red'
 )
 
-pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
+pkg_names=$(yay -Qe --color=always | fzf "${fzf_args[@]}" | awk '{print $1}')
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay


### PR DESCRIPTION
So I've made some improvements I think most people would like.
- Colored package information - looks better and helps you decide faster if it's the right package.
- Fixed multi package install support - it had an issue where it wouldn't parse them properly.
- Smoother performance - pacman lines show up instantly so it feels more responsive now.

<img width="1019" height="784" alt="image" src="https://github.com/user-attachments/assets/31cb4d20-f65f-411f-bb5f-5115c55285d9" />


Some stuff that might not be trivial:
- `generate_pkg_lines()` returns rows that look like: `package_name` `(tab)` `colored_info`
- `--delimiter=$'\t'` and `--with-nth=2..` hide the first `package_name` in fzf.
- `cut -f1` to return the `package_name` only.
- `--no-sort` and `--exact` so pacman results show first.

Let me know if I should change anything or do the same thing with omarchy-pkg-remove.
