### PR TITLE
fix: Add lock file to omarchy-cmd-tzupdate

### DIFF
--- a/bin/omarchy-cmd-tzupdate
+++ b/bin/omarchy-cmd-tzupdate
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+lockfile="/tmp/omarchy-cmd-tzupdate.lock"
+max_age=300
+
+# If lockfile exists, check if the process is still running or if lock is fresh
+if [[ -e "$lockfile" ]]; then
+  pid=$(<"$lockfile")
+  if kill -0 "$pid" 2>/dev/null; then
+    exit 0
+  fi
+
+  lock_age=$(($(date +%s) - $(stat -c %Y "$lockfile" 2>/dev/null || echo 0)))
+  if ((lock_age < max_age)); then
+    exit 0
+  fi
+
+  rm -f "$lockfile"
+fi
+
+# Create lockfile with current PID and ensure cleanup on exit
+echo $$ >"$lockfile"
+trap 'rm -f "$lockfile"' EXIT
+
 sudo systemctl restart systemd-timesyncd
 sudo tzupdate
 new_timezone=$(timedatectl show -p Timezone --value)


### PR DESCRIPTION
This PR improves the timezone update script by adding:

- A lockfile mechanism to prevent concurrent runs
- Automatic cleanup with trap
- Handling of stale lockfiles (5 min expiry)

Without this, repeated right clicks on the clock may result in multiple Waybar instances:

<img width="5108" height="778" alt="screenshot-2025-09-09_15-15-42" src="https://github.com/user-attachments/assets/cfcfcd6d-8798-4e74-8d67-f3f51974cd20" />
