### PR TITLE
Enhance JetBrains window rules in jetbrains.conf

### DIFF
--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -8,3 +8,8 @@ windowrule = nofocus, class:^(.*jetbrains.*)$, title:^(win.*)$
 # Fix tab dragging (always have a single space character as their title)
 windowrule = noinitialfocus, class:^(.*jetbrains.*)$, title:^\\s$
 windowrule = nofocus, class:^(.*jetbrains.*)$, title:^\\s$
+
+# Avoid unclickable window (see https://github.com/hyprwm/Hyprland/issues/4257#issuecomment-2875655706)
+windowrulev2 = tag +jb, class:^jetbrains-.+$,floating:1
+windowrulev2 = stayfocused, tag:jb
+windowrulev2 = noinitialfocus, tag:jb


### PR DESCRIPTION
Hi,

Android Studio is not clickable with the default configuration. We need to add some windowrules2, see #1261 and (https://github.com/hyprwm/Hyprland/issues/4257#issuecomment-2875655706)