### PR TITLE
Add mako notification bindings (dismiss, dismiss-all)

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -24,6 +24,11 @@ bindd = SUPER ALT, G, Google Messages, exec, $webapp="https://messages.google.co
 bindd = SUPER, X, X, exec, $webapp="https://x.com/"
 bindd = SUPER SHIFT, X, X Post, exec, $webapp="https://x.com/compose/post"
 
+# Notifications
+bind = SUPER, period, exec, makoctl dismiss
+bind = SUPER SHIFT, period, exec, makoctl dismiss -a
+
+
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, Space
 # bindd = SUPER, SPACE, Omarchy menu, exec, omarchy-menu


### PR DESCRIPTION
The motivation for this PR is to provide default keybindings for the mako notification daemon. 
Currently users must manually configure their own binds. This adds sensible defaults for dismissing and restoring notifications.

**What this PR adds**
Adds three bindings in `hypr/bindings.conf`:
- SUPER + . → dismiss newest notification
- SUPER + SHIFT + . → dismiss all notification