### PR TITLE
fix: Add Feedback when no Docker DB Selected

### DIFF
--- a/bin/omarchy-install-docker-dbs
+++ b/bin/omarchy-install-docker-dbs
@@ -13,4 +13,7 @@ if [[ -n "$choices" ]]; then
     MongoDB) sudo docker run -d --restart unless-stopped -p "127.0.0.1:27017:27017" --name mongodb -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=admin123 mongo:noble ;;
     esac
   done
+else
+  echo "No databases selected for installation."
+  sleep 1
 fi


### PR DESCRIPTION
This PR addresses an issue where users reported confusion on [Discord](https://discord.com/channels/1390012484194275541/1390012487000395859/1410684011025535067) when they didn’t select any databases to install in the Omarchy database installation script. Previously, if no databases were selected (e.g., by pressing Esc or Enter without choosing an option), the script would silently return to the main menu.

This PR adds a message when no selection is made.