### PR TITLE
Fix: Full install nvidia

### DIFF
--- a/bin/omarchy-nvidia-setup
+++ b/bin/omarchy-nvidia-setup
@@ -22,7 +22,6 @@ echo "==> Adding Nvidia variables at the end of $HYPRCONF ..."
     echo "env = LIBVA_DRIVER_NAME,nvidia"
     echo "env = GBM_BACKEND,nvidia-drm"
     echo "env = __GLX_VENDOR_LIBRARY_NAME,nvidia"
-    echo "env = WLR_NO_HARDWARE_CURSORS,1"
 } >> "$HYPRCONF"
 
 echo "==> Configuration completed!"

--- a/bin/omarchy-nvidia-setup
+++ b/bin/omarchy-nvidia-setup
@@ -1,0 +1,28 @@
+#!/bin/bash
+# omarchy-nvidia-setup
+# Script to configure Nvidia drivers on Arch Linux with Hyprland
+
+set -e
+
+echo "==> Installing drivers NVIDIA..."
+sudo pacman -S --noconfirm nvidia nvidia-utils nvidia-settings lib32-nvidia-utils
+
+echo "==> Removing Nvidia-Open-DKMS (if it exists)..."
+sudo pacman -R --noconfirm nvidia-open-dkms || true
+
+HYPRCONF="$HOME/.config/hypr/hyprland.conf"
+
+echo "==> Creating configuration directory if it does not exist..."
+mkdir -p "$(dirname "$HYPRCONF")"
+
+echo "==> Adding Nvidia variables at the end of $HYPRCONF ..."
+{
+    echo ""
+    echo "# NVIDIA setup"
+    echo "env = LIBVA_DRIVER_NAME,nvidia"
+    echo "env = GBM_BACKEND,nvidia-drm"
+    echo "env = __GLX_VENDOR_LIBRARY_NAME,nvidia"
+    echo "env = WLR_NO_HARDWARE_CURSORS,1"
+} >> "$HYPRCONF"
+
+echo "==> Configuration completed!"


### PR DESCRIPTION
# Changelog - omarchy-nvidia-setup

### Added
- Created the `omarchy-nvidia-setup` bash script to automate NVIDIA driver setup on Arch Linux with Hyprland.

### Changes
- Installed required NVIDIA packages:
  - `nvidia`, `nvidia-utils`, `nvidia-settings`, and `lib32-nvidia-utils`.
  - Purpose: provide full NVIDIA driver support, utilities, and 32-bit compatibility.
- Removed `nvidia-open-dkms` if present.
  - Purpose: avoid conflicts between open and proprietary drivers.
- Automatically appended environment variables to `~/.config/hypr/hyprland.conf`:
  - `LIBVA_DRIVER_NAME=nvidia` → enable NVIDIA VAAPI driver.
  - `GBM_BACKEND=nvidia-drm` → set GBM backend for NVIDIA.
  - `__GLX_VENDOR_LIBRARY_NAME=nvidia` → use NVIDIA GLX vendor library.

### Notes
- The script ensures NVIDIA proprietary drivers are configured properly.
