### PR TITLE
Update audio switch script to filter available sinks

### DIFF
--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -2,7 +2,7 @@
 
 focused_monitor="$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')"
 
-sinks=$(pactl -f json list sinks)
+sinks=$(pactl -f json list sinks | jq '[.[] | select([.ports[]? | .availability == "available"] | any)]')
 sinks_count=$(echo "$sinks" | jq '. | length')
 
 if [ "$sinks_count" -eq 0 ]; then


### PR DESCRIPTION
Filter audio sinks to include only available ports.

This fixes an issue where if the next sink is `not available` then the sink will not allow change even if there are other available sinks.