### PR TITLE
Make omarchy-menu respect EDITOR env var

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -31,7 +31,7 @@ present_terminal() {
 
 edit_in_nvim() {
   notify-send "Editing config file" "$1"
-  alacritty -e nvim "$1"
+  alacritty -e "${EDITOR:-nvim}" "$1"
 }
 
 install() {


### PR DESCRIPTION
Currently there is no way to change what editor is open from omarchy menu. This PR solves it by querying EDITOR variable with fallback to nvim.