### PR TITLE
feat(bin-env-tools): Update omarchy-menu to use default editor instead nvim

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -71,8 +71,8 @@ show_style_menu() {
   *Theme*) show_theme_menu ;;
   *Font*) show_font_menu ;;
   *Background*) omarchy-theme-bg-next ;;
-  *Screensaver*) edit_in_nvim ~/.config/omarchy/branding/screensaver.txt ;;
-  *About*) edit_in_nvim ~/.config/omarchy/branding/about.txt ;;
+  *Screensaver*) edit_with_default_editor ~/.config/omarchy/branding/screensaver.txt ;;
+  *About*) edit_with_default_editor ~/.config/omarchy/branding/about.txt ;;
   *) show_main_menu ;;
   esac
 }
@@ -148,9 +148,9 @@ show_setup_menu() {
     blueberry
     ;;
   *Power*) show_setup_power_menu ;;
-  *Monitors*) edit_in_nvim ~/.config/hypr/monitors.conf ;;
-  *Keybindings*) edit_in_nvim ~/.config/hypr/bindings.conf ;;
-  *Input*) edit_in_nvim ~/.config/hypr/input.conf ;;
+  *Monitors*) edit_with_default_editor ~/.config/hypr/monitors.conf ;;
+  *Keybindings*) edit_with_default_editor ~/.config/hypr/bindings.conf ;;
+  *Input*) edit_with_default_editor ~/.config/hypr/input.conf ;;
   *DNS*) present_terminal omarchy-setup-dns ;;
   *Config*) show_setup_config_menu ;;
   *Fingerprint*) present_terminal omarchy-setup-fingerprint ;;
@@ -171,14 +171,14 @@ show_setup_power_menu() {
 
 show_setup_config_menu() {
   case $(menu "Setup" "  Hyprland\n  Hypridle\n  Hyprlock\n  Hyprsunset\n  Swayosd\n󰌧  Walker\n󰍜  Waybar\n󰞅  XCompose") in
-  *Hyprland*) edit_in_nvim ~/.config/hypr/hyprland.conf ;;
-  *Hypridle*) edit_in_nvim ~/.config/hypr/hypridle.conf && omarchy-restart-hypridle ;;
-  *Hyprlock*) edit_in_nvim ~/.config/hypr/hyprlock.conf ;;
-  *Hyprsunset*) edit_in_nvim ~/.config/hypr/hyprsunset.conf && omarchy-restart-hyprsunset ;;
-  *Swayosd*) edit_in_nvim ~/.config/swayosd/config.toml && omarchy-restart-swayosd ;;
-  *Walker*) edit_in_nvim ~/.config/walker/config.toml && omarchy-restart-walker ;;
-  *Waybar*) edit_in_nvim ~/.config/waybar/config.jsonc && omarchy-restart-waybar ;;
-  *XCompose*) edit_in_nvim ~/.XCompose && omarchy-restart-xcompose ;;
+  *Hyprland*) edit_with_default_editor ~/.config/hypr/hyprland.conf ;;
+  *Hypridle*) edit_with_default_editor ~/.config/hypr/hypridle.conf && omarchy-restart-hypridle ;;
+  *Hyprlock*) edit_with_default_editor ~/.config/hypr/hyprlock.conf ;;
+  *Hyprsunset*) edit_with_default_editor ~/.config/hypr/hyprsunset.conf && omarchy-restart-hyprsunset ;;
+  *Swayosd*) edit_with_default_editor ~/.config/swayosd/config.toml && omarchy-restart-swayosd ;;
+  *Walker*) edit_with_default_editor ~/.config/walker/config.toml && omarchy-restart-walker ;;
+  *Waybar*) edit_with_default_editor ~/.config/waybar/config.jsonc && omarchy-restart-waybar ;;
+  *XCompose*) edit_with_default_editor ~/.XCompose && omarchy-restart-xcompose ;;
   *) show_main_menu ;;
   esac
 }


### PR DESCRIPTION
Currently, the Omarchy menu always uses nvim to open the config file shortcut.
This is strange if you don’t want to install nvim and prefer another editor, like helix in my case.

There is an environment variable EDITOR that already defines the default editor (set to nvim by default).
This change will use the EDITOR variable instead of hardcoding nvim, so users can choose their own text editor.

It may also be a good idea to review other tools that can be made flexible in the same way.
If a tool cannot be replaced (because of how the command works), then the system should warn the user when uninstalling it, showing that some features will break.