### PR TITLE
Add symlink to use systemd‑resolved stub DNS configuration

### DIFF
--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -6,3 +6,6 @@ sudo systemctl enable iwd.service
 # Prevent systemd-networkd-wait-online timeout on boot
 sudo systemctl disable systemd-networkd-wait-online.service
 sudo systemctl mask systemd-networkd-wait-online.service
+
+# Provide domain name resolution for software that reads /etc/resolv.conf directly
+sudo ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf


### PR DESCRIPTION
When I installed omarchy, steam was not working well on the featured page:
<img width="1107" height="702" alt="image" src="https://github.com/user-attachments/assets/794ef47c-fe53-488b-8ce4-c8b7bb72cb80" />

It seems like more people had this issue too.

While investigating, Arch wiki recommends creating a symlink from /run/systemd/resolve/stub-resolv.conf to /etc/resolv.conf in order to ensure connection for applications that look on this file directly.

This pull request is doing the exact symlink that worked for me.

https://wiki.archlinux.org/title/Systemd-resolved