### PR TITLE
Replace Omarchy-specific themes with themes for both Omarchy and Omakub

### DIFF
--- a/bin/omarchy-theme-install
+++ b/bin/omarchy-theme-install
@@ -15,7 +15,7 @@ if [ -z "$REPO_URL" ]; then
 fi
 
 THEMES_DIR="$HOME/.config/omarchy/themes"
-THEME_NAME=$(basename "$REPO_URL" .git | sed -E 's/^omarchy-//; s/-theme$//')
+THEME_NAME=$(basename "$REPO_URL" .git | sed -E 's/^(omarchy|omacom)-//; s/-theme$//')
 THEME_PATH="$THEMES_DIR/$THEME_NAME"
 
 # Remove existing theme if present

--- a/bin/omarchy-theme-list
+++ b/bin/omarchy-theme-list
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-find ~/.config/omarchy/themes/ -mindepth 1 -maxdepth 1 \( -type d -o -type l \) | sort | while read -r path; do
+find -L ~/.config/omarchy/themes/ -mindepth 1 -maxdepth 1 -type d | sort | while read -r path; do
   echo "$(basename "$path" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g')"
 done

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -40,7 +40,10 @@ else
 fi
 
 # Apply VS Code theme if it exists
-if [[ -f ~/.config/omarchy/current/theme/vscode.sh ]]; then
+if [[ -f ~/.config/omarchy/current/theme/vscode.sh && -d ~/.config/Code/User ]]; then
+  if [[ ! -f ~/.config/Code/User/settings.json ]]; then
+    cp ~/.local/share/omacom-core/configs/vscode.json ~/.config/Code/User/settings.json
+  fi
   source ~/.config/omarchy/current/theme/vscode.sh
 fi
 

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -39,6 +39,11 @@ else
   gsettings set org.gnome.desktop.interface icon-theme "Yaru-blue"
 fi
 
+# Apply VS Code theme if it exists
+if [[ -f ~/.config/omarchy/current/theme/vscode.sh ]]; then
+  source ~/.config/omarchy/current/theme/vscode.sh
+fi
+
 # Change Chromium colors
 if command -v chromium &>/dev/null; then
   if [[ -f ~/.config/omarchy/current/theme/light.mode ]]; then

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Omarchy
+
 # Get remote tag
 latest_tag=$(git -C "$OMARCHY_PATH" ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
 if [[ -z "$latest_tag" ]]; then
@@ -9,6 +11,27 @@ fi
 
 # Get local tag
 current_tag=$(git -C "$OMARCHY_PATH" describe --tags $(git -C "$OMARCHY_PATH" rev-list --tags --max-count=1))
+if [[ -z "$current_tag" ]]; then
+  echo "Error: Could not retrieve current tag."
+  exit 1
+fi
+
+if [[ "$current_tag" != "$latest_tag" ]]; then
+  echo "Omarchy update available ($latest_tag)"
+  exit 0
+fi
+
+# omacom-core
+
+# Get remote tag
+latest_tag=$(git -C "$OMACOM_CORE_PATH" ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
+if [[ -z "$latest_tag" ]]; then
+  echo "Error: Could not retrieve latest tag."
+  exit 1
+fi
+
+# Get local tag
+current_tag=$(git -C "$OMACOM_CORE_PATH" describe --tags $(git -C "$OMACOM_CORE_PATH" rev-list --tags --max-count=1))
 if [[ -z "$current_tag" ]]; then
   echo "Error: Could not retrieve current tag."
   exit 1

--- a/bin/omarchy-update-git
+++ b/bin/omarchy-update-git
@@ -3,3 +3,5 @@
 echo -e "\e[32mUpdate Omarchy\e[0m"
 git -C $OMARCHY_PATH pull --autostash
 git -C $OMARCHY_PATH diff --check || git -C $OMARCHY_PATH reset --merge
+git -C $OMACOM_CORE_PATH pull --autostash
+git -C $OMACOM_CORE_PATH diff --check || git -C $OMACOM_CORE_PATH reset --merge

--- a/boot.sh
+++ b/boot.sh
@@ -16,6 +16,8 @@ echo -e "\n$ansi_art\n"
 
 sudo pacman -Syu --noconfirm --needed git
 
+# Omarchy
+
 # Use custom repo if specified, otherwise default to basecamp/omarchy
 OMARCHY_REPO="${OMARCHY_REPO:-basecamp/omarchy}"
 
@@ -29,6 +31,25 @@ if [[ $OMARCHY_REF != "master" ]]; then
   echo -e "\eUsing branch: $OMARCHY_REF"
   cd ~/.local/share/omarchy
   git fetch origin "${OMARCHY_REF}" && git checkout "${OMARCHY_REF}"
+  cd -
+fi
+
+# omacom-core
+
+# Use custom repo if specified, otherwise default to rplopes/omacom-core
+# Needs to be replaced with basecamp/omacom-core before releasing
+OMACOM_CORE_REPO="${OMACOM_CORE_REPO:-rplopes/omacom-core}"
+
+echo -e "\nCloning omacom-core from: https://github.com/${OMACOM_CORE_REPO}.git"
+rm -rf ~/.local/share/omacom-core/
+git clone "https://github.com/${OMACOM_CORE_REPO}.git" ~/.local/share/omacom-core >/dev/null
+
+# Use custom branch if instructed, otherwise default to master
+OMACOM_CORE_REF="${OMACOM_CORE_REF:-master}"
+if [[ $OMACOM_CORE_REF != "master" ]]; then
+  echo -e "\eUsing branch: $OMACOM_CORE_REF"
+  cd ~/.local/share/omacom-core
+  git fetch origin "${OMACOM_CORE_REF}" && git checkout "${OMACOM_CORE_REF}"
   cd -
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,9 @@
 set -eE
 
 OMARCHY_PATH="$HOME/.local/share/omarchy"
+OMACOM_CORE_PATH="$HOME/.local/share/omacom-core"
 OMARCHY_INSTALL="$OMARCHY_PATH/install"
-export PATH="$OMARCHY_PATH/bin:$PATH"
+export PATH="$OMARCHY_PATH/bin:$OMACOM_CORE_PATH/bin:$PATH"
 
 # Preparation
 source $OMARCHY_INSTALL/preflight/show-env.sh

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -11,7 +11,7 @@ sudo gtk-update-icon-cache /usr/share/icons/Yaru
 
 # Setup theme links
 mkdir -p ~/.config/omarchy/themes
-for f in ~/.local/share/omarchy/themes/*; do ln -nfs "$f" ~/.config/omarchy/themes/; done
+for f in ~/.local/share/omacom-core/themes/*; do ln -nfs "$f" ~/.config/omarchy/themes/; done
 
 # Set initial theme
 mkdir -p ~/.config/omarchy/current

--- a/migrations/1757541165.sh
+++ b/migrations/1757541165.sh
@@ -1,0 +1,26 @@
+echo "Replace Omarchy-specific themes with themes for both Omarchy and Omakub"
+
+export OMACOM_CORE_PATH="$HOME/.local/share/omacom-core"
+export PATH="$OMARCHY_PATH/bin:$OMACOM_CORE_PATH/bin:$PATH"
+
+# Pull new omacom-core repository
+
+# Use custom repo if specified, otherwise default to rplopes/omacom-core
+# Needs to be replaced with basecamp/omacom-core before releasing
+OMACOM_CORE_REPO="${OMACOM_CORE_REPO:-rplopes/omacom-core}"
+
+echo -e "\nCloning omacom-core from: https://github.com/${OMACOM_CORE_REPO}.git"
+rm -rf ~/.local/share/omacom-core/
+git clone "https://github.com/${OMACOM_CORE_REPO}.git" ~/.local/share/omacom-core >/dev/null
+
+# Use custom branch if instructed, otherwise default to master
+OMACOM_CORE_REF="${OMACOM_CORE_REF:-master}"
+if [[ $OMACOM_CORE_REF != "master" ]]; then
+  echo -e "\eUsing branch: $OMACOM_CORE_REF"
+  cd ~/.local/share/omacom-core
+  git fetch origin "${OMACOM_CORE_REF}" && git checkout "${OMACOM_CORE_REF}"
+  cd -
+fi
+
+# Replace installed themes
+for f in ~/.local/share/omacom-core/themes/*; do ln -nfs "$f" ~/.config/omarchy/themes/; done


### PR DESCRIPTION
This PR proposes an initial extraction of Omarchy and Omakub content into a shared `omacom-core` repo. This should allow keeping a single source of truth for shared configuration, avoiding having to maintain two sources separately. Some tangible benefits:
- Omarchy can get configuration that hasn't been ported from Omakub yet, such as VS Code themes
- Omakub could benefit from Omarchy's faster pace of development without lagging so much behind
- Derivative distros by the community (e.g. a NixOS version) could also benefit from this shared repo

As a first step, this PR extracts themes. This makes it possible in Omarchy to use VS Code themes from Omakub, for instance.

Before this PR:

<img width="3286" height="1080" alt="screenshot-2025-09-10_23-32-55" src="https://github.com/user-attachments/assets/91b45b19-f993-42f9-becf-ff00ad6e341f" />

With this PR:

<img width="3286" height="1080" alt="screenshot-2025-09-11_00-56-49" src="https://github.com/user-attachments/assets/48369a2f-b5d1-49fb-8fff-baf95b04090b" />

Future work, out of scope of this PR:
- Changing instructions on how to create an Omarchy theme to call it an Omacom theme, and including the Omakub-specific files such as the VS Code theme
- Back-filling missing theme data, i.e. adding Omakub configs to current Omarchy-only themes, so that they can start being used in Omakub too
- Doing a similar PR in the Omakub repo, to actually benefit from the new Omarchy themes and the new extraction there as well
- Extending the extraction to other parts of the codebase where it would make sense to share code between both distros

**Warning:** This PR fetches `omacom-core` from my own repo, https://github.com/rplopes/omacom-core, as it's not available under the Basecamp GitHub org. It should be changed to a repo under the Basecamp org before merging.