### PR TITLE
Removed duplicating zoxide aliases/logic

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -4,16 +4,6 @@ alias lsa='ls -a'
 alias lt='eza --tree --level=2 --long --icons --git'
 alias lta='lt -a'
 alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
-alias cd="zd"
-zd() {
-  if [ $# -eq 0 ]; then
-    builtin cd ~ && return
-  elif [ -d "$1" ]; then
-    builtin cd "$1"
-  else
-    z "$@" && printf "\U000F17A9 " && pwd || echo "Error: Directory not found"
-  fi
-}
 open() {
   xdg-open "$@" >/dev/null 2>&1 &
 }

--- a/default/bash/init
+++ b/default/bash/init
@@ -7,7 +7,7 @@ if command -v starship &> /dev/null; then
 fi
 
 if command -v zoxide &> /dev/null; then
-  eval "$(zoxide init bash)"
+  eval "$(zoxide init bash --cmd cd)"
 fi
 
 if command -v fzf &> /dev/null; then


### PR DESCRIPTION
If you look what `zoxide init bash` brings, you will see actually the same logic:
```bash
function __zoxide_cd() {
    # shellcheck disable=SC2164
    \builtin cd -- "$@"
}


function __zoxide_z() {
    __zoxide_doctor

    # shellcheck disable=SC2199
    if [[ $# -eq 0 ]]; then
        __zoxide_cd ~
    elif [[ $# -eq 1 && $1 == '-' ]]; then
        __zoxide_cd "${OLDPWD}"
    elif [[ $# -eq 1 && -d $1 ]]; then
        __zoxide_cd "$1"
    elif [[ $# -eq 2 && $1 == '--' ]]; then
        __zoxide_cd "$2"
    elif [[ ${@: -1} == "${__zoxide_z_prefix}"?* ]]; then
        # shellcheck disable=SC2124
        \builtin local result="${@: -1}"
        __zoxide_cd "${result:${#__zoxide_z_prefix}}"
    else
        \builtin local result
        # shellcheck disable=SC2312
        result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@")" &&
            __zoxide_cd "${result}"
    fi
}
```
By adding `--cmd cd` we also didn't need the alias part - it actually sets the zoxide to it in eval:
```bash
\builtin unalias cd &>/dev/null || \builtin true
function cd() {
    __zoxide_z "$@"
}

\builtin unalias cdi &>/dev/null || \builtin true
function cdi() {
    __zoxide_zi "$@"
}
```

So configs I removed in this PR are actually duplicating and not really needed

