### PR TITLE
feat: Notification settings persist across theme changes

### DIFF
--- a/config/mako/core.ini
+++ b/config/mako/core.ini
@@ -1,0 +1,17 @@
+anchor=top-right
+default-timeout=5000
+max-icon-size=32
+width=420
+height=110
+
+[app-name=Spotify]
+invisible=1
+
+[mode=do-not-disturb]
+invisible=true
+
+[mode=do-not-disturb app-name=notify-send]
+invisible=false
+
+[urgency=critical]
+default-timeout=0

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -24,5 +24,4 @@ ln -snf ~/.config/omarchy/current/theme/neovim.lua ~/.config/nvim/lua/plugins/th
 mkdir -p ~/.config/btop/themes
 ln -snf ~/.config/omarchy/current/theme/btop.theme ~/.config/btop/themes/current.theme
 
-mkdir -p ~/.config/mako
 ln -snf ~/.config/omarchy/current/theme/mako.ini ~/.config/mako/config

--- a/themes/catppuccin-latte/mako.ini
+++ b/themes/catppuccin-latte/mako.ini
@@ -1,25 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#4c4f69
 border-color=#1e66f5
 background-color=#eff1f5
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/catppuccin/mako.ini
+++ b/themes/catppuccin/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#cad3f5
 border-color=#c6d0f5
 background-color=#24273a
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/everforest/mako.ini
+++ b/themes/everforest/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#d3c6aa
 border-color=#d3c6aa
 background-color=#2d353b
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/gruvbox/mako.ini
+++ b/themes/gruvbox/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#d4be98
 border-color=#a89984
 background-color=#282828
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/kanagawa/mako.ini
+++ b/themes/kanagawa/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#dcd7ba
 border-color=#dcd7ba
 background-color=#1f1f28
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/matte-black/mako.ini
+++ b/themes/matte-black/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#8a8a8d
 border-color=#8A8A8D
 background-color=#1e1e1e
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/nord/mako.ini
+++ b/themes/nord/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#d8dee9
 border-color=#D8DEE9
 background-color=#2e3440
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/osaka-jade/mako.ini
+++ b/themes/osaka-jade/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#C1C497
 border-color=#214237
 background-color=#11221C
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 12
-anchor=top-right
-outer-margin=5
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=5

--- a/themes/ristretto/mako.ini
+++ b/themes/ristretto/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#e6d9db
 border-color=#e6d9db
 background-color=#2c2525
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/rose-pine/mako.ini
+++ b/themes/rose-pine/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#575279
 border-color=#575279
 background-color=#faf4ed
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20

--- a/themes/tokyo-night/mako.ini
+++ b/themes/tokyo-night/mako.ini
@@ -1,24 +1,10 @@
+include=~/.config/mako/core.ini
+
 text-color=#a9b1d6
 border-color=#33ccff
 background-color=#1a1b26
-width=420
-height=110
 padding=10
 border-size=2
 font=Liberation Sans 11
-anchor=top-right
-outer-margin=20
-default-timeout=5000
 max-icon-size=32
-
-[app-name=Spotify]
-invisible=1
-
-[mode=do-not-disturb]
-invisible=true
-
-[mode=do-not-disturb app-name=notify-send]
-invisible=false
-
-[urgency=critical]
-default-timeout=0
+outer-margin=20


### PR DESCRIPTION
This PR separates the theme values from common settings in each theme's `mako.ini`. 
Common values are set in `~/config/mako/core.ini` and then included per theme.

The main motivation for this was having a central location to set app specific mako preferences, and having them persist when changing themes.