### PR TITLE
Remove Omarchy from the list of selectable fonts

### DIFF
--- a/bin/omarchy-font-list
+++ b/bin/omarchy-font-list
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-fc-list :spacing=100 -f "%{family[0]}\n" | grep -v -i -E 'emoji|signwriting' | sort -u
+fc-list :spacing=100 -f "%{family[0]}\n" | grep -v -i -E 'emoji|signwriting|omarchy' | sort -u


### PR DESCRIPTION
Currently we see `omarchy` as a selectable font on the font list.

<img width="475" height="653" alt="image" src="https://github.com/user-attachments/assets/8625b78a-8781-4fd9-9073-14b8ba0bf35e" />


We should remove it as the omarchy font does not have the complete set of characters.

<img width="1539" height="599" alt="image" src="https://github.com/user-attachments/assets/3cbc38c2-8f82-40b7-82ba-cac2a321e81c" />
