### PR TITLE
Update Omarchy icon in unified menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -315,7 +315,7 @@ show_remove_menu() {
 }
 
 show_update_menu() {
-  case $(menu "Update" "󰣇  Omarchy\n  Config\n󰸌  Themes\n  Process\n  Timezone") in
+  case $(menu "Update" " Omarchy\n  Config\n󰸌  Themes\n  Process\n  Timezone") in
   *Omarchy*) present_terminal omarchy-update ;;
   *Config*) show_update_config_menu ;;
   *Themes*) present_terminal omarchy-theme-update ;;


### PR DESCRIPTION
This PR changes the icon for Omarchy in the unified menu > update page.

<img width="433" height="489" alt="2025-08-26-000716_hyprshot" src="https://github.com/user-attachments/assets/53120f7f-196b-42a0-8063-cf8ac9ad9e05" />

