### PR TITLE
Looser GUI editor handling in `omarchy-launch-editor` script

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -4,10 +4,7 @@ case "${EDITOR:-nvim}" in
 nvim | vim | nano | micro | hx)
   exec setsid uwsm app -- "$TERMINAL" -e "$EDITOR" "$@"
   ;;
-code | codium | subl | gedit | kate | zeditor)
-  exec setsid uwsm app -- "$EDITOR" "$@"
-  ;;
 *)
-  exec setsid uwsm app -- "$TERMINAL" -e nvim "$@"
+  exec setsid uwsm app -- "$EDITOR" "$@"
   ;;
 esac

--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-case "$EDITOR" in
+case "${EDITOR:-nvim}" in
 nvim | vim | nano | micro | hx)
   exec setsid uwsm app -- "$TERMINAL" -e "$EDITOR" "$@"
   ;;


### PR DESCRIPTION
## Synopsis

Looser handling of `$EDITOR` in the `omarchy-launch-editor` wrapper script. Specifically:

1. If `$EDITOR` is not set, default to `nvim`
2. If `$EDITOR` is not a known/tabulated TUI editor, launch as a GUI app

See discussion [here](https://github.com/basecamp/omarchy/pull/1697/files#r2352727184) for background/motivation for these changes.