### PR TITLE
Support for wallpapers in hyprlock

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -3,6 +3,7 @@ source = ~/.config/omarchy/current/theme/hyprlock.conf
 background {
     monitor =
     color = $color
+    path = $background
 }
 
 animations {

--- a/migrations/1757277657.sh
+++ b/migrations/1757277657.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+conf="$HOME/.config/hypr/hyprlock.conf"
+
+if ! grep -q "path = \$background" "$conf"; then
+  sed -i '/color = \$color/a \    path = \$background' "$conf"
+fi


### PR DESCRIPTION
(closed original #1413 and opened this one to target _from_ and _to_ dev branch)

Adds support for showing the current theme's wallpaper on the lock screen.

This change adds a 'path = $background' entry to the hyprlock.conf file.

The theme must add a '$background = ~/.config/omarchy/current/background' line to the hyprlock.conf file in the theme folder for this to work.

If $background is not set, hyprlock simply ignores the line.