### PR TITLE
Set default image viewer to feh

### DIFF
--- a/install/apps/mimetypes.sh
+++ b/install/apps/mimetypes.sh
@@ -2,13 +2,13 @@
 
 update-desktop-database ~/.local/share/applications
 
-# Open all images with imv
-xdg-mime default imv.desktop image/png
-xdg-mime default imv.desktop image/jpeg
-xdg-mime default imv.desktop image/gif
-xdg-mime default imv.desktop image/webp
-xdg-mime default imv.desktop image/bmp
-xdg-mime default imv.desktop image/tiff
+# Open all images with feh
+xdg-mime default feh.desktop image/png
+xdg-mime default feh.desktop image/jpeg
+xdg-mime default feh.desktop image/gif
+xdg-mime default feh.desktop image/webp
+xdg-mime default feh.desktop image/bmp
+xdg-mime default feh.desktop image/tiff
 
 # Open PDFs with the Document Viewer
 xdg-mime default org.gnome.Evince.desktop application/pdf

--- a/install/desktop/desktop.sh
+++ b/install/desktop/desktop.sh
@@ -5,7 +5,7 @@ yay -S --noconfirm --needed \
   fcitx5 fcitx5-gtk fcitx5-qt wl-clip-persist \
   nautilus sushi ffmpegthumbnailer gvfs-mtp \
   slurp satty \
-  mpv evince imv \
+  mpv evince imv feh \
   chromium
 
 # Add screen recorder based on GPU


### PR DESCRIPTION
Dear Mr. DHH, I think this PR makes a lot of sense, since imv is quite clunky, eg. why would you use an image viewer that doesn't support .webp and many other formats.

I suggest using feh (https://github.com/derf/feh), since it's way more powerful than imv, yet lightweight and integrates well with tiling managers. I hope you'll merge this PR, it's quite a QoL thing in my opinion!