### PR TITLE
Use Omarchy version as fastfetch header

### DIFF
--- a/config/fastfetch/config.jsonc
+++ b/config/fastfetch/config.jsonc
@@ -85,9 +85,9 @@
     "break",
     {
       "type": "command",
-      "key": "│ ├Ø",
+      "key": "Ø Omarchy",
       "keyColor": "blue",
-      "text": "version=$(git -C ~/.local/share/omarchy describe --tags --abbrev=0 2>/dev/null); echo \"Omarchy $version\""
+      "text": "version=$(git -C ~/.local/share/omarchy describe --tags --abbrev=0 2>/dev/null); echo \"$version\""
     },
     {
       "type": "command",


### PR DESCRIPTION
The fastfetch configuration is missing some elements because they’re simply not present in the system. One of these is the DE, which was previously used as the header for the second block in _Software_.

Since there’s no suitable replacement, I suggest using an "Omarchy" label instead—one that reflects all the customizations applied to the base Arch system.

Here is the version without DE and with the two flying lines: 
<img width="198" height="43" alt="image" src="https://github.com/user-attachments/assets/ee03cc55-ef78-4f04-8b46-4c59e2af3348" />


Here is the proposed fixed version: 
<img width="722" height="537" alt="image" src="https://github.com/user-attachments/assets/d3c6a45a-b6c6-4746-be11-9ac6fb1172e7" />
