### PR TITLE
make clicking on the battery icon open the power menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -382,6 +382,7 @@ go_to_menu() {
   *update*) show_update_menu ;;
   *system*) show_system_menu ;;
   *about*) alacritty --class Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s' ;;
+  *power*) show_setup_power_menu ;;
   esac
 }
 

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -88,6 +88,7 @@
     "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
     "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
     "interval": 5,
+    "on-click": "omarchy-menu power",
     "states": {
       "warning": 20,
       "critical": 10


### PR DESCRIPTION
Bothered me that the power profile setting was so hidden away, so I made it pop up by clicking the battery icon. :) At the very least, opening the power profiles list should be in the go_to_menu function anyway. 
Thanks for omarchy!