### PR TITLE
Add private browser key binding

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -1,3 +1,19 @@
 #!/bin/bash
 
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$(xdg-settings get default-web-browser) 2>/dev/null | head -1) ${args[@]} $@
+browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$(xdg-settings get default-web-browser) 2>/dev/null | head -1)
+
+case "$browser_exec" in
+*firefox*)
+  private_flag="--private-window"
+  ;;
+*)
+  private_flag="--incognito"
+  ;;
+esac
+
+args=("$@")
+for i in "${!args[@]}"; do
+  [[ "${args[i]}" == "--private" ]] && args[i]="$private_flag"
+done
+
+exec setsid uwsm app -- "$browser_exec" "${args[@]}"

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -5,6 +5,7 @@ $browser = omarchy-launch-browser
 bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)
 bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window
 bindd = SUPER, B, Browser, exec, $browser
+bindd = SUPER SHIFT, B, Browser (private), exec, $browser --private
 bindd = SUPER, M, Music, exec, uwsm app -- spotify
 bindd = SUPER, N, Neovim, exec, $terminal -e nvim
 bindd = SUPER, T, Activity, exec, $terminal -e btop


### PR DESCRIPTION
This PR adds a private (window) browser keybinding available under `SUPER SHIFT + B` as an alternative to the normal (window) browser keybinding of `SUPER + B`. It's setup to be compatible with other default web browsers like Firefox. It's easy to extend it for more browsers.

To test you can (for example) install Firefox and use `xdg-settings set default-web-browser firefox.desktop`. Then use `SUPER + B` and `SUPER SHIFT + B` to see it in action.

<img width="1093" height="318" alt="screenshot-2025-08-30_11-53-00" src="https://github.com/user-attachments/assets/8d492c1e-c9a0-4a14-a9c6-ae7f80473b20" />

As a developer I often use a private window for testing (Rails :wink:) web apps. And occasionally to keep my (normal) browsing history clean.