### PR TITLE
Prevent insertion of duplicate Alacritty option (#1154)

### DIFF
--- a/migrations/1755870033.sh
+++ b/migrations/1755870033.sh
@@ -1,3 +1,3 @@
 echo "Use current terminal shell cwd for new terminal working directories"
 
-sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal|bindd = SUPER, return, Terminal, exec, $terminal --working-directory $(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf
+sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal$|bindd = SUPER, return, Terminal, exec, $terminal --working-directory $(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf


### PR DESCRIPTION
My terminal binding from a previous install was:

```
bindd = SUPER, return, Terminal, exec, $terminal
```

After upgrading to v2.0.1 it became:

```
bindd = SUPER, return, Terminal, exec, $terminal --working-directory $(omarchy-cmd-terminal-cwd) --working-directory $(omarchy-cmd-terminal-cwd)
```

This broke the shortcut due to the double `--working-directory` arg. 

I can only imagine this happened because `migrations/1755870033.sh` ran twice somehow (not sure) - but this change should ensure the sed replacement has an idempotent outcome,