### PR TITLE
Waybar: Simple media controls via built‑in MPRIS

### DIFF
--- a/.nvimlog
+++ b/.nvimlog
@@ -1,0 +1,1 @@
+WRN 2025-09-14T20:30:49.344 ?.112200   server_start:193: Failed to start server: operation not permitted: /run/user/1000/nvim.112200.0

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -139,11 +139,12 @@ show_screenrecord_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n  Media Controls") in
   *Screensaver*) omarchy-toggle-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
   *Idle*) omarchy-toggle-idle ;;
   *Bar*) omarchy-toggle-waybar ;;
+  *Media*) omarchy-toggle-waybar-media ;;
   *) show_main_menu ;;
   esac
 }

--- a/bin/omarchy-toggle-waybar-media
+++ b/bin/omarchy-toggle-waybar-media
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+USER_CFG="$HOME/.config/waybar/config.jsonc"
+
+if [[ ! -f "$USER_CFG" ]]; then
+  echo "Waybar config not found at $USER_CFG" >&2
+  exit 1
+fi
+
+if grep -q '"modules-left"' "$USER_CFG"; then
+  if grep -q '"modules-left".*"mpris"' "$USER_CFG"; then
+    # Disable: remove mpris from modules-left
+    sed -i -E 's/("hyprland\/workspaces")\s*,\s*"mpris"/\1/g' "$USER_CFG"
+    notify-send -a omarchy "Waybar: Media controls disabled"
+  else
+    # Enable: insert after hyprland/workspaces inside modules-left
+    sed -i -E '/"modules-left"/ s/("hyprland\/workspaces")/\1, "mpris"/' "$USER_CFG"
+    notify-send -a omarchy "Waybar: Media controls enabled"
+  fi
+  omarchy-restart-waybar
+else
+  echo "Could not locate modules-left in $USER_CFG" >&2
+  exit 1
+fi
+

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -4,7 +4,7 @@
   "position": "top",
   "spacing": 0,
   "height": 26,
-  "modules-left": ["custom/omarchy", "hyprland/workspaces"],
+  "modules-left": ["custom/omarchy", "hyprland/workspaces", "mpris"],
   "modules-center": ["clock", "custom/update"],
   "modules-right": [
     "group/tray-expander",
@@ -123,6 +123,14 @@
   "custom/expand-icon": {
     "format": " ",
     "tooltip": false
+  },
+  "mpris": {
+    "format": "  {title} — {artist}",
+    "format-paused": " {title} — {artist}",
+    "max-length": 60,
+    "tooltip": false,
+    "on-click": "playerctl play-pause",
+    "on-click-right": "playerctl next"
   },
   "tray": {
     "icon-size": 12,

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -61,3 +61,8 @@ tooltip {
 .hidden {
   opacity: 0;
 }
+
+/* Space the mpris module away from workspaces */
+#mpris {
+  margin-left: 8px;
+}

--- a/migrations/1757907001.sh
+++ b/migrations/1757907001.sh
@@ -1,0 +1,15 @@
+echo "Enable Waybar mpris module (built-in)"
+
+CFG="$HOME/.config/waybar/config.jsonc"
+
+if [[ -f "$CFG" ]] && grep -q '"mpris"' "$CFG"; then
+  echo "mpris already present in Waybar config; skipping."
+  exit 0
+fi
+
+if command -v gum >/dev/null 2>&1; then
+  gum confirm "Replace current Waybar config (backup will be made) to enable the mpris module?" && omarchy-refresh-waybar || true
+else
+  echo "Replacing Waybar config to enable mpris..."
+  omarchy-refresh-waybar
+fi


### PR DESCRIPTION
- Add built‑in mpris next to workspaces (/ icons; left=play/pause, right=next).
- Separate commit: Walker toggle (Toggle → “Media Controls”) to enable/disable mpris.
- Migration: enable mpris only if missing; no‑op otherwise.
- Rationale: keep controls simple and native; the toggle helps users who prefer a cleaner bar or want to hide controls for screenshots/recording.