### PR TITLE
Make shift+insert paste from clipboard in Alacritty

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -18,7 +18,5 @@ opacity = 0.98
 [keyboard]
 bindings = [
 { key = "F11", action = "ToggleFullscreen" }
+{ key = "Insert", mods = "Shift", action = "Paste" }
 ]
-
-[selection]
-save_to_clipboard = true

--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -17,6 +17,6 @@ opacity = 0.98
 
 [keyboard]
 bindings = [
-{ key = "F11", action = "ToggleFullscreen" }
+{ key = "F11", action = "ToggleFullscreen" },
 { key = "Insert", mods = "Shift", action = "Paste" }
 ]

--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -19,3 +19,6 @@ opacity = 0.98
 bindings = [
 { key = "F11", action = "ToggleFullscreen" }
 ]
+
+[selection]
+save_to_clipboard = true


### PR DESCRIPTION
Implemented suggestion from #988 to add the config for alacritty to save to the clipboard instead of to the primary clipboard. 