### PR TITLE
Fix update script interruption handling

### DIFF
--- a/bin/omarchy-update-git
+++ b/bin/omarchy-update-git
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Trap interruption signals to prevent data loss
+trap 'echo -e "\n\e[33mUpdate interrupted.\e[0m"; exit 130' INT TERM HUP
+
 echo -e "\e[32mUpdate Omarchy\e[0m"
 git -C $OMARCHY_PATH pull --autostash
-git -C $OMARCHY_PATH diff --check || git -C $OMARCHY_PATH reset --merge


### PR DESCRIPTION
Fixes #1298 

## Problem
A user reported that interrupting omarchy-update with Ctrl+C caused data loss in their ~/.local/share/omarchy directory. The `git reset --merge` after an interrupted git pull can be destructive.

## Solution
- Add signal trap for INT/TERM/HUP to handle interruptions gracefully
- Remove the problematic `git diff --check || git reset --merge` line
- Minimal change to preserve script simplicity

## Testing
Verified all three signals are handled correctly:
- INT (Ctrl+C) - exits cleanly
- TERM (kill) - exits cleanly  
- HUP (terminal close) - exits cleanly

The git pull command has sufficient built-in error handling, so no additional error recovery is needed.