### PR TITLE
ensure wayland is used for chromium browsers

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -2,9 +2,21 @@
 
 browser=$(xdg-settings get default-web-browser)
 
+# Prefer Chromium-family desktop entries; otherwise fall back to Chromium.
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi*) ;;
-*) browser="chromium.desktop" ;;
+  google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi*) ;;
+  *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+# Resolve the underlying executable from the desktop file
+exec_cmd=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,/usr}/share/applications/$browser 2>/dev/null | head -1)
+
+# Build optional flags depending on the browser engine
+extra_args=()
+case "$exec_cmd" in
+  *chromium*|*chrome*|*brave*|*edge*|*opera*|*vivaldi*)
+    extra_args+=(--ozone-platform=wayland)
+    ;;
+esac
+
+exec setsid uwsm app -- "$exec_cmd" ${extra_args[@]} --app="$1" "${@:2}"


### PR DESCRIPTION
I'm pretty sure this isn't the best way to do this, but with the v2 update, everything seemed to break if you weren't using chromium. 

All this is doing is doing the same check we already do for valid browsers after finding the executable, and applying the wayland ozone platform if it's valid.