### PR TITLE
feat: Add “Boot Lock” Option to Toggle Menu

### DIFF
--- a/bin/omarchy-lock-screen
+++ b/bin/omarchy-lock-screen
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check if this is being called from autostart (boot lock)
+if [[ "$1" == "--boot" ]]; then
+  # Exit early if boot lock is disabled
+  if ! [[ -f ~/.local/state/omarchy/toggles/boot-lock-enabled ]]; then
+    exit 1
+  fi
+fi
+
 # Lock the screen
 pidof hyprlock || hyprlock &
 

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -128,11 +128,12 @@ show_share_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n󰍁  Boot Lock") in
   *Screensaver*) omarchy-toggle-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
   *Idle*) omarchy-toggle-idle ;;
   *Bar*) omarchy-toggle-waybar ;;
+  *Boot*) omarchy-toggle-boot-lock ;;
   *) show_trigger_menu ;;
   esac
 }

--- a/bin/omarchy-toggle-boot-lock
+++ b/bin/omarchy-toggle-boot-lock
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+STATE_FILE=~/.local/state/omarchy/toggles/boot-lock-enabled
+
+if [[ -f $STATE_FILE ]]; then
+  rm -f $STATE_FILE
+  notify-send "󰍁 Boot lock disabled"
+else
+  mkdir -p "$(dirname $STATE_FILE)"
+  touch $STATE_FILE
+  notify-send "󰍁 Boot lock enabled"
+fi

--- a/config/hypr/autostart.conf
+++ b/config/hypr/autostart.conf
@@ -1,2 +1,5 @@
+# Boot lock if enabled
+exec-once = omarchy-lock-screen --boot
+
 # Extra autostart processes
 # exec-once = uwsm app -- my-service


### PR DESCRIPTION
This PR introduces a new Boot Lock option in the Toggle Menu, enabling users to decide whether the system should automatically lock after boot.

Currently, systems with auto-login enabled can be accessed simply by restarting, which poses a security risk — especially for devices used in public spaces.

With this change, users can enable the Boot Lock option, which automatically locks the screen once the system finishes booting. This improves security and protects user sessions on shared or public machines.