### PR TITLE
fix: omarchy-battery-monitor

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -6,7 +6,13 @@ BATTERY_THRESHOLD=10
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
 
 get_battery_percentage() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
+  upower -i "$(upower -e | grep 'BAT')" \
+  | awk -F: '/percentage/ {
+      gsub(/[%[:space:]]/, "", $2);
+      val=$2;
+      printf("%d\n", (val+0.5))
+      exit
+    }'
 }
 
 get_battery_state() {


### PR DESCRIPTION
cleans the output of upower, strips the percentage and decimals, prevents arithmetic syntax error later on in the script.

I was getting weird behaviour when my battery was discharging - i'd get notifications at odd times. In the logs I'd see things like

> Aug 28 09:51:02 archlinux omarchy-battery-monitor[13463]: /home/xz/.local/share/omarchy/bin/omarchy-battery-monitor: line 24: [[: 88.2547: arithmetic syntax error: invalid arithmetic operator (error token is ".2547")

`get_battery_percent()` would output `7161`
```bash
  upower -i $(upower -e | grep 'BAT') | grep -E "percentage" | grep -o '[0-9]\+%' | sed 's/%//'
```

New function outputs a rounded integer eg.`90`, which plays nicer with the notification / threshold checks
```bash
upower -i "$(upower -e | grep 'BAT')" \
  | awk -F: '/percentage/ {
      gsub(/[%[:space:]]/, "", $2);
      val=$2;
      printf("%d\n", (val+0.5))
      exit
    }'
