### PR TITLE
Add tabbed group shortcuts and missing styles

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -25,6 +25,27 @@ if [[ -n "$font_name" && "$font_name" != "CNCLD" ]]; then
       -v "$font_name" \
       ~/.config/fontconfig/fonts.conf
 
+    # Update Hyprland group tab font in both default and user config
+    if [[ -f ~/.local/share/omarchy/default/hypr/looknfeel.conf ]]; then
+      sed -i "s/font_family = .*/font_family = $font_name/g" ~/.local/share/omarchy/default/hypr/looknfeel.conf
+    fi
+    if [[ -f ~/.config/hypr/looknfeel.conf ]]; then
+      # Check if groupbar section exists in user config
+      if grep -q "groupbar" ~/.config/hypr/looknfeel.conf; then
+        sed -i "s/font_family = .*/font_family = $font_name/g" ~/.config/hypr/looknfeel.conf
+      else
+        # Add groupbar section if it doesn't exist
+        if ! grep -q "group {" ~/.config/hypr/looknfeel.conf; then
+          echo "" >> ~/.config/hypr/looknfeel.conf
+          echo "group {" >> ~/.config/hypr/looknfeel.conf
+          echo "    groupbar {" >> ~/.config/hypr/looknfeel.conf
+          echo "        font_family = $font_name" >> ~/.config/hypr/looknfeel.conf
+          echo "    }" >> ~/.config/hypr/looknfeel.conf
+          echo "}" >> ~/.config/hypr/looknfeel.conf
+        fi
+      fi
+    fi
+
     omarchy-restart-waybar
     omarchy-restart-swayosd
     omarchy-restart-walker

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -89,3 +89,9 @@ bindd = SUPER, L, Toggle active group lock state, lockactivegroup, toggle
 bindd = SUPER SHIFT, L, Toggle all groups lock state, lockgroups, toggle
 bindd = SUPER CTRL, L, Toggle window groupable state, denywindowfromgroup, toggle
 bindd = SUPER ALT, L, Toggle all groups lock rules, setignoregrouplock, toggle
+
+# Smart group-aware window movement
+bindd = SUPER CTRL SHIFT, up, Smart move window up, movewindoworgroup, u
+bindd = SUPER CTRL SHIFT, down, Smart move window down, movewindoworgroup, d
+bindd = SUPER CTRL SHIFT, left, Smart move window left, movewindoworgroup, l
+bindd = SUPER CTRL SHIFT, right, Smart move window right, movewindoworgroup, r

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -83,3 +83,9 @@ bindd = SUPER CTRL, down, Push window into group below, moveintogroup, d
 bindd = SUPER CTRL, left, Push window into group left, moveintogroup, l
 bindd = SUPER CTRL, right, Push window into group right, moveintogroup, r
 bindd = SUPER, end, Drop window out of group, moveoutofgroup
+
+# Group lock control
+bindd = SUPER, L, Toggle active group lock state, lockactivegroup, toggle
+bindd = SUPER SHIFT, L, Toggle all groups lock state, lockgroups, toggle
+bindd = SUPER CTRL, L, Toggle window groupable state, denywindowfromgroup, toggle
+bindd = SUPER ALT, L, Toggle all groups lock rules, setignoregrouplock, toggle

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -69,3 +69,17 @@ bindd = SUPER, mouse_up, Scroll active workspace backward, workspace, e-1
 # Move/resize windows with mainMod + LMB/RMB and dragging
 bindmd = SUPER, mouse:272, Move window, movewindow
 bindmd = SUPER, mouse:273, Resize window, resizewindow
+
+# Group tab manipulation
+bindd = SUPER, R, Toggle active window group state, togglegroup
+bindd = SUPER, bracketright, Cycle to next tab in group, changegroupactive, f
+bindd = SUPER, bracketleft, Cycle to previous tab in group, changegroupactive, b
+bindd = SUPER SHIFT, bracketright, Move active tab to the right, movegroupwindow, f
+bindd = SUPER SHIFT, bracketleft, Move active tab to the left, movegroupwindow, b
+
+# Group membership control
+bindd = SUPER CTRL, up, Push window into group above, moveintogroup, u
+bindd = SUPER CTRL, down, Push window into group below, moveintogroup, d
+bindd = SUPER CTRL, left, Push window into group left, moveintogroup, l
+bindd = SUPER CTRL, right, Push window into group right, moveintogroup, r
+bindd = SUPER, end, Drop window out of group, moveoutofgroup

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -9,10 +9,10 @@ general {
 
     # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
     col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
-    col.inactive_border = rgba(595959aa)
+    col.inactive_border = rgba(32344aaa)
 
-    col.nogroup_border = rgba(595959aa)
-    col.nogroup_border_active = rgb(e67e80)
+    col.nogroup_border = rgba(32344aaa)
+    col.nogroup_border_active = rgb(787c99)
 
     # Set to true enable resizing windows by clicking and dragging on borders and gaps
     resize_on_border = false
@@ -26,10 +26,10 @@ general {
 # See https://wiki.hypr.land/Configuring/Variables/#group for more
 group {
     col.border_active = rgba(33ccffee) rgba(00ff99ee) 45deg
-    col.border_inactive = rgba(595959aa)
+    col.border_inactive = rgba(32344aaa)
 
-    col.border_locked_active = rgb(e67e80)
-    col.border_locked_inactive = rgba(595959aa)
+    col.border_locked_active = rgb(787c99)
+    col.border_locked_inactive = rgba(32344aaa)
 
     groupbar {
         font_family = CaskaydiaMono Nerd Font
@@ -37,15 +37,15 @@ group {
         height = 18
         gradients = true
         indicator_height = 0
-        text_color = rgb(2d353b)
-        text_color_inactive = rgba(d3c6aa50)
-        col.active = rgb(d3c6aa)
-        col.inactive = rgb(2d353b)
+        text_color = rgb(1a1b26)
+        text_color_inactive = rgba(cdd6f480)
+        col.active = rgb(cdd6f4)
+        col.inactive = rgb(1a1b26)
 
-        text_color_locked_active = rgb(d3c6aa)
-        text_color_locked_inactive = rgba(d3c6aa50)
-        col.locked_active = rgb(e67e80)
-        col.locked_inactive = rgb(2d353b)
+        text_color_locked_active = rgb(cdd6f4)
+        text_color_locked_inactive = rgba(cdd6f480)
+        col.locked_active = rgb(787c99)
+        col.locked_inactive = rgb(1a1b26)
     }
 }
 

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -11,6 +11,9 @@ general {
     col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
     col.inactive_border = rgba(595959aa)
 
+    col.nogroup_border = rgba(595959aa)
+    col.nogroup_border_active = rgb(e67e80)
+
     # Set to true enable resizing windows by clicking and dragging on borders and gaps
     resize_on_border = false
 
@@ -25,11 +28,24 @@ group {
     col.border_active = rgba(33ccffee) rgba(00ff99ee) 45deg
     col.border_inactive = rgba(595959aa)
 
+    col.border_locked_active = rgb(e67e80)
+    col.border_locked_inactive = rgba(595959aa)
+
     groupbar {
         font_family = CaskaydiaMono Nerd Font
-        font_size = 11
-        col.active = rgba(33ccffee) rgba(00ff99ee) 45deg
-        col.inactive = rgba(595959aa)
+        font_size = 12
+        height = 18
+        gradients = true
+        indicator_height = 0
+        text_color = rgb(2d353b)
+        text_color_inactive = rgba(d3c6aa50)
+        col.active = rgb(d3c6aa)
+        col.inactive = rgb(2d353b)
+
+        text_color_locked_active = rgb(d3c6aa)
+        text_color_locked_inactive = rgba(d3c6aa50)
+        col.locked_active = rgb(e67e80)
+        col.locked_inactive = rgb(2d353b)
     }
 }
 

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -26,6 +26,8 @@ group {
     col.border_inactive = rgba(595959aa)
 
     groupbar {
+        font_family = CaskaydiaMono Nerd Font
+        font_size = 11
         col.active = rgba(33ccffee) rgba(00ff99ee) 45deg
         col.inactive = rgba(595959aa)
     }

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -20,6 +20,17 @@ general {
     layout = dwindle
 }
 
+# See https://wiki.hypr.land/Configuring/Variables/#group for more
+group {
+    col.border_active = rgba(33ccffee) rgba(00ff99ee) 45deg
+    col.border_inactive = rgba(595959aa)
+
+    groupbar {
+        col.active = rgba(33ccffee) rgba(00ff99ee) 45deg
+        col.inactive = rgba(595959aa)
+    }
+}
+
 # https://wiki.hyprland.org/Configuring/Variables/#decoration
 decoration {
     rounding = 0

--- a/themes/catppuccin-latte/hyprland.conf
+++ b/themes/catppuccin-latte/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(1e66f5)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(bcc0ccaa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(bcc0ccaa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(d20f39)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(1e66f5)
-    col.border_locked_active = rgb(1e66f5)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(bcc0ccaa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(d20f39)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(bcc0ccaa)
 
     groupbar {
-        col.active = rgb(1e66f5)
+        # taken from waybar's background color
+        text_color = rgb(eff1f5)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(4c4f6980)
+        # taken from waybar's foreground color
+        col.active = rgb(4c4f69)
+        # taken from waybar's background color
+        col.inactive = rgb(eff1f5)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(4c4f69)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(4c4f6980)
+        # taken from alacritty's red color
+        col.locked_active = rgb(d20f39)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(eff1f5)
     }
 }

--- a/themes/catppuccin-latte/hyprland.conf
+++ b/themes/catppuccin-latte/hyprland.conf
@@ -2,3 +2,11 @@ general {
     col.active_border = rgb(1e66f5)
 }
 
+group {
+    col.border_active = rgb(1e66f5)
+    col.border_locked_active = rgb(1e66f5)
+
+    groupbar {
+        col.active = rgb(1e66f5)
+    }
+}

--- a/themes/catppuccin/hyprland.conf
+++ b/themes/catppuccin/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(c6d0f5)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(494d64aa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(494d64aa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(ed8796)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(c6d0f5)
-    col.border_locked_active = rgb(c6d0f5)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(494d64aa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(ed8796)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(494d64aa)
 
     groupbar {
-        col.active = rgb(c6d0f5)
+        # taken from waybar's background color
+        text_color = rgb(181824)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(cdd6f480)
+        # taken from waybar's foreground color
+        col.active = rgb(cdd6f4)
+        # taken from waybar's background color
+        col.inactive = rgb(181824)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(cdd6f4)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(cdd6f480)
+        # taken from alacritty's red color
+        col.locked_active = rgb(ed8796)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(181824)
     }
 }

--- a/themes/catppuccin/hyprland.conf
+++ b/themes/catppuccin/hyprland.conf
@@ -1,3 +1,12 @@
 general {
     col.active_border = rgb(c6d0f5)
 }
+
+group {
+    col.border_active = rgb(c6d0f5)
+    col.border_locked_active = rgb(c6d0f5)
+
+    groupbar {
+        col.active = rgb(c6d0f5)
+    }
+}

--- a/themes/everforest/hyprland.conf
+++ b/themes/everforest/hyprland.conf
@@ -1,3 +1,12 @@
 general {
     col.active_border = rgb(d3c6aa)
 }
+
+group {
+    col.border_active = rgb(d3c6aa)
+    col.border_locked_active = rgb(d3c6aa)
+
+    groupbar {
+        col.active = rgb(d3c6aa)
+    }
+}

--- a/themes/everforest/hyprland.conf
+++ b/themes/everforest/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(d3c6aa)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(475258aa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(475258aa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(e67e80)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(d3c6aa)
-    col.border_locked_active = rgb(d3c6aa)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(475258aa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(e67e80)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(475258aa)
 
     groupbar {
+        # taken from waybar's background color
+        text_color = rgb(2d353b)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(d3c6aa80)
+        # taken from waybar's foreground color
         col.active = rgb(d3c6aa)
+        # taken from waybar's background color
+        col.inactive = rgb(2d353b)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(d3c6aa)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(d3c6aa80)
+        # taken from alacritty's red color
+        col.locked_active = rgb(e67e80)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(2d353b)
     }
 }

--- a/themes/gruvbox/hyprland.conf
+++ b/themes/gruvbox/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(a89984)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(3c3836aa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(3c3836aa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(ea6962)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(a89984)
-    col.border_locked_active = rgb(a89984)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(3c3836aa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(ea6962)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(3c3836aa)
 
     groupbar {
-        col.active = rgb(a89984)
+        # taken from waybar's background color
+        text_color = rgb(282828)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(d4be9880)
+        # taken from waybar's foreground color
+        col.active = rgb(d4be98)
+        # taken from waybar's background color
+        col.inactive = rgb(282828)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(d4be98)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(d4be9880)
+        # taken from alacritty's red color
+        col.locked_active = rgb(ea6962)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(282828)
     }
 }

--- a/themes/gruvbox/hyprland.conf
+++ b/themes/gruvbox/hyprland.conf
@@ -1,3 +1,12 @@
 general {
     col.active_border = rgb(a89984)
 }
+
+group {
+    col.border_active = rgb(a89984)
+    col.border_locked_active = rgb(a89984)
+
+    groupbar {
+        col.active = rgb(a89984)
+    }
+}

--- a/themes/kanagawa/hyprland.conf
+++ b/themes/kanagawa/hyprland.conf
@@ -2,5 +2,14 @@ general {
     col.active_border = rgb(dcd7ba)
 }
 
+group {
+    col.border_active = rgb(dcd7ba)
+    col.border_locked_active = rgb(dcd7ba)
+
+    groupbar {
+        col.active = rgb(dcd7ba)
+    }
+}
+
 # Kanagawa backdrop is too strong for detault opacity
 windowrule = opacity 0.98 0.95, tag:terminal

--- a/themes/kanagawa/hyprland.conf
+++ b/themes/kanagawa/hyprland.conf
@@ -1,13 +1,44 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(dcd7ba)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(090618aa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(090618aa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(c34043)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(dcd7ba)
-    col.border_locked_active = rgb(dcd7ba)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(090618aa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(c34043)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(090618aa)
 
     groupbar {
+        # taken from waybar's background color
+        text_color = rgb(1f1f28)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(dcd7ba80)
+        # taken from waybar's foreground color
         col.active = rgb(dcd7ba)
+        # taken from waybar's background color
+        col.inactive = rgb(1f1f28)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(dcd7ba)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(dcd7ba80)
+        # taken from alacritty's red color
+        col.locked_active = rgb(c34043)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(1f1f28)
     }
 }
 

--- a/themes/matte-black/hyprland.conf
+++ b/themes/matte-black/hyprland.conf
@@ -1,3 +1,12 @@
 general {
     col.active_border = rgb(8A8A8D)
 }
+
+group {
+    col.border_active = rgb(8A8A8D)
+    col.border_locked_active = rgb(8A8A8D)
+
+    groupbar {
+        col.active = rgb(8A8A8D)
+    }
+}

--- a/themes/matte-black/hyprland.conf
+++ b/themes/matte-black/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(8A8A8D)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(333333aa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(333333aa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(D35F5F)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(8A8A8D)
-    col.border_locked_active = rgb(8A8A8D)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(333333aa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(D35F5F)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(333333aa)
 
     groupbar {
-        col.active = rgb(8A8A8D)
+        # taken from waybar's background color
+        text_color = rgb(1e1e1e)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(8a8a8d80)
+        # taken from waybar's foreground color
+        col.active = rgb(8a8a8d)
+        # taken from waybar's background color
+        col.inactive = rgb(1e1e1e)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(8a8a8d)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(8a8a8d80)
+        # taken from alacritty's red color
+        col.locked_active = rgb(D35F5F)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(1e1e1e)
     }
 }

--- a/themes/nord/hyprland.conf
+++ b/themes/nord/hyprland.conf
@@ -1,3 +1,12 @@
 general {
     col.active_border = rgb(D8DEE9)
 }
+
+group {
+    col.border_active = rgb(D8DEE9)
+    col.border_locked_active = rgb(D8DEE9)
+
+    groupbar {
+        col.active = rgb(D8DEE9)
+    }
+}

--- a/themes/nord/hyprland.conf
+++ b/themes/nord/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(D8DEE9)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(3b4252aa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(3b4252aa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(bf616a)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(D8DEE9)
-    col.border_locked_active = rgb(D8DEE9)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(3b4252aa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(bf616a)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(3b4252aa)
 
     groupbar {
-        col.active = rgb(D8DEE9)
+        # taken from waybar's background color
+        text_color = rgb(2e3440)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(d8dee980)
+        # taken from waybar's foreground color
+        col.active = rgb(d8dee9)
+        # taken from waybar's background color
+        col.inactive = rgb(2e3440)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(d8dee9)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(d8dee980)
+        # taken from alacritty's red color
+        col.locked_active = rgb(bf616a)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(2e3440)
     }
 }

--- a/themes/osaka-jade/hyprland.conf
+++ b/themes/osaka-jade/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(71CEAD)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(23372Baa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(23372Baa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(FF5345)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(71CEAD)
-    col.border_locked_active = rgb(71CEAD)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(23372Baa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(FF5345)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(23372Baa)
 
     groupbar {
-        col.active = rgb(71CEAD)
+        # taken from waybar's background color
+        text_color = rgb(11221C)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(e6d8ba80)
+        # taken from waybar's foreground color
+        col.active = rgb(e6d8ba)
+        # taken from waybar's background color
+        col.inactive = rgb(11221C)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(e6d8ba)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(e6d8ba80)
+        # taken from alacritty's red color
+        col.locked_active = rgb(FF5345)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(11221C)
     }
 }

--- a/themes/osaka-jade/hyprland.conf
+++ b/themes/osaka-jade/hyprland.conf
@@ -1,4 +1,12 @@
-# focus window color (border)
 general {
     col.active_border = rgb(71CEAD)
+}
+
+group {
+    col.border_active = rgb(71CEAD)
+    col.border_locked_active = rgb(71CEAD)
+
+    groupbar {
+        col.active = rgb(71CEAD)
+    }
 }

--- a/themes/ristretto/hyprland.conf
+++ b/themes/ristretto/hyprland.conf
@@ -1,4 +1,12 @@
 general {
-    # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
     col.active_border = rgb(e6d9db)
+}
+
+group {
+    col.border_active = rgb(e6d9db)
+    col.border_locked_active = rgb(e6d9db)
+
+    groupbar {
+        col.active = rgb(e6d9db)
+    }
 }

--- a/themes/ristretto/hyprland.conf
+++ b/themes/ristretto/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(e6d9db)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(72696aaa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(72696aaa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(fd6883)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(e6d9db)
-    col.border_locked_active = rgb(e6d9db)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(72696aaa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(fd6883)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(72696aaa)
 
     groupbar {
+        # taken from waybar's background color
+        text_color = rgb(2c2525)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(e6d9db80)
+        # taken from waybar's foreground color
         col.active = rgb(e6d9db)
+        # taken from waybar's background color
+        col.inactive = rgb(2c2525)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(e6d9db)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(e6d9db80)
+        # taken from alacritty's red color
+        col.locked_active = rgb(fd6883)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(2c2525)
     }
 }

--- a/themes/rose-pine/hyprland.conf
+++ b/themes/rose-pine/hyprland.conf
@@ -1,3 +1,12 @@
 general {
     col.active_border = rgb(575279)
 }
+
+group {
+    col.border_active = rgb(575279)
+    col.border_locked_active = rgb(575279)
+
+    groupbar {
+        col.active = rgb(575279)
+    }
+}

--- a/themes/rose-pine/hyprland.conf
+++ b/themes/rose-pine/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgb(575279)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(f2e9e1aa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(f2e9e1aa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(b4637a)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgb(575279)
-    col.border_locked_active = rgb(575279)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(f2e9e1aa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(b4637a)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(f2e9e1aa)
 
     groupbar {
+        # taken from waybar's background color
+        text_color = rgb(faf4ed)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(57527980)
+        # taken from waybar's foreground color
         col.active = rgb(575279)
+        # taken from waybar's background color
+        col.inactive = rgb(faf4ed)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(575279)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(57527980)
+        # taken from alacritty's red color
+        col.locked_active = rgb(b4637a)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(faf4ed)
     }
 }

--- a/themes/tokyo-night/hyprland.conf
+++ b/themes/tokyo-night/hyprland.conf
@@ -2,3 +2,11 @@ general {
     col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
 }
 
+group {
+    col.border_active = rgba(33ccffee) rgba(00ff99ee) 45deg
+    col.border_locked_active = rgba(33ccffee) rgba(00ff99ee) 45deg
+
+    groupbar {
+        col.active = rgba(33ccffee) rgba(00ff99ee) 45deg
+    }
+}

--- a/themes/tokyo-night/hyprland.conf
+++ b/themes/tokyo-night/hyprland.conf
@@ -1,12 +1,43 @@
 general {
+    # theme's existing active border color
     col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.inactive_border = rgba(32344aaa)
+
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.nogroup_border = rgba(32344aaa)
+    # taken from alacritty's red color
+    col.nogroup_border_active = rgb(787c99)
 }
 
 group {
+    # theme's existing active border color
     col.border_active = rgba(33ccffee) rgba(00ff99ee) 45deg
-    col.border_locked_active = rgba(33ccffee) rgba(00ff99ee) 45deg
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_inactive = rgba(32344aaa)
+
+    # taken from alacritty's red color
+    col.border_locked_active = rgb(787c99)
+    # taken from alacritty's black color with `aa` for opacity (66.7%)
+    col.border_locked_inactive = rgba(32344aaa)
 
     groupbar {
-        col.active = rgba(33ccffee) rgba(00ff99ee) 45deg
+        # taken from waybar's background color
+        text_color = rgb(1a1b26)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_inactive = rgba(cdd6f480)
+        # taken from waybar's foreground color
+        col.active = rgb(cdd6f4)
+        # taken from waybar's background color
+        col.inactive = rgb(1a1b26)
+
+        # taken from waybar's foreground color
+        text_color_locked_active = rgb(cdd6f4)
+        # taken from waybar's foreground color with `80` for opacity (50%)
+        text_color_locked_inactive = rgba(cdd6f480)
+        # taken from alacritty's red color
+        col.locked_active = rgb(787c99)
+        # taken from waybar's background color
+        col.locked_inactive = rgb(1a1b26)
     }
 }


### PR DESCRIPTION
I use tabbed groups sometimes, so I made sure the usual border colors are also applied there. A couple of notes:

- I set the base style in `looknfeel.conf`, the same way it was done for general borders. I believe this matches the tokyo night theme in the newer versions of Omarchy, but on mine (installed pre-2.0) those colors were yellow.
- I never used locked groups but I saw in the Hypr docs that the variables were there - I assumed we would be using the same values.
- Set the font of group tabs to Caskaydia to match the rest, but this needs to be changed to be dynamic. I'm not sure how this is done - I tried with the `omarchy-font-set` file but there's probably a better way than adding another file to be modified.
- Added the missing colors (active group border, active locked group border, active tab) to all built-in themes, copying the general active border color.

I noticed that we don't override the inactive border color. The color is quite neutral, so that's probably fine. Modifying it for each theme would require extra work.

EDIT: Before and after screenshots on an active group/tab:
<img width="2560" height="1440" alt="Before - active" src="https://github.com/user-attachments/assets/4e81e21c-bb06-45d0-a1f2-69ac640ebacf" />
<img width="2560" height="1440" alt="After - active" src="https://github.com/user-attachments/assets/19d72914-8910-4e34-8abb-2240878af606" />