### PR TITLE
Fix Minecraft installation

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -243,7 +243,7 @@ show_install_gaming_menu() {
   case $(menu "Install" "  Steam\n  RetroArch [AUR]\n󰍳  Minecraft") in
   *Steam*) present_terminal omarchy-install-steam ;;
   *RetroArch*) aur_install_and_launch "RetroArch" "retroarch retroarch-assets libretro libretro-fbneo" "com.libretro.RetroArch.desktop" ;;
-  *Minecraft*) install_and_launch "Minecraft" "minecraft-launcher" "minecraft-launcher" ;;
+  *Minecraft*) aur_install_and_launch "Minecraft [AUR]" "minecraft-launcher" "minecraft-launcher" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
I tried to install `Minecraft` through Omarchy's menu, however it fails with the following error message:

    error: target not found: minecraft-launcher

This occurs because, [according to Arch's documentation, the package is available through AUR](https://wiki.archlinux.org/title/Minecraft#Installation) rather than the official repositories.