### PR TITLE
delete deprecated workspace_swipe

### DIFF
--- a/default/hypr/input.conf
+++ b/default/hypr/input.conf
@@ -14,8 +14,3 @@ input {
         natural_scroll = false
     }
 }
-
-# https://wiki.hyprland.org/Configuring/Variables/#gestures
-gestures {
-    workspace_swipe = false
-}


### PR DESCRIPTION
The new hyprland release removes workspace_swipe variable and adds configurable gestures. 
https://wiki.hypr.land/Configuring/Gestures/
https://github.com/hyprwm/Hyprland/pull/11490
Deleting the deprecated variable for now.