### PR TITLE
fix: Apple Broadcom BCM4360 for WiFi

### DIFF
--- a/install/config/hardware/fix-apple-bcm4360.sh
+++ b/install/config/hardware/fix-apple-bcm4360.sh
@@ -1,8 +1,10 @@
+#!/bin/bash
+
 # Look for BCM4360 802.11ac chipset on Apple
 echo "Checking for Apple BCM4360 wireless chipset..."
 if lspci -nnv | grep -A2 "14e4:43a0" | grep -q "106b:"; then
   echo "Apple BCM4360 detected, installing broadcom-wl driver..."
-  pacman -S --noconfirm --needed broadcom-wl dkms linux-headers
+  sudo pacman -S --noconfirm --needed broadcom-wl dkms linux-headers
 else
   echo "Apple BCM4360 not detected, skipping driver installation"
 fi


### PR DESCRIPTION
While the current code correctly detects the presence of Broadcom BCM4360 wireless chipset, the `omarchy-install.log` shows that the `pacman` installation at this point requires to be prefixed by `sudo`:

~~~
Checking for Apple BBM4360 wireless chipset...
Apple BCM4360 detected, installing broadcom-wl driver...
error: you cannot perform this operation unless you are root.
Failed: ~/.local/share/omarchy/install/config/hardware/fix-apple-bcm4360.sh (exit code: 1)
~~~

This PR adds that `sudo` prefix, which results in successful installation of required packages to make that WiFi chipset work:

<details>
  <summary>extract from the <code>/var/log/omarchy-install.log</code></summary>

~~~
Starting: ~/.local/share/omarchy/install/config/hardware/fix-apple-bcm4360.sh
Checking for Apple BCM4360 wireless chipset...
Apple BCM4360 detected, installing broadcom-wl driver...
resolving dependencies...
looking for conflicting packages...

Packages (4) pahole-1:1.30-2  broadcom-wl-6.30.223.271-645  dkms-3.2.1-1  linux-headers-6.16.6.arch1-1

Total Download Size:    54.44 MiB
Total Installed Size:  247.43 MiB

:: Proceed with installation? [Y/n] 
:: Retrieving packages...
 linux-headers-6.16.6.arch1-1-x86_64 downloading...
 broadcom-wl-6.30.223.271-645-x86_64 downloading...
 pahole-1:1.30-2-x86_64 downloading...
 dkms-3.2.1-1-any downloading...
checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
:: Processing package changes...
installing broadcom-wl...
installing dkms...
Optional dependencies for dkms
    linux-headers: build modules against the Arch kernel [pending]
    linux-lts-headers: build modules against the LTS kernel
    linux-zen-headers: build modules against the ZEN kernel
    linux-hardened-headers: build modules against the HARDENED kernel
installing pahole...
Optional dependencies for pahole
    ostra-cg: Generate call graphs from encoded traces
installing linux-headers...
:: Running post-transaction hooks...
(1/3) Arming ConditionNeedsUpdate...
(2/3) Updating module dependencies...
(3/3) Install DKMS modules
Completed: ~/.local/share/omarchy/install/config/hardware/fix-apple-bcm4360.sh
~~~
</details>

Additionally added shebang `#!/bin/bash` for consistency with other scripts.

## Testing

~~~sh
git clone -b offline-iso https://github.com/omacom-io/omarchy-iso.git
cd omarchy-iso

OMARCHY_INSTALLER_REPO=DoppioJP/omarchy \
OMARCHY_INSTALLER_REF=offline-iso-installer \
OMARCHY_CONFIGURATOR_REF=update-styling \
./bin/omarchy-iso-make
~~~

The image I have built works, but has a glitch:
_Something is not exactly right with that image. The Omarchy installer presented at the beginning has the Omarchy logo not centred and searching time zones is not available._


### Omarchy installation

I have done fresh offline installation on MacBookPro11,1 (Retina, 13-inch, Late 2013/M) from that ISO image and WiFi works 🎉 

## Complexity compression 🗜badge

<details>
<summary>This fix compresses those steps to zero</summary>

1. Start the MBP from Omarchy ISO again (because that ISO has those drivers and is capable of connecting WiFi)
2. Go to tty2
3. Do the WiFi dance

   ~~~sh
   # Remove conflicting drivers that might block the correct Broadcom driver:
   modprobe -r b43 b43legacy ssb brcmsmac bcma wl

   # Load the Broadcom `wl` driver (the proprietary Broadcom driver which works best): 
   modprobe wl
   # ip link should now show wlan0

   # Start or restart the `iwd` daemon (if it is running), because `iwctl` relies on it
   systemctl restart iwd

   iwctl
   [iwd] station wlan0 scan
   [iwd] station wlan0 connect <tab>
   [iwd] exit
   ~~~

4. Mount the installed Omarchy to /mnt:
    1. Find the root partition from your installed Omarchy system with `fdisk -l`  (`lsblk -f` will show that it is encrypted)
    2. Mount your installed Omarchy system's root partition (example below is based on `/dev/sda2` and `boot` being under `/dev/sda1`, but your partition might be named differently): 

        ~~~sh
        # Open the encrypted partition with a name (e.g., `cryptroot`) - you will be asked for the LUKS password
        sudo cryptsetup luksOpen /dev/sda2 cryptroot
        # The mapped, decrypted device will be available at /dev/mapper/cryptroot

        # Now you mount this decrypted `root` volume and `boot` volume:
        sudo mount -o subvol=@  /dev/mapper/cryptroot /mnt
        sudo mount /dev/sda1 /mnt/boot

        # Mount `home`, `log` & `pkg` volumes (maybe not needed):
        sudo mount -o subvol=@home  /dev/mapper/cryptroot /mnt/home
        sudo mount -o subvol=@log /dev/mapper/cryptroot /mnt/var/log
        sudo mount -o subvol=@pkg /dev/mapper/cryptroot /mnt/var/cache/pacman/pkg
        ~~~

5. Use pacman in the live environment to install the broadcom-wl driver (and dependencies like dkms and linux-headers as needed) onto the mounted system by chrooting into it:

   ~~~sh
   arch-chroot /mnt

   # it is executed as `root`, so no `sudo` required
   pacman -S broadcom-wl dkms linux-headers
   ~~~

6. Exit the chroot (`exit`) and `reboot now`

The module should now be installed and loaded correctly for the WiFi to just work 🤞 

</details>