### PR TITLE
change firefox class regex

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -1,6 +1,6 @@
 # Browser types
 windowrule = tag +chromium-based-browser, class:([cC]hrom(e|ium)|[bB]rave-browser|Microsoft-edge|Vivaldi-stable)
-windowrule = tag +firefox-based-browser, class:(Firefox|zen|librewolf)
+windowrule = tag +firefox-based-browser, class:([fF]irefox|zen|librewolf)
 
 # Force chromium-based browsers into a tile to deal with --app bug
 windowrule = tile, tag:chromium-based-browser


### PR DESCRIPTION
It wouldn't recognize Firefox with this kind of regex so browser was still transparent when it shouldn't