### PR TITLE
Don't hardcode snapper configs, read the config list first

### DIFF
--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -16,7 +16,10 @@ case "$COMMAND" in
 create)
   DESC="$(omarchy-version)"
 
-  for config in root home; do
+  # Get existing snapper config names from CSV output
+  mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
+
+  for config in "${CONFIGS[@]}"; do
     sudo snapper -c "$config" create -c number -d "$DESC"
   done
   ;;

--- a/migrations/1756153445.sh
+++ b/migrations/1756153445.sh
@@ -1,0 +1,10 @@
+echo "Checking and correcting Snapper configs if needed"
+if command -v snapper &>/dev/null; then
+  if ! sudo snapper list-configs 2>/dev/null | grep -q "root"; then
+    sudo snapper -c root create-config /
+  fi
+
+  if ! sudo snapper list-configs 2>/dev/null | grep -q "home"; then
+    sudo snapper -c home create-config /home
+  fi
+fi


### PR DESCRIPTION
Not everyone has used the default BTRFS layout, or has the same names for their snapper configs. This commit lists out the existing snapper configs and loops over them to create snapper snapshots.

I only had a `root` config and the omarchy update script was breaking showing: `unknown config`.

This commit fixes the issue for me and should result in the existing behavior for everyone else.

#1216 