### PR TITLE
feat: add support for launching flatpak applications

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$(xdg-settings get default-web-browser) 2>/dev/null | head -1) ${args[@]} $@
+exec setsid uwsm app -- $(sed -n 's/^Exec=\(\/usr\/bin\/flatpak .*\) @@u %u @@/\1/Ip; t; s/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr,/var/lib/flatpak/exports}/share/applications/$(xdg-settings get default-web-browser) 2>/dev/null | head -1) ${args[@]} $@


### PR DESCRIPTION
### Overview
Add support for user switching to flatpak browsers.

### Motivation
Changing the default browser with `xdg-settings set default-web-browser <some-flatpak>`, causes `omarchy-launch-browser` to try to launch `/usr/bin/flatpak` instead of the proper app.

### Testing
Tested with the following flatpaks
- `app.zen_browser.zen`
- `com.vivaldi.Vivaldi`