### PR TITLE
exit if screensaver not in focus

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -21,5 +21,9 @@ while true; do
     if read -n 1 -t 3; then
       exit_screensaver
     fi
+    # Exit if screensaver is not in focus 
+    if ! hyprctl activewindow -j | jq -e '.class == "Screensaver"' >/dev/null 2>&1; then
+      exit_screensaver
+    fi
   done
 done


### PR DESCRIPTION
Fixes #1672 

Workspace switching (e.g. super+1) does not send input the the terminal which runs the screensaver. Hyperlandland keybindings never reach the terminal. So the following condition for screensaver exit has been added:

- whenever something else than the terminal which runs the screensaver is in focus -> exit 

This runs well on my local testing (single monitor). Cant speak about multi monitors - would love some support here. 


