### PR TITLE
Remove vestigial $passwordManager variable reference

### DIFF
--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -9,7 +9,7 @@ bindd = SUPER, T, Top, exec, $terminal -e btop
 bindd = SUPER, D, Lazy Docker, exec, $terminal -e lazydocker
 bindd = SUPER, G, Messenger, exec, $messenger
 bindd = SUPER, O, Obsidian, exec, obsidian -disable-gpu
-bindd = SUPER, slash, Password manager, exec, $passwordManager
+bindd = SUPER, slash, Password manager, exec, uwsm app -- 1password
 
 source = ~/.local/share/omarchy/default/hypr/bindings/media.conf
 source = ~/.local/share/omarchy/default/hypr/bindings/tiling.conf


### PR DESCRIPTION
`$passwordManager` is no longer defined so remove it here.