### PR TITLE
View the release notes of a current or past release from the terminal

### DIFF
--- a/bin/omarchy-release-notes
+++ b/bin/omarchy-release-notes
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Use the passed in version or grab the current omarchy version
+version=${1:-$(omarchy-version)}
+
+# Ensure the version starts with 'v', i.e. v2.0.1
+[[ $version == v* ]] || version="v$version"
+
+url="https://api.github.com/repos/basecamp/omarchy/releases/tags/${version}"
+response=$(curl -s "$url")
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to fetch release notes from GitHub API - ${url}" >&2
+    exit 1
+fi
+release_notes=$(echo "$response" | jq -r '.body // "No release notes found for this tag."')
+
+echo "Release Notes for Omarchy $version:"
+echo "$release_notes" | glow

--- a/migrations/1756204305.sh
+++ b/migrations/1756204305.sh
@@ -1,0 +1,5 @@
+echo "Installing 'glow' for displaying markdown content in the terminal - For new omarchy-release-notes"
+
+if ! pacman -Q glow &>/dev/null; then
+    sudo pacman -S --noconfirm glow
+fi


### PR DESCRIPTION
After updating Omarchy sometimes I thought it could be useful to view the release notes from the terminal.

<img height="600" alt="image" src="https://github.com/user-attachments/assets/559313eb-f16e-4d49-ad9f-e923bd3d9244" />

Also supports a specific version to be passed in.

<img height="600" alt="image" src="https://github.com/user-attachments/assets/a62cf6bd-f49e-4eec-bf8f-4264d7b7e177" />

This uses the 'glow' package to display the markdown content.