### PR TITLE
Add fullscreen toggle (monocle) bindings for up and down keys

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -7,6 +7,8 @@ bindd = SUPER, J, Toggle split, togglesplit, # dwindle
 bindd = SUPER, P, Pseudo window, pseudo, # dwindle
 bindd = SUPER, V, Toggle floating, togglefloating,
 bindd = SHIFT, F11, Force full screen, fullscreen, 0
+bindd = SUPER, up, Toggle full screen, fullscreen, 1 # Monocle mode
+bindd = SUPER, down, Toggle full screen, fullscreen, 1 # Monocle mode
 
 # Move focus with SUPER + arrow keys
 bindd = SUPER, left, Move focus left, movefocus, l


### PR DESCRIPTION
This PR allows the user to put a window in monocle mode by pressing Super ↓ or ↑ to toggle a window in monocle mode Fullscreen but still with a waybar, just like you only have a single window.

Video incoming.