### PR TITLE
fix: keybinding menu size

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -83,7 +83,11 @@ parse_bindings() {
 }'
 }
 
+monitor_height=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .height')
+menu_height=$((monitor_height * 40 / 100))
+
 dynamic_bindings | \
   sort -u | \
   parse_bindings | \
-  walker --dmenu --theme keybindings -p 'Keybindings'
+  walker --dmenu --theme keybindings -p 'Keybindings' -w 800 -h "$menu_height"
+


### PR DESCRIPTION
On my ThinkPad X1 Carbon - 6th Gen (2560 x 1440), the keybinding menu gets cut off at the top and the bottom because the menu it's too tall. This dynamically adjusts the height of the keybinding menu window so that it fits within the display.

This is my first open source contribution!

Before:

<img width="2560" height="1440" alt="screenshot-2025-08-26_18-23-21" src="https://github.com/user-attachments/assets/3c019808-7aef-47f9-9b5a-14cb9afa3144" />

After:

<img width="2560" height="1440" alt="screenshot-2025-08-26_18-24-03" src="https://github.com/user-attachments/assets/2308dc99-b59e-4c5a-a48c-900f5a33ba3b" />

