### PR TITLE
Make DHCP the default DNS provider

### DIFF
--- a/bin/omarchy-setup-dns
+++ b/bin/omarchy-setup-dns
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z $1 ]]; then
-  dns=$(gum choose --height 5 --header "Select DNS provider" Cloudflare DHCP Custom)
+  dns=$(gum choose --height 5 --header "Select DNS provider" DHCP Cloudflare Custom)
 else
   dns=$1
 fi


### PR DESCRIPTION
Fixes #1072 

Changes the menu order so DHCP is the default (first) option instead of Cloudflare.

This addresses the connectivity issues in countries where Cloudflare is blocked. DHCP works universally as it uses the router's DNS settings.

One-line change for inclusion in 2.0.1 as requested by @dhh.