### PR TITLE
DRAFT: Fix Broadcom wifi on mid-2010s MacBooks (#1022) -- untested

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ source $OMARCHY_INSTALL/config/mise-ruby.sh
 source $OMARCHY_INSTALL/config/docker.sh
 source $OMARCHY_INSTALL/config/mimetypes.sh
 source $OMARCHY_INSTALL/config/hardware/network.sh
+source $OMARCHY_INSTALL/config/hardware/broadcom-wifi.sh
 source $OMARCHY_INSTALL/config/hardware/fix-fkeys.sh
 source $OMARCHY_INSTALL/config/hardware/bluetooth.sh
 source $OMARCHY_INSTALL/config/hardware/printer.sh

--- a/install/config/hardware/broadcom-wifi.sh
+++ b/install/config/hardware/broadcom-wifi.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fix for Broadcom BCM4360 WiFi on MacBooks
+# The BCM4360 chip family (PCI IDs 14e4:43a0, 14e4:43ba) has problematic 
+# firmware features that cause connection failures with "Operation failed" errors in iwctl.
+# This fix disables those features to restore WiFi functionality.
+# See: https://github.com/basecamp/omarchy/issues/1022
+
+# Only apply if a BCM4360 variant is detected AND the module exists
+# Known affected chips: 14e4:43a0, 14e4:43ba (add more as discovered)
+if lspci -nn 2>/dev/null | grep -qE "14e4:(43a0|43ba)" && modinfo brcmfmac &>/dev/null; then
+  echo "Detected Broadcom BCM4360 WiFi chip, applying compatibility fix..."
+  echo "options brcmfmac feature_disable=0x82000" | sudo tee /etc/modprobe.d/broadcom-macbook-wifi.conf >/dev/null
+fi


### PR DESCRIPTION
Based on [pointers](https://github.com/basecamp/omarchy/issues/1022#issuecomment-3221561121) from @bcorcoran

This patch:
- detects Broadcom BCM4360 which fail with "Operation failed" in iwctl
- applies kernel param `brcmfmac.feature_disable=0x82000`
- only when affected hardware should be detected (14e4:43a0, 14e4:43ba)

Needs to be tested. Untested (but attempting to test)

Notes: 
- Issue exists in current Arch (which makes sense ofc)
- Omarchy ISO doesn't allow access to Arch's pre-load (afaict?) so need to test in Arch
- Additional suggestions from @bcorcoran [here](https://github.com/basecamp/omarchy/issues/1022#issuecomment-3224377036) not incorporated