### PR TITLE
Create git config file under `~/.config`

### DIFF
--- a/install/config/git.sh
+++ b/install/config/git.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Create git config file under .config if it doesn't exist
+# This helps to keep all our configs in one place
+if [[ ! -f "~/.config/git/config" ]]; then
+  mkdir -p "~/.config/git"
+  touch "~/.config/git/config"
+fi
+
 # Set common git aliases
 git config --global alias.co checkout
 git config --global alias.br branch


### PR DESCRIPTION
This will help to keep our git config alongside our other configuration files instead of in the home directory under `~/.gitconfig`.

Git will look for files under this directory when first initializing its configuration alongside ~/.gitconfig

[Git Docs Link 1](https://git-scm.com/docs/git-config#:~:text=By%20default%2C%20git,present%20in%20%24GIT_DIR/config.)
[Git Docs Link 2](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#:~:text=First%2C%20a%20quick,%2D%2Dglobal%20option.)

