### PR TITLE
Set hypridle exception for fullscreen apps

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -7,5 +7,8 @@ windowrule = opacity 0.97 0.9, class:.*
 # Fix some dragging issues with XWayland
 windowrule = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0
 
+# Prevent screensaver/lock while running apps fullscreen
+windowrule = idleinhibit fullscreen, class:.*
+
 # App-specific tweaks
 source = ~/.local/share/omarchy/default/hypr/apps.conf


### PR DESCRIPTION
https://github.com/basecamp/omarchy/issues/1269
Prevent screensaver/lockscreen from activating during games and such