### PR TITLE
Add example scaling configuration for 24" monitors

### DIFF
--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -11,7 +11,11 @@ monitor=,preferred,auto,auto
 # env = GDK_SCALE,1.75
 # monitor=,preferred,auto,1.666667
 
-# Straight 1x setup for low-resolution displays like 1080p or 1440p
+# Good compromise for 24" monitors (2560x1440)
+# env = GDK_SCALE,1.5
+# monitor=,preferred,auto,1.333333
+
+# Straight 1x setup for low-resolution displays like 1080p
 # env = GDK_SCALE,1
 # monitor=,preferred,auto,1
 

--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -12,8 +12,8 @@ monitor=,preferred,auto,auto
 # monitor=,preferred,auto,1.666667
 
 # Good compromise for 24" monitors (2560x1440)
-# env = GDK_SCALE,1.5
-# monitor=,preferred,auto,1.333333
+# env = GDK_SCALE,1
+# monitor=,preferred,auto,1.250000
 
 # Straight 1x setup for low-resolution displays like 1080p
 # env = GDK_SCALE,1


### PR DESCRIPTION
Hi,

Since some fonts are a bit small at scale 1 with a 2560x1440 monitor, the scalling can be set at a higher scaling than 1. This PR adds an example scaling configuration for that kind of monitors.