### PR TITLE
Fix power menu case order

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -377,12 +377,12 @@ go_to_menu() {
   *screenrecord*) show_screenrecord_menu ;;
   *toggle*) show_toggle_menu ;;
   *setup*) show_setup_menu ;;
-  *power*) show_setup_power_menu ;;
   *install*) show_install_menu ;;
   *remove*) show_remove_menu ;;
   *update*) show_update_menu ;;
-  *about*) alacritty --class Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s' ;;
   *system*) show_system_menu ;;
+  *about*) alacritty --class Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s' ;;
+  *power*) show_setup_power_menu ;;
   esac
 }
 


### PR DESCRIPTION
Fixes battery icon click functionality by placing `*power*)` case after `*about*)` as intended in PR #1178.