### PR TITLE
[#643] Add zen-browser to possible webapp launchers

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -3,7 +3,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi*) ;;
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | zen-browser*) ;;
 *) browser="chromium.desktop" ;;
 esac
 


### PR DESCRIPTION
This adds the zen-browser as a possible option to use when launching webapps. Making it possible to use this browser as an alternative to chromium.
This addresses the issue I am experiencing in #643 but does not fully resolve the issue.