### PR TITLE
include more chromium browsers in chromium rules

### DIFF
--- a/default/hypr/apps/chromium.conf
+++ b/default/hypr/apps/chromium.conf
@@ -1,6 +1,8 @@
-# Force chromium into a tile to deal with --app bug
-windowrule = tile, class:^(Chromium)$
+# Force chromium-based browsers into a tile to deal with --app bug
+# Includes common Chromium variants: Chrome, Edge, Brave, Vivaldi, Opera, etc.
+windowrule = tile, class:.*(([cC]hrom(e|ium))|([bB]rave)|([eE]dge)|([oO]pera)|([vV]ivaldi)).*
 
 # Only slight opacity when unfocused
-windowrule = opacity 1 0.97, class:^(Chromium|chromium|google-chrome|google-chrome-unstable|Brave-browser|brave-browser)$
+# Extend to include Microsoft Edge and other Chromium-based browsers
+windowrule = opacity 1 0.97, class:.*(([cC]hrom(e|ium))|([bB]rave)|([eE]dge)|([oO]pera)|([vV]ivaldi)).*
 windowrule = opacity 1 1, initialTitle:(youtube.com_/|app.zoom.us_/wc/home)


### PR DESCRIPTION
Similar to the omarchy-launch-webapp change, this broadens the chromium rules to encompass more chromium browsers