### PR TITLE
Install PHP Xdebug debugger

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -6,7 +6,7 @@ if [[ -z "$1" ]]; then
 fi
 
 install_php() {
-  sudo pacman -S php composer php-sqlite --noconfirm
+  sudo pacman -S php composer php-sqlite xdebug --noconfirm
 
   # Install Path for Composer
   if [[ ":$PATH:" != *":$HOME/.config/composer/vendor/bin:"* ]]; then
@@ -27,6 +27,12 @@ install_php() {
     "pdo_sqlite"
     "pdo_mysql"
   )
+
+  # Enable Xdebug
+  sudo sed -i \
+    -e 's/^;zend_extension=xdebug.so/zend_extension=xdebug.so/' \
+    -e 's/^;xdebug.mode=debug/xdebug.mode=debug/' \
+    /etc/php/conf.d/xdebug.ini
 
   for ext in "${extensions_to_enable[@]}"; do
     sudo sed -i "s/^;extension=${ext}/extension=${ext}/" "$php_ini_path"


### PR DESCRIPTION
While working in a non-trivial feature, I needed debugger support.

Since Xdebug is the official PHP debugger, is available in Arch's official repositories, and is trivial to configure, it makes sense to include it in the PHP development environment.

This addition improves the overall development experience for PHP developers by enabling easier inspection and troubleshooting.

With this PR, the debugger now shows up as an enabled extension:

```diff
$ php -v

    PHP 8.4.12 (cli) (built: Aug 27 2025 06:23:40) (NTS)
    Copyright (c) The PHP Group
    Zend Engine v4.4.12, Copyright (c) Zend Technologies
+++    with Xdebug v3.4.4, Copyright (c) 2002-2025, by Derick Rethans
```

As an additional reference, [Laravel does install Xdebug as well in its dockerized environment](https://github.com/laravel/sail/blob/1.x/runtimes/8.4/Dockerfile#L38).