### PR TITLE
Normalize branch name

### DIFF
--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -18,9 +18,12 @@ if [[ -z "$APP_NAME" || -z "$APP_EXEC" || -z "$ICON_URL" ]]; then
   exit 1
 fi
 
+# Create normalized name (lowercase, spaces replaced with underscores)
+NORMALIZED_NAME=$(echo "$APP_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')
+
 ICON_DIR="$HOME/.local/share/applications/icons"
-DESKTOP_FILE="$HOME/.local/share/applications/$APP_NAME.desktop"
-ICON_PATH="$ICON_DIR/$APP_NAME.png"
+DESKTOP_FILE="$HOME/.local/share/applications/$NORMALIZED_NAME.desktop"
+ICON_PATH="$ICON_DIR/$NORMALIZED_NAME.png"
 
 mkdir -p "$ICON_DIR"
 

--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -16,9 +16,12 @@ if [[ -z "$APP_NAME" || -z "$APP_URL" || -z "$ICON_URL" ]]; then
   exit 1
 fi
 
+# Create normalized name (lowercase, spaces replaced with underscores)
+NORMALIZED_NAME=$(echo "$APP_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')
+
 ICON_DIR="$HOME/.local/share/applications/icons"
-DESKTOP_FILE="$HOME/.local/share/applications/$APP_NAME.desktop"
-ICON_PATH="$ICON_DIR/$APP_NAME.png"
+DESKTOP_FILE="$HOME/.local/share/applications/$NORMALIZED_NAME.desktop"
+ICON_PATH="$ICON_DIR/$NORMALIZED_NAME.png"
 
 mkdir -p "$ICON_DIR"
 


### PR DESCRIPTION
Not a real problem, but for convenience. When creating new .desktop-files with the "Install -> Web App" or "Install -> TUI" the filename of the .desktop file would use the name of the App, i.e. the same name as what would be displayed in the launcher.

I added an app with the name that contained a space, and it still works, but it is annoying if you want to reference the files for some reason as you have to "escape" the space or use citation marks to contain the name:

1. cat "My App.desktop"
2. cat My\ App.desktop"

It is neater to have lower-case filenames and replace the space with a underscore. I.e. instead of having the .desktop-filename "My App.desktop" it would be "my_app.desktop".

This PR just adds normalization of the `APP_NAME`, `NORMALIZED_NAME`, and uses the normalized name for the creating of the .desktop-file.

As the filename doesn't really matter, I don't see any issues with this change. From the user, the change is completely transparent. It just makes it better and/or easier if you want to manually mess around with the .desktop-files.