### PR TITLE
Add health to Waybar battery tooltip

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -85,8 +85,9 @@
       "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
     },
     "format-full": "󰂅",
-    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
-    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "tooltip-format-discharging": "{power:>1.0f}W↓\n  {capacity}%\n {health}%",
+    "tooltip-format-charging": "{power:>1.0f}W↑\n  {capacity}%\n {health}%",
+    "tooltip-format-full": "  {capacity}%\n {health}%",
     "interval": 5,
     "on-click": "omarchy-menu power",
     "states": {


### PR DESCRIPTION
Changed the Waybay config for the battery to have capacity and health in the tool tip:

1. tooltip-format-full (added new)
<img width="240" height="111" alt="image" src="https://github.com/user-attachments/assets/ffbedada-a674-47b1-8b80-20843c9306ab" />

2. tooltip-format-discharging (update)

<img width="241" height="120" alt="image" src="https://github.com/user-attachments/assets/b3d75edc-ff77-4c15-8a67-120bb2afaaf5" />

3. tooltip-format-charging (update)