### PR TITLE
Added script to fix the touchpad on the Rog Flow Z13

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,8 +74,12 @@ source $OMARCHY_INSTALL/config/usb-autosuspend.sh
 source $OMARCHY_INSTALL/config/timezones.sh
 source $OMARCHY_INSTALL/config/login.sh
 source $OMARCHY_INSTALL/config/nvidia.sh
+<<<<<<< Updated upstream
 source $OMARCHY_INSTALL/config/increase-sudo-tries.sh
 source $OMARCHY_INSTALL/config/ignore-power-button.sh
+=======
+source $OMARCHY_INSTALL/config/asus-touchpad.sh
+>>>>>>> Stashed changes
 
 # Development
 source $OMARCHY_INSTALL/development/terminal.sh

--- a/install/config/asus-touchpad.sh
+++ b/install/config/asus-touchpad.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Fix touchpad detection on ASUS Flow Z13
+if grep -qi "flow z13" /sys/class/dmi/id/product_name 2>/dev/null; then
+  if [[ ! -f /etc/modprobe.d/hid_asus.conf ]]; then
+    echo "options hid_asus enable_touchpad=1" | sudo tee /etc/modprobe.d/hid_asus.conf >/dev/null
+    
+    # Create systemd service to reload hid_asus module on boot
+    sudo tee /etc/systemd/system/reload-hid_asus.service >/dev/null <<'EOF'
+[Unit]
+Description=Reload hid_asus with correct options
+After=multi-user.target
+ConditionKernelModule=hid_asus
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/modprobe -r hid_asus
+ExecStart=/usr/bin/modprobe hid_asus
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    
+    sudo systemctl enable reload-hid_asus.service
+  fi
+fi


### PR DESCRIPTION
Adds install script to fix the touchpad so two finger scrolling works as well as touch gestures. Before this is just sees the device as a pointer and not a touchpad.

Fix comes from here:
https://forum.level1techs.com/t/flow-z13-asus-setup-on-linux-may-2025-wip/229551

I tried some other methods to avoid the reload script but this is the only thing that worked for me. Tested by disabling the service and removing the files on my local machine and running the script but I didn't do a full reinstall on the system.