### PR TITLE
fix: assigning correct variable for direct exit in menu navigation

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -2,9 +2,6 @@
 
 export PATH="$HOME/.local/share/omarchy/bin:$PATH"
 
-# Set to true when going directly to a submenu, so we can exit directly
-BACK_TO_EXIT=false
-
 back_to() {
   local parent_menu="$1"
 
@@ -432,7 +429,8 @@ go_to_menu() {
 }
 
 if [[ -n "$1" ]]; then
-  BACK_TO_EXIT=true
+  # Set to true when going directly to a submenu, so we can exit directly
+  DIRECT_ACCESS=true
   go_to_menu "$1"
 else
   show_main_menu


### PR DESCRIPTION
# Summary
Fixes menu navigation behavior from #1100 
# Problem
When opening the theme menu and the power menu, the behaviour of Theme menu → Style menu (was going to main menu) was still happening.
# Solution
Declaring the DIRECT_ACCESS instead of BACK_TO_EXIT