### PR TITLE
Improve git config defaults and structure

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -1,0 +1,28 @@
+# See https://git-scm.com/docs/git-config
+
+[alias]
+	co = checkout
+	br = branch
+	ci = commit
+	st = status
+[init]
+	defaultBranch = master
+[pull]
+	rebase = true 			 # Rebase (instead of merge) on pull
+[push]
+	autoSetupRemote = true   # Automatically set upstream branch on push
+[diff]
+	algorithm = histogram    # Clearer diffs on moved/edited lines
+	colorMoved = plain       # Highlight moved blocks in diffs
+	mnemonicPrefix = true    # More intuitive refs in diff output
+[commit]
+	verbose = true           # Include diff comment in commit message template
+[column]
+	ui = auto 			     # Output in columns when possible
+[branch]
+	sort = -committerdate    # Sort branches by most recent commit first
+[tag]
+	sort = -version:refname  # Sort version numbers as you would expect
+[rerere]
+	enabled = true           # Record and reuse conflict resolutions
+	autoupdate = true        # Apply stored conflict resolutions automatically

--- a/install/config/git.sh
+++ b/install/config/git.sh
@@ -1,15 +1,3 @@
-# Ensure git settings live under ~/.config
-mkdir -p ~/.config/git
-touch ~/.config/git/config
-
-# Set common git aliases
-git config --global alias.co checkout
-git config --global alias.br branch
-git config --global alias.ci commit
-git config --global alias.st status
-git config --global pull.rebase true
-git config --global init.defaultBranch master
-
 # Set identification from install inputs
 if [[ -n "${OMARCHY_USER_NAME//[[:space:]]/}" ]]; then
   git config --global user.name "$OMARCHY_USER_NAME"


### PR DESCRIPTION
~~This PR aligns `git` configuration with other tools: a bare user config referencing an Omarchy default config.~~

It also adds additional rules, specifically around `git` terminal usage:

- `push.autoSetupRemote = true` Automatically set upstream branch on push
- `diff.algorithm = histogram` Clearer diffs on moved/edited lines
- `diff.colorMoved = plain` Highlight moved blocks in diffs
- `diff.mnemonicPrefix = true` More intuitive refs in diff output
- `commit.verbose = true` Include diff comment in commit message template
- `column.ui = auto` Output in columns when useful (not when piping into grep for example)
- `branch.sort = -committerdate` Sort branches by most recent commit first
- `tag.sort = -version:refname` Sort version numbers as you would expect (default is alphabetically)
- `rerere.enabled = true` Record and reuse conflict resolutions
- `rerere.autoupdate = true` Apply stored conflict resolutions automatically

Obviously a matter of taste, but Omarchy *is* opinionated! I've been running this config for a few months, prompted by the blog post [How Core Git Developers Configure Git](https://blog.gitbutler.com/how-git-core-devs-configure-git#clearly-makes-git-better).
