### PR TITLE
guard: root warning message should be reversed

### DIFF
--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -14,8 +14,8 @@ for marker in /etc/cachyos-release /etc/eos-release /etc/garuda-release /etc/man
   [[ -f "$marker" ]] && abort "Vanilla Arch"
 done
 
-# Must not be runnig as root
-[ "$EUID" -eq 0 ] && abort "Running as user (not root)"
+# Must not be running as root
+[ "$EUID" -eq 0 ] && abort "Running as root (not user)"
 
 # Must be x86 only to fully work
 [ "$(uname -m)" != "x86_64" ] && abort "x86_64 CPU"


### PR DESCRIPTION
- `[ "$EUID" -eq 0 ]` checks if root, so I think the guard message should be reversed (unless I'm misunderstanding)
- typo: should be _running_ 