### PR TITLE
Add keyd keyboard remapping for sysrq shortcut on Mac mode keyboards

### DIFF
--- a/install/config/hardware/keyd.sh
+++ b/install/config/hardware/keyd.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Install keyd and configure Keychron K3 keyboard remapping
+
+# Install keyd if not already installed
+if ! yay -Qq keyd &>/dev/null; then
+  echo "Installing keyd (keyboard remapping daemon)"
+  yay -S --noconfirm --needed keyd || true
+fi
+
+# Create keyd config directory
+sudo mkdir -p /etc/keyd
+
+# Create keyd config file
+if [[ ! -f /etc/keyd/default.conf ]]; then
+  echo "Creating keyd config for keyboard remapping"
+  cat <<EOF | sudo tee /etc/keyd/default.conf >/dev/null
+[main]
+leftmeta+leftshift+4 = sysrq
+EOF
+fi
+
+# Enable and start keyd service
+if ! systemctl is-enabled --quiet keyd.service; then
+  echo "Enabling keyd service"
+  sudo systemctl enable --now keyd.service || true
+fi

--- a/migrations/1756583646.sh
+++ b/migrations/1756583646.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Migration: Install keyd and configure Keychron K3 keyboard remapping
+
+source $OMARCHY_PATH/install/config/hardware/keyd.sh


### PR DESCRIPTION
This PR adds support for the `keyd` keyboard remapping daemon to fix print screen functionality on Mac mode keyboards by mapping `leftmeta+leftshift+4` to the `sysrq` key.
You **can** still use `left super + left shift + 4` to move a window to the 4th workspace.

### Changes Made

**New Files:**
- keyd.sh - Hardware configuration script that:
  - Installs the `keyd` package from AUR
  - Creates `/etc/keyd/default.conf` with keyboard mappings
  - Enables and starts the keyd service

- 1756583646.sh - Migration script that sources the hardware config for automatic setup

### Why This Change?
- **Mac Mode Keyboards**: Many Mac-style keyboards like my Keychron K3 send `leftmeta+leftshift+4` at the firmware level to simulate a print screen for mac instead of the button being mapped to a true print screen.
- **Universal Compatibility**: Uses `default.conf` without device-specific IDs, so it works with any keyboard.