### PR TITLE
feat: Add binding management system

### DIFF
--- a/bin/omarchy-bindings-current
+++ b/bin/omarchy-bindings-current
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# omarchy-bindings-current: Show the currently active binding set
+# Usage: omarchy-bindings-current
+
+CURRENT_BINDINGS_DIR="$HOME/.config/omarchy/current/bindings"
+
+if [[ -L "$CURRENT_BINDINGS_DIR" ]]; then
+  CURRENT_TARGET=$(readlink "$CURRENT_BINDINGS_DIR")
+  CURRENT_NAME=$(basename "$CURRENT_TARGET")
+  echo "$(echo "$CURRENT_NAME" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g')"
+else
+  echo "No binding set active"
+fi

--- a/bin/omarchy-bindings-install
+++ b/bin/omarchy-bindings-install
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# omarchy-bindings-install: Install a new binding set from a git repo for Omarchy
+# Usage: omarchy-bindings-install <git-repo-url>
+
+if [ -z "$1" ]; then
+  echo -e "\e[32mEnter the Git repository URL for the binding set.\n\e[0m"
+  REPO_URL=$(gum input --placeholder="Git repo URL for bindings" --header="")
+else
+  REPO_URL="$1"
+fi
+
+if [ -z "$REPO_URL" ]; then
+  exit 1
+fi
+
+BINDINGS_DIR="$HOME/.config/omarchy/bindings"
+BINDING_NAME=$(basename "$REPO_URL" .git | sed -E 's/^omarchy-//; s/-bindings$//')
+BINDING_PATH="$BINDINGS_DIR/$BINDING_NAME"
+
+# Create the bindings directory if it doesn't exist
+mkdir -p "$BINDINGS_DIR"
+
+# Remove existing binding set if present
+if [ -d "$BINDING_PATH" ]; then
+  rm -rf "$BINDING_PATH"
+fi
+
+# Clone the repo directly to ~/.config/omarchy/bindings
+echo "Cloning repository..."
+if ! git clone "$REPO_URL" "$BINDING_PATH"; then
+  echo "Error: Failed to clone binding set repository."
+  exit 1
+fi
+
+# Check if metadata.json exists
+if [[ ! -f "$BINDING_PATH/metadata.json" ]]; then
+  echo "Error: Invalid binding set - missing metadata.json" >&2
+  rm -rf "$BINDING_PATH" # Clean up failed install
+  exit 3
+fi
+
+echo "Binding set '$BINDING_NAME' installed successfully."
+
+# Apply the new binding set with omarchy-bindings-set
+echo "Applying new binding set..."
+omarchy-bindings-set "$BINDING_NAME"

--- a/bin/omarchy-bindings-list
+++ b/bin/omarchy-bindings-list
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# omarchy-bindings-list: List all available binding sets
+# Usage: omarchy-bindings-list
+
+find ~/.config/omarchy/bindings/ -mindepth 1 -maxdepth 1 \( -type d -o -type l \) 2>/dev/null | sort | while read -r path; do
+  if [[ -f "$path/metadata.json" ]]; then
+    echo "$(basename "$path" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g')"
+  fi
+done

--- a/bin/omarchy-bindings-next
+++ b/bin/omarchy-bindings-next
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# omarchy-bindings-next: Cycle to the next available binding set
+# Usage: omarchy-bindings-next
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Get list of available binding sets
+mapfile -t BINDING_SETS < <("$SCRIPT_DIR/omarchy-bindings-list")
+
+if [[ ${#BINDING_SETS[@]} -eq 0 ]]; then
+  echo "No binding sets available" >&2
+  exit 1
+fi
+
+# Get current binding set
+CURRENT_BINDING=$("$SCRIPT_DIR/omarchy-bindings-current")
+
+# Find current index
+CURRENT_INDEX=-1
+for i in "${!BINDING_SETS[@]}"; do
+  if [[ "${BINDING_SETS[$i]}" == "$CURRENT_BINDING" ]]; then
+    CURRENT_INDEX=$i
+    break
+  fi
+done
+
+# Calculate next index (wrap around)
+if [[ $CURRENT_INDEX -eq -1 ]]; then
+  NEXT_INDEX=0
+else
+  NEXT_INDEX=$(( (CURRENT_INDEX + 1) % ${#BINDING_SETS[@]} ))
+fi
+
+# Switch to next binding set
+"$SCRIPT_DIR/omarchy-bindings-set" "${BINDING_SETS[$NEXT_INDEX]}"

--- a/bin/omarchy-bindings-remove
+++ b/bin/omarchy-bindings-remove
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# omarchy-bindings-remove: Remove a binding set.
+# Usage: omarchy-bindings-remove [binding-set-name]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BINDINGS_DIR="$HOME/.config/omarchy/bindings"
+
+# If no binding set is specified, prompt the user to select one
+if [ -z "$1" ]; then
+  mapfile -t BINDING_SETS < <("$SCRIPT_DIR/omarchy-bindings-list")
+  if [ ${#BINDING_SETS[@]} -eq 0 ]; then
+    echo "No binding sets to remove."
+    exit 0
+  fi
+  
+  SELECTED_BINDING=$(printf "%s\n" "${BINDING_SETS[@]}" | gum choose --header "Select a binding set to remove")
+  if [ -z "$SELECTED_BINDING" ]; then
+    exit 1 # User cancelled
+  fi
+  BINDING_TO_REMOVE="$SELECTED_BINDING"
+else
+  BINDING_TO_REMOVE="$1"
+fi
+
+BINDING_NAME=$(echo "$BINDING_TO_REMOVE" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+BINDING_PATH="$BINDINGS_DIR/$BINDING_NAME"
+
+# Check if the binding set exists
+if [[ ! -d "$BINDING_PATH" ]]; then
+  echo "Binding set '$BINDING_TO_REMOVE' does not exist in $BINDINGS_DIR" >&2
+  exit 2
+fi
+
+# Check if the binding set to be removed is the current one
+CURRENT_BINDING=$("$SCRIPT_DIR/omarchy-bindings-current")
+if [[ "$CURRENT_BINDING" == "$BINDING_TO_REMOVE" ]]; then
+  echo "Binding set '$BINDING_TO_REMOVE' is currently active. Switching to the next available set..."
+  "$SCRIPT_DIR/omarchy-bindings-next"
+fi
+
+# Remove the binding set directory
+rm -rf "$BINDING_PATH"
+
+echo "Binding set '$BINDING_TO_REMOVE' has been removed."

--- a/bin/omarchy-bindings-set
+++ b/bin/omarchy-bindings-set
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# omarchy-bindings-set: Set a binding set, specified by its name.
+# Usage: omarchy-bindings-set <binding-set-name>
+
+if [[ -z "$1" || "$1" == "CNCLD" ]]; then
+  echo "Usage: omarchy-bindings-set <binding-set-name>" >&2
+  exit 1
+fi
+
+DISPLAY_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g')
+BINDING_NAME=$(echo "$DISPLAY_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+
+BINDINGS_DIR="$HOME/.config/omarchy/bindings"
+BINDING_PATH="$BINDINGS_DIR/$BINDING_NAME"
+CURRENT_BINDINGS_DIR="$HOME/.config/omarchy/current/bindings"
+
+# Check if the binding set exists
+if [[ ! -d "$BINDING_PATH" ]]; then
+  echo "Binding set '$BINDING_NAME' does not exist in $BINDINGS_DIR" >&2
+  exit 2
+fi
+
+# Check if metadata.json exists (validate binding set)
+if [[ ! -f "$BINDING_PATH/metadata.json" ]]; then
+  echo "Invalid binding set '$BINDING_NAME' - missing metadata.json" >&2
+  exit 3
+fi
+
+# Create the current directory if it doesn't exist
+mkdir -p "$(dirname "$CURRENT_BINDINGS_DIR")"
+
+# Update symlink
+ln -nsf "$BINDING_PATH" "$CURRENT_BINDINGS_DIR"
+
+# Reload Hyprland configuration
+if command -v hyprctl >/dev/null 2>&1; then
+  hyprctl reload 2>/dev/null || echo "Warning: Could not reload Hyprland configuration"
+fi
+
+echo "Switched to binding set: $DISPLAY_NAME"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -67,14 +67,25 @@ show_learn_menu() {
 }
 
 show_style_menu() {
-  case $(menu "Style" "󰸌  Theme\n  Font\n  Background\n󱄄  Screensaver\n  About") in
+  case $(menu "Style" "󰸌  Theme\n  Bindings\n  Font\n  Background\n󱄄  Screensaver\n  About") in
   *Theme*) show_theme_menu ;;
+  *Bindings*) show_bindings_menu ;;
   *Font*) show_font_menu ;;
   *Background*) omarchy-theme-bg-next ;;
   *Screensaver*) edit_in_nvim ~/.config/omarchy/branding/screensaver.txt ;;
   *About*) edit_in_nvim ~/.config/omarchy/branding/about.txt ;;
   *) show_main_menu ;;
   esac
+}
+
+show_bindings_menu() {
+  binding=$(menu "Bindings" "$(omarchy-bindings-list)" "" "$(omarchy-bindings-current)")
+  if [[ "$binding" == "CNCLD" || -z "$binding" ]]; then
+    show_style_menu
+  else
+    omarchy-bindings-set "$binding"
+    show_style_menu
+  fi
 }
 
 show_theme_menu() {
@@ -240,8 +251,9 @@ show_install_gaming_menu() {
 }
 
 show_install_style_menu() {
-  case $(menu "Install" "󰸌  Theme\n  Background\n  Font") in
+  case $(menu "Install" "󰸌  Theme\n  Bindings\n  Background\n  Font") in
   *Theme*) present_terminal omarchy-theme-install ;;
+  *Bindings*) present_terminal omarchy-bindings-install ;;
   *Background*) nautilus ~/.config/omarchy/current/theme/backgrounds ;;
   *Font*) show_install_font_menu ;;
   *) show_install_menu ;;
@@ -303,11 +315,12 @@ show_install_elixir_menu() {
 }
 
 show_remove_menu() {
-  case $(menu "Remove" "󰣇  Package\n  Web App\n  TUI\n󰸌  Theme\n󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Remove" "󰣇  Package\n  Web App\n  TUI\n󰸌  Theme\n  Bindings\n󰈷  Fingerprint\n  Fido2") in
   *Package*) terminal omarchy-pkg-remove ;;
   *Web*) present_terminal omarchy-webapp-remove ;;
   *TUI*) present_terminal omarchy-tui-remove ;;
   *Theme*) present_terminal omarchy-theme-remove ;;
+  *Bindings*) present_terminal omarchy-bindings-remove ;;
   *Fingerprint*) present_terminal "omarchy-setup-fingerprint --remove" ;;
   *Fido2*) present_terminal "omarchy-setup-fido2 --remove" ;;
   *) show_main_menu ;;


### PR DESCRIPTION
A way for users to share bindings sets similar to the theme sharing functionality - Readme below:

# Making your own binding set

You can add your own binding sets to `~/.config/omarchy/bindings`. Just copy one of the existing ones as a base, then tweak to your delight. As long as your binding set is inside that folder, it'll be included in the binding selection menu.

A binding set is a directory that contains at least the following files:

*   `metadata.json`: A file containing information about your binding set, such as its name, author, and description.
*   `applications.conf`: A file containing keybindings for launching applications.
*   `system.conf`: A file containing keybindings for system actions, like taking screenshots or controlling volume.
*   `tiling.conf`: A file containing keybindings for window management, such as moving focus or switching workspaces.

## Distributing your binding set

If you want to distribute your binding set so others can use it, you need to put it on a public git server, like GitHub. Then people can install it using `Install > Bindings` in the Omarchy menu using that URL. It's recommended that you follow the naming convention of `omarchy-[binding-set-name]-bindings`, as the binding set will show correctly as just `[binding-set-name]` in the binding selection menu after installation.

You can have your binding set added to the extra bindings page by pinging @dhh on the #omarchy Discord.

