### PR TITLE
hypr: remove deprecated workspace_swipe setting

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -29,3 +29,9 @@ input {
 
 # Scroll faster in the terminal
 windowrule = scrolltouchpad 1.5, class:Alacritty
+
+# Uncomment to enable trackpad gestures
+# See https://wiki.hypr.land/Configuring/Gestures/
+# gesture = 3, down, mod: ALT, close
+# gesture = 3, up, mod: SUPER, scale: 1.5, fullscreen
+# gesture = 3, left, scale: 1.5, float

--- a/default/hypr/input.conf
+++ b/default/hypr/input.conf
@@ -15,7 +15,3 @@ input {
     }
 }
 
-# https://wiki.hyprland.org/Configuring/Variables/#gestures
-gestures {
-    workspace_swipe = false
-}


### PR DESCRIPTION
Hyprland 0.51 removed the workspace_swipe setting from gestures configuration. Remove with gestures block and add commented examples in user config template.

Fixes:
<img width="3838" height="362" alt="image" src="https://github.com/user-attachments/assets/2b4518f1-61f7-41e9-85a9-7d2ecc9500c8" />