### PR TITLE
Add robust safeguard to prevent omarchy-update from beginning an update during an AUR ddos

### DIFF
--- a/bin/omarchy-ensure-aur-available
+++ b/bin/omarchy-ensure-aur-available
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if ! gum spin --spinner "globe" --title "Verifying that the AUR package repository is reachable, please stand by" -- \
+	  curl -s --retry 4 --connect-timeout 30 --head -A "omarchy-update" "https://aur.archlinux.org/"
+then
+  gum confirm "Can not reach the AUR package repository, proceed anyway?"
+  exit $?
+fi
+

--- a/bin/omarchy-ensure-aur-available
+++ b/bin/omarchy-ensure-aur-available
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if ! gum spin --spinner "globe" --title "Verifying that the AUR package repository is reachable, please stand by" -- \
-	  curl -s --retry 4 --connect-timeout 30 --head -A "omarchy-update" "https://aur.archlinux.org/"
+	  curl -s --retry 4 --connect-timeout 30 --head -A "omarchy-update" "https://aur.archlinux.org/static/images/rss.svg"
 then
   gum confirm "Can not reach the AUR package repository, proceed anyway?"
   exit $?

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -2,6 +2,7 @@
 
 set -e
 
+omarchy-ensure-aur-available
 omarchy-update-git
 omarchy-migrate
 omarchy-update-system-pkgs


### PR DESCRIPTION
New take on this PR since the [old one](https://github.com/basecamp/omarchy/pull/823) proved a bit too flakey.

The script now polls a static resource on the AUR repository server instead of
triggering a slow PHP-rendered request.  This is not only much faster, but 
will consume far less resources server-side.

Curl now uses its built-in retry logic for a maximum of four attempts, with exponential backoff.

To ensure the path to updating is never blocked, the user will be prompted 
whether to proceed anyway if an outage is detected, so as to never block 
anyone from running the updater.