### PR TITLE
Update windowrule to include Twitch, Kick and Vimeo with full opacity

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -10,4 +10,5 @@ windowrule = opacity 1 0.97, tag:chromium-based-browser
 windowrule = opacity 1 0.97, tag:firefox-based-browser
 
 # Some video sites should never have opacity applied to them
-windowrule = opacity 1.0 1.0, initialTitle:((?i)(?:[a-z0-9-]+\.)*youtube\.com_/|app\.zoom\.us_/wc/home)
+windowrule = opacity 1.0 1.0, initialTitle:((?i)(?:[a-z0-9-]+\.)*(youtube\.com_/|twitch\.tv_/|kick\.com_/|vimeo\.com_/)|app\.zoom\.us_/wc/home)
+


### PR DESCRIPTION
This PR updates the existing Hyprland windowrule configuration to ensure full opacity (1.0 / 1.0) not only for YouTube and Zoom, but also for Twitch, Kick, and Vimeo.

The goal of this change is to avoid any level of transparency when watching videos or using Zoom, ensuring a consistent and distraction-free experience on these platforms.

Changes included:
- Extended the regex in the windowrule to match Twitch, Kick, and Vimeo domains.
- Kept YouTube and Zoom behavior unchanged.
- Consolidated everything into a single rule for easier maintenance.