### PR TITLE
Fix Hyprland 0.51 breaking change

### DIFF
--- a/default/hypr/input.conf
+++ b/default/hypr/input.conf
@@ -15,7 +15,5 @@ input {
     }
 }
 
-# https://wiki.hyprland.org/Configuring/Variables/#gestures
-gestures {
-    workspace_swipe = false
-}
+# See https://wiki.hypr.land/Configuring/Gestures
+gesture = 3, horizontal, workspace


### PR DESCRIPTION
Hyperland 0.51 was just released, which removes `gestures:workspace_swipe`

https://hypr.land/news/update51/

Relevant PR: https://github.com/hyprwm/Hyprland/pull/11490