### PR TITLE
Match youtube subdomains in opacity windowrule

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -10,4 +10,4 @@ windowrule = opacity 1 0.97, tag:chromium-based-browser
 windowrule = opacity 1 0.97, tag:firefox-based-browser
 
 # Some video sites should never have opacity applied to them
-windowrule = opacity 1.0 1.0, initialTitle:(youtube\.com_/|app\.zoom\.us_/wc/home)
+windowrule = opacity 1.0 1.0, initialTitle:((?i)(?:[a-z0-9-]+\.)*youtube\.com_/|app\.zoom\.us_/wc/home)


### PR DESCRIPTION
Ensures that any browser apps opening youtube or its subdomains (e.g. tv.youtube.com) have no transparency.  This regex matches examples like:

tv.youtube.com
music.youtube.com
kids.youtube.com
youtube.com

but not:

notyoutube.com