### PR TITLE
Add option to show PKGBUILD in omarchy-pkg-aur-install

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -12,7 +12,7 @@ fzf_args=(
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'
   --bind 'alt-b:change-preview:yay -Gpa {1} | tail -n +5'
-  --bind 'alt-B:change-preview:yay -Siia {1})'
+  --bind 'alt-B:change-preview:yay -Siia {1}'
   --color 'pointer:green,marker:green'
 )
 

--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -4,13 +4,15 @@ set -e
 
 fzf_args=(
   --multi
-  --preview 'yay -Sii {1}'
-  --preview-label='alt-p: toggle description, alt-j/k: scroll, tab: multi-select, F11: maximize'
+  --preview 'yay -Siia {1}'
+  --preview-label='alt-p: toggle description, alt-b/B: toggle PKGBUILD, alt-j/k: scroll, tab: multi-select, F11: maximize'
   --preview-label-pos='bottom'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'
+  --bind 'alt-b:change-preview:yay -Gpa {1} | tail -n +5'
+  --bind 'alt-B:change-preview:yay -Siia {1})'
   --color 'pointer:green,marker:green'
 )
 


### PR DESCRIPTION
Due to the recent [malicious packages found in the AUR](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/thread/7EZTJXLIAQLARQNTMEW2HBWZYE626IFJ/), it's good to check the PKGBUILD of the things you install to ensure nothing fishy is going on...

I binded that to `alt-b` (for "Build", as `alt-p` is already used). The thing is there's no (straightforward[^1]) way in fzf to toggle between different previews with one keybinding, so I opted for using `alt-B` to go back to the info (`-Siia`) preview.

Another alternative is using `preview` instead of `change-preview` in the `--bind`, making it so that when you select other package, it resets to the info preview.

Also note that the `tail -n +5` is for removing the header of the output of the yay command, as they are not actually part of the PKGBUILD file.

[^1]: It _should_ be possible, but I wasn't able to. If someone wants to try, they can find more information about it in [junegunn/fzf#2505](https://github.com/junegunn/fzf/issues/2505), [junegunn/fzf#3354](https://github.com/junegunn/fzf/issues/3354) and [ADVANCED.md#toggling-between-data-sources](https://github.com/junegunn/fzf/blob/master/ADVANCED.md#toggling-between-data-sources).