### PR TITLE
Add cursor selection menu

### DIFF
--- a/bin/omarchy-cursor-current
+++ b/bin/omarchy-cursor-current
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+CONFIG_FILE="$HOME/.config/hypr/envs.conf"
+
+[[ ! -f "$CONFIG_FILE" ]] && exit
+
+grep 'env = HYPRCURSOR_THEME' "$CONFIG_FILE" | cut -d ',' -f2 | tr -d ' ' | sed -E 's/-/ /g'

--- a/bin/omarchy-cursor-list
+++ b/bin/omarchy-cursor-list
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+find ~/.local/share/icons/ /usr/share/icons/ -mindepth 1 -maxdepth 2 -iname 'cursors' \( -type d -o -type l \) -exec dirname {} \; | sort | while read -r path; do
+  echo "$(
+    basename "$path" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g'
+  )"
+done

--- a/bin/omarchy-cursor-set
+++ b/bin/omarchy-cursor-set
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# omarchy-cursor-set: Set a cursor theme, specified by its name.
+# Usage: omarchy-cursor-set <cursor-theme-name>
+
+if [[ -z "$1" && "$1" != "CNCLD" ]]; then
+  echo "Usage: omarchy-cursor-set <cursor-theme-name>" >&2
+  exit 1
+fi
+
+GLOBAL_CURSOR_THEME_PATH="/usr/share/icons/"
+LOCAL_CURSOR_THEME_PATH="$HOME/.local/share/icons"
+
+CURSOR_THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr ' ' '-')
+CURSOR_THEME_PATH=$(find $GLOBAL_CURSOR_THEME_PATH $LOCAL_CURSOR_THEME_PATH -maxdepth 1 -type d -iname "$CURSOR_THEME_NAME")
+
+CURSOR_SIZE=${HYPRCURSOR_SIZE:-24}
+CONFIG_FILE="$HOME/.config/hypr/envs.conf"
+
+HYPR_ENV_LINE="env = HYPRCURSOR_THEME"
+X_ENV_LINE="env = XCURSOR_THEME"
+
+if [[ ! -d $CURSOR_THEME_PATH ]]; then
+  echo "Cursor theme '$CURSOR_THEME_NAME' could not be found in $GLOBAL_CURSOR_THEME_PATH or $LOCAL_CURSOR_THEME_PATH"
+  exit 2
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Cursor theme '$CURSOR_THEME_NAME' could not be applied. The config file $CONFIG_FILE does not exist"
+  exit 3
+fi
+
+# hyprcursor and xcursor are case sensitive so its
+# important that the cursor theme name is the same
+# as the path name
+CURSOR_THEME_NAME=$(basename "$CURSOR_THEME_PATH")
+
+if grep -q "^$HYPR_ENV_LINE," "$CONFIG_FILE"; then
+  sed -i "s|^$HYPR_ENV_LINE,.*|$HYPR_ENV_LINE,$CURSOR_THEME_NAME|" "$CONFIG_FILE"
+else
+  echo "$HYPR_ENV_LINE,$CURSOR_THEME_NAME" >>"$CONFIG_FILE"
+fi
+
+if grep -q "^$X_ENV_LINE," "$CONFIG_FILE"; then
+  sed -i "s|^$X_ENV_LINE,.*|$X_ENV_LINE,$CURSOR_THEME_NAME|" "$CONFIG_FILE"
+else
+  echo "$X_ENV_LINE,$CURSOR_THEME_NAME" >>"$CONFIG_FILE"
+fi
+
+hyprctl setcursor $CURSOR_THEME_NAME $CURSOR_SIZE
+
+gsettings set org.gnome.desktop.interface cursor-theme "$CURSOR_THEME_NAME"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -67,9 +67,10 @@ show_learn_menu() {
 }
 
 show_style_menu() {
-  case $(menu "Style" "󰸌  Theme\n  Font\n  Background\n󱄄  Screensaver\n  About") in
+  case $(menu "Style" "󰸌  Theme\n  Font\n󰇀  Cursor\n  Background\n󱄄  Screensaver\n  About") in
   *Theme*) show_theme_menu ;;
   *Font*) show_font_menu ;;
+  *Cursor*) show_cursor_menu ;;
   *Background*) omarchy-theme-bg-next ;;
   *Screensaver*) edit_in_nvim ~/.config/omarchy/branding/screensaver.txt ;;
   *About*) edit_in_nvim ~/.config/omarchy/branding/about.txt ;;
@@ -92,6 +93,15 @@ show_font_menu() {
     show_main_menu
   else
     omarchy-font-set "$theme"
+  fi
+}
+
+show_cursor_menu() {
+  theme=$(menu "Cursor" "$(omarchy-cursor-list)" "-w 350" "$(omarchy-cursor-current)")
+  if [[ "$theme" == "CNCLD" || -z "$theme" ]]; then
+    show_main_menu
+  else
+    omarchy-cursor-set "$theme"
   fi
 }
 


### PR DESCRIPTION
This commit features a new style menu that allows the user to change their cursor theme.

Three new scripts were created:
- omarchy-cursor-set (sets cursor theme)
- omarchy-cursor-list (lists all available cursors)
- omarchy-cursor-current (displays active cursor theme)

In addition, the file "omarchy-menu" was also updated to accommodate the new menu option.

The cursor is set by searching /usr/share/icons and ~/.local/share/icons for the provided theme name and applies the changes by 1) updating ~/.config/hypr/envs.conf with two environment variables "HYPRCURSOR_THEME" and "XCURSOR_THEME", 2) changing the active cursor theme using hyprctl, and 3) updating the GTK cursor theme using gsettings.

More information can be found here: https://wiki.hypr.land/Hypr-Ecosystem/hyprcursor/

The cursor theme selection list is built by searching the two directories mentioned previously by finding directories that contain a child directory called "cursors" (which indicates a cursor theme).

The current cursor theme is detected by searching the user's envs.conf for the value of "HYPRCURSOR_THEME".