### PR TITLE
Fix issues preventing update checker from working

### DIFF
--- a/bin/omarchy-pkg-repos-accessible
+++ b/bin/omarchy-pkg-repos-accessible
@@ -22,10 +22,10 @@ done
 # Ensure AUR is available
 i=0
 while true; do
-  if curl -sfI --connect-timeout 30 -A "omarchy-update" https://aur.archlinux.org >/dev/null &&
+  if curl -fsS --connect-timeout 30 -A "omarchy-update" https://aur.archlinux.org >/dev/null &&
     curl -sf -A "omarchy-update" \
       "https://aur.archlinux.org/rpc/?v=5&type=info&arg=base" |
-    jq -e '.type=="info"' >/dev/null; then
+    jq -e '.type=="multiinfo"' >/dev/null; then
     break
   else
     wait=${BACKOFFS[$i]:-${BACKOFFS[-1]}}


### PR DESCRIPTION
There are 2 issues preventing this script from working as expected:

1. The script is doing a HEAD request to https://aur.archlinux.org but is getting a 405 Method Not Allowed error. I have updated the script to do a GET request instead.

2. The script was expecting the JSON object returned from https://aur.archlinux.org/rpc/?v=5&type=info&arg=base to have a type of info, but it has a type of multiinfo. I have updated the script to check for multiinfo instead.