### PR TITLE
Implement omarchy-launch-editor with state-based preference

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Launch the user's preferred editor
+# Reads preference from ~/.local/state/omarchy/default/editor
+# Falls back to nvim if not set
+
+STATE_FILE="$HOME/.local/state/omarchy/default/editor"
+
+# Read the preferred editor
+if [[ -f "$STATE_FILE" ]]; then
+  PREFERRED_EDITOR=$(cat "$STATE_FILE")
+else
+  PREFERRED_EDITOR="nvim"
+fi
+
+# Launch the editor with the file
+case "$PREFERRED_EDITOR" in
+  nvim|vim|nano|micro|helix)
+    # Terminal editors need alacritty
+    alacritty -e "$PREFERRED_EDITOR" "$1"
+    ;;
+  code|codium|zed|sublime)
+    # GUI editors launch directly
+    "$PREFERRED_EDITOR" "$1"
+    ;;
+  *)
+    # Default fallback
+    alacritty -e nvim "$1"
+    ;;
+esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -31,7 +31,7 @@ present_terminal() {
 
 edit_in_nvim() {
   notify-send "Editing config file" "$1"
-  alacritty -e nvim "$1"
+  omarchy-launch-editor "$1"
 }
 
 install() {
@@ -144,6 +144,7 @@ show_setup_menu() {
   *Keybindings*) edit_in_nvim ~/.config/hypr/bindings.conf ;;
   *Input*) edit_in_nvim ~/.config/hypr/input.conf ;;
   *DNS*) present_terminal omarchy-setup-dns ;;
+  *Editor*) present_terminal omarchy-set-editor ;;
   *Config*) show_setup_config_menu ;;
   *Fingerprint*) present_terminal omarchy-setup-fingerprint ;;
   *Fido2*) present_terminal omarchy-setup-fido2 ;;

--- a/bin/omarchy-set-editor
+++ b/bin/omarchy-set-editor
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Set the default editor for omarchy-launch-editor
+
+STATE_DIR="$HOME/.local/state/omarchy/default"
+STATE_FILE="$STATE_DIR/editor"
+
+# Create state directory if it doesn't exist
+mkdir -p "$STATE_DIR"
+
+if [[ -z "$1" ]]; then
+  # Show menu to select editor
+  EDITOR_CHOICE=$(gum choose --header "Select default editor" \
+    "nvim" \
+    "vim" \
+    "nano" \
+    "micro" \
+    "helix" \
+    "code" \
+    "codium" \
+    "zed" \
+    "sublime")
+else
+  EDITOR_CHOICE="$1"
+fi
+
+if [[ -n "$EDITOR_CHOICE" ]]; then
+  echo "$EDITOR_CHOICE" > "$STATE_FILE"
+  echo "Default editor set to: $EDITOR_CHOICE"
+fi


### PR DESCRIPTION
Implements customizable editor support as discussed in #634 and requested by @dhh.

@logannc initially proposed this feature in PR #808. DHH requested a different approach using state files instead of Hyprland environment variables to avoid session restarts.

This PR implements DHH's requested approach:
- Uses ~/.local/state/omarchy/default/editor to store preference
- omarchy-launch-editor reads preference from state file, falls back to nvim
- omarchy-set-editor provides menu interface for selecting default editor  
- Adds Editor option to Setup menu
- Editor can be changed without restarting Hyprland

Supports terminal editors (nvim, vim, nano, micro, helix) and GUI editors (code, codium, zed, sublime).

Fixes #634

Thanks to @logannc for the initial idea and groundwork in #808.