### PR TITLE
bug: figma icon link is broken

### DIFF
--- a/install/packaging/webapps.sh
+++ b/install/packaging/webapps.sh
@@ -10,6 +10,6 @@ omarchy-webapp-install "ChatGPT" https://chatgpt.com/ https://cdn.jsdelivr.net/g
 omarchy-webapp-install "YouTube" https://youtube.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/youtube.png
 omarchy-webapp-install "GitHub" https://github.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/github-light.png
 omarchy-webapp-install "X" https://x.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/x-light.png
-omarchy-webapp-install "Figma" https://figma.com/ https://www.veryicon.com/download/png/application/app-icon-7/figma-1?s=256
+omarchy-webapp-install "Figma" https://figma.com/ https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/figma.png
 omarchy-webapp-install "Discord" https://discord.com/channels/@me https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/discord.png
 omarchy-webapp-install "Zoom" https://app.zoom.us/wc/home https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/zoom.png


### PR DESCRIPTION
The icon link for the Figma webapp is broken. Use homarr-labs instead.