### PR TITLE
FEAT: added clambshell mode utils

### DIFF
--- a/bin/omarchy-toggle-clambshell-mode
+++ b/bin/omarchy-toggle-clambshell-mode
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [[ "$(hyprctl monitors)" =~ [[:space:]]DP-[0-9]+ ]]; then # Check if external monitor is connected
+  if [[ $1 == "open" ]]; then
+    hyprctl keyword monitor "eDP-1,preferred,auto,auto" # Enable laptop screen
+  else
+    hyprctl keyword monitor "eDP-1,disable" # Disable laptop screen
+  fi
+fi
+

--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -18,3 +18,6 @@ monitor=,preferred,auto,auto
 # Example for Framework 13 w/ 6K XDR Apple display
 # monitor = DP-5, 6016x3384@60, auto, 2
 # monitor = eDP-1, 2880x1920@120, auto, 2
+
+bindl=,switch:off:Lid Switch,exec,~/.local/share/omarchy/bin/omarchy-toggle-clambshell-mode open
+bindl=,switch:on:Lid Switch,exec,~~/.local/share/omarchy/bin/omarchy-toggle-clambshell-mode close

--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -20,4 +20,4 @@ monitor=,preferred,auto,auto
 # monitor = eDP-1, 2880x1920@120, auto, 2
 
 bindl=,switch:off:Lid Switch,exec,~/.local/share/omarchy/bin/omarchy-toggle-clambshell-mode open
-bindl=,switch:on:Lid Switch,exec,~~/.local/share/omarchy/bin/omarchy-toggle-clambshell-mode close
+bindl=,switch:on:Lid Switch,exec,~/.local/share/omarchy/bin/omarchy-toggle-clambshell-mode close


### PR DESCRIPTION
## What changed?

This new feature adds in support for "clambshell mode" operation on omarchy. Clambshell mode allows a laptop to be closed while connected to an external monitor without locking the screen, thus, disabling the laptop screen and only using the external monitor. 

## How it works

The omarchy-toggle-clambshell-mode script takes in a single string argument of `open` or `close`. When open is passed to the script the external monitor is treated as an external monitor, allowing both the laptop screen and external monitor to work together. When close is passed to the script the laptop monitor is disabled, and the external monitor is treated as the sole and primary display. 

The monitors.conf file in ~/.config/hypr/monitors.conf file is what is used to call the script. When hyprland detects a state change in monitors, it calls the script with the appropriate arguments.

```plain
bindl=,switch:off:Lid Switch,exec,~/.local/share/omarchy/bin/omarchy-toggle-clambshell-mode open
bindl=,switch:on:Lid Switch,exec,~~/.local/share/omarchy/bin/omarchy-toggle-clambshell-mode close
```

Do note that I have not tested this with multiple external monitors. It reliably has been working for a laptop with a single external monitor.