### PR TITLE
fix multiple word app names

### DIFF
--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -20,7 +20,7 @@ if [ "$#" -ne 1 ]; then
     exit 1
   fi
 else
-  APP_NAME="$1"
+  APP_NAME="$*"
 fi
 
 if [[ -z "$APP_NAME" ]]; then

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -3,8 +3,8 @@
 ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
 
-if [ "$#" -ne 1 ]; then
-  # Find all web apps
+if [ "$#" -eq 0 ]; then
+  # Find all TUIs
   while IFS= read -r -d '' file; do
     if grep -q '^Exec=.*alacritty.*-e' "$file"; then
       TUIS+=("$(basename "${file%.desktop}")")
@@ -14,23 +14,28 @@ if [ "$#" -ne 1 ]; then
   if ((${#TUIS[@]})); then
     IFS=$'\n' SORTED_TUIS=($(sort <<<"${TUIS[*]}"))
     unset IFS
-    APP_NAME=$(gum choose --header "Select TUI to remove..." "${SORTED_TUIS[@]}")
+    APP_NAMES_STRING=$(gum choose --no-limit --header "Select TUI to remove..." --selected-prefix="✗ " "${SORTED_TUIS[@]}")
+    # Convert newline-separated string to array
+    APP_NAMES=()
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && APP_NAMES+=("$line")
+    done <<< "$APP_NAMES_STRING"
   else
     echo "No TUIs to remove."
     exit 1
   fi
 else
-  APP_NAME="$*"
+  # Use array to preserve spaces in app names
+  APP_NAMES=("$@")
 fi
 
-if [[ -z "$APP_NAME" ]]; then
-  echo "You must provide TUI name."
+if [[ ${#APP_NAMES[@]} -eq 0 ]]; then
+  echo "You must provide TUI names."
   exit 1
 fi
 
-rm "$DESKTOP_DIR/$APP_NAME.desktop"
-rm "$ICON_DIR/$APP_NAME.png"
-
-if [ "$#" -ne 1 ]; then
-  echo -e "Removed $APP_NAME\n"
-fi
+for APP_NAME in "${APP_NAMES[@]}"; do
+  rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
+  rm -f "$ICON_DIR/$APP_NAME.png"
+  echo "Removed $APP_NAME"
+done

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -14,21 +14,27 @@ if [ "$#" -eq 0 ]; then
   if ((${#WEB_APPS[@]})); then
     IFS=$'\n' SORTED_WEB_APPS=($(sort <<<"${WEB_APPS[*]}"))
     unset IFS
-    APP_NAMES=$(gum choose --no-limit --header "Select web app to remove..." "${SORTED_WEB_APPS[@]}")
+    APP_NAMES_STRING=$(gum choose --no-limit --header "Select web app to remove..." "${SORTED_WEB_APPS[@]}")
+    # Convert newline-separated string to array
+    APP_NAMES=()
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && APP_NAMES+=("$line")
+    done <<< "$APP_NAMES_STRING"
   else
     echo "No web apps to remove."
     exit 1
   fi
 else
-  APP_NAMES="$*"
+  # Use array to preserve spaces in app names
+  APP_NAMES=("$@")
 fi
 
-if [[ -z "$APP_NAMES" ]]; then
+if [[ ${#APP_NAMES[@]} -eq 0 ]]; then
   echo "You must provide web app names."
   exit 1
 fi
 
-for APP_NAME in $APP_NAMES; do
+for APP_NAME in "${APP_NAMES[@]}"; do
   rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
   rm -f "$ICON_DIR/$APP_NAME.png"
   echo "Removed $APP_NAME"

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -14,7 +14,7 @@ if [ "$#" -eq 0 ]; then
   if ((${#WEB_APPS[@]})); then
     IFS=$'\n' SORTED_WEB_APPS=($(sort <<<"${WEB_APPS[*]}"))
     unset IFS
-    APP_NAMES_STRING=$(gum choose --no-limit --header "Select web app to remove..." "${SORTED_WEB_APPS[@]}")
+    APP_NAMES_STRING=$(gum choose --no-limit --header "Select web app to remove..." --selected-prefix="✗ " "${SORTED_WEB_APPS[@]}")
     # Convert newline-separated string to array
     APP_NAMES=()
     while IFS= read -r line; do


### PR DESCRIPTION
Greetings!

I've noticed in 2.0 that the multiple select and the script itself do not work with multiple word app name inputs, e.g. "Google Photos" but rather tries to remove both "Google" and "Photos" in that case.

Attempt to fix in this PR.