### PR TITLE
feat: Add `SUPER+L` shortcut for session lock

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -12,7 +12,7 @@ bindd = SUPER, D, Docker, exec, $terminal -e lazydocker
 bindd = SUPER, G, Signal, exec, uwsm app -- signal-desktop
 bindd = SUPER, O, Obsidian, exec, uwsm app -- obsidian -disable-gpu
 bindd = SUPER, slash, Passwords, exec, uwsm app -- 1password
-bindd = SUPER, L, Lock, exec, loginctl lock-session
+bindd = SUPER, L, Lock, exec, omarchy-lock-screen
 
 # If your web app url contains #, type it as ## to prevent hyperland treat it as comments
 bindd = SUPER, A, ChatGPT, exec, omarchy-launch-webapp "https://chatgpt.com"


### PR DESCRIPTION
This PR introduces a `SUPER+L` keyboard shortcut to quickly lock the current session, providing a familiar and convenient way to secure the workspace.