### PR TITLE
Check for apps.desktop in ~/.nix-profile - omarchy-launch-*

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,/usr}/share/applications/$(xdg-settings get default-web-browser) 2>/dev/null | head -1) ${args[@]} $@
+exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$(xdg-settings get default-web-browser) 2>/dev/null | head -1) ${args[@]} $@

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,4 +7,4 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"


### PR DESCRIPTION
The current sed breaks if it is unable to find the desktop file for the default browser in one of the two existing locations:

- ~/.local/profile/share/applications/
- /usr/profile/share/applications/

This results in similar looking error message that drops a `/`:
`omarchy-launch-webapp "https://chatgpt.com"`
`Path "--app=“https:/chatgpt.com”" does not exist!`

I utilize nix home manager to manage my user installed packages on vanilla arch + omarchy. These packages put their desktop files in ~/.nix-profile/share/applications so I have added that location to `omarchy-launch-webapp` and `omarchy-launch-browser`. 

I may be worth looking into using `XDG_DATA_DIRS` instead of this static list and this should cover any edge cases like this in the future.