### PR TITLE
Enable built-in calendar in Waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -59,7 +59,17 @@
   "clock": {
     "format": "{:%A %H:%M}",
     "format-alt": "{:%d %B W%V %Y}",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "{calendar}",
+    "calendar": {
+      "format": {
+        "today": "<b><u>{}</u></b>"
+      }
+    },
+    "actions": {
+      "on-scroll-up": "shift_down",
+      "on-scroll-down": "shift_up"
+    },
     "on-click-right": "omarchy-cmd-tzupdate"
   },
   "network": {


### PR DESCRIPTION
Simple PR that enables the integrated calendar feature in Waybar with scroll navigation for switching months. I think it would be a nice QoL improvement to have quick date access directly from the status bar using Waybar's native functionality.