### PR TITLE
Fix working directory syntax

### DIFF
--- a/migrations/1755870033.sh
+++ b/migrations/1755870033.sh
@@ -1,7 +1,3 @@
 echo "Use current terminal shell cwd for new terminal working directories"
 
-# Handle the case where no --working-directory exists yet
-sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal$|bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf
-
-# Handle the case where --working-directory exists without equals sign
-sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal --working-directory \$(.*)|bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf
+sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal|bindd = SUPER, return, Terminal, exec, $terminal --working-directory $(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf

--- a/migrations/1756146722.sh
+++ b/migrations/1756146722.sh
@@ -1,0 +1,8 @@
+echo "Use current terminal shell cwd for new terminal working directories"
+
+# Handle the case where no --working-directory exists yet
+sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal$|bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf
+
+# Handle the case where --working-directory exists without equals sign
+sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal --working-directory \$(.*)|bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf
+


### PR DESCRIPTION
Alacritty is able to take in the working directory argument with or without an `=` while ghostty will not open if working directory is passed in without the `=`. 
I updated the migration script to create a syntax that works with the default Alacritty or ghostty if the user updates their `$terminal`.

After running the migration, the result in `.config/hypr/bindings.conf` should look like: 

`bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)`

as this syntax is compatible across terminals.