### PR TITLE
On update-icon right-click open tags list on github

### DIFF
--- a/bin/omarchy-update-notes
+++ b/bin/omarchy-update-notes
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Get remote tag
+latest_tag=$(git -C "$OMARCHY_PATH" ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
+if [[ -z "$latest_tag" ]]; then
+  echo "Error: Could not retrieve latest tag."
+  exit 1
+fi
+
+# Get local tag
+current_tag=$(git -C "$OMARCHY_PATH" describe --tags $(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1))
+if [[ -z "$current_tag" ]]; then
+  echo "Error: Could not retrieve current tag."
+  exit 1
+fi
+
+if [[ "$current_tag" != "$latest_tag" ]]; then
+  omarchy-launch-webapp https://github.com/basecamp/omarchy/releases/tag/$latest_tag
+  exit 0
+else
+  exit 1
+fi

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -47,6 +47,7 @@
     "format": "",
     "exec": "omarchy-update-available",
     "on-click": "omarchy-launch-floating-terminal-with-presentation omarchy-update",
+    "on-click-right": "omarchy-update-notes",
     "tooltip-format": "Omarchy update available",
     "interval": 3600
   },


### PR DESCRIPTION
When updating omarchy, I am curious on what has been updated. This merge request adds a right click on the update icon, which will open the latest tag on github.

