### PR TITLE
Fix: Remove trailing slash from repository URL in pacman.conf setup

### DIFF
--- a/install/preflight/repositories.sh
+++ b/install/preflight/repositories.sh
@@ -10,7 +10,7 @@ fi
 
 # Add the Omarchy repository as first choice
 if ! grep -q "omarchy" /etc/pacman.conf; then
-  sudo sed -i '/^\[core\]/i [omarchy]\nSigLevel = Optional TrustAll\nServer = https:\/\/pkgs.omarchy.org\/$arch\/\n' /etc/pacman.conf
+  sudo sed -i '/^\[core\]/i [omarchy]\nSigLevel = Optional TrustAll\nServer = https:\/\/pkgs.omarchy.org\/$arch\n' /etc/pacman.conf
 fi
 
 # Set mirrors to global ones only


### PR DESCRIPTION
The installation script at `install/preflight/repositories.sh` currently adds the Omarchy repository to `/etc/pacman.conf` with a trailing slash (/) at the end of the Server URL. While this does not affect pacman itself, tools like debtap append another slash when resolving paths, resulting in an incorrect URL with a double slash (e.g., `https://pkgs.omarchy.org/$arch//omarchy.files`).