### PR TITLE
Default `OMARCHY_REF` to `master` in boot.sh

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -23,8 +23,9 @@ echo -e "\nCloning Omarchy from: https://github.com/${OMARCHY_REPO}.git"
 rm -rf ~/.local/share/omarchy/
 git clone "https://github.com/${OMARCHY_REPO}.git" ~/.local/share/omarchy >/dev/null
 
-# Use custom branch if instructed
-if [[ -n "$OMARCHY_REF" ]]; then
+# Use custom branch if instructed, otherwise default to master
+OMARCHY_REF="${OMARCHY_REF:-master}"
+if [[ $OMARCHY_REF != "master" ]]; then
   echo -e "\eUsing branch: $OMARCHY_REF"
   cd ~/.local/share/omarchy
   git fetch origin "${OMARCHY_REF}" && git checkout "${OMARCHY_REF}"


### PR DESCRIPTION
Ref: https://github.com/basecamp/omarchy/issues/216#issuecomment-3217919769

This will allow us to change GitHub's default branch to `dev`, so that PRs will target the correct branch by default, but new installations will still default to using the stable `master` branch.