### PR TITLE
Add "Extras" menu to Omarchy installer menu

### DIFF
--- a/bin/omarchy-install-nushell
+++ b/bin/omarchy-install-nushell
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Install and configure Nushell as default shell
+echo "Installing Nushell..."
+yay -S --needed nushell zoxide
+
+if command -v nu &>/dev/null; then
+  echo "Nushell installed successfully"
+
+  # Get the nushell binary path
+  NU_PATH=$(which nu)
+  echo "Nushell path: $NU_PATH"
+
+  # Add nushell to /etc/shells if not already there
+  if ! grep -q "$NU_PATH" /etc/shells; then
+    echo "Adding nushell to /etc/shells..."
+    echo "$NU_PATH" | sudo tee -a /etc/shells
+  fi
+
+  # Create nushell config directory
+  mkdir -p ~/.config/nushell
+
+  # Create config files
+  echo "Setting up nushell configuration..."
+
+  # Create config.nu
+  cat >~/.config/nushell/config.nu <<'EOF'
+# Nushell configuration file
+
+# Settings
+
+$env.EDITOR = "nvim"
+$env.VISUAL = "nvim"
+
+$env.PROMPT_INDICATOR = " "
+$env.PROMPT_COMMAND_RIGHT = ""
+$env.PROMPT_MULTILINE_INDICATOR = ""
+$env.PROMPT_COMMAND = ""
+
+$env.config = {
+	show_banner: false
+	buffer_editor: "nvim"
+	highlight_resolved_externals: true
+}
+
+# Environment variables
+
+$env.TRANSIENT_PROMPT_COMMAND = null
+$env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/ssh-agent.socket"
+
+# Source external configuration files
+
+source ~/.config/nushell/alias.nu
+
+source ~/.zoxide.nu
+
+# Startup programs
+
+sleep 0.1sec
+fastfetch
+source $"($nu.home-path)/.cargo/env.nu"
+
+# Starship support
+mkdir ($nu.data-dir | path join "vendor/autoload")
+starship init nu | save -f ($nu.data-dir | path join "vendor/autoload/starship.nu")
+EOF
+
+  # Create env.nu
+  cat >~/.config/nushell/env.nu <<'EOF'
+# env.nu
+#
+# Installed by:
+# version = "0.106.1"
+#
+# Previously, environment variables were typically configured in `env.nu`.
+# In general, most configuration can and should be performed in `config.nu`
+# or one of the autoload directories.
+#
+# This file is generated for backwards compatibility for now.
+# It is loaded before config.nu and login.nu
+#
+# See https://www.nushell.sh/book/configuration.html
+#
+# Also see `help config env` for more options.
+#
+# You can remove these comments if you want or leave
+# them for future reference.
+
+# Initialize zoxide support for nu
+zoxide init nushell --cmd cd | save -f ~/.zoxide.nu
+EOF
+
+  # Create alias.nu
+  cat >~/.config/nushell/alis.nu <<'EOF'
+# You can define your custom aliases here
+# Some examples you can uncomment:
+#
+# fzf with file preview
+# alias pfzf = fzf --preview="bat --color=always {}"
+#
+# Use bat instead of cat
+# alias cat = bat
+#
+# Fzf with image preview and selection opening to a nvim buffer
+# def nfzf [] {
+#     try {
+#         let selected_file = (fzf --preview="bat --color=always {}" | str trim)
+#         if ($selected_file != "" and ($selected_file | path exists)) {
+#             nvim $selected_file
+#         } else {
+#             print "No file selected or file doesn't exist"
+#         }
+#     } catch {
+#         print "fzf was cancelled or failed"
+#     }
+# }
+EOF
+
+  # Set nushell as default shell
+  echo "Setting nushell as default shell..."
+  chsh -s "$NU_PATH"
+
+  echo "Nushell has been configured successfully!"
+  echo "Please log out and log back in for the shell change to take effect."
+else
+  echo "Failed to install nushell"
+  exit 1
+fi

--- a/bin/omarchy-install-yazi
+++ b/bin/omarchy-install-yazi
@@ -59,6 +59,14 @@ EOF
     ]
 EOF
 
+  # Add yazi keybinding to hyprland config
+  if [ -f ~/.config/hypr/bindings.conf ]; then
+    echo "Adding yazi keybinding to hyprland..."
+    echo 'bind = SUPER SHIFT, F, File manager (Yazi), exec, $terminal -e yazi' >> ~/.config/hypr/bindings.conf
+  else
+    echo "Warning: ~/.config/hypr/bindings.conf not found. Skipping keybinding setup."
+  fi
+
   echo "Yazi has been configured with plugins and custom settings"
 else
   echo "Yazi is not installed. Please install yazi first."

--- a/bin/omarchy-install-yazi
+++ b/bin/omarchy-install-yazi
@@ -5,6 +5,7 @@ yay -S yazi ueberzugpp dragon-drop
 
 # Configure Yazi file manager with plugins and custom settings
 if command -v yazi &>/dev/null; then
+  echo "Yazi successfully installed"
   mkdir -p ~/.config/yazi
 
   # Install Yazi plugins ya pkg add yazi-rs/plugins:full-border

--- a/bin/omarchy-install-yazi
+++ b/bin/omarchy-install-yazi
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+echo "Installing yazi and dependencies"
+yay -S yazi ueberzugpp dragon-drop
+
+# Configure Yazi file manager with plugins and custom settings
+if command -v yazi &>/dev/null; then
+  mkdir -p ~/.config/yazi
+
+  # Install Yazi plugins ya pkg add yazi-rs/plugins:full-border
+  ya pkg add AnirudhG07/plugins-yazi:copy-file-contents
+  ya pkg add yazi-rs/plugins:full-border
+
+  # Create init.lua configuration
+  cat >~/.config/yazi/init.lua <<'EOF'
+  -- Show symlink in status bar
+  Status:children_add(function(self)
+  local h = self._current.hovered
+  if h and h.link_to then
+      return " -> " .. tostring(h.link_to)
+  else
+      return ""
+  end
+end, 3300, Status.LEFT)
+
+-- Show user/group of files in status bar
+Status:children_add(function()
+local h = cx.active.current.hovered
+if not h or ya.target_family() ~= "unix" then
+    return ""
+end
+return ui.Line({
+    ui.Span(ya.user_name(h.cha.uid) or tostring(h.cha.uid)):fg("magenta"),
+    ":",
+    ui.Span(ya.group_name(h.cha.gid) or tostring(h.cha.gid)):fg("magenta"),
+    " ",
+})
+end, 500, Status.RIGHT)
+
+-- Plugins
+-- Copy file content (Use "ya pkg add AnirudhG07/plugins-yazi:copy-file-contents" to install on new environments)
+require("copy-file-contents"):setup({
+    append_char = "\n",
+    notification = true,
+})
+-- Full-border line (Use "ya pkg add yazi-rs/plugins:full-border")
+require("full-border"):setup({
+    type = ui.Border.PLAIN,
+})
+EOF
+
+  # Create keymap.toml configuration
+  cat >~/.config/yazi/keymap.toml <<'EOF'
+  [mgr]
+  prepend_keymap = [
+    { on = [ "<A-y>" ], run = "plugin copy-file-contents", desc = "Copy file contents" },
+    { on = [ "<C-n>" ], run = 'shell -- dragon-drop -x -i -T "$1"', desc = "Drag'n'drop selected files" },
+    ]
+EOF
+
+  echo "Yazi has been configured with plugins and custom settings"
+else
+  echo "Yazi is not installed. Please install yazi first."
+fi

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -278,8 +278,9 @@ show_install_development_menu() {
 }
 
 show_install_extras_menu() {
-  case $(menu "Install" "󰇥  Yazi") in
+  case $(menu "Install" "󰇥  Yazi\n  Nushell") in
   *Yazi*) present_terminal omarchy-install-yazi ;;
+  *Nushell*) present_terminal omarchy-install-nushell ;;
   *) show_install_menu ;;
   esac
 }

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -184,7 +184,7 @@ show_setup_config_menu() {
 }
 
 show_install_menu() {
-  case $(menu "Install" "󰣇  Package\n󰣇  AUR\n  Web App\n  TUI\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming") in
+  case $(menu "Install" "󰣇  Package\n  Web App\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming\n  Extras") in
   *Package*) terminal omarchy-pkg-install ;;
   *AUR*) terminal omarchy-pkg-aur-install ;;
   *Web*) present_terminal omarchy-webapp-install ;;
@@ -195,6 +195,7 @@ show_install_menu() {
   *Editor*) show_install_editor_menu ;;
   *AI*) show_install_ai_menu ;;
   *Gaming*) show_install_gaming_menu ;;
+  *Extras*) show_install_extras_menu ;;
   *) show_main_menu ;;
   esac
 }
@@ -272,6 +273,13 @@ show_install_development_menu() {
   *Java*) present_terminal "omarchy-install-dev-env java" ;;
   *NET*) present_terminal "omarchy-install-dev-env dotnet" ;;
   *OCaml*) present_terminal "omarchy-install-dev-env ocaml" ;;
+  *) show_install_menu ;;
+  esac
+}
+
+show_install_extras_menu() {
+  case $(menu "Install" "󰇥  Yazi") in
+  *Yazi*) present_terminal omarchy-install-yazi ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
Hello! I've been working on adding an “Extras” section to the Omarchy installer menu. The idea is to have a place for optional packages/tools that might not be part of the basic Omarchy experience and require some configuration to be used in a pleasant way beyond simply installing the package. This way the Omarchy's _"Omakase"_ philosophy is respected.

The idea is that it should be extensible so that anyone can add packages here that they consider useful for other users, but which require additional configuration to make them work correctly in Omarchy. Some people might want to try them but it's definitely not something everyone would want as their default.

Right now I've added two things as an example:

- **Nushell**: this downloads nushell. Adds support for Omarchy's starship prompt. Adds nu bin to /etc/shells and changes the default user shell to nu. Adds support for zoxide (it'll replace default cd). Also creates some convenient and extensible config files for aliases and user's custom config.

- **Yazi** (This time with drag'n'drop support): installs yazi plus dependencies, sets up all the plugins and adds a hyprland keybinding compatible with nautilus, (Super+Shift+F) to launch it. Press \<C-n\> to drag'n'drop a file and \<A-y\> to copy the file content to system clipboard without needing to open it.

Other tools I think that could work well with this menu (I can work on them if you like this idea):

- **Jujutsu**: could install jj and prompt for user's name and email for the config. Then add jj completions for the user's default shell.
- **Tmux/Zellij**: omarchy already comes with a default nvim config. We could do the same for these multiplexers but in a way that the users can easily modify it (as done with nu and yazi's configs above).