### PR TITLE
feat(waybar): add recording indicator

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -7,6 +7,7 @@
   "modules-left": ["custom/omarchy", "hyprland/workspaces"],
   "modules-center": ["clock", "custom/update"],
   "modules-right": [
+    "custom/screen-rec-indicator",
     "group/tray-expander",
     "bluetooth",
     "network",
@@ -123,6 +124,12 @@
   "custom/expand-icon": {
     "format": " ",
     "tooltip": false
+  },
+  "custom/screen-rec-indicator": {
+    "on-click": "omarchy-cmd-screenrecord",
+    "exec": "~/.config/waybar/scripts/screen-rec-indicator.sh",
+    "interval": 1,
+    "return-type": "json"
   },
   "tray": {
     "icon-size": 12,

--- a/config/waybar/scripts/screen-rec-indicator.sh
+++ b/config/waybar/scripts/screen-rec-indicator.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
+  echo '{"text": "⏺", "tooltip": "Recording in progress", "class": "recording"}'
+else
+  echo '{"text": "", "tooltip": "Not recording", "class": "idle"}'
+fi

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -37,6 +37,7 @@
 #bluetooth,
 #pulseaudio,
 #custom-omarchy,
+#custom-screen-rec-indicator,
 #custom-update {
   min-width: 12px;
   margin: 0 7.5px;
@@ -60,4 +61,13 @@ tooltip {
 
 .hidden {
   opacity: 0;
+}
+
+#custom-screen-rec-indicator.recording {
+    color: red;
+    font-weight: bold;
+}
+
+#custom-screen-rec-indicator.idle {
+    color: transparent; /* hides it when idle */
 }


### PR DESCRIPTION
### Summary
Adds a custom Waybar module that shows an indicator when screen recording with recording is active.

### Details
- Introduced a `screen-rec-indicator.sh` script in `~/.config/waybar/scripts/`
- Waybar config updated with a `custom/screen-rec-indicator` module
- Indicator shows a red ⏺ while recording, hidden when idle

### Why
This makes it immediately clear when a screen recording is running, helping avoid accidental recordings and improving usability.

### Notes
- Styling for the indicator is defined in `style.css` (`.recording` in red, `.idle` hidden).
- Can be extended later to support clickable start/stop actions.
