### PR TITLE
Ensure that Ollama can run on NVIDIA GPUs

### DIFF
--- a/bin/omarchy-install-ollama
+++ b/bin/omarchy-install-ollama
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo -e "Installing Ollama...\n"
+sudo pacman -S --noconfirm ollama
+
+# Ensure that Ollama can run on NVIDIA GPUs.
+if command -v nvidia-smi &>/dev/null; then
+  echo -e "Installing CUDA-enabled Ollama...\n"
+  sudo pacman -S --noconfirm ollama-cuda
+fi

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -223,7 +223,7 @@ show_install_ai_menu() {
   *Claude*) aur_install "Claude Code" "claude-code" ;;
   *Gemini*) install "Gemini" "gemini-cli" ;;
   *Studio*) aur_install "LM Studio" "lmstudio" ;;
-  *Ollama*) install "Ollama" "ollama" ;;
+  *Ollama*) present_terminal omarchy-install-ollama ;;
   *Crush*) aur_install "Crush" "crush-bin" ;;
   *opencode*) aur_install "opencode" "opencode-bin" ;;
   *) show_install_menu ;;

--- a/migrations/1756536994.sh
+++ b/migrations/1756536994.sh
@@ -1,0 +1,7 @@
+echo "Ensure Ollama is properly configured to utilize NVIDIA GPUs"
+
+if command -v ollama &>/dev/null; then
+  if command -v nvidia-smi &>/dev/null; then
+    sudo pacman -S --noconfirm ollama-cuda
+  fi
+fi


### PR DESCRIPTION
When installing Ollama via the `Install > AI > Ollama` menu, I noticed that language models defaulted to running on the CPU instead of the GPU.

This happens because Ollama requires the `ollama-cuda` package to enable CUDA support for NVIDIA GPUs.

Additionally, I’ve extracted the installation logic into a dedicated `omarchy-install-ollama` script. This keeps the menu code simpler and easier to maintain.