### PR TITLE
feat: add wallpaper auto-rotation

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -67,10 +67,11 @@ show_learn_menu() {
 }
 
 show_style_menu() {
-  case $(menu "Style" "󰸌  Theme\n  Font\n  Background\n󱄄  Screensaver\n  About") in
+  case $(menu "Style" "󰸌  Theme\n  Font\n  Background\n  Wallpaper Rotation\n󱄄  Screensaver\n  About") in
   *Theme*) show_theme_menu ;;
   *Font*) show_font_menu ;;
   *Background*) omarchy-theme-bg-next ;;
+  *Wallpaper*) show_wallpaper_rotation_menu ;;
   *Screensaver*) edit_in_nvim ~/.config/omarchy/branding/screensaver.txt ;;
   *About*) edit_in_nvim ~/.config/omarchy/branding/about.txt ;;
   *) show_main_menu ;;
@@ -93,6 +94,16 @@ show_font_menu() {
   else
     omarchy-font-set "$theme"
   fi
+}
+
+show_wallpaper_rotation_menu() {
+  case $(menu "Wallpaper Rotation" "  Hourly\n  Daily\n  Weekly\n  Disabled") in
+  *Hourly*) omarchy-wallpaper-rotation-config hourly ;;
+  *Daily*) omarchy-wallpaper-rotation-config daily ;;
+  *Weekly*) omarchy-wallpaper-rotation-config weekly ;;
+  *Disabled*) omarchy-wallpaper-rotation-config disable ;;
+  *) show_style_menu ;;
+  esac
 }
 
 show_capture_menu() {
@@ -122,11 +133,12 @@ show_screenrecord_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n  Wallpaper Rotation") in
   *Screensaver*) omarchy-toggle-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
   *Idle*) omarchy-toggle-idle ;;
   *Bar*) omarchy-toggle-waybar ;;
+  *Wallpaper*) omarchy-wallpaper-rotation-toggle ;;
   *) show_main_menu ;;
   esac
 }

--- a/bin/omarchy-wallpaper-rotation-config
+++ b/bin/omarchy-wallpaper-rotation-config
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+FREQUENCY="$1"
+
+case "$FREQUENCY" in
+  hourly)
+    CALENDAR="hourly"
+    MESSAGE="Wallpaper rotation set to hourly"
+    ;;
+  daily)
+    CALENDAR="daily"
+    MESSAGE="Wallpaper rotation set to daily"
+    ;;
+  weekly)
+    CALENDAR="weekly"
+    MESSAGE="Wallpaper rotation set to weekly"
+    ;;
+  disable)
+    systemctl --user disable --now omarchy-wallpaper-rotation.timer
+    notify-send "Wallpaper auto-rotation disabled"
+    exit 0
+    ;;
+  *)
+    echo "Usage: omarchy-wallpaper-rotation-config {hourly|daily|weekly|disable}"
+    exit 1
+    ;;
+esac
+
+# Update the timer file
+TIMER_FILE="$HOME/.config/systemd/user/omarchy-wallpaper-rotation.timer"
+sed -i "s/OnCalendar=.*/OnCalendar=$CALENDAR/" "$TIMER_FILE"
+
+# Reload systemd and restart timer
+systemctl --user daemon-reload
+systemctl --user enable --now omarchy-wallpaper-rotation.timer
+
+notify-send "$MESSAGE"

--- a/bin/omarchy-wallpaper-rotation-toggle
+++ b/bin/omarchy-wallpaper-rotation-toggle
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if systemctl --user is-enabled omarchy-wallpaper-rotation.timer >/dev/null 2>&1; then
+  systemctl --user disable --now omarchy-wallpaper-rotation.timer
+  notify-send "Wallpaper auto-rotation disabled"
+else
+  systemctl --user enable --now omarchy-wallpaper-rotation.timer
+  notify-send "Wallpaper auto-rotation enabled"
+fi

--- a/config/systemd/user/omarchy-wallpaper-rotation.service
+++ b/config/systemd/user/omarchy-wallpaper-rotation.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Omarchy Wallpaper Rotation
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/share/omarchy/bin/omarchy-theme-bg-next
+Environment=DISPLAY=:0

--- a/config/systemd/user/omarchy-wallpaper-rotation.timer
+++ b/config/systemd/user/omarchy-wallpaper-rotation.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Omarchy Wallpaper Rotation Timer
+Requires=omarchy-wallpaper-rotation.service
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/migrations/1757433251.sh
+++ b/migrations/1757433251.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Add wallpaper rotation feature for existing users
+if [[ ! -f ~/.config/systemd/user/omarchy-wallpaper-rotation.timer ]]; then
+  # Copy systemd files to user config
+  cp ~/.local/share/omarchy/config/systemd/user/omarchy-wallpaper-rotation.* ~/.config/systemd/user/
+  
+  # Reload systemd user daemon
+  systemctl --user daemon-reload
+  
+  # Don't enable by default - let users opt-in via menu
+  notify-send "New Feature" "Wallpaper auto-rotation available in Toggle and Style menus" -t 3000
+fi


### PR DESCRIPTION
## Summary
Adds automatic wallpaper rotation functionality to Omarchy with user-friendly menu controls and systemd timer integration.

## Features Added
- **Toggle Control**: Quick on/off toggle in Toggle menu
- **Frequency Settings**: Hourly/Daily/Weekly/Disabled options in Style menu
- **Systemd Integration**: Uses systemd user timers for reliable scheduling
- **Migration Support**: Automatic setup for existing users
- **Opt-in Design**: Disabled by default, users choose to enable

## Menu Integration
- **Toggle Menu** → "Wallpaper Rotation" - Quick toggle
- **Style Menu** → "Wallpaper Rotation" → Frequency submenu

## Files Added
- `bin/omarchy-wallpaper-rotation-toggle` - Toggle script
- `bin/omarchy-wallpaper-rotation-config` - Configuration script  
- `config/systemd/user/omarchy-wallpaper-rotation.{service,timer}` - Systemd files
- `migrations/1757433251.sh` - Migration for existing users

## Files Modified
- `bin/omarchy-menu` - Added menu integration

## Test Plan
- [x] Toggle functionality works (enable/disable)
- [x] Configuration script updates timer frequency correctly
- [x] Systemd timer schedules and reschedules properly
- [x] Menu navigation works in both Toggle and Style menus
- [x] Migration script copies files and notifies users

## Implementation Notes
- Uses existing `omarchy-theme-bg-next` script for wallpaper cycling
- Systemd timers persist across reboots