### PR TITLE
Fix installation command for ufw-docker

### DIFF
--- a/bin/omarchy-install-firewall
+++ b/bin/omarchy-install-firewall
@@ -5,7 +5,7 @@ if ! command -v ufw &>/dev/null; then
 fi
 
 if ! command -v ufw-docker &>/dev/null; then
-  yay -S --noconfirm ufw
+  yay -S --noconfirm ufw-docker
 fi
 
 # Allow nothing in, everything out


### PR DESCRIPTION
It seems we attempt to install ufw when ufw-docker command is not found. This needs to be ufw-docker instead, right?