### PR TITLE
Security - Remove relative bin from $PATH

### DIFF
--- a/default/bash/shell
+++ b/default/bash/shell
@@ -10,5 +10,5 @@ if [[ ! -v BASH_COMPLETION_VERSINFO && -f /usr/share/bash-completion/bash_comple
 fi
 
 # Set complete path
-export PATH="./bin:$HOME/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 set +h


### PR DESCRIPTION
Having ./bin in your PATH is extremely dangerous, and even moreso when it's the first entry and will override base system tools like `ls` . A different mechanism should be used for in-project executables.

This PR removes the security hole without addressing ways to handle in-project executables.