### PR TITLE
Add env vars to hyprland for screen sharing

### DIFF
--- a/config/hypr/envs.conf
+++ b/config/hypr/envs.conf
@@ -1,3 +1,8 @@
 # Extra env variables
 # Note: You must relaunch Hyprland after changing envs (use Super+Esc, then Relaunch)
 # env = MY_GLOBAL_ENV,setting
+
+# Allow better support for screen sharing (Google Meet, Discord, etc)
+env = XDG_SESSION_TYPE,wayland
+env = XDG_CURRENT_DESKTOP,Hyprland
+env = XDG_SESSION_DESKTOP,Hyprland


### PR DESCRIPTION
Previously it was not possible to screen share via apps like Google Meet. These environment variables are used to tell the applications to use session type wayland and desktop environment to hyprland instead of X11 which is defaulted to by many applications. 