### PR TITLE
Change default screencapture storage directories

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
-OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
+OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR}/Screenrecordings}"
 
 if [[ ! -d "$OUTPUT_DIR" ]]; then
-  notify-send "Screen recording directory does not exist: $OUTPUT_DIR" -u critical -t 3000
-  exit 1
+  mkdir -p "$OUTPUT_DIR"
+  if [[ ! -d "$OUTPUT_DIR" ]]; then
+    notify-send "Screen recording directory cannot be created at path: $OUTPUT_DIR" -u critical -t 3000
+  fi
 fi
 
 screenrecording() {

--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
-OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}}"
+OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR}/Screenshots}"
 
 if [[ ! -d "$OUTPUT_DIR" ]]; then
-  notify-send "Screenshot directory does not exist: $OUTPUT_DIR" -u critical -t 3000
-  exit 1
+  mkdir -p "$OUTPUT_DIR"
+  if [[ ! -d "$OUTPUT_DIR" ]]; then
+    notify-send "Screenshot directory cannot be created at path: $OUTPUT_DIR" -u critical -t 3000
+  fi
 fi
 
 pkill slurp || hyprshot -m ${1:-region} --raw |


### PR DESCRIPTION
We put the screenshots and screen recordings in their own folders in the Pictures/Videos directories. We make sure that the set directory exists, otherwise we create it.

We do this without using localized language, following the XDG standard.

Closes https://github.com/basecamp/omarchy/issues/1205
Improves https://github.com/basecamp/omarchy/pull/1241

See also: https://github.com/basecamp/omarchy/issues/1205#issuecomment-3232282938