### PR TITLE
fix: correct ANSI escape sequence in boot branch message

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -29,7 +29,7 @@ git clone "https://github.com/${OMARCHY_REPO}.git" ~/.local/share/omarchy >/dev/
 # Use custom branch if instructed, otherwise default to master
 OMARCHY_REF="${OMARCHY_REF:-master}"
 if [[ $OMARCHY_REF != "master" ]]; then
-  echo -e "\eUsing branch: $OMARCHY_REF"
+  echo -e "\e[32mUsing branch: $OMARCHY_REF\e[0m"
   cd ~/.local/share/omarchy
   git fetch origin "${OMARCHY_REF}" && git checkout "${OMARCHY_REF}"
   cd -


### PR DESCRIPTION
  The branch message had an incomplete ANSI escape sequence that was
  cutting off the first character and breaking the display formatting.

  Before: \eUsing branch: master (displayed as 'sing branch: master')
  After: \e[32mUsing branch: master\e[0m (displayed as 'Using branch: master' in green)

  This fix ensures the complete message is displayed with proper green coloring.
  
![image2](https://github.com/user-attachments/assets/bca153e1-ff70-4a76-8594-4e06ce4c57c9)
![image1](https://github.com/user-attachments/assets/c9fdc817-7e8e-4249-967c-dd8bfe18d2ef)
