### PR TITLE
Fix comment formatting for key unbinding example

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -25,5 +25,5 @@ bindd = SUPER, X, X, exec, omarchy-launch-webapp "https://x.com/"
 bindd = SUPER SHIFT, X, X Post, exec, omarchy-launch-webapp "https://x.com/compose/post"
 
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
-# unbind = SUPER, Space
+# unbind = SUPER, SPACE
 # bindd = SUPER, SPACE, Omarchy menu, exec, omarchy-menu


### PR DESCRIPTION
`unbind = SUPER, Space` will not work, but `unbind = SUPER, SPACE` will