### PR TITLE
Include wireless-regdb to resolve #1083

### DIFF
--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -3,7 +3,7 @@
 # Install iwd explicitly if it wasn't included in archinstall
 # This can happen if archinstall used ethernet
 if ! command -v iwctl &>/dev/null; then
-  sudo pacman -S --noconfirm --needed iwd
+  sudo pacman -S --noconfirm --needed iwd wireless-regdb
   sudo systemctl enable iwd.service
 fi
 

--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -3,7 +3,7 @@
 # Install iwd explicitly if it wasn't included in archinstall
 # This can happen if archinstall used ethernet
 if ! command -v iwctl &>/dev/null; then
-  sudo pacman -S --noconfirm --needed iwd wireless-regdb
+  sudo pacman -S --noconfirm --needed iwd
   sudo systemctl enable iwd.service
 fi
 

--- a/install/packages.sh
+++ b/install/packages.sh
@@ -106,6 +106,7 @@ sudo pacman -S --noconfirm --needed \
   waybar \
   wf-recorder \
   whois \
+  wireless-regdb \
   wiremix \
   wireplumber \
   wl-clip-persist \


### PR DESCRIPTION
Installs the wireless-regdb package to allow the user to configure the regulatory region, which is required for 6GHz bands (and likely some other bands as well) for Wi-Fi.

Note that the user still has to manually set their region using `iw reg set` or by editing /etc/conf.d/wireless-regdom.  As discussed in #1083 there is a further package that is currently in development that will be used to set region automatically using the timezone.

Once that is in place, we'll also need to update omarchy-iso and omarchy-configurator to integrate it so that those Wi-Fi networks can be correctly joined during installation.

I tested this change both in the VM and on a Framework Laptop 16 with RZ717 Wi-Fi.