### PR TITLE
Use correct vscode theme for Matte Black

### DIFF
--- a/themes/matte-black/vscode.json
+++ b/themes/matte-black/vscode.json
@@ -1,4 +1,4 @@
 {
-  "name": "Matte Black Theme",
-  "extension": "cleanthemes.matte-black-theme"
+  "name": "MatteBlack",
+  "extension": "TahaYVR.matteblack"
 }


### PR DESCRIPTION
I published the Matte Black theme on VS Code so it now fits the theme correctly.

