### PR TITLE
Feed the image folder to the Image Viewer so the next/previous image navigation works

### DIFF
--- a/applications/imv.desktop
+++ b/applications/imv.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Image Viewer
-Exec=imv %F
+Exec=sh -c 'imv -n "$1" "$(dirname "$1")"' sh %f
 Icon=imv
 Type=Application
 MimeType=image/png;image/jpeg;image/jpg;image/gif;image/bmp;image/webp;image/tiff;image/x-xcf;image/x-portable-pixmap;image/x-xbitmap;

--- a/migrations/1757273064.sh
+++ b/migrations/1757273064.sh
@@ -1,9 +1,4 @@
-echo "Update imv.desktop file with the navigation fix"
+echo "Allow Image Viewer to see all images in directory and use arrow keys to navigate"
 
-src="$HOME/.local/share/omarchy/applications/imv.desktop"
-dst="$HOME/.local/share/applications/imv.desktop"
+cp -f "$HOME/.local/share/omarchy/applications/imv.desktop" "$HOME/.local/share/applications/imv.desktop"
 
-exec_line=$(grep '^Exec' "$src")
-if [ -n "$exec_line" ]; then
-    sed -i "/^Exec/c\\$exec_line" "$dst"
-fi

--- a/migrations/1757273064.sh
+++ b/migrations/1757273064.sh
@@ -1,0 +1,9 @@
+echo "Update imv.desktop file with the navigation fix"
+
+src="$HOME/.local/share/omarchy/applications/imv.desktop"
+dst="$HOME/.local/share/applications/imv.desktop"
+
+exec_line=$(grep '^Exec' "$src")
+if [ -n "$exec_line" ]; then
+    sed -i "/^Exec/c\\$exec_line" "$dst"
+fi


### PR DESCRIPTION
When double clicking an image in Nautilus, my expectation is that I can navigate to the other images in the folder with the arrow keys.

This doesn't happen currently because the imv command receives only the filename as a parameter.

However, if we use:

`imv -n /myfolder/image.jpg /myfolder`

works becasue we're opening  the folder starting at the image given by the -n parameter.