### PR TITLE
Allow failed migrations to be skipped

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -2,20 +2,22 @@
 
 # Where we store an empty file for each migration that has already been performed.
 STATE_DIR="$HOME/.local/state/omarchy/migrations"
+mkdir -p "$STATE_DIR"
+
+# Skipped migrations are tracked separately
 mkdir -p "$STATE_DIR/skipped"
 
 # Run any pending migrations
 for file in ~/.local/share/omarchy/migrations/*.sh; do
   filename=$(basename "$file")
 
-  if [[ ! (-f "$STATE_DIR/$filename") && ! (-f "$STATE_DIR/skipped/$filename") ]]; then
+  if [[ ! -f "$STATE_DIR/$filename" && ! -f "$STATE_DIR/skipped/$filename" ]]; then
     echo -e "\e[32m\nRunning migration (${filename%.sh})\e[0m"
-    source $file
-    if [ $? -eq 0 ]; then
+
+    if bash -e $file; then
       touch "$STATE_DIR/$filename"
     else
-      gum confirm "migration ${filename%.sh} failed, do you wish to skip this migration?"
-      if [ $? -eq 0 ]; then
+      if gum confirm "Migration ${filename%.sh} failed. Skip and continue?"; then
         touch "$STATE_DIR/skipped/$filename"
       else
         exit 1

--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -1,18 +1,25 @@
 #!/bin/bash
 
-set -e
-
 # Where we store an empty file for each migration that has already been performed.
 STATE_DIR="$HOME/.local/state/omarchy/migrations"
-mkdir -p "$STATE_DIR"
+mkdir -p "$STATE_DIR/skipped"
 
 # Run any pending migrations
 for file in ~/.local/share/omarchy/migrations/*.sh; do
   filename=$(basename "$file")
 
-  if [[ ! -f "$STATE_DIR/$filename" ]]; then
+  if [[ ! (-f "$STATE_DIR/$filename") && ! (-f "$STATE_DIR/skipped/$filename") ]]; then
     echo -e "\e[32m\nRunning migration (${filename%.sh})\e[0m"
     source $file
-    touch "$STATE_DIR/$filename"
+    if [ $? -eq 0 ]; then
+      touch "$STATE_DIR/$filename"
+    else
+      gum confirm "migration ${filename%.sh} failed, do you wish to skip this migration?"
+      if [ $? -eq 0 ]; then
+        touch "$STATE_DIR/skipped/$filename"
+      else
+        exit 1
+      fi
+    fi
   fi
 done


### PR DESCRIPTION
Failed migrations can be now be skipped by a prompt. This means that if a migration is "stuck" then a user can opt to store it in a separate skipped directory. Skipped migrations will be considered for the purposes of running the pending migrations, however in future, we can allow the user to run their skipped migrations with a flag.

To allow the script to continue and prompt for failed migrations, the `set -e` has been removed. A manual check on the exit code is used instead.