### PR TITLE
(fix) Omarchy menu fix wrong variable for exiting back_to function

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -8,7 +8,7 @@ BACK_TO_EXIT=false
 back_to() {
   local parent_menu="$1"
 
-  if [[ "$DIRECT_ACCESS" == "true" ]]; then
+  if [[ "$BACK_TO_EXIT" == "true" ]]; then
     exit 0
   elif [[ -n "$parent_menu" ]]; then
     "$parent_menu"


### PR DESCRIPTION
Hi,

The variable specified in the back_to function was incorrect, which caused unintended behavior.

Pressing Escape in the “power menu” or “shutdown menu” now closes the menu instead of returning to the main menu.