### PR TITLE
feat: Hide cursor in screensaver

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function exit_screensaver {
+  hyprctl keyword cursor:invisible false
   pkill -x tte 2>/dev/null
   pkill -f "alacritty --class Screensaver" 2>/dev/null
   exit 0

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -15,6 +15,8 @@ fi
 
 focused=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')
 
+hyprctl keyword cursor:invisible true
+
 for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
   hyprctl dispatch focusmonitor $m
   hyprctl dispatch exec -- \


### PR DESCRIPTION
This PR hides the cursor when in screensaver mode.

The config ```cursor:invisible``` is new in Hyprland 0.51

Uses a trap to ensure the user isn't left in a desktop with no cursor

Tested on my machine with 2 displays, closing with a normal keypress, CTRL + C, CTRL + D, CTRL + \ with no issues