### PR TITLE
added a check that the shell is bash before running mise activate

### DIFF
--- a/config/uwsm/env
+++ b/config/uwsm/env
@@ -2,6 +2,6 @@ export OMARCHY_PATH=$HOME/.local/share/omarchy
 export PATH=$OMARCHY_PATH/bin/:$PATH
 export TERMINAL=alacritty
 
-if command -v mise &> /dev/null; then
+if command -v mise &> /dev/null && [[ "$SHELL" == "/bin/bash" ]]; then
   eval "$(mise activate bash)"
 fi

--- a/default/bash/init
+++ b/default/bash/init
@@ -1,4 +1,4 @@
-if command -v mise &> /dev/null && [[ "$SHELL" == "/bin/bash" ]]; then
+if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 

--- a/default/bash/init
+++ b/default/bash/init
@@ -1,4 +1,4 @@
-if command -v mise &> /dev/null; then
+if command -v mise &> /dev/null && [[ "$SHELL" == "/bin/bash" ]]; then
   eval "$(mise activate bash)"
 fi
 

--- a/migrations/1757878303.sh
+++ b/migrations/1757878303.sh
@@ -1,0 +1,3 @@
+echo "Adding shell check to mise activate in config/uwsm/env"
+
+sed -i '5s|if command -v mise &> /dev/null; then|if command -v mise \&> /dev/null \&\& [[ "$SHELL" == "/bin/bash" ]]; then|'

--- a/migrations/1757878303.sh
+++ b/migrations/1757878303.sh
@@ -1,3 +1,3 @@
 echo "Adding shell check to mise activate in config/uwsm/env"
 
-sed -i '5s|if command -v mise &> /dev/null; then|if command -v mise \&> /dev/null \&\& [[ "$SHELL" == "/bin/bash" ]]; then|'
+sed -i '5s|if command -v mise &> /dev/null; then|if command -v mise \&> /dev/null \&\& [[ "$SHELL" == "/bin/bash" ]]; then|' ../config/uwsm/env


### PR DESCRIPTION
In **omarchy/default/bash** and **omarchy/config/uwsm/env**, I added a check that `$SHELL == "/bin/bash"` before running `eval "$(mise activate bash)".` Without this check, Mise may not function properly when the user's interactive shell is not bash (and will absolutely not function properly if the user's shell is fish.)

The issue occurs because mise keeps its own environment variable under MISE_SHELL, which it sets to whatever is supplied as the argument to _mise activate_. 

Note: this change does not enable mise to run in other shells. (Since Omarchy assumes bash, the idea is that a user will need to manually setup mise activate in their new shell if they want to run a different shell,) for instance in _zsh.rc_ or in _.config/fish/config.fish_.
