### PR TITLE
custom install for existing Arch installs

### DIFF
--- a/INSTALL_CHANGES.md
+++ b/INSTALL_CHANGES.md
@@ -1,0 +1,79 @@
+# Installation Script Modifications
+
+## Changes Made
+
+### 1. Modified `install/packages.sh`
+- Added a function `is_installed()` to check if a package is already installed
+- Created arrays to track all packages and only install missing ones
+- The script now checks each package individually and only installs those not already present
+- Uses `pacman -Q` to determine if a package is installed
+
+### 2. Modified `install/config/config.sh`
+- Changed to replace existing Hyprland configurations with Omarchy versions
+- Removes existing Hyprland configs before installing fresh Omarchy configs
+- Focuses on Hyprland, Waybar, SwayOSD, Walker, and Mako configurations
+- Preserves environment configuration and bashrc
+- Includes most application-specific configs except for starship and neovim
+- Avoids copying only starship and neovim configurations as requested
+
+### 3. Added `install/config/hyprland-config.sh`
+- New specialized script that replaces existing Hyprland configurations with Omarchy versions
+- Removes existing configs before installing fresh Omarchy configs
+- Includes refreshing of Hyprland services after installation
+- Can be run separately to update only Hyprland configurations
+- Includes most application-specific configs except for starship and neovim
+
+### 4. Added `custom-install.sh`
+- New all-in-one installation script that combines the functionality of multiple scripts
+- Provides a dry run option to show what would be done without making changes
+- Allows for selection of optional packages and web applications
+- Properly handles the installation of themes to avoid dependency on the original download location
+- Separates required packages from optional ones
+- Gives individual control over each optional application installation
+- Features optional installation of web apps including:
+  - Figma, Zoom, Discord, GitHub, YouTube
+  - ChatGPT, Grok
+  - Google services (Contacts, Photos, Mail, Drive, Docs, Calendar)
+  - WhatsApp, Basecamp, Hey
+- Includes optional installation of Neovim and Starship prompt with their configurations
+
+## Usage
+
+### Standard Installation Scripts
+When you run the standard installation script:
+1. It will check if each package is already installed
+2. Only install packages that are missing
+3. Replace your existing Hyprland configuration with Omarchy configurations
+4. Include most application-specific configs except for starship and neovim
+
+To use the specialized Hyprland configuration script:
+```bash
+./install/config/hyprland-config.sh
+```
+
+### Custom Installation Script
+The new custom installation script provides more flexibility:
+
+```bash
+./custom-install.sh            # Run with interactive prompts
+./custom-install.sh --dry-run  # Show what would be done without making changes
+./custom-install.sh -n         # Short form for dry run
+```
+
+This script:
+1. Prompts for dry run mode to preview changes without modifying anything
+2. Installs required Hyprland packages automatically
+3. Asks about each optional web application individually
+4. Properly sets up the theme structure by:
+   - Copying themes to ~/.local/share/omarchy/themes/
+   - Creating proper symlinks to ~/.config/omarchy/themes/
+5. Offers optional installation of Neovim and Starship prompt
+6. Fixes common installation issues automatically
+
+This approach ensures that:
+- You don't reinstall packages you already have
+- Your existing Hyprland setup is completely replaced with Omarchy configurations
+- Configuration files are installed with preference for Omarchy setup
+- Services are properly refreshed after configuration changes
+- You have full control over which optional components are installed
+- The installation is not dependent on the original download location

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -381,7 +381,7 @@ go_to_menu() {
   *remove*) show_remove_menu ;;
   *update*) show_update_menu ;;
   *system*) show_system_menu ;;
-  *about*) alacritty --class Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s' ;;
+  *about*) terminal bash -c 'fastfetch; read -n 1 -s' ;;
   esac
 }
 

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -2,12 +2,13 @@
 
 # Copy and sync icon files
 mkdir -p ~/.local/share/icons/hicolor/48x48/apps/
-cp ~/.local/share/omarchy/applications/icons/*.png ~/.local/share/icons/hicolor/48x48/apps/
+OMARCHY_REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cp "$OMARCHY_REPO_DIR"/applications/icons/*.png ~/.local/share/icons/hicolor/48x48/apps/ 2>/dev/null || cp ~/.local/share/omarchy/applications/icons/*.png ~/.local/share/icons/hicolor/48x48/apps/ 2>/dev/null || true
 gtk-update-icon-cache ~/.local/share/icons/hicolor &>/dev/null
 
 # Copy .desktop declarations
 mkdir -p ~/.local/share/applications
-cp ~/.local/share/omarchy/applications/*.desktop ~/.local/share/applications/
-cp ~/.local/share/omarchy/applications/hidden/*.desktop ~/.local/share/applications/
+cp "$OMARCHY_REPO_DIR"/applications/*.desktop ~/.local/share/applications/ 2>/dev/null || cp ~/.local/share/omarchy/applications/*.desktop ~/.local/share/applications/ 2>/dev/null || true
+cp "$OMARCHY_REPO_DIR"/applications/hidden/*.desktop ~/.local/share/applications/ 2>/dev/null || cp ~/.local/share/omarchy/applications/hidden/*.desktop ~/.local/share/applications/ 2>/dev/null || true
 
 update-desktop-database ~/.local/share/applications

--- a/bin/omarchy-show-logo
+++ b/bin/omarchy-show-logo
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+# Create directory if it doesn't exist
+mkdir -p ~/.local/share/omarchy
+
+# Copy logo.txt if it doesn't exist in the target location
+if [ ! -f ~/.local/share/omarchy/logo.txt ] && [ -f "$(dirname "$(dirname "$0")")/logo.txt" ]; then
+  cp "$(dirname "$(dirname "$0")")/logo.txt" ~/.local/share/omarchy/logo.txt
+fi
+
 clear
 echo -e "\033[32m"
-cat <~/.local/share/omarchy/logo.txt
+cat ~/.local/share/omarchy/logo.txt 2>/dev/null || cat "$(dirname "$(dirname "$0")")/logo.txt"
 echo -e "\033[0m"
 echo

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -1,13 +1,12 @@
 #!/bin/bash
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
-echo "sudo pacman -Syu --noconfirm --ignore \"$(omarchy-pkg-ignored)\""
-sudo pacman -Syu --noconfirm --ignore "$(omarchy-pkg-ignored)"
+sudo pacman -Syu --noconfirm
+echo
 
 if omarchy-pkg-aur-accessible; then
   echo -e "\e[32m\nUpdate AUR packages\e[0m"
-  echo "yay -Syu --noconfirm  --ignore \"$(omarchy-pkg-ignored)\""
-  yay -Syu --noconfirm --ignore "$(omarchy-pkg-ignored)"
+  yay -Syu --noconfirm
   echo
 else
   echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"

--- a/config/fastfetch/config.jsonc
+++ b/config/fastfetch/config.jsonc
@@ -63,40 +63,31 @@
       "format": "\u001b[90m┌──────────────────────Software──────────────────────┐"
     },
     {
-      "type": "command",
-      "key": "\ue900 OS",
-      "keyColor": "blue",
-      "text": "version=$(omarchy-version); echo \"Omarchy $version\""
+      "type": "os",
+      "key": "󰣇 OS",
+      "keyColor": "yellow"
     },
     {
       "type": "kernel",
       "key": "│ ├",
-      "keyColor": "blue"
-    },
-    {
-      "type": "wm",
-      "key": "│ ├",
-      "keyColor": "blue"
-    },
-    {
-      "type": "de",
-      "key": " DE",
-      "keyColor": "blue"
-    },
-    {
-      "type": "terminal",
-      "key": "│ ├",
-      "keyColor": "blue"
+      "keyColor": "yellow"
     },
     {
       "type": "packages",
       "key": "│ ├󰏖",
-      "keyColor": "blue"
+      "keyColor": "yellow"
     },
     {
-      "type": "wmtheme",
-      "key": "│ ├󰉼",
-      "keyColor": "blue"
+      "type": "shell",
+      "key": "└ └",
+      "keyColor": "yellow"
+    },
+    "break",
+    {
+      "type": "command",
+      "key": "Ø Omarchy",
+      "keyColor": "blue",
+      "text": "version=$(git -C ~/.local/share/omarchy describe --tags --abbrev=0 2>/dev/null); echo \"$version\""
     },
     {
       "type": "command",
@@ -105,8 +96,38 @@
       "text": "theme=$(omarchy-theme-current); echo -e \"$theme \\e[38m●\\e[37m●\\e[36m●\\e[35m●\\e[34m●\\e[33m●\\e[32m●\\e[31m●\""
     },
     {
+      "type": "de",
+      "key": " DE",
+      "keyColor": "blue"
+    },
+    {
+      "type": "wm",
+      "key": "│ ├",
+      "keyColor": "blue"
+    },
+    {
+      "type": "wmtheme",
+      "key": "│ ├󰉼",
+      "keyColor": "blue"
+    },
+    {
+      "type": "icons",
+      "key": "│ ├󰀻",
+      "keyColor": "blue"
+    },
+    {
+      "type": "cursor",
+      "key": "│ ├",
+      "keyColor": "blue"
+    },
+    {
       "type": "terminalfont",
-      "key": "└ └",
+      "key": "│ ├",
+      "keyColor": "blue"
+    },
+    {
+      "type": "terminal",
+      "key": "└ └",
       "keyColor": "blue"
     },
     {

--- a/custom-install.sh
+++ b/custom-install.sh
@@ -1,0 +1,621 @@
+#!/bin/bash
+
+# Custom Omarchy Installation Script
+
+if [[ "$1" != "--dry-run" && "$1" != "-n" ]]; then
+  read -p "Do you want to run in dry run mode (shows what would happen without making changes)? (y/N): " -n 1 -r DRY_RUN_PROMPT
+  echo
+  if [[ $DRY_RUN_PROMPT =~ ^[Yy]$ ]]; then
+    DRY_RUN=true
+  fi
+fi
+
+# Exit immediately if a command exits with a non-zero status
+set -eE
+
+# Get the absolute path to the omarchy repository
+OMARCHY_REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+echo "Omarchy repository directory: $OMARCHY_REPO_DIR"
+
+# Setup path and variables
+export PATH="$OMARCHY_REPO_DIR/bin:$HOME/.local/share/omarchy/bin:$PATH"
+OMARCHY_INSTALL="$OMARCHY_REPO_DIR/install"
+
+# Define helper functions for dry run mode
+run_cmd() {
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would execute: $*"
+  else
+    eval "$@"
+  fi
+}
+
+copy_file() {
+  local src="$1"
+  local dest="$2"
+  local opts="$3"
+
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would copy: $src -> $dest $opts"
+  else
+    cp $opts "$src" "$dest" 2>/dev/null || true
+  fi
+}
+
+make_dir() {
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would create directory: $1"
+  else
+    mkdir -p "$1"
+  fi
+}
+
+create_link() {
+  local target="$1"
+  local link="$2"
+  local opts="$3"
+
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would create symlink: $target -> $link $opts"
+  else
+    ln $opts "$target" "$link" 2>/dev/null || true
+  fi
+}
+
+remove_path() {
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would remove: $1"
+  else
+    rm -rf "$1"
+  fi
+}
+
+# Define package groups
+REQUIRED_PACKAGES=(
+  # Core Hyprland packages
+  "hyprland"     # Core window manager
+  "waybar"       # Status bar
+  "wl-clipboard" # Clipboard utility
+
+  # Hypr utility packages
+  "hypridle"   # Idle daemon
+  "hyprlock"   # Screen locking
+  "hyprpicker" # Color picker
+  "hyprshot"   # Screenshot utility
+  "hyprsunset" # Night light utility
+
+  # UI packages
+  "mako"       # Notification daemon
+  "swayosd"    # On-screen display
+  "walker-bin" # App launcher
+)
+
+# Web app packages
+WEB_APPS=(
+  "figma"
+  "zoom"
+  "discord"
+  "github"
+  "youtube"
+  "chatgpt"
+  "google-contacts"
+  "google-photos"
+  "google-mail"
+  "google-drive"
+  "google-docs"
+  "google-calendar"
+  "whatsapp"
+  "basecamp"
+  "hey"
+  "grok"
+)
+
+# Other optional packages
+OTHER_OPTIONAL=(
+  "obsidian" # Note-taking app
+  "nvim"     # Neovim text editor
+  "starship" # Shell prompt
+)
+
+# Function to create webapp desktop file
+create_webapp() {
+  local app_name="$1"
+  local app_url="$2"
+  local app_title="$3"
+
+  make_dir ~/.local/share/applications
+
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would create desktop shortcut for ${app_title} (${app_url}) at ~/.local/share/applications/${app_name}.desktop"
+  else
+    cat >~/.local/share/applications/"${app_name}.desktop" <<EOF
+[Desktop Entry]
+Name=${app_title}
+Exec=omarchy-launch-webapp "${app_url}"
+Icon=${app_name}
+Type=Application
+Categories=Network;WebApps;
+StartupWMClass=${app_name}
+EOF
+    echo "Created desktop shortcut for ${app_title}"
+  fi
+}
+
+echo "==== OMARCHY INSTALLATION STARTED ===="
+echo
+
+# PART 1: Create ~/.local/share/omarchy directory structure
+echo "==== STEP 1: Creating omarchy directory structure ===="
+make_dir ~/.local/share/omarchy
+make_dir ~/.local/share/omarchy/bin
+make_dir ~/.local/share/omarchy/config
+make_dir ~/.local/share/omarchy/default
+make_dir ~/.local/share/omarchy/install
+make_dir ~/.local/share/omarchy/applications
+make_dir ~/.local/share/omarchy/applications/icons
+make_dir ~/.local/share/omarchy/applications/hidden
+make_dir ~/.local/share/fonts
+
+# Copy bin directory
+echo "Copying bin directory..."
+copy_file "$OMARCHY_REPO_DIR/bin/"* ~/.local/share/omarchy/bin/ "-R"
+
+# Copy config directory
+echo "Copying config directory..."
+copy_file "$OMARCHY_REPO_DIR/config/"* ~/.local/share/omarchy/config/ "-R"
+
+# Copy default directory
+echo "Copying default directory..."
+copy_file "$OMARCHY_REPO_DIR/default/"* ~/.local/share/omarchy/default/ "-R"
+
+# Copy install directory
+echo "Copying install directory..."
+copy_file "$OMARCHY_REPO_DIR/install/"* ~/.local/share/omarchy/install/ "-R"
+
+# Copy applications directory
+echo "Copying applications directory..."
+copy_file "$OMARCHY_REPO_DIR/applications/"* ~/.local/share/omarchy/applications/ "-R"
+
+# Copy logo and other files
+echo "Copying logo and other files..."
+copy_file "$OMARCHY_REPO_DIR/logo.txt" ~/.local/share/omarchy/logo.txt
+copy_file "$OMARCHY_REPO_DIR/logo.svg" ~/.local/share/omarchy/logo.svg
+copy_file "$OMARCHY_REPO_DIR/icon.txt" ~/.local/share/omarchy/icon.txt
+
+echo "Directory structure setup completed."
+echo
+
+# PART 2: Setup theme configuration
+echo "==== STEP 2: Setting up theme configuration ===="
+
+# Create necessary directories
+make_dir ~/.config/omarchy/themes
+make_dir ~/.config/omarchy/current
+make_dir ~/.config/omarchy/branding
+
+# Copy icon and logo files
+copy_file "$OMARCHY_REPO_DIR/icon.txt" ~/.config/omarchy/branding/about.txt
+copy_file "$OMARCHY_REPO_DIR/logo.txt" ~/.config/omarchy/branding/screensaver.txt
+
+# Create symlinks for all themes
+echo "Creating theme symlinks..."
+for theme_dir in "$OMARCHY_REPO_DIR/themes/"*; do
+  if [ -d "$theme_dir" ]; then
+    theme_name=$(basename "$theme_dir")
+    echo "  Linking theme: $theme_name"
+    create_link "$theme_dir" ~/.config/omarchy/themes/ "-snf"
+  fi
+done
+
+# Set Tokyo Night as the default theme
+echo "Setting default theme to Tokyo Night..."
+create_link ~/.config/omarchy/themes/tokyo-night ~/.config/omarchy/current/theme "-snf"
+
+# Create a fallback hyprland.conf if it doesn't exist in the theme
+if $DRY_RUN || [ ! -f ~/.config/omarchy/current/theme/hyprland.conf ]; then
+  echo "Creating fallback hyprland.conf..."
+  make_dir ~/.config/omarchy/current/theme
+
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would create fallback hyprland.conf at ~/.config/omarchy/current/theme/hyprland.conf"
+  else
+    cat >~/.config/omarchy/current/theme/hyprland.conf <<'EOF'
+# Omarchy default theme settings for Hyprland
+
+# General theming
+general {
+    gaps_in = 5
+    gaps_out = 10
+    border_size = 2
+    col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
+    col.inactive_border = rgba(595959aa)
+
+    layout = dwindle
+}
+
+# Decoration theming
+decoration {
+    rounding = 10
+    
+    blur {
+        enabled = true
+        size = 3
+        passes = 1
+    }
+
+    drop_shadow = true
+    shadow_range = 4
+    shadow_render_power = 3
+    col.shadow = rgba(1a1a1aee)
+}
+
+# Animation settings
+animations {
+    enabled = true
+
+    bezier = myBezier, 0.05, 0.9, 0.1, 1.05
+
+    animation = windows, 1, 7, myBezier
+    animation = windowsOut, 1, 7, default, popin 80%
+    animation = border, 1, 10, default
+    animation = borderangle, 1, 8, default
+    animation = fade, 1, 7, default
+    animation = workspaces, 1, 6, default
+}
+EOF
+  fi
+fi
+
+echo "Theme configuration setup completed."
+echo
+
+# PART 3: Install packages
+echo "==== STEP 3: Installing packages ===="
+
+# Function to check if a package is installed
+is_installed() {
+  if $DRY_RUN; then
+    return 1 # In dry run mode, pretend package is not installed
+  else
+    pacman -Q "$1" &>/dev/null
+  fi
+}
+
+# Function to install packages that aren't already installed
+install_if_missing() {
+  local missing_packages=()
+
+  for package in "$@"; do
+    if ! is_installed "$package"; then
+      missing_packages+=("$package")
+    else
+      echo "Package $package is already installed, skipping..."
+    fi
+  done
+
+  if [ ${#missing_packages[@]} -gt 0 ]; then
+    if $DRY_RUN; then
+      echo "[DRY RUN] Would install packages: ${missing_packages[*]}"
+    else
+      echo "Installing missing packages: ${missing_packages[*]}"
+      sudo pacman -S --noconfirm --needed "${missing_packages[@]}"
+    fi
+  else
+    echo "All packages in this group are already installed."
+  fi
+}
+
+# Install required packages (no option to skip)
+echo "Installing required packages..."
+install_if_missing "${REQUIRED_PACKAGES[@]}"
+
+# Ask about installing optional packages individually
+echo
+echo "==== Optional Packages Installation ===="
+echo "Any packages not installed will require modifying it's associated keybind"
+echo
+
+# Install web apps
+echo "Web Applications:"
+WEBAPPS_TO_INSTALL=()
+
+# Figma
+read -p "Install Figma web app? (y/N): " -n 1 -r INSTALL_FIGMA
+echo
+if [[ $INSTALL_FIGMA =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("figma")
+  create_webapp "figma" "https://www.figma.com" "Figma"
+fi
+
+# Zoom
+read -p "Install Zoom web app? (y/N): " -n 1 -r INSTALL_ZOOM
+echo
+if [[ $INSTALL_ZOOM =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("zoom")
+  create_webapp "zoom" "https://zoom.us/join" "Zoom"
+fi
+
+# Discord
+read -p "Install Discord web app? (y/N): " -n 1 -r INSTALL_DISCORD
+echo
+if [[ $INSTALL_DISCORD =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("discord")
+  create_webapp "discord" "https://discord.com/app" "Discord"
+fi
+
+# GitHub
+read -p "Install GitHub web app? (y/N): " -n 1 -r INSTALL_GITHUB
+echo
+if [[ $INSTALL_GITHUB =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("github")
+  create_webapp "github" "https://github.com" "GitHub"
+fi
+
+# YouTube
+read -p "Install YouTube web app? (y/N): " -n 1 -r INSTALL_YOUTUBE
+echo
+if [[ $INSTALL_YOUTUBE =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("youtube")
+  create_webapp "youtube" "https://youtube.com" "YouTube"
+fi
+
+# ChatGPT
+read -p "Install ChatGPT web app? (y/N): " -n 1 -r INSTALL_CHATGPT
+echo
+if [[ $INSTALL_CHATGPT =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("chatgpt")
+  create_webapp "chatgpt" "https://chat.openai.com" "ChatGPT"
+fi
+
+# Google Contacts
+read -p "Install Google Contacts web app? (y/N): " -n 1 -r INSTALL_GCONTACTS
+echo
+if [[ $INSTALL_GCONTACTS =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("google-contacts")
+  create_webapp "google-contacts" "https://contacts.google.com" "Google Contacts"
+fi
+
+# Google Photos
+read -p "Install Google Photos web app? (y/N): " -n 1 -r INSTALL_GPHOTOS
+echo
+if [[ $INSTALL_GPHOTOS =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("google-photos")
+  create_webapp "google-photos" "https://photos.google.com" "Google Photos"
+fi
+
+# Google Mail (Gmail)
+read -p "Install Gmail web app? (y/N): " -n 1 -r INSTALL_GMAIL
+echo
+if [[ $INSTALL_GMAIL =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("google-mail")
+  create_webapp "google-mail" "https://mail.google.com" "Gmail"
+fi
+
+# Google Drive
+read -p "Install Google Drive web app? (y/N): " -n 1 -r INSTALL_GDRIVE
+echo
+if [[ $INSTALL_GDRIVE =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("google-drive")
+  create_webapp "google-drive" "https://drive.google.com" "Google Drive"
+fi
+
+# Google Docs
+read -p "Install Google Docs web app? (y/N): " -n 1 -r INSTALL_GDOCS
+echo
+if [[ $INSTALL_GDOCS =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("google-docs")
+  create_webapp "google-docs" "https://docs.google.com" "Google Docs"
+fi
+
+# Google Calendar
+read -p "Install Google Calendar web app? (y/N): " -n 1 -r INSTALL_GCALENDAR
+echo
+if [[ $INSTALL_GCALENDAR =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("google-calendar")
+  create_webapp "google-calendar" "https://calendar.google.com" "Google Calendar"
+fi
+
+# WhatsApp
+read -p "Install WhatsApp web app? (y/N): " -n 1 -r INSTALL_WHATSAPP
+echo
+if [[ $INSTALL_WHATSAPP =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("whatsapp")
+  create_webapp "whatsapp" "https://web.whatsapp.com" "WhatsApp"
+fi
+
+# Basecamp
+read -p "Install Basecamp web app? (y/N): " -n 1 -r INSTALL_BASECAMP
+echo
+if [[ $INSTALL_BASECAMP =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("basecamp")
+  create_webapp "basecamp" "https://basecamp.com" "Basecamp"
+fi
+
+# Hey
+read -p "Install Hey web app? (y/N): " -n 1 -r INSTALL_HEY
+echo
+if [[ $INSTALL_HEY =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("hey")
+  create_webapp "hey" "https://app.hey.com" "Hey"
+fi
+
+# Grok
+read -p "Install Grok web app? (y/N): " -n 1 -r INSTALL_GROK
+echo
+if [[ $INSTALL_GROK =~ ^[Yy]$ ]]; then
+  WEBAPPS_TO_INSTALL+=("grok")
+  create_webapp "grok" "https://grok.x.ai" "Grok"
+fi
+
+# Other optional packages
+echo
+echo "Other Optional Applications:"
+OTHER_TO_INSTALL=()
+
+# Obsidian
+read -p "Install Obsidian? (y/N): " -n 1 -r INSTALL_OBSIDIAN
+echo
+if [[ $INSTALL_OBSIDIAN =~ ^[Yy]$ ]]; then
+  OTHER_TO_INSTALL+=("obsidian")
+  install_if_missing "obsidian"
+fi
+
+# Neovim
+read -p "Install Neovim (nvim)? (y/N): " -n 1 -r INSTALL_NVIM
+echo
+if [[ $INSTALL_NVIM =~ ^[Yy]$ ]]; then
+  OTHER_TO_INSTALL+=("nvim")
+  install_if_missing "nvim"
+
+  # Copy Neovim configuration if selected
+  make_dir ~/.config/nvim
+  copy_file ~/.local/share/omarchy/config/nvim ~/.config/ "-R"
+  echo "Installed Neovim with configuration."
+fi
+
+# Starship prompt
+read -p "Install Starship prompt? (y/N): " -n 1 -r INSTALL_STARSHIP
+echo
+if [[ $INSTALL_STARSHIP =~ ^[Yy]$ ]]; then
+  OTHER_TO_INSTALL+=("starship")
+  install_if_missing "starship"
+
+  # Copy Starship configuration if selected
+  copy_file ~/.local/share/omarchy/config/starship.toml ~/.config/
+  echo "Installed Starship prompt with configuration."
+fi
+
+echo "Optional package installation completed."
+echo
+
+# PART 4: Install configuration files
+echo "==== STEP 4: Installing configuration files ===="
+
+# Copy over Omarchy configs
+echo "Installing configuration files..."
+make_dir ~/.config
+
+# Remove existing Hyprland configs to ensure clean replacement
+echo "Removing existing Hyprland configuration files..."
+remove_path ~/.config/hypr
+remove_path ~/.config/waybar
+remove_path ~/.config/swayosd
+remove_path ~/.config/walker
+remove_path ~/.config/mako
+
+# Required configs
+echo "Installing core configuration files..."
+copy_file ~/.local/share/omarchy/config/hypr ~/.config/ "-R"
+copy_file ~/.local/share/omarchy/config/waybar ~/.config/ "-R"
+copy_file ~/.local/share/omarchy/config/mako ~/.config/ "-R"
+copy_file ~/.local/share/omarchy/config/swayosd ~/.config/ "-R"
+copy_file ~/.local/share/omarchy/config/walker ~/.config/ "-R"
+
+# Always copy environment configuration
+copy_file ~/.local/share/omarchy/config/environment.d ~/.config/ "-R"
+
+# Copy custom fonts
+copy_file ~/.local/share/omarchy/config/omarchy.ttf ~/.local/share/fonts/
+
+# Copy default bashrc from Omarchy if desired
+read -p "Do you want to install the Omarchy default bashrc? (y/N): " -n 1 -r INSTALL_BASHRC
+echo
+if [[ $INSTALL_BASHRC =~ ^[Yy]$ ]]; then
+  copy_file ~/.local/share/omarchy/default/bashrc ~/.bashrc
+  echo "Installed default bashrc."
+else
+  echo "Skipping default bashrc installation."
+fi
+
+echo "Configuration files installed successfully!"
+echo
+
+# PART 5: Update system packages
+read -p "Do you want to update system packages? (y/N): " -n 1 -r UPDATE_PACKAGES
+echo
+if [[ $UPDATE_PACKAGES =~ ^[Yy]$ ]]; then
+  echo "==== STEP 5: Updating system packages ===="
+  if $DRY_RUN; then
+    echo "[DRY RUN] Would update package database with: sudo updatedb"
+    echo "[DRY RUN] Would update system packages with: sudo pacman -Syu --noconfirm"
+  else
+    sudo updatedb 2>/dev/null || true
+    sudo pacman -Syu --noconfirm
+  fi
+  echo "System packages updated."
+else
+  echo "Skipping system package updates."
+fi
+echo
+
+# PART 6: Refresh services
+echo "==== STEP 6: Refreshing services ===="
+if $DRY_RUN; then
+  echo "[DRY RUN] Would refresh Hyprland configuration"
+  echo "[DRY RUN] Would refresh Waybar configuration"
+  echo "[DRY RUN] Would refresh SwayOSD configuration"
+  echo "[DRY RUN] Would refresh Hypridle configuration"
+  echo "[DRY RUN] Would refresh Hyprlock configuration"
+  echo "[DRY RUN] Would refresh Hyprsunset configuration"
+  echo "[DRY RUN] Would refresh Walker configuration"
+elif [ -f "$HOME/.local/share/omarchy/bin/omarchy-refresh-hyprland" ]; then
+  "$HOME/.local/share/omarchy/bin/omarchy-refresh-hyprland" 2>/dev/null || true
+  "$HOME/.local/share/omarchy/bin/omarchy-refresh-waybar" 2>/dev/null || true
+  "$HOME/.local/share/omarchy/bin/omarchy-refresh-swayosd" 2>/dev/null || true
+  "$HOME/.local/share/omarchy/bin/omarchy-refresh-hypridle" 2>/dev/null || true
+  "$HOME/.local/share/omarchy/bin/omarchy-refresh-hyprlock" 2>/dev/null || true
+  "$HOME/.local/share/omarchy/bin/omarchy-refresh-hyprsunset" 2>/dev/null || true
+  "$HOME/.local/share/omarchy/bin/omarchy-refresh-walker" 2>/dev/null || true
+fi
+
+echo "All services refreshed."
+echo
+
+# PART 7: Complete installation
+echo "==== OMARCHY INSTALLATION COMPLETED ===="
+if $DRY_RUN; then
+  echo "Dry run completed. No changes were made to your system."
+  echo "To perform the actual installation, run this script without the --dry-run option."
+else
+  echo "Omarchy has been successfully installed!"
+fi
+echo
+
+# Display logo if available and not in dry run mode
+if ! $DRY_RUN; then
+  if [ -x "$(command -v tte)" ]; then
+    tte -i ~/.local/share/omarchy/logo.txt --frame-rate 920 laseretch 2>/dev/null || true
+    echo
+    echo "You're done! So we're ready to reboot now..." | tte --frame-rate 640 wipe 2>/dev/null || true
+  else
+    echo "
+        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+        █  ▄▄▄  █▄ ▄█ ▄▄▄█ ▄▄▄█ ▄▄▀█▀▄▄▀█ ▄▀▄ █▀▄▀█ ▄▄▀█ ▄▄█ ▄▄▀
+        █ █▄▀▀▄▄█ █ █▄▄▄█▄▄▄▀█ ▀▀▄█ ██ █ █ █ █ █▀█ █▀▄█▄▄▄█ ██ 
+        █▄▄▄▄▄▄▄█▄▄▄█▄▄▄█▄▄▄▄█▄█▄▄█▄▄█▄█▄█ ▀▄█▄█▄█▄█▄▄█▄▄▄█▄██▄
+        "
+    echo "You're done! So we're ready to reboot now..."
+  fi
+
+  if sudo test -f /etc/sudoers.d/99-omarchy-installer; then
+    if $DRY_RUN; then
+      echo "[DRY RUN] Would remove installer sudoers file"
+    else
+      sudo rm -f /etc/sudoers.d/99-omarchy-installer &>/dev/null
+      echo -e "\nRemember to remove USB installer!\n\n"
+    fi
+  fi
+
+  # Ask user if they want to reboot
+  if ! $DRY_RUN; then
+    read -p "Do you want to reboot now? [Y/n]: " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+      echo "Rebooting in 5 seconds..."
+      sleep 5
+      reboot
+    else
+      echo "Skipping reboot. You can manually reboot later to apply all changes."
+    fi
+  fi
+fi

--- a/default/bash/bashrc
+++ b/default/bash/bashrc
@@ -1,0 +1,14 @@
+# All the default Omarchy aliases and functions
+# (don't mess with these directly, just overwrite them here!)
+source ~/.local/share/omarchy/default/bash/rc
+
+# Add your own exports, aliases, and functions here.
+#
+# Make an alias for invoking commands you use constantly
+# alias p='python'
+#
+# Use VSCode instead of neovim as your default editor
+# export EDITOR="code"
+#
+# Set a custom prompt with the directory revealed (alternatively use https://starship.rs)
+# PS1="\W \[\e]0;\w\a\]$PS1"

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,6 @@ source $OMARCHY_INSTALL/config/xcompose.sh
 source $OMARCHY_INSTALL/config/mise-ruby.sh
 source $OMARCHY_INSTALL/config/docker.sh
 source $OMARCHY_INSTALL/config/mimetypes.sh
-source $OMARCHY_INSTALL/config/localdb.sh
 source $OMARCHY_INSTALL/config/hardware/network.sh
 source $OMARCHY_INSTALL/config/hardware/fix-fkeys.sh
 source $OMARCHY_INSTALL/config/hardware/bluetooth.sh
@@ -52,8 +51,11 @@ source $OMARCHY_INSTALL/login/plymouth.sh
 source $OMARCHY_INSTALL/login/limine-snapper.sh
 source $OMARCHY_INSTALL/login/alt-bootloaders.sh
 
-# Pin bad packages
-sudo pacman -U --noconfirm https://pkgs.omarchy.org/x86_64/abseil-cpp-20250512.1-1-x86_64.pkg.tar.zst
+# Updates
+sudo updatedb
+
+# Update system packages
+sudo pacman -Syu --noconfirm
 
 # Reboot
 clear

--- a/install/config/branding.sh
+++ b/install/config/branding.sh
@@ -2,5 +2,11 @@
 
 # Allow the user to change the branding for fastfetch and screensaver
 mkdir -p ~/.config/omarchy/branding
-cp ~/.local/share/omarchy/icon.txt ~/.config/omarchy/branding/about.txt
-cp ~/.local/share/omarchy/logo.txt ~/.config/omarchy/branding/screensaver.txt
+mkdir -p ~/.local/share/omarchy
+
+# Copy icon and logo files to both locations
+cp "$(dirname "$OMARCHY_INSTALL")/../icon.txt" ~/.config/omarchy/branding/about.txt 2>/dev/null || true
+cp "$(dirname "$OMARCHY_INSTALL")/../logo.txt" ~/.config/omarchy/branding/screensaver.txt 2>/dev/null || true
+
+# Ensure logo.txt exists in ~/.local/share/omarchy/
+cp "$(dirname "$OMARCHY_INSTALL")/../logo.txt" ~/.local/share/omarchy/logo.txt 2>/dev/null || true

--- a/install/config/config.sh
+++ b/install/config/config.sh
@@ -1,8 +1,56 @@
 #!/bin/bash
 
-# Copy over Omarchy configs
+# Copy over Omarchy configs, replacing existing Hyprland configs
+echo "Installing Omarchy configuration files and replacing existing Hyprland configs..."
 mkdir -p ~/.config
-cp -R ~/.local/share/omarchy/config/* ~/.config/
+mkdir -p ~/.local/share/fonts
 
-# Use default bashrc from Omarchy
-cp ~/.local/share/omarchy/default/bashrc ~/.bashrc
+# Remove existing Hyprland configs to ensure clean replacement
+echo "Removing existing Hyprland configuration files..."
+rm -rf ~/.config/hypr
+rm -rf ~/.config/waybar
+rm -rf ~/.config/swayosd 2>/dev/null || true
+rm -rf ~/.config/walker 2>/dev/null || true
+rm -rf ~/.config/mako 2>/dev/null || true
+
+# Copy fresh Omarchy Hyprland configs
+echo "Installing fresh Omarchy Hyprland configuration files..."
+OMARCHY_REPO_DIR="$(cd "$(dirname "$OMARCHY_INSTALL")/.." && pwd)"
+echo "Repo directory: $OMARCHY_REPO_DIR"
+# Use the correct path for local installation
+LOCAL_REPO_DIR="$(pwd)"
+echo "Local repo directory: $LOCAL_REPO_DIR"
+cp -R "$LOCAL_REPO_DIR/config/hypr" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/hypr ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/waybar" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/waybar ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/swayosd" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/swayosd ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/walker" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/walker ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/mako" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/mako ~/.config/ 2>/dev/null || true
+
+# Copy other application-specific configs (excluding starship and neovim)
+echo "Installing other Omarchy application configurations..."
+cp -R "$LOCAL_REPO_DIR/config/Typora" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/Typora ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/alacritty" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/alacritty ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/btop" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/btop ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/chromium" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/chromium ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/fastfetch" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/fastfetch ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/fcitx5" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/fcitx5 ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/fontconfig" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/fontconfig ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/lazygit" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/lazygit ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/systemd" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/systemd ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/uwsm" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/uwsm ~/.config/ 2>/dev/null || true
+cp -R "$LOCAL_REPO_DIR/config/xournalpp" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/xournalpp ~/.config/ 2>/dev/null || true
+
+# Copy environment configuration
+cp -R "$LOCAL_REPO_DIR/config/environment.d" ~/.config/ 2>/dev/null || cp -R ~/.local/share/omarchy/config/environment.d ~/.config/ 2>/dev/null || true
+
+# Copy browser flags
+cp "$LOCAL_REPO_DIR/config/brave-flags.conf" ~/.config/ 2>/dev/null || cp ~/.local/share/omarchy/config/brave-flags.conf ~/.config/ 2>/dev/null || true
+cp "$LOCAL_REPO_DIR/config/chromium-flags.conf" ~/.config/ 2>/dev/null || cp ~/.local/share/omarchy/config/chromium-flags.conf ~/.config/ 2>/dev/null || true
+
+# Copy custom fonts
+cp "$LOCAL_REPO_DIR/config/omarchy.ttf" ~/.local/share/fonts/ 2>/dev/null || cp ~/.local/share/omarchy/config/omarchy.ttf ~/.local/share/fonts/ 2>/dev/null || true
+
+# Copy default bashrc from Omarchy
+cp "$LOCAL_REPO_DIR/default/bashrc" ~/.bashrc 2>/dev/null || cp ~/.local/share/omarchy/default/bashrc ~/.bashrc 2>/dev/null || true
+
+echo "Omarchy configuration files installed successfully!"

--- a/install/config/gpg.sh
+++ b/install/config/gpg.sh
@@ -2,7 +2,8 @@
 
 # Setup GPG configuration with multiple keyservers for better reliability
 sudo mkdir -p /etc/gnupg
-sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/
-sudo chmod 644 /etc/gnupg/dirmngr.conf
+OMARCHY_REPO_DIR="$(dirname "$OMARCHY_INSTALL")/.."
+sudo cp "$OMARCHY_REPO_DIR/default/gpg/dirmngr.conf" /etc/gnupg/ 2>/dev/null || sudo cp ~/.local/share/omarchy/default/gpg/dirmngr.conf /etc/gnupg/ 2>/dev/null || true
+sudo chmod 644 /etc/gnupg/dirmngr.conf 2>/dev/null || true
 sudo gpgconf --kill dirmngr || true
 sudo gpgconf --launch dirmngr || true

--- a/install/config/hyprland-config.sh
+++ b/install/config/hyprland-config.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Install and replace Hyprland configuration files with Omarchy versions
+echo "Replacing existing Hyprland configuration with Omarchy versions..."
+
+# Create config directories if they don't exist
+mkdir -p ~/.config
+mkdir -p ~/.local/share/fonts
+
+# Remove existing Hyprland configs to ensure clean replacement
+echo "Removing existing Hyprland configuration files..."
+rm -rf ~/.config/hypr
+rm -rf ~/.config/waybar
+rm -rf ~/.config/swayosd 2>/dev/null || true
+rm -rf ~/.config/walker 2>/dev/null || true
+rm -rf ~/.config/mako 2>/dev/null || true
+
+# Copy fresh Omarchy Hyprland configs
+echo "Installing fresh Omarchy Hyprland configuration files..."
+cp -R ~/.local/share/omarchy/config/hypr ~/.config/
+cp -R ~/.local/share/omarchy/config/waybar ~/.config/
+cp -R ~/.local/share/omarchy/config/swayosd ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/walker ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/mako ~/.config/ 2>/dev/null || true
+
+# Copy other application-specific configs (excluding starship and neovim)
+echo "Installing other Omarchy application configurations..."
+cp -R ~/.local/share/omarchy/config/Typora ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/alacritty ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/btop ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/chromium ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/fastfetch ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/fcitx5 ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/fontconfig ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/lazygit ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/systemd ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/uwsm ~/.config/ 2>/dev/null || true
+cp -R ~/.local/share/omarchy/config/xournalpp ~/.config/ 2>/dev/null || true
+
+# Copy environment configuration
+cp -R ~/.local/share/omarchy/config/environment.d ~/.config/ 2>/dev/null || true
+
+# Copy browser flags
+cp ~/.local/share/omarchy/config/brave-flags.conf ~/.config/ 2>/dev/null || true
+cp ~/.local/share/omarchy/config/chromium-flags.conf ~/.config/ 2>/dev/null || true
+
+# Copy custom fonts
+cp ~/.local/share/omarchy/config/omarchy.ttf ~/.local/share/fonts/ 2>/dev/null || true
+
+echo "Omarchy configuration files installed successfully!"
+
+# Refresh Hyprland services
+echo "Refreshing Hyprland services..."
+~/.local/share/omarchy/bin/omarchy-refresh-hyprland 2>/dev/null || true
+~/.local/share/omarchy/bin/omarchy-refresh-waybar 2>/dev/null || true
+~/.local/share/omarchy/bin/omarchy-refresh-swayosd 2>/dev/null || true
+~/.local/share/omarchy/bin/omarchy-refresh-hypridle 2>/dev/null || true
+~/.local/share/omarchy/bin/omarchy-refresh-hyprlock 2>/dev/null || true
+~/.local/share/omarchy/bin/omarchy-refresh-hyprsunset 2>/dev/null || true
+~/.local/share/omarchy/bin/omarchy-refresh-walker 2>/dev/null || true
+
+echo "All Hyprland services refreshed with Omarchy configurations!"

--- a/install/login/plymouth.sh
+++ b/install/login/plymouth.sh
@@ -7,8 +7,15 @@
 # ==============================================================================
 
 if [ "$(plymouth-set-default-theme)" != "omarchy" ]; then
-  sudo cp -r "$HOME/.local/share/omarchy/default/plymouth" /usr/share/plymouth/themes/omarchy/
-  sudo plymouth-set-default-theme -R omarchy
+  LOCAL_REPO_DIR="$(cd "$(dirname "$OMARCHY_INSTALL")/.." && pwd)"
+  echo "Copying plymouth theme from $LOCAL_REPO_DIR/default/plymouth"
+  sudo cp -r "$LOCAL_REPO_DIR/default/plymouth" /usr/share/plymouth/themes/omarchy/ 2>/dev/null || sudo cp -r "$HOME/.local/share/omarchy/default/plymouth" /usr/share/plymouth/themes/omarchy/ 2>/dev/null || true
+  # Check if the theme was copied successfully
+  if [ -f "/usr/share/plymouth/themes/omarchy/omarchy.plymouth" ]; then
+    sudo plymouth-set-default-theme -R omarchy
+  else
+    echo "Warning: Plymouth theme not found, skipping theme setup"
+  fi
 fi
 
 # ==============================================================================

--- a/install/packages.sh
+++ b/install/packages.sh
@@ -1,122 +1,160 @@
-sudo pacman -S --noconfirm --needed \
-  1password-beta \
-  1password-cli \
-  alacritty \
-  avahi \
-  bash-completion \
-  bat \
-  blueberry \
-  brightnessctl \
-  btop \
-  cargo \
-  clang \
-  cups \
-  cups-browsed \
-  cups-filters \
-  cups-pdf \
-  docker \
-  docker-buildx \
-  docker-compose \
-  dust \
-  evince \
-  eza \
-  fastfetch \
-  fcitx5 \
-  fcitx5-gtk \
-  fcitx5-qt \
-  fd \
-  ffmpegthumbnailer \
-  fzf \
-  gcc14 \
-  github-cli \
-  gnome-calculator \
-  gnome-keyring \
-  gnome-themes-extra \
-  gum \
-  gvfs-mtp \
-  hypridle \
-  hyprland \
-  hyprland-qtutils \
-  hyprlock \
-  hyprpicker \
-  hyprshot \
-  hyprsunset \
-  imagemagick \
-  impala \
-  imv \
-  inetutils \
-  jq \
-  kdenlive \
-  kvantum-qt5 \
-  lazydocker \
-  lazygit \
-  less \
-  libqalculate \
-  libreoffice \
-  llvm \
-  localsend \
-  luarocks \
-  mako \
-  man \
-  mariadb-libs \
-  mise \
-  mpv \
-  nautilus \
-  noto-fonts \
-  noto-fonts-cjk \
-  noto-fonts-emoji \
-  noto-fonts-extra \
-  nss-mdns \
-  nvim \
-  obs-studio \
-  obsidian \
-  omarchy-chromium \
-  pamixer \
-  pinta \
-  playerctl \
-  plocate \
-  plymouth \
-  polkit-gnome \
-  postgresql-libs \
-  power-profiles-daemon \
-  python-gobject \
-  python-poetry-core \
-  python-terminaltexteffects \
-  ripgrep \
-  satty \
-  signal-desktop \
-  slurp \
-  spotify \
-  starship \
-  sushi \
-  swaybg \
-  swayosd \
-  system-config-printer \
-  tldr \
-  tree-sitter-cli \
-  ttf-cascadia-mono-nerd \
-  ttf-font-awesome \
-  ttf-ia-writer \
-  ttf-jetbrains-mono \
-  typora \
-  tzupdate \
-  ufw \
-  ufw-docker \
-  unzip \
-  uwsm \
-  walker-bin \
-  waybar \
-  wf-recorder \
-  whois \
-  wiremix \
-  wireplumber \
-  wl-clip-persist \
-  wl-clipboard \
-  wl-screenrec \
-  xdg-desktop-portal-gtk \
-  xdg-desktop-portal-hyprland \
-  xmlstarlet \
-  xournalpp \
-  yaru-icon-theme \
-  yay \
-  zoxide
+# Function to check if a package is installed
+is_installed() {
+    pacman -Q "$1" &>/dev/null
+}
+
+# Function to check if a browser is already installed
+is_browser_installed() {
+    which chromium &>/dev/null || which google-chrome &>/dev/null || which brave &>/dev/null
+}
+
+# Create arrays for all packages and packages to install
+all_packages=(
+  "1password-beta"
+  "1password-cli"
+  "alacritty"
+  "avahi"
+  "bash-completion"
+  "bat"
+  "blueberry"
+  "brightnessctl"
+  "btop"
+  "cargo"
+  "clang"
+  "cups"
+  "cups-browsed"
+  "cups-filters"
+  "cups-pdf"
+  "docker"
+  "docker-buildx"
+  "docker-compose"
+  "dust"
+  "evince"
+  "eza"
+  "fastfetch"
+  "fcitx5"
+  "fcitx5-gtk"
+  "fcitx5-qt"
+  "fd"
+  "ffmpegthumbnailer"
+  "fzf"
+  "gcc14"
+  "github-cli"
+  "gnome-calculator"
+  "gnome-keyring"
+  "gnome-themes-extra"
+  "gum"
+  "gvfs-mtp"
+  "hypridle"
+  "hyprland"
+  "hyprland-qtutils"
+  "hyprlock"
+  "hyprpicker"
+  "hyprshot"
+  "hyprsunset"
+  "imagemagick"
+  "impala"
+  "imv"
+  "inetutils"
+  "jq"
+  "kdenlive"
+  "kvantum-qt5"
+  "lazydocker"
+  "lazygit"
+  "less"
+  "libqalculate"
+  "libreoffice"
+  "llvm"
+  "localsend"
+  "luarocks"
+  "mako"
+  "man"
+  "mariadb-libs"
+  "mise"
+  "mpv"
+  "nautilus"
+  "noto-fonts"
+  "noto-fonts-cjk"
+  "noto-fonts-emoji"
+  "noto-fonts-extra"
+  "nss-mdns"
+  "nvim"
+  "obs-studio"
+  "obsidian"
+  "omarchy-chromium"
+  "pamixer"
+  "pinta"
+  "playerctl"
+  "plocate"
+  "plymouth"
+  "polkit-gnome"
+  "postgresql-libs"
+  "power-profiles-daemon"
+  "python-gobject"
+  "python-poetry-core"
+  "python-terminaltexteffects"
+  "ripgrep"
+  "satty"
+  "signal-desktop"
+  "slurp"
+  "spotify"
+  "starship"
+  "sushi"
+  "swaybg"
+  "swayosd"
+  "system-config-printer"
+  "tldr"
+  "tree-sitter-cli"
+  "ttf-cascadia-mono-nerd"
+  "ttf-font-awesome"
+  "ttf-ia-writer"
+  "ttf-jetbrains-mono"
+  "typora"
+  "tzupdate"
+  "ufw"
+  "ufw-docker"
+  "unzip"
+  "uwsm"
+  "walker-bin"
+  "waybar"
+  "wf-recorder"
+  "whois"
+  "wiremix"
+  "wireplumber"
+  "wl-clip-persist"
+  "wl-clipboard"
+  "wl-screenrec"
+  "xdg-desktop-portal-gtk"
+  "xdg-desktop-portal-hyprland"
+  "xmlstarlet"
+  "xournalpp"
+  "yaru-icon-theme"
+  "yay"
+  "zoxide"
+)
+
+packages_to_install=()
+
+# Check which packages need to be installed
+echo "Checking installed packages..."
+for package in "${all_packages[@]}"; do
+    # Skip omarchy-chromium if a browser is already installed
+    if [[ "$package" == "omarchy-chromium" ]] && is_browser_installed; then
+        echo "Browser already installed, skipping $package..."
+        continue
+    fi
+    
+    if ! is_installed "$package"; then
+        packages_to_install+=("$package")
+    else
+        echo "Package $package is already installed, skipping..."
+    fi
+done
+
+# Install only the packages that aren't already installed
+if [ ${#packages_to_install[@]} -gt 0 ]; then
+    echo "Installing missing packages: ${packages_to_install[*]}"
+    sudo pacman -S --noconfirm --needed "${packages_to_install[@]}"
+else
+    echo "All required packages are already installed."
+fi

--- a/install/packaging/fonts.sh
+++ b/install/packaging/fonts.sh
@@ -2,5 +2,5 @@
 
 # Omarchy logo in a font for Waybar use
 mkdir -p ~/.local/share/fonts
-cp ~/.local/share/omarchy/config/omarchy.ttf ~/.local/share/fonts/
+cp "$(dirname "$(dirname "$OMARCHY_INSTALL")")/config/omarchy.ttf" ~/.local/share/fonts/ 2>/dev/null || cp ~/.local/share/omarchy/config/omarchy.ttf ~/.local/share/fonts/ 2>/dev/null || true
 fc-cache

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -7,11 +7,11 @@ abort() {
 }
 
 # Must be an Arch distro
-[[ -f /etc/arch-release ]] || abort "Vanilla Arch"
+[[ -f /etc/arch-release ]] || abort "Arch Linux (or derivative)"
 
 # Must not be an Arch derivative distro
 for marker in /etc/cachyos-release /etc/eos-release /etc/garuda-release /etc/manjaro-release; do
-  [[ -f "$marker" ]] && abort "Vanilla Arch"
+  [[ -f "$marker" ]] && abort "Arch Linux (or derivative)"
 done
 
 # Must not be running as root
@@ -20,9 +20,8 @@ done
 # Must be x86 only to fully work
 [ "$(uname -m)" != "x86_64" ] && abort "x86_64 CPU"
 
-# Must not have Gnome or KDE already install
-pacman -Qe gnome-shell &>/dev/null && abort "Fresh + Vanilla Arch"
-pacman -Qe plasma-desktop &>/dev/null && abort "Fresh + Vanilla Arch"
+# Must not have KDE already installed (Gnome is acceptable)
+pacman -Qe plasma-desktop &>/dev/null && abort "Fresh Arch installation (without KDE)"
 
 # Cleared all guards
 echo "Guards: OK"


### PR DESCRIPTION
This custom install script allow you to install omarchy onto an existing Arch system without overwriting your existing program configs, such as nvim.

1. Prompts for dry run mode to preview changes without modifying anything
2. Installs required Hyprland packages automatically
3. Asks about each optional web application individually
4. Properly sets up the theme structure by:
   - Copying themes to ~/.local/share/omarchy/themes/
   - Creating proper symlinks to ~/.config/omarchy/themes/
5. Offers optional installation of Neovim and Starship prompt
6. Fixes common installation issues automatically