### PR TITLE
Changed Keybindings for resize active window to code syntax

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -55,10 +55,10 @@ bindd = ALT, Tab, Reveal active window on top, bringactivetotop
 bindd = ALT SHIFT, Tab, Reveal active window on top, bringactivetotop
 
 # Resize active window
-bindd = SUPER, minus, Expand window left, resizeactive, -100 0
-bindd = SUPER, equal, Shrink window left, resizeactive, 100 0
-bindd = SUPER SHIFT, minus, Shrink window up, resizeactive, 0 -100
-bindd = SUPER SHIFT, equal, Expand window down, resizeactive, 0 100
+bindd = SUPER, code:20, Expand window left, resizeactive, -100 0    # - key
+bindd = SUPER, code:21, Shrink window left, resizeactive, 100 0     # = key
+bindd = SUPER SHIFT, code:20, Shrink window up, resizeactive, 0 -100
+bindd = SUPER SHIFT, code:21, Expand window down, resizeactive, 0 100
 
 # Scroll through existing workspaces with SUPER + scroll
 bindd = SUPER, mouse_down, Scroll active workspace forward, workspace, e+1


### PR DESCRIPTION
Solves Issue: #1028 

Changes made to the tiling bindings to use the code syntax. This way it will work also on a German layout (and all other keyboards where one or both of the keys - and = are not available)

