### PR TITLE
Simplify Waybar clock format

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -57,8 +57,7 @@
     "on-click": "alacritty -e btop"
   },
   "clock": {
-    "format": "{:%A %H:%M}",
-    "format-alt": "{:%d %B W%V %Y}",
+    "format": "{:%a %d %B %H:%M}",
     "tooltip": false,
     "on-click-right": "omarchy-cmd-tzupdate"
   },


### PR DESCRIPTION
Users frequently need to view both the date and time simultaneously— for example, when writing notes, reports, or commit messages. Currently, the Waybar clock module requires a mouse click to reveal both, and upon clicking, the initial information is hidden. This forces users to memorize the first piece of information, increasing cognitive load. Perhaps most important issue is the disruption of Omarchy's keyboard-centric workflow. I wrote this PR because this distraction happens to me many times during the day.

This PR simplifies the clock by removing the two-mode format (along with the week number and year, which may not provide value to most users). Instead, it displays a concise "Wed 27 August 12:34".

Thanks for Omarchy! It's great.