### PR TITLE
Fix emoji picker description

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -1,6 +1,6 @@
 # Menus
 bindd = SUPER, SPACE, Launch apps, exec, walker -p "Start…"
-bindd = SUPER CTRL, E, Show clipboard, exec, walker -m Emojis
+bindd = SUPER CTRL, E, Emoji picker, exec, walker -m Emojis
 bindd = SUPER ALT, SPACE, Omarchy menu, exec, omarchy-menu
 bindd = SUPER, ESCAPE, Power menu, exec, omarchy-menu system
 bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system


### PR DESCRIPTION
Seems like the description was made for something else.

Should be easier for people to find using `SUPER + K` now.