### PR TITLE
Bind calculator key with gnome-calculator

### DIFF
--- a/bin/omarchy-refresh-plymouth
+++ b/bin/omarchy-refresh-plymouth
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-if [[ "$1" == "-y" ]]; then
-  sudo cp ~/.local/share/omarchy/default/plymouth/* /usr/share/plymouth/themes/omarchy/
-  sudo plymouth-set-default-theme -R omarchy
-fi
+sudo cp ~/.local/share/omarchy/default/plymouth/* /usr/share/plymouth/themes/omarchy/
+sudo plymouth-set-default-theme -R omarchy

--- a/bin/omarchy-refresh-plymouth
+++ b/bin/omarchy-refresh-plymouth
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 sudo cp ~/.local/share/omarchy/default/plymouth/* /usr/share/plymouth/themes/omarchy/
-sudo plymouth-set-default-theme -R omarchy
+sudo plymouth-set-default-theme omarchy
+
+if command -v limine-mkinitcpio &>/dev/null; then
+  sudo limine-mkinitcpio
+else
+  sudo mkinitcpio -P
+fi

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -5,6 +5,7 @@ bindd = SUPER ALT, SPACE, Omarchy menu, exec, omarchy-menu
 bindd = SUPER, ESCAPE, Power menu, exec, omarchy-menu system
 bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system
 bindd = SUPER, K, Show key bindings, exec, omarchy-menu-keybindings
+bindd = , XF86Calculator, Calculator, exec, gnome-calculator
 
 # Aesthetics
 bindd = SUPER SHIFT, SPACE, Toggle top bar, exec, omarchy-toggle-waybar


### PR DESCRIPTION
Added a line to bind the calculator key with the default gnome-calculator.