### PR TITLE
Move starship init to the default .bashrc

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -2,10 +2,6 @@ if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 
-if command -v starship &> /dev/null; then
-  eval "$(starship init bash)"
-fi
-
 if command -v zoxide &> /dev/null; then
   eval "$(zoxide init bash)"
 fi

--- a/default/bash/init
+++ b/default/bash/init
@@ -2,8 +2,10 @@ if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 
-if [[ "$SKIP_STARSHIP_PROMPT" == "false" ]] && [ command -v starship ] &> /dev/null; then
-  eval "$(starship init bash)"
+if [[ "$SKIP_STARSHIP_PROMPT" = false ]]; then
+  if command -v starship &> /dev/null; then
+    eval "$(starship init bash)"
+  fi
 fi
 
 if command -v zoxide &> /dev/null; then

--- a/default/bash/init
+++ b/default/bash/init
@@ -2,7 +2,7 @@ if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 
-if [[ "$SKIP_STARSHIP_PROMPT" = false ]]; then
+if [[ "$SKIP_STARSHIP_PROMPT" != true ]]; then
   if command -v starship &> /dev/null; then
     eval "$(starship init bash)"
   fi

--- a/default/bash/init
+++ b/default/bash/init
@@ -2,6 +2,10 @@ if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 
+if [[ "$SKIP_STARSHIP_PROMPT" == "false" ]] && [ command -v starship ] &> /dev/null; then
+  eval "$(starship init bash)"
+fi
+
 if command -v zoxide &> /dev/null; then
   eval "$(zoxide init bash)"
 fi

--- a/default/bashrc
+++ b/default/bashrc
@@ -1,3 +1,5 @@
+# Change to true to turn off starship
+SKIP_STARSHIP_PROMPT = false
 # All the default Omarchy aliases and functions
 # (don't mess with these directly, just overwrite them here!)
 source ~/.local/share/omarchy/default/bash/rc
@@ -12,9 +14,3 @@ source ~/.local/share/omarchy/default/bash/rc
 #
 # Set a custom prompt with the directory revealed, starship must be turned off
 # PS1="\W \[\e]0;\w\a\]$PS1"
-
-# Omarchy ships with a simple starship prompt. Remove the section below
-# to turn it off.
-if command -v starship &>/dev/null; then
-  eval "$(starship init bash)"
-fi

--- a/default/bashrc
+++ b/default/bashrc
@@ -10,5 +10,11 @@ source ~/.local/share/omarchy/default/bash/rc
 # Use VSCode instead of neovim as your default editor
 # export EDITOR="code"
 #
-# Set a custom prompt with the directory revealed (alternatively use https://starship.rs)
+# Set a custom prompt with the directory revealed, starship must be turned off
 # PS1="\W \[\e]0;\w\a\]$PS1"
+
+# Omarchy ships with a simple starship prompt. Remove the section below
+# to turn it off.
+if command -v starship &>/dev/null; then
+  eval "$(starship init bash)"
+fi

--- a/default/bashrc
+++ b/default/bashrc
@@ -1,5 +1,5 @@
 # Change to true to turn off starship
-SKIP_STARSHIP_PROMPT = false
+SKIP_STARSHIP_PROMPT=false
 # All the default Omarchy aliases and functions
 # (don't mess with these directly, just overwrite them here!)
 source ~/.local/share/omarchy/default/bash/rc


### PR DESCRIPTION
Fixes #1197

Currently the new starship init is taking over the bash prompt, preventing oh-my-posh or even manually setting `PS1=...` in a user's .bashrc.

By moving the starship init to the default .bashrc, a fresh install will start with it, but users can turn it off or customize it easily and in a way that won't be overridden with future updates.