### PR TITLE
Activate animation on manual resizing

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -86,4 +86,5 @@ misc {
     disable_hyprland_logo = true
     disable_splash_rendering  = true
     focus_on_activate = true
+    animate_manual_resizes = true
 }


### PR DESCRIPTION
Seeing that Omarchy otherwise has animations on by default, and has a mainly keyboard-driven usage, I believe this animation adds delight.

The only downside is mouse-resizing not being as responsive because of the added animation-easing.

Still, I believe the improvements when using it keyboard-driven are more important.