### PR TITLE
Add font rendering optimizations to fonts.conf

### DIFF
--- a/config/fontconfig/fonts.conf
+++ b/config/fontconfig/fonts.conf
@@ -1,6 +1,82 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
+  <!-- Font rendering optimizations for better clarity on modern displays -->
+  <!-- Adjust the DPI value below based on your monitor type -->
+  
+  <!-- Common display DPI values:
+       27" 5K (5120x2880): 218 PPI
+       32" 6K (6016x3384): 218 PPI
+       27" 4K (3840x2160): 163 PPI
+       32" 4K (3840x2160): 138 PPI
+       13.5" Framework (2880x1920): 266 PPI
+       27" 1440p (2560x1440): 109 PPI
+       27" 1080p (1920x1080): 82 PPI
+  -->
+  
+  <!-- Font rendering settings -->
+  <match target="font">
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <!-- RGB subpixel rendering for LCD displays -->
+    <edit name="rgba" mode="assign">
+      <const>rgb</const>
+    </edit>
+    <!-- Hinting style: hintslight for high-DPI (>150), hintmedium for low-DPI (<150) -->
+    <edit name="hintstyle" mode="assign">
+      <const>hintslight</const>
+    </edit>
+    <edit name="lcdfilter" mode="assign">
+      <const>lcddefault</const>
+    </edit>
+  </match>
+
+  <!-- Set DPI for your display (uncomment and adjust as needed) -->
+  
+  <!-- For 27" 5K or 32" 6K displays -->
+  <match target="pattern">
+    <edit name="dpi" mode="assign">
+      <double>218</double>
+    </edit>
+  </match>
+  
+  <!-- For 27" 4K displays
+  <match target="pattern">
+    <edit name="dpi" mode="assign">
+      <double>163</double>
+    </edit>
+  </match>
+  -->
+  
+  <!-- For 32" 4K displays
+  <match target="pattern">
+    <edit name="dpi" mode="assign">
+      <double>138</double>
+    </edit>
+  </match>
+  -->
+  
+  <!-- For Framework 13.5" laptop
+  <match target="pattern">
+    <edit name="dpi" mode="assign">
+      <double>266</double>
+    </edit>
+  </match>
+  -->
+  
+  <!-- For standard displays (1080p/1440p)
+  <match target="pattern">
+    <edit name="dpi" mode="assign">
+      <double>96</double>
+    </edit>
+  </match>
+  -->
+
+  <!-- Font family mappings -->
   <match target="pattern">
     <test name="family" qual="any">
       <string>sans-serif</string>


### PR DESCRIPTION
Hey! I noticed fonts.conf could benefit from rendering optimizations for better clarity on modern displays.

This PR adds font rendering settings to fonts.conf, following the same pattern as monitors.conf - sensible defaults with commented options for different setups.

Added:
- Font rendering settings (antialiasing, hinting, RGB subpixel, LCD filter)
- DPI configuration with examples for common displays (5K, 4K, Framework, etc)
- Comments explaining what values to use for different monitor types

The default is set for 5K/6K displays (218 DPI) with light hinting, but users can easily uncomment and adjust for their specific display, just like they do with monitors.conf.

Feel free to adjust the defaults or close if this doesn't fit.