### PR TITLE
add command to open chromium webapp on localhost

### DIFF
--- a/bin/omarchy-launch-localhost
+++ b/bin/omarchy-launch-localhost
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    echo "Usage: omarchy-launch-localhost <port>"
+    echo "Example: omarchy-launch-localhost 3000"
+    exit 1
+fi
+
+port=$1
+
+if ! [[ "$port" =~ ^[0-9]+$ ]]; then
+    echo "Error: Port must be a number"
+    exit 1
+fi
+
+exec omarchy-launch-webapp "http://localhost:$port"

--- a/migrations/1757693534.sh
+++ b/migrations/1757693534.sh
@@ -1,0 +1,2 @@
+echo "Add Walker localhost launcher plugin"
+omarchy-refresh-walker


### PR DESCRIPTION
Devs work all the time in browses with ports

localhost:3000 etc...

But they are not yet able to use our beautiful chromium webapps

This pr has to goal to be able to easily open a chromium webapp on localhost

# Current state:

just the bin command

I've been trying to integrate it with walker, but it's harder than it seemed, so I wanted confirmation that people want this, and how to implement this. Should we do it with walker, or maybe on the omarchy-menu, or a separate tui?...

Running:
```
omarchy-launch-localhost 3000
```

Has this result:
<img width="1921" height="1201" alt="image" src="https://github.com/user-attachments/assets/b3de8abd-4440-41c9-b61a-eb2435273d4f" />

(Currently nothing is running on localhost 3000 on my computer)