### PR TITLE
feat: add audio to screen records

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -14,9 +14,9 @@ screenrecording() {
   sleep 1
 
   if lspci | grep -qi 'nvidia'; then
-    wf-recorder -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@"
+    wf-recorder --audio -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@"
   else
-    wl-screenrec -f "$filename" --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart" "$@"
+    wl-screenrec --audio -f "$filename" --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart" "$@"
   fi
 }
 


### PR DESCRIPTION
There's a flag that automatically adds audio to screen records. Usually you want the audio with the record but if this is not the case, or the community prefers muted records we might add a different CMD with audio enabled.