### PR TITLE
 Add release notes display to omarchy-update commands

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -2,6 +2,30 @@
 
 set -e
 
+# Show update information with release notes before proceeding
+echo "Checking for updates..."
+set +e  # Temporarily disable exit on error for the update check
+omarchy-update-available
+update_status=$?
+set -e  # Re-enable exit on error
+
+if [[ $update_status -eq 0 ]]; then
+  echo ""
+  read -p "Proceed with update? (y/N): " -n 1 -r
+  echo ""
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Update cancelled."
+    exit 0
+  fi
+else
+  echo "No updates available."
+  exit 0
+fi
+
+echo ""
+echo "Starting update process..."
+echo ""
+
 omarchy-snapshot create || [ $? -eq 127 ]
 omarchy-update-git
 omarchy-migrate

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -1,21 +1,73 @@
 #!/bin/bash
 
-# Get remote tag
-latest_tag=$(git -C "$OMARCHY_PATH" ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
+# Constants
+UPSTREAM_REPO="basecamp/omarchy"
+
+# Get remote tag from upstream repository
+latest_tag=$(git ls-remote --tags "https://github.com/$UPSTREAM_REPO" | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
 if [[ -z "$latest_tag" ]]; then
   echo "Error: Could not retrieve latest tag."
   exit 1
 fi
 
-# Get local tag
-current_tag=$(git -C "$OMARCHY_PATH" describe --tags $(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1))
+# Get local tag (current checked out tag)
+current_tag=$(git -C "$OMARCHY_PATH" describe --tags --exact-match 2>/dev/null || git -C "$OMARCHY_PATH" describe --tags)
 if [[ -z "$current_tag" ]]; then
   echo "Error: Could not retrieve current tag."
   exit 1
 fi
 
 if [[ "$current_tag" != "$latest_tag" ]]; then
-  echo "Omarchy update available ($latest_tag)"
+  echo "Omarchy update available: $current_tag → $latest_tag"
+  echo ""
+  
+  # Get all tags between current and latest
+  all_tags=$(git ls-remote --tags "https://github.com/$UPSTREAM_REPO" | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V)
+  
+  # Find tags newer than current_tag up to and including latest_tag
+  newer_tags=""
+  found_current=false
+  while IFS= read -r tag; do
+    if [[ "$found_current" == true ]]; then
+      newer_tags="$newer_tags$tag "
+      if [[ "$tag" == "$latest_tag" ]]; then
+        break
+      fi
+    elif [[ "$tag" == "$current_tag" ]]; then
+      found_current=true
+    fi
+  done <<< "$all_tags"
+  
+  # Fetch and combine release notes for all versions being skipped
+  if [[ -n "$newer_tags" ]]; then
+    echo "Release notes for updates:"
+    echo "================================"
+    
+    for tag in $newer_tags; do
+      release_notes=$(curl -s "https://api.github.com/repos/$UPSTREAM_REPO/releases/tags/$tag" | \
+        jq -r '.body // ""' 2>/dev/null)
+      
+      if [[ -n "$release_notes" && "$release_notes" != "null" ]]; then
+        echo ""
+        echo "## Version $tag"
+        echo "--------------------------------"
+        echo "$release_notes"
+      fi
+    done
+  else
+    # Fallback: just show notes for latest version
+    release_notes=$(curl -s "https://api.github.com/repos/$UPSTREAM_REPO/releases/tags/$latest_tag" | \
+      jq -r '.body // "No release notes available"' 2>/dev/null)
+    
+    if [[ -n "$release_notes" && "$release_notes" != "No release notes available" && "$release_notes" != "null" ]]; then
+      echo "Release notes for $latest_tag:"
+      echo "--------------------------------"
+      echo "$release_notes"
+    else
+      echo "No release notes available for $latest_tag"
+    fi
+  fi
+  
   exit 0
 else
   echo "Omarchy is up to date ($current_tag)"

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -29,7 +29,7 @@ if [[ "$current_tag" != "$latest_tag" ]]; then
   found_current=false
   while IFS= read -r tag; do
     if [[ "$found_current" == true ]]; then
-      newer_tags="$newer_tags$tag "
+      newer_tags="$tag $newer_tags"  # Prepend to reverse order
       if [[ "$tag" == "$latest_tag" ]]; then
         break
       fi


### PR DESCRIPTION
## Summary

This PR enhances the Omarchy update system to display release notes from GitHub, giving users visibility into what changes they'll receive before updating.

## Changes

### Enhanced `omarchy-update-available`
- Fetches and displays release notes from GitHub releases API
- When updating through multiple versions, combines all intermediate release notes
- Shows update path clearly: `current_version → latest_version`
- Uses proper current tag detection (checked-out tag, not latest in repo)
- Centralizes upstream repository URL in a constant

### Enhanced `omarchy-update`
- Now shows release notes before prompting for update confirmation
- Allows users to review changes and cancel if desired
- Only proceeds with update after explicit user confirmation

### Technical Details
- Fixed tag detection to use `git describe --tags --exact-match` for current version
- All GitHub URLs now reference single `UPSTREAM_REPO="basecamp/omarchy"` constant
- Gracefully handles missing release notes
- No changes to core update mechanism (`omarchy-update-git` remains unchanged)

## Testing

Tested by checking out an older tag (v1.10.0) and running the update scripts, which correctly displayed combined release notes for all versions from v1.10.0 to v2.0.5.

## Example Output

When running `omarchy-update-available` with an outdated installation:

Omarchy update available: v2.0.0 → v2.0.5

```bash
Release notes for updates:
================================

## Version v2.0.5
--------------------------------
# What changed?

* Fix package repository order so Arch defaults come before Omarchy Package Repository by @dhh
* Fix Omarchy branch name should be exposed in the About screen by @dhh
* Fix node.js is needed for a full Laravel installation by @roberto-aguilar
* Fix new installs should use woff2-font-awesome instead of ttf-font-awesome per Font Awesome 7.0 by @dhh
* Fix strange case where walker-bin went missing by @dhh
* Fix Waybar shouldn't restart after unlock now that we've fixed the stacking problem by @dhh
* Fix snapper usage for custom btrfs setups by @michielryvers + @ryanrhughes 

## New Contributors
* @roberto-aguilar made their first contribution in https://github.com/basecamp/omarchy/pull/1201
* @michielryvers made their first contribution in https://github.com/basecamp/omarchy/pull/1160

**Full Changelog**: https://github.com/basecamp/omarchy/compare/v2.0.4...v2.0.5

## Version v2.0.4
--------------------------------
# What changed?

* Fix pinning package no longer needed after we shrinked the Omarchy repo by @dhh 
* Fix iwd service shouldn't start during installation by @dhh 
* Fix keyboard layout at install by @bastnic in https://github.com/basecamp/omarchy/pull/1188
* Fix clicking on the battery icon should open the power menu by @cstrickjacke in https://github.com/basecamp/omarchy/pull/1178

## New Contributors
* @bastnic made their first contribution in https://github.com/basecamp/omarchy/pull/1188
* @cstrickjacke made their first contribution in https://github.com/basecamp/omarchy/pull/1178

**Full Changelog**: https://github.com/basecamp/omarchy/compare/v2.0.3...v2.0.4

## Version v2.0.3
--------------------------------
# What changed?

* Fix top bar would disappear when running upgrade from the update-available icon by @dhh 
* Fix phantom update-available icon in top bar showing up due to git network errors by @dhh
* Fix migration to add --working-directory to bindings.conf if its already there by @dhh
* Fix non-kosher use of pacman -Sy that would cause partial system updates by @dhh

**Full Changelog**: https://github.com/basecamp/omarchy/compare/v2.0.2...v2.0.3

## Version v2.0.2
--------------------------------
# What changed?

* Fix black-screen-of-death installs following [abseil-cpp package release](https://archlinux.org/packages/extra/x86_64/abseil-cpp/) at 2025-08-26 22:15 UTC that broke installs by @dhh
* Fix About info display by @tahayvr 
* Fix font size for About when system font size has changed by @dhh

Update as per usual using _Update > Omarchy_ from the Omarchy Menu.

## Fixing black-screen-of-death installs

If you installed Omarchy via the ISO between 2025-08-26 22:15 UTC and 2025-08-27 12:50 UTC, you'll likely have hit the black-screen-of-death after installation. You can fix it with these steps:

1) CTRL + ALT + F2
2) Login with your credentials
3) curl -fsSL https://omarchy.org/patch/pin-abseil-cpp | bash

This will restore the working version of abseil-cpp and restart your system. Now you're back in business!

**Full Changelog**: https://github.com/basecamp/omarchy/compare/v2.0.1...v2.0.2

## Version v2.0.1
--------------------------------
# What changed?

* Fix AMI bios bricking bug by @ryanrhughes 
* Fix omarchy-launch-browser and omarchy-launch-webapp for folks using Nix home manager by @manofcolombia
* Fix _Update > Omarchy_ should use our new icon instead of Arch by @tahayvr 
* Fix _Remove > Web App_ and _Remove > TUI_ for removing multi-word entries by @jopesh
* Fix _Remove > Web App_ and _Remove > TUI_ should use an x instead of checkmark for selection by @hipsterusername
* Fix emoji picker description in keybindings overview by @AdiY00
* Fix that all chromium-based and firefox-based browser should have the same transparency rules by @joshleblanc + @dhh
* Fix that omarchy-icon font shouldn't should up as an option in the _Style > Font_ menu by @WToa
* Fix workspace tabbing should use `bindd` by @arcbjorn
* Fix old installations still had About, Activity, Audio Settings apps in launcher that we've moved to Omarchy Menu by @dhh

## New Contributors

* @manofcolombia made their first contribution in https://github.com/basecamp/omarchy/pull/1076
* @hipsterusername made their first contribution in https://github.com/basecamp/omarchy/pull/1104
* @meerzulee made their first contribution in https://github.com/basecamp/omarchy/pull/1103
* @WToa made their first contribution in https://github.com/basecamp/omarchy/pull/1101
* @arcbjorn made their first contribution in https://github.com/basecamp/omarchy/pull/1098
* @AdiY00 made their first contribution in https://github.com/basecamp/omarchy/pull/1091
* @jopesh made their first contribution in https://github.com/basecamp/omarchy/pull/1087
* @joshleblanc made their first contribution in https://github.com/basecamp/omarchy/pull/1090

**Full Changelog**: https://github.com/basecamp/omarchy/compare/v2.0.0...v2.0.1
```