### PR TITLE
UX: Change webapp removal selection icons

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -14,7 +14,7 @@ if [ "$#" -eq 0 ]; then
   if ((${#WEB_APPS[@]})); then
     IFS=$'\n' SORTED_WEB_APPS=($(sort <<<"${WEB_APPS[*]}"))
     unset IFS
-    APP_NAMES=$(gum choose --no-limit --header "Select web app to remove..." "${SORTED_WEB_APPS[@]}")
+    APP_NAMES=$(gum choose --no-limit --header "Select web app to remove..." --selected-prefix="✗ " --cursor-prefix=" " "${SORTED_WEB_APPS[@]}")
   else
     echo "No web apps to remove."
     exit 1


### PR DESCRIPTION
This tiny change to the gum command makes the removal process much clearer for selected Web Apps being sent on their one-way journey.

Current:
<img width="438" height="101" alt="image" src="https://github.com/user-attachments/assets/b42204b9-400d-4406-8e10-6634947c54fc" />


New:
<img width="448" height="100" alt="image" src="https://github.com/user-attachments/assets/3c665eaf-79c0-4afd-9fe2-23334a39ee0d" />
