### PR TITLE
fixing typo at waybar/config.jsonc

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -72,7 +72,7 @@
     "tooltip-format-ethernet": "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
     "tooltip-format-disconnected": "Disconnected",
     "interval": 3,
-    "nospacing": 1,
+    "spacing": 1,
     "on-click": "alacritty --class=Impala -e impala"
   },
   "battery": {


### PR DESCRIPTION
Fixing `nospacing` to `spacing`. 

There is no such a config as `nospacing` in Waybar's source code: https://github.com/search?q=repo%3AAlexays%2FWaybar%20nospacing&type=code

But there is `spacing` : https://github.com/search?q=repo%3AAlexays%2FWaybar+spacing&type=code 