### PR TITLE
Install `node` as part of Laravel's dev env

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -33,6 +33,11 @@ install_php() {
   done
 }
 
+install_node() {
+  echo -e "Installing Node.js...\n"
+  mise use --global node@lts
+}
+
 case "$1" in
 ruby)
   echo -e "Installing Ruby on Rails...\n"
@@ -42,8 +47,7 @@ ruby)
   echo -e "\nYou can now run: rails new myproject"
   ;;
 node)
-  echo -e "Installing Node.js...\n"
-  mise use --global node@lts
+  install_node
   ;;
 bun)
   echo -e "Installing Bun...\n"
@@ -64,6 +68,7 @@ php)
 laravel)
   echo -e "Installing PHP and Laravel...\n"
   install_php
+  install_node
   composer global require laravel/installer
   echo -e "\nYou can now run: laravel new myproject"
   ;;


### PR DESCRIPTION
When running `laravel new`, if a starter kit like `React` or `Vue` are selected:

```
   _                               _
  | |                             | |
  | |     __ _ _ __ __ ___   _____| |
  | |    / _` |  __/ _` \ \ / / _ \ |
  | |___| (_| | | | (_| |\ V /  __/ |
  |______\__,_|_|  \__,_| \_/ \___|_|


 ┌ Which starter kit would you like to install? ────────────────┐
 │ › ● None                                                     │
 │   ○ React                                                    │
 │   ○ Vue                                                      │
 │   ○ Livewire                                                 │
 └──────────────────────────────────────────────────────────────┘
```

the installer will ask:

```
 ┌ Would you like to run npm install and npm run build? ────────┐
 │ ● Yes / ○ No                                                 │
 └──────────────────────────────────────────────────────────────┘
```

And in order for it to work, `npm` should be available.

Having this installed will definitively smooth out the experience from install to up-and-running!