### PR TITLE
fix(hypr): convert TAB workspace bindings from bind to bindd

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -39,8 +39,8 @@ bindd = SUPER SHIFT, code:18, Move window to workspace 9, movetoworkspace, 9
 bindd = SUPER SHIFT, code:19, Move window to workspace 10, movetoworkspace, 10
 
 # Tab between workspaces
-bind = SUPER, TAB, workspace, e+1
-bind = SUPER SHIFT, TAB, workspace, e-1
+bindd = SUPER, TAB, Next workspace, workspace, e+1
+bindd = SUPER SHIFT, TAB, Previous workspace, workspace, e-1
 
 # Swap active window with the one next to it with SUPER + SHIFT + arrow keys
 bindd = SUPER SHIFT, left, Swap window to the left, swapwindow, l


### PR DESCRIPTION
## Summary
- Converts SUPER+TAB and SUPER+SHIFT+TAB workspace navigation bindings from `bind` to `bindd`
- Adds descriptions "Next workspace" and "Previous workspace"
- Enables proper overriding in user configurations

## Problem
The current `bind` format prevents users from properly overriding these keybindings in their custom configs, causing conflicts when trying to reassign TAB keys for window group navigation or other purposes.

## Test plan
- [x] Verify bindings work as expected for workspace navigation
- [x] Test that user configs can now properly override these bindings
- [x] Confirm descriptions appear in omarchy-menu or similar tools