### PR TITLE
Make the Docker DBs file scriptable

### DIFF
--- a/bin/omarchy-install-docker-dbs
+++ b/bin/omarchy-install-docker-dbs
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 options=("MySQL" "PostgreSQL" "Redis" "MongoDB" "MariaDB")
-choices=$(printf "%s\n" "${options[@]}" | gum choose --no-limit --header "Select databases (space to select, return to install, esc to cancel)") || main_menu
+
+if [[ "$#" -eq 0 ]]; then
+  choices=$(printf "%s\n" "${options[@]}" | gum choose --no-limit --header "Select databases (space to select, return to install, esc to cancel)") || main_menu
+else
+  choices="$@"
+fi
 
 if [[ -n "$choices" ]]; then
   for db in $choices; do


### PR DESCRIPTION
I'm creating dotfiles that as soon as Omarchy is installed, allow me to perform my own customizations to get the system up and running in no time according to my own needs.

One of them for example setups the Laravel development environment:

```
~/.local/share/omarchy/bin/omarchy-install-dev-env laravel
```

However, something like that is not possible with the Docker databases because it assumes interactivity via `gum`.

This PR fixes that by either continue to provide interactivity to collect choices:

```
$ ~/.local/share/omarchy/bin/omarchy-install-docker-dbs

Select databases (space to select, return to install, esc to cancel)
> • MySQL
  • PostgreSQL
  • Redis
  • MongoDB
  • MariaDB
```

or using the provided arguments as choices:

```
$ ~/.local/share/omarchy/bin/omarchy-install-docker-dbs MySQL Redis

66b3efcb3d1af35ffc6c96ab467ee180d8d59dcec3a3ae8da4ba2ba600bf0787
52fe06e6f54e526fff446f2de58d15ee8d9eed01d13fe4e9c71e99557f9b619c
```