### PR TITLE
Fix DNS migration to handle UseDNS=no in network files

### DIFF
--- a/migrations/1755109182.sh
+++ b/migrations/1755109182.sh
@@ -22,9 +22,16 @@ if [ -f /etc/systemd/resolved.conf ]; then
     sudo rm -f /etc/systemd/network/99-omarchy-dns.network
     sudo systemctl restart systemd-networkd
   fi
+  
+  # Remove UseDNS=no from all network files to allow DHCP DNS
+  # This matches what omarchy-setup-dns DHCP does
+  for file in /etc/systemd/network/*.network; do
+    [[ -f "$file" ]] || continue
+    sudo sed -i '/^UseDNS=no/d' "$file"
+  done
 
-  # Restart systemd-resolved to apply changes
-  sudo systemctl restart systemd-resolved
+  # Restart systemd services to apply changes
+  sudo systemctl restart systemd-networkd systemd-resolved
 
   echo "DNS configuration reset to use DHCP (router DNS)"
   echo "To use Cloudflare DNS, run: omarchy-setup-dns Cloudflare"

--- a/migrations/1755109182.sh
+++ b/migrations/1755109182.sh
@@ -22,18 +22,10 @@ if [ -f /etc/systemd/resolved.conf ]; then
     sudo rm -f /etc/systemd/network/99-omarchy-dns.network
     sudo systemctl restart systemd-networkd
   fi
-  
-  # Remove UseDNS=no from all network files to allow DHCP DNS
-  # This matches what omarchy-setup-dns DHCP does
-  for file in /etc/systemd/network/*.network; do
-    [[ -f "$file" ]] || continue
-    sudo sed -i '/^UseDNS=no/d' "$file"
-  done
 
-  # Restart systemd services to apply changes
-  sudo systemctl restart systemd-networkd systemd-resolved
+  # Restart systemd-resolved to apply changes
+  sudo systemctl restart systemd-resolved
 
   echo "DNS configuration reset to use DHCP (router DNS)"
   echo "To use Cloudflare DNS, run: omarchy-setup-dns Cloudflare"
 fi
-

--- a/migrations/1756491748.sh
+++ b/migrations/1756491748.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Migration to fix DNS issue for existing users who already ran 1755109182.sh
+# Remove UseDNS=no from all network files to allow DHCP DNS
+# This matches what omarchy-setup-dns DHCP does
+
+echo "Removing UseDNS=no from network files to fix DNS issue..."
+
+for file in /etc/systemd/network/*.network; do
+  [[ -f "$file" ]] || continue
+  if grep -q "^UseDNS=no" "$file"; then
+    echo "Removing UseDNS=no from $file"
+    sudo sed -i '/^UseDNS=no/d' "$file"
+  fi
+done
+
+echo "DNS migration completed - DHCP DNS should work after reboot"

--- a/migrations/1756491748.sh
+++ b/migrations/1756491748.sh
@@ -1,17 +1,6 @@
-#!/bin/bash
-
-# Migration to fix DNS issue for existing users who already ran 1755109182.sh
-# Remove UseDNS=no from all network files to allow DHCP DNS
-# This matches what omarchy-setup-dns DHCP does
-
-echo "Removing UseDNS=no from network files to fix DNS issue..."
+echo "Removing UseDNS=no from network files to fix DNS issue"
 
 for file in /etc/systemd/network/*.network; do
   [[ -f "$file" ]] || continue
-  if grep -q "^UseDNS=no" "$file"; then
-    echo "Removing UseDNS=no from $file"
-    sudo sed -i '/^UseDNS=no/d' "$file"
-  fi
+  sudo sed -i '/^UseDNS=no/d' "$file"
 done
-
-echo "DNS migration completed - DHCP DNS should work after reboot"


### PR DESCRIPTION
Fixes #1246

Reopening the DNS fix since the previous PR #1271 got closed accidentally.

Migration 1755109182.sh only fixed resolved.conf but didn't remove UseDNS=no from network files, causing DNS to revert to Cloudflare after reboot.

This adds:
- Fix to migration 1755109182.sh to remove UseDNS=no from network files
- New migration 1756491748.sh for users who already ran the old version

Both now match what omarchy-setup-dns DHCP does.

Tested and confirmed it fixes the issue.