### PR TITLE
feat: configurable window close confirmation

### DIFF
--- a/bin/omarchy-cmd-close-window
+++ b/bin/omarchy-cmd-close-window
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Closes the active window, with optional confirmation for configured apps
+CONFIG_FILE="$HOME/.config/omarchy/confirm-close.conf"
+CLASS="$(hyprctl activewindow -j | jq -r '.class // ""')"
+
+if ! grep -Fxq -- "$CLASS" "$CONFIG_FILE"; then
+  hyprctl dispatch killactive
+  exit 0
+fi
+
+# Confirmation is needed - tracked using a temp file
+CONFIRM_FILE="/tmp/omarchy-confirm-close-${CLASS:-global}"
+NOW="$(date +%s)"
+LAST="$(stat -c %Y "$CONFIRM_FILE" 2>/dev/null || echo 0)"
+
+# If SUPER+W pressed again within 3s, confirm and close
+if [ $((NOW - LAST)) -le 3 ]; then
+  rm -f -- "$CONFIRM_FILE"
+  hyprctl dispatch killactive
+else
+  # Otherwise: record the attempt and show a reminder
+  echo "$NOW" > "$CONFIRM_FILE"
+  swayosd-client --custom-message "SUPER + W to confirm"
+fi

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -152,7 +152,7 @@ show_setup_menu() {
   local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n󰍹  Monitors"
   [ -f ~/.config/hypr/bindings.conf ] && options="$options\n  Keybindings"
   [ -f ~/.config/hypr/input.conf ] && options="$options\n  Input"
-  options="$options\n󰱔  DNS\n  Config\n󰈷  Fingerprint\n  Fido2"
+  options="$options\n󰱔  DNS\n  Config\n󱄊  Confirm Close\n󰈷  Fingerprint\n  Fido2"
 
   case $(menu "Setup" "$options") in
   *Audio*) alacritty --class=Wiremix -e wiremix ;;
@@ -170,6 +170,7 @@ show_setup_menu() {
   *Input*) edit_in_nvim ~/.config/hypr/input.conf ;;
   *DNS*) present_terminal omarchy-setup-dns ;;
   *Config*) show_setup_config_menu ;;
+  *Close*) edit_in_nvim ~/.config/omarchy/confirm-close.conf ;;
   *Fingerprint*) present_terminal omarchy-setup-fingerprint ;;
   *Fido2*) present_terminal omarchy-setup-fido2 ;;
   *) show_main_menu ;;

--- a/config/omarchy/confirm-close.conf
+++ b/config/omarchy/confirm-close.conf
@@ -1,0 +1,9 @@
+# Window Close Confirmation Configuration
+# 
+# Add application class names (one per line) that should require confirmation 
+# before closing with SUPER+W.
+#
+# Example entries:
+# chromium
+# code
+# obsidian

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -1,5 +1,5 @@
 # Close windows
-bindd = SUPER, W, Close active window, killactive,
+bindd = SUPER, W, Close active window, exec, omarchy-cmd-close-window
 bindd = CTRL ALT, DELETE, Close all Windows, exec, omarchy-cmd-close-all-windows
 
 # Control tiling

--- a/migrations/1757633801.sh
+++ b/migrations/1757633801.sh
@@ -1,0 +1,4 @@
+echo "Create configuration file for window close confirmation"
+
+mkdir -p ~/.config/omarchy
+cp $OMARCHY_PATH/config/omarchy/confirm-close.conf ~/.config/omarchy/


### PR DESCRIPTION
Allows the user to configure apps that require a confirmation before closing with `Super + W`.

Apps that require confirmation will show an OSD message on the first `Super + W`, then closed on a second `Super + W`.



https://github.com/user-attachments/assets/0dc42d6e-7874-4bb9-ab86-3b4d3663824b

