### PR TITLE
Add omarchy-confirm script which defaults to gum

### DIFF
--- a/bin/omarchy-confirm
+++ b/bin/omarchy-confirm
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# omarchy-confirm - A gum-compatible confirmation prompt with fallback
+# Usage: omarchy-confirm [--default=false] "prompt message"
+
+set -e
+
+DEFAULT_YES=true
+PROMPT=""
+
+# Parse arguments to match gum's API
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  --default=false)
+    DEFAULT_YES=false
+    shift
+    ;;
+  --default=true)
+    DEFAULT_YES=true
+    shift
+    ;;
+  --default)
+    if [[ "${2:-}" == "false" ]]; then
+      DEFAULT_YES=false
+    else
+      DEFAULT_YES=true
+    fi
+    shift 2
+    ;;
+  *)
+    PROMPT="$1"
+    shift
+    ;;
+  esac
+done
+
+# Ensure we have a prompt
+if [[ -z "$PROMPT" ]]; then
+  echo "Usage: omarchy-confirm [--default=false] \"prompt message\"" >&2
+  exit 1
+fi
+
+# Try to use gum if available
+if command -v gum >/dev/null 2>&1; then
+  if [[ "$DEFAULT_YES" == true ]]; then
+    gum confirm --default=true "$PROMPT"
+  else
+    gum confirm --default=false "$PROMPT"
+  fi
+else
+  # Fallback to basic y/n prompt
+  if [[ "$DEFAULT_YES" == true ]]; then
+    echo -n "$PROMPT [Y/n]: "
+    read -r response
+    case "$response" in
+    [nN] | [nN][oO])
+      exit 1
+      ;;
+    *)
+      exit 0
+      ;;
+    esac
+  else
+    echo -n "$PROMPT [y/N]: "
+    read -r response
+    case "$response" in
+    [yY] | [yY][eE][sS])
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+    esac
+  fi
+fi
+

--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -17,7 +17,7 @@ for file in ~/.local/share/omarchy/migrations/*.sh; do
     if bash $file; then
       touch "$STATE_DIR/$filename"
     else
-      if gum confirm "Migration ${filename%.sh} failed. Skip and continue?"; then
+      if omarchy-confirm "Migration ${filename%.sh} failed. Skip and continue?"; then
         touch "$STATE_DIR/skipped/$filename"
       else
         exit 1

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $2}')" ]; then
-  gum confirm "Linux kernel has been updated. Reboot?" && omarchy-state clear re*-required && sudo reboot now
+  omarchy-confirm "Linux kernel has been updated. Reboot?" && omarchy-state clear re*-required && sudo reboot now
 
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
-  gum confirm "Updates require reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
+  omarchy-confirm "Updates require reboot. Ready?" && omarchy-state clear re*-required && sudo reboot now
 
 elif [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
-  gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
+  omarchy-confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
 fi
 
 for file in "$HOME"/.local/state/omarchy/restart-*-required; do

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -3,7 +3,7 @@
 abort() {
   echo -e "\e[31mOmarchy install requires: $1\e[0m"
   echo
-  gum confirm "Proceed anyway on your own accord and without assistance?" || exit 1
+  omarchy-confirm "Proceed anyway on your own accord and without assistance?" || exit 1
 }
 
 # Must be an Arch distro

--- a/install/preflight/trap-errors.sh
+++ b/install/preflight/trap-errors.sh
@@ -24,7 +24,7 @@ catch_errors() {
   echo "    ▀▀▀▀▀▀▀ ▀ ▀ ▀▀▀  ▀ ▀▀▀▀▀▀    "
   echo "                                 "
 
-  if command -v gum >/dev/null && gum confirm "Retry installation?"; then
+  if command -v omarchy-confirm >/dev/null && omarchy-confirm "Retry installation?"; then
     bash ~/.local/share/omarchy/install.sh
   else
     echo "You can retry later by running: bash ~/.local/share/omarchy/install.sh"

--- a/migrations/1751134560.sh
+++ b/migrations/1751134560.sh
@@ -9,6 +9,6 @@ omarchy-refresh-config uwsm/env
 echo -e "\n\e[31mOmarchy bins have been added to PATH (and OMARCHY_PATH is now system-wide).\nYou must immediately relaunch Hyprland or most Omarchy cmds won't work.\nPlease run Omarchy > Update again after the quick relaunch is complete.\e[0m"
 echo
 
-gum confirm "Ready to relaunch Hyprland? (All applications will be closed)" &&
+omarchy-confirm "Ready to relaunch Hyprland? (All applications will be closed)" &&
   touch ~/.local/state/omarchy/migrations/1751134560.sh &&
   uwsm stop

--- a/migrations/1754389057.sh
+++ b/migrations/1754389057.sh
@@ -3,7 +3,7 @@ echo "Offer to reorganize hyprland.conf as per new defaults"
 if [[ ! -f ~/.config/hypr/autostarts.conf ]]; then
   echo -e "\nOmarchy now splits default .config/hypr/hyprland.conf into sub-configs."
   echo -e "Resetting to defaults will overwrite your configuration, but save it as .bak.\n"
-  if gum confirm "Use new default hyprland.conf config?"; then
+  if omarchy-confirm "Use new default hyprland.conf config?"; then
     omarchy-refresh-hyprland || true
   else
     echo "Left your existing configuration in place!"

--- a/migrations/1755164105.sh
+++ b/migrations/1755164105.sh
@@ -14,7 +14,7 @@ if omarchy-cmd-present chromium; then
   omarchy-pkg-add omarchy-chromium
 
   if pgrep -x chromium; then
-    if gum confirm "Chromium must be restarted. Ready?"; then
+    if omarchy-confirm "Chromium must be restarted. Ready?"; then
       pkill -x chromium
       set_theme_colors
     fi

--- a/migrations/1755930114.sh
+++ b/migrations/1755930114.sh
@@ -5,4 +5,4 @@ cp ~/.local/share/omarchy/config/omarchy.ttf ~/.local/share/fonts/
 fc-cache
 
 echo
-gum confirm "Replace current Waybar config (backup will be made)?" && omarchy-refresh-waybar
+omarchy-confirm "Replace current Waybar config (backup will be made)?" && omarchy-refresh-waybar


### PR DESCRIPTION
The omarchy-confirm script is partially API compatible with gum, which will use gum If available, otherwise it will fall back to a simple y/n prompt.