### PR TITLE
Feed the image folder to the Image Viewer so the next/previous image navigation works

### DIFF
--- a/applications/imv.desktop
+++ b/applications/imv.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Image Viewer
-Exec=imv %F
+Exec=sh -c 'imv -n "$1" "$(dirname "$1")"' sh %f
 Icon=imv
 Type=Application
 MimeType=image/png;image/jpeg;image/jpg;image/gif;image/bmp;image/webp;image/tiff;image/x-xcf;image/x-portable-pixmap;image/x-xbitmap;


### PR DESCRIPTION
When double clicking an image in Nautilus, my expectation is that I can navigate to the other images in the folder with the arrow keys.

This doesn't happen currently because the imv command receives only the filename as a parameter.

However, if we use:

`imv -n /myfolder/image.jpg /myfolder`

This works because we're opening  the folder starting at the image given by the -n parameter.

I couldn't find a more elegant way of doing this, so better ideas are welcome!