### PR TITLE
Write 'Waybar' instead of 'top bar' in Walker's toggle menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -122,11 +122,11 @@ show_screenrecord_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Waybar") in
   *Screensaver*) omarchy-toggle-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
   *Idle*) omarchy-toggle-idle ;;
-  *Bar*) omarchy-toggle-waybar ;;
+  *Waybar*) omarchy-toggle-waybar ;;
   *) show_main_menu ;;
   esac
 }

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -7,7 +7,7 @@ bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system
 bindd = SUPER, K, Show key bindings, exec, omarchy-menu-keybindings
 
 # Aesthetics
-bindd = SUPER SHIFT, SPACE, Toggle top bar, exec, pkill -SIGUSR1 waybar
+bindd = SUPER SHIFT, SPACE, Toggle Waybar, exec, pkill -SIGUSR1 waybar
 bindd = SUPER CTRL, SPACE, Next background in theme, exec, omarchy-theme-bg-next
 bindd = SUPER SHIFT CTRL, SPACE, Pick new theme, exec, omarchy-menu theme
 


### PR DESCRIPTION
We probably want to spell it "Waybar" everywhere, right?