### PR TITLE
Install Gemini CLI via AUR

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -227,7 +227,7 @@ show_install_ai_menu() {
       echo ollama
   )
 
-  case $(menu "Install" "󱚤  Claude Code\n󱚤  Gemini\n󱚤  OpenAI Codex [AUR]\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
+  case $(menu "Install" "󱚤  Claude Code\n󱚤  Gemini [AUR]\n󱚤  OpenAI Codex [AUR]\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
   *Claude*) install "Claude Code" "claude-code" ;;
   *OpenAI*) aur_install "OpenAI Codex" "openai-codex-bin" ;;
   *Gemini*) aur_install "Gemini" "gemini-cli" ;;


### PR DESCRIPTION
This updates the `Install → AI`  installation of `gemini-cli` to use AUR, as Gemini CLI is not available via `pacman`, and currently results in this error::

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/ba730b66-9a37-4f72-9dd1-57e40d644cd4" />


