### PR TITLE
Support current wallpaper on lock screen

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -3,6 +3,7 @@ source = ~/.config/omarchy/current/theme/hyprlock.conf
 background {
     monitor =
     color = $color
+    path = $background
 }
 
 animations {


### PR DESCRIPTION
Adds support for showing the current theme's wallpaper on the lock screen.

This change adds a 'path = $background' entry to the hyprlock.conf file.

The theme must add a '$background = ~/.config/omarchy/current/background' line to the hyprlock.conf file in the theme folder for this to work.

If $background is not set, hyprlock simply ignores the line.