### PR TITLE
feat: add `format-bluetooth` option to Waybar’s PulseAudio module

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -103,6 +103,7 @@
   },
   "pulseaudio": {
     "format": "{icon}",
+    "format-bluetooth": "{icon}",
     "on-click": "alacritty --class=Wiremix -e wiremix",
     "on-click-right": "pamixer -t",
     "tooltip-format": "Playing at {volume}%",


### PR DESCRIPTION
Adds a `format-bluetooth `option to display a bluetooth icon when audio is routed through a Bluetooth device.