### PR TITLE
Fix screensaver exit behavior on multiple monitors

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -1,4 +1,11 @@
 #!/bin/bash
+function exit_screensaver {
+  pkill -x tte 2>/dev/null
+  pkill -f "alacritty --class Screensaver" 2>/dev/null
+  exit 0
+}
+
+trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
 
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)
@@ -8,9 +15,7 @@ while true; do
 
   while pgrep -x tte >/dev/null; do
     if read -n 1 -t 0.01; then
-      pkill -x tte 2>/dev/null
-      pkill -f "alacritty --class Screensaver" 2>/dev/null
-      exit 0
+      exit_screensaver
     fi
   done
 done


### PR DESCRIPTION
This PR adds a trap to omarchy-cmd-screensaver, capturing SIGINT SIGTERM SIGHUP SIGQUIT and exiting the screensaver cleanly.

Previously, if a user with multiple monitors exited the screensaver with CTRL + C or SUPER + W, only one screensaver (the "active" one) would close. This PR fixes this.

