### PR TITLE
fix: symlinks to default icons to prevent text chevron fallbacks

### DIFF
--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -4,6 +4,10 @@ gsettings set org.gnome.desktop.interface gtk-theme "Adwaita-dark"
 gsettings set org.gnome.desktop.interface color-scheme "prefer-dark"
 gsettings set org.gnome.desktop.interface icon-theme "Yaru-blue"
 
+# Set links for Nautilius action icons
+ln -sf /usr/share/icons/Adwaita/symbolic/actions/go-previous-symbolic.svg" "/usr/share/icons/Yaru/scalable/actions/go-previous-symbolic.svg
+ln -sf /usr/share/icons/Adwaita/symbolic/actions/go-next-symbolic.svg /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
+
 # Setup theme links
 mkdir -p ~/.config/omarchy/themes
 for f in ~/.local/share/omarchy/themes/*; do ln -nfs "$f" ~/.config/omarchy/themes/; done


### PR DESCRIPTION
fixes #1063

* adds symlinks to two svg action icons from default icon set 