### PR TITLE
Install opencode using AUR

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -234,7 +234,7 @@ show_install_ai_menu() {
   *Studio*) install "LM Studio" "lmstudio" ;;
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;
-  *opencode*) install "opencode" "opencode-bin" ;;
+  *opencode*) aur_install "opencode" "opencode-bin" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
The `opencode-bin` package doesn't exist in Arch official repositories. It's using the name of the package in AUR.

In the current version, the package can't be found:
<img width="1172" height="428" alt="image" src="https://github.com/user-attachments/assets/020cea8f-3ecb-4e8b-baea-631e57d8e6a0" />

With this change applied the package will try to get installed:
<img width="1340" height="1168" alt="image" src="https://github.com/user-attachments/assets/12f4ca75-6f84-4906-9822-ada6120d19f1" />