### PR TITLE
Add binding to switch to previous workspace

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -41,6 +41,7 @@ bindd = SUPER SHIFT, code:19, Move window to workspace 10, movetoworkspace, 10
 # Tab between workspaces
 bindd = SUPER, TAB, Next workspace, workspace, e+1
 bindd = SUPER SHIFT, TAB, Previous workspace, workspace, e-1
+bindd = SUPER, backslash, Switch to the previous workspace, workspace, previous
 
 # Swap active window with the one next to it with SUPER + SHIFT + arrow keys
 bindd = SUPER SHIFT, left, Swap window to the left, swapwindow, l


### PR DESCRIPTION
I noticed that the previously rejected PR for workspace switching shortcuts included a “previous workspace” feature. I’m not sure if this was intentionally left out, but I think it would be a valuable addition!

For example, you draw something in Pinta on workspace 9 and look at some images in a web browser (which you might often use on workspace 2). Using the shortcut to navigate to the previous workspace, you can go back and forth between these two workspaces with the same shortcut.

I believe this feature would fit well with omarchy’s design philosophy. While it might need a different default keybinding than what was originally proposed, I encourage you to try it out - I think  other users would find it really useful!