### PR TITLE
Add Qwen-Code AI tool to installation menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -227,7 +227,7 @@ show_install_ai_menu() {
       echo ollama
   )
 
-  case $(menu "Install" "󱚤  Claude Code\n󱚤  Gemini\n󱚤  OpenAI Codex [AUR]\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
+  case $(menu "Install" "󱚤  Claude Code\n󱚤  Gemini\n󱚤  OpenAI Codex [AUR]\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode\n󱚤 Qwen Code [AUR]") in
   *Claude*) install "Claude Code" "claude-code" ;;
   *OpenAI*) aur_install "OpenAI Codex" "openai-codex-bin" ;;
   *Gemini*) install "Gemini" "gemini-cli" ;;
@@ -235,6 +235,7 @@ show_install_ai_menu() {
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;
   *opencode*) install "opencode" "opencode-bin" ;;
+  *Qwen*) aur_install "Qwen Code" "qwen-code" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
- Uses AUR to install **qwen-code** CLI tool
- Added Qwen-Code installation option to **bin/omarchy-menu** file in the AI Installation function e.g. (show_install_ai_menu())
- Follows existing pattern for AUR-based AI tools