### PR TITLE
Fix(boot.sh): potential partial upgrade

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -14,7 +14,7 @@ ansi_art='                 ▄▄▄
 clear
 echo -e "\n$ansi_art\n"
 
-sudo pacman -Sy --noconfirm --needed git
+sudo pacman -Syu --noconfirm --needed git
 
 # Use custom repo if specified, otherwise default to basecamp/omarchy
 OMARCHY_REPO="${OMARCHY_REPO:-basecamp/omarchy}"


### PR DESCRIPTION
Currently, the script runs:

```bash
sudo pacman -Sy --noconfirm --needed git
```

This can lead to partial upgrades, which are [unsupported on Arch Linux](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported).

Replaced it with:

```bash
sudo pacman -Syu --noconfirm --needed git
```

This ensures the package database and system are in sync before installing `git`, following Arch best practices.