### PR TITLE
Make `omarchy-cmd-terminal-cwd` work with Ghostty

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -2,7 +2,7 @@
 $terminal = uwsm app -- alacritty
 $browser = omarchy-launch-browser
 
-bindd = SUPER, return, Terminal, exec, $terminal --working-directory $(omarchy-cmd-terminal-cwd)
+bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)
 bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window
 bindd = SUPER, B, Browser, exec, $browser
 bindd = SUPER, M, Music, exec, uwsm app -- spotify


### PR DESCRIPTION
When using Ghostty as the default terminal, the newly added `--working-directory $(omarchy-cmd-terminal-cwd)` option crashes Ghostty. This is because the `ghostty` CLI command requires an `=` sign between a long option name and its value, while Alacritty works with or without the `=` sign.

This PR adds the `=` sign to make it work for Ghossty.