### PR TITLE
Fix keyboard layout at install

### DIFF
--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -2,7 +2,7 @@
 
 # Copy over the keyboard layout that's been set in Arch during install to Hyprland
 conf="/etc/vconsole.conf"
-hyprconf="$HOME/.config/hypr/hyprland.conf"
+hyprconf="$HOME/.config/hypr/input.conf"
 
 layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
 variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')


### PR DESCRIPTION
Keyboard is wrongly set after install because the config moved to a dedicated input.conf so no substitution is done.

Fix that and use https://github.com/omacom-io/omarchy-configurator/pull/14 in a new iso and the locale will be ok from  start to finish.