### PR TITLE
Minor Limine / Snapper Tweaks and Fixes

### DIFF
--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 if command -v limine &>/dev/null; then
-  yay -S --noconfirm --needed limine-mkinitcpio-hook limine-snapper-sync
-
   sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
 HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
 EOF
@@ -64,6 +62,7 @@ term_background_bright: 24283b
  
 EOF
 
+  yay -S --noconfirm --needed limine-mkinitcpio-hook limine-snapper-sync
   sudo limine-update
 
   # Match Snapper configs if not installing from the ISO


### PR DESCRIPTION
- Makes UKI available for everyone with EFI
- Changes the check for UKI to be in line with the rest of the EFI checks
- Removes the config file gate -- can cause failures on re-run situations
- Define ESP_PATH for performance and error prevention
- Set config files before running installs to prevent ESP_PATH complaints