### PR TITLE
Refine audio sink selection

### DIFF
--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -2,7 +2,7 @@
 
 focused_monitor="$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')"
 
-sinks=$(pactl -f json list sinks | jq '[.[] | select([.ports[]? | .availability == "available"] | any)]')
+sinks=$(pactl -f json list sinks | jq '[.[] | select((.ports | length == 0) or ([.ports[]? | .availability != "not available"] | any))]')
 sinks_count=$(echo "$sinks" | jq '. | length')
 
 if [ "$sinks_count" -eq 0 ]; then

--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -2,7 +2,7 @@
 
 focused_monitor="$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')"
 
-sinks=$(pactl -f json list sinks)
+sinks=$(pactl -f json list sinks | jq '[.[] | select([.ports[]? | .availability == "available"] | any)]')
 sinks_count=$(echo "$sinks" | jq '. | length')
 
 if [ "$sinks_count" -eq 0 ]; then


### PR DESCRIPTION
The previous PR #1555 has an issue where sinks that don't have a port availability of 'available', such as 'availability unknown', are missed but may still be valid. This PR updates the selection to include all sinks except those with port availability of 'not available' for all ports and should work in most cases.

However, the root of the issue is really that the `pactl set-default-sink` command is not guaranteed to set the sink asked for and may silently defer to another sink without error. This can cause edge cases where cycling through every sink does not work as intended as the loop is short-circuited.

A more robust solution is needed, but right now I'm not sure what that is.