### PR TITLE
Enable numlock by default in input configuration

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -9,6 +9,9 @@ input {
   repeat_rate = 40
   repeat_delay = 600
 
+  # Start with numlock on by default
+  numlock_by_default = true
+
   # Increase sensitity for mouse/trackpack (default: 0)
   # sensitivity = 0.35
 


### PR DESCRIPTION
I believe this is a sensible default for those that have keyboards with num pads. Whenever I want to enter a number I reach for the numpad, just to realize that numlock is off and it doesn't do what I expect it.