### PR TITLE
Update waybar config with proper sized mute icon and wifi-off icon in matching style

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -67,7 +67,7 @@
     "format": "{icon}",
     "format-wifi": "{icon}",
     "format-ethernet": "󰀂",
-    "format-disconnected": "󰖪",
+    "format-disconnected": "󰤮",
     "tooltip-format-wifi": "{essid} ({frequency} GHz)\n⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
     "tooltip-format-ethernet": "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
     "tooltip-format-disconnected": "Disconnected",

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -107,7 +107,7 @@
     "on-click-right": "pamixer -t",
     "tooltip-format": "Playing at {volume}%",
     "scroll-step": 5,
-    "format-muted": "󰝟",
+    "format-muted": "",
     "format-icons": {
       "default": ["", "", ""]
     }


### PR DESCRIPTION
Update waybar config with proper sized mute icon - same size as the two volume indicators. Current mute icon is smaller.

Mute icon after update:
<img width="176" height="26" alt="image" src="https://github.com/user-attachments/assets/9a10a3e0-ccf4-4baf-b90b-bab169d563ae" />

Current mute icon:
<img width="173" height="24" alt="image" src="https://github.com/user-attachments/assets/6a37a229-d4cc-4387-804e-522fe8d84bd6" />

Additionally, updates the wifi-off icon (which is also shown just before wifi connection is established) to an icon that matches the style of the remaining wifi icons. 
Current icon used: 󰖪
Updated icon: 󰤮