### PR TITLE
Use Quad9 as fallback DNS for better privacy

### DIFF
--- a/bin/omarchy-setup-dns
+++ b/bin/omarchy-setup-dns
@@ -11,7 +11,7 @@ Cloudflare)
   sudo tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
 [Resolve]
 DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com
-FallbackDNS=8.8.8.8#dns.google 8.8.4.4#dns.google
+FallbackDNS=9.9.9.9 149.112.112.112
 DNSOverTLS=opportunistic
 EOF
   
@@ -63,7 +63,7 @@ Custom)
   sudo tee /etc/systemd/resolved.conf >/dev/null <<EOF
 [Resolve]
 DNS=$dns_servers
-FallbackDNS=1.1.1.1 8.8.8.8
+FallbackDNS=9.9.9.9 149.112.112.112
 EOF
   
   # Ensure network interfaces don't override our DNS settings


### PR DESCRIPTION
Replace Google DNS with Quad9 as the fallback DNS provider for better privacy consistency.

Users choosing Cloudflare likely value privacy, so Quad9 (9.9.9.9, 149.112.112.112) is a more appropriate fallback than Google.

As discussed in #752 and approved by @dhh in #1043.