### PR TITLE
Add --freeze option to screenshot command for improved capture stability

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -8,7 +8,7 @@ if [[ ! -d "$OUTPUT_DIR" ]]; then
   exit 1
 fi
 
-pkill slurp || hyprshot -m ${1:-region} --raw |
+pkill slurp || hyprshot -m ${1:-region} --raw --freeze |
   satty --filename - \
     --output-filename "$OUTPUT_DIR/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png" \
     --early-exit \


### PR DESCRIPTION
Without the --freeze (-z) flag in hyprshot, the target screen or application continues to respond to events during capture.

This means the actual screenshot is taken only after the selection area has been drawn. As a result:

- Menus, context menus, or tooltips may disappear before they can be captured, since the application reacts to the PRINT key while the area is still being selected.
- Capturing a specific frame from a video call, animation, or any other moving content is unreliable.

The --freeze option solves this by pausing updates during capture, ensuring the screenshot includes the exact elements visible at the moment of triggering.