### PR TITLE
fix: add quotes around font names in `omarchy-font-set`

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -5,8 +5,8 @@ font_name="$1"
 if [[ -n "$font_name" && "$font_name" != "CNCLD" ]]; then
   if fc-list | grep -iq "$font_name"; then
     sed -i "s/family = \".*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
-    sed -i "s/font-family: .*/font-family: $font_name;/g" ~/.config/waybar/style.css
-    sed -i "s/font-family: .*/font-family: $font_name;/g" ~/.config/swayosd/style.css
+    sed -i "s/font-family: .*/font-family: '$font_name';/g" ~/.config/waybar/style.css
+    sed -i "s/font-family: .*/font-family: '$font_name';/g" ~/.config/swayosd/style.css
     xmlstarlet ed -L \
       -u '//match[@target="pattern"][test/string="monospace"]/edit[@name="family"]/string' \
       -v "$font_name" \


### PR DESCRIPTION
Problem:

When I install the `0xProto` font ("Menu > Install > Package", `ttf-0xproto-nerd`) and set it as the system font ("Menu > Style > Font", `0xProto Nerd Font Mono`), `waybar` disappears.

When I run `waybar` from the terminal, I get the error:

```
[error] style.css:10:15Expected a string.
```

This is because the font name starts with a `0`, so it's interpreted as a number.

The same happens for `swayosd`, but I was not able to find any errors caused by it.

Solution:

Put quotes around the font names in `omarchy-font-set`.

(I used single quotes because they can be put in the replacement string without being escaped)