### PR TITLE
fix(omarchy-webapp-remove): clarify empty selection message in gum ch…

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -30,7 +30,7 @@ else
 fi
 
 if [[ ${#APP_NAMES[@]} -eq 0 ]]; then
-  echo "You must provide web app names."
+  echo "No selection. (Tip: press X to select, Enter to confirm.)"
   exit 1
 fi
 


### PR DESCRIPTION
Previously, if the user pressed Enter without marking any items in `gum choose --no-limit`, the script exited with a generic "You must provide web app names." message. This was confusing because it looked like no apps were found, even though the menu listed them.

A better message would be "No selection. (Tip: use X to select, Enter to confirm.)".
The error message now explicitly explains that X is needed to select items before pressing Enter, making the UX much clearer.