### PR TITLE
Fix VPN DNS resolution in DHCP mode

### DIFF
--- a/bin/omarchy-setup-dns
+++ b/bin/omarchy-setup-dns
@@ -37,8 +37,6 @@ EOF
 DHCP)
   sudo tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
 [Resolve]
-DNS=
-FallbackDNS=
 DNSOverTLS=no
 EOF
   

--- a/migrations/1757361127.sh
+++ b/migrations/1757361127.sh
@@ -1,0 +1,8 @@
+echo "Fix DHCP DNS to allow VPN DNS override"
+
+if [ -f /etc/systemd/resolved.conf ]; then
+  if grep -q "^DNS=$" /etc/systemd/resolved.conf && grep -q "^FallbackDNS=$" /etc/systemd/resolved.conf; then
+    sudo sed -i '/^DNS=$/d; /^FallbackDNS=$/d' /etc/systemd/resolved.conf
+    sudo systemctl restart systemd-resolved
+  fi
+fi


### PR DESCRIPTION
Fixes #1509

## Problem
When VPN clients replace `/etc/resolv.conf` with their DNS servers, systemd-resolved ignores them because of empty `DNS=` and `FallbackDNS=` values in resolved.conf.

## Solution  
Remove empty DNS values from DHCP mode configuration. This allows systemd-resolved to:
- Use DHCP DNS from network interfaces (existing behavior preserved)
- Fall back to system defaults when needed
- Switch to 'foreign' mode when VPN overrides resolv.conf

## Changes
1. Updated `omarchy-setup-dns` DHCP mode - removed empty DNS lines
2. Added migration for existing users with empty DNS values

## Testing
- DHCP DNS continues working (192.168.x.x from router)
- VPN DNS override works (foreign mode activated)
- System fallback DNS available (Cloudflare, Quad9)
- No breaking changes for existing users

Thanks to @PavelAlennikov for the detailed bug report.