### PR TITLE
Bind calculator key with gnome-calculator

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -5,6 +5,7 @@ bindd = SUPER ALT, SPACE, Omarchy menu, exec, omarchy-menu
 bindd = SUPER, ESCAPE, Power menu, exec, omarchy-menu system
 bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system
 bindd = SUPER, K, Show key bindings, exec, omarchy-menu-keybindings
+bindd = , XF86Calculator, Calculator, exec, gnome-calculator
 
 # Aesthetics
 bindd = SUPER SHIFT, SPACE, Toggle top bar, exec, omarchy-toggle-waybar


### PR DESCRIPTION
Just added a line that binds the calculator key in some keyboards with the default gnome-calculator.