### PR TITLE
Add gvfs-smb so GNOME Files (Nautilus) can handle smb:// URIs.

### DIFF
--- a/install/packages.sh
+++ b/install/packages.sh
@@ -34,6 +34,7 @@ sudo pacman -S --noconfirm --needed \
   gnome-themes-extra \
   gum \
   gvfs-mtp \
+  gvfs-smb \
   hypridle \
   hyprland \
   hyprland-qtutils \

--- a/migrations/1756556731.sh
+++ b/migrations/1756556731.sh
@@ -1,0 +1,3 @@
+echo "Add Samba network drive support to the file manager"
+
+pkg-add gvfs-smb


### PR DESCRIPTION
### Challenge:
GNOME Files on Omarchy did not handle `smb://` URIs by default (common for Synology NAS).

### Proposed solution:
Add `gvfs-smb` to package list.
This includes additional dependencies:
- `samba`
- `smbclient`
- `cifs-utils`

### Outcome:
Files → Network → Server address accepts `smb://<IP>` and mounts shares.

<img width="1248" height="676" alt="image" src="https://github.com/user-attachments/assets/07c3958b-92a2-4ef3-9b4f-5425be8da168" />
