### PR TITLE
Unify top bar toggle: always pkill waybar

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -7,7 +7,7 @@ bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system
 bindd = SUPER, K, Show key bindings, exec, omarchy-menu-keybindings
 
 # Aesthetics
-bindd = SUPER SHIFT, SPACE, Toggle top bar, exec, pkill -SIGUSR1 waybar
+bindd = SUPER SHIFT, SPACE, Toggle top bar, exec, omarchy-toggle-waybar
 bindd = SUPER CTRL, SPACE, Next background in theme, exec, omarchy-theme-bg-next
 bindd = SUPER SHIFT CTRL, SPACE, Pick new theme, exec, omarchy-menu theme
 


### PR DESCRIPTION
Currently, toggling Top Bar from the menu kills Waybar, while toggling via the keyboard shortcut sends SIGUSR1. This mismatch is confusing: not only two code paths, but after using the menu, the shortcut no longer works because Waybar is gone.

This PR fixes this.

