### PR TITLE
Wait for screen lock before suspend

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -3,6 +3,7 @@ general {
     before_sleep_cmd = loginctl lock-session               # lock before suspend.
     after_sleep_cmd = hyprctl dispatch dpms on             # to avoid having to press a key twice to turn on the display.
     on_unlock_cmd = omarchy-restart-waybar                 # prevent stacking of waybar when waking
+    inhibit_sleep = 3                                      # wait until screen is locked
 }
 
 listener {


### PR DESCRIPTION
Only the option 3 works on my machine. The screen is locked after wakeup but it takes a second or two for the "Enter password" message to become visible.

fixes #1038 