### PR TITLE
Add smart region selection to omarchy-cmd-snapshot

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -8,7 +8,58 @@ if [[ ! -d "$OUTPUT_DIR" ]]; then
   exit 1
 fi
 
-pkill slurp || hyprshot -m ${1:-region} --raw |
+pkill slurp && exit 0
+
+MODE="${1:-smart}"
+
+get_rectangles() {
+  hyprctl monitors -j | jq -r '.[] | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"'
+  hyprctl clients -j | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
+}
+
+# Select based on mode
+case "$MODE" in
+  region)
+    SELECTION=$(slurp 2>/dev/null)
+    ;;
+  windows)
+    SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
+    ;;
+  fullscreen)
+    SELECTION=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"')
+    ;;
+  smart|*)
+    RECTS=$(get_rectangles)
+    SELECTION=$(echo "$RECTS" | slurp 2>/dev/null)
+
+    # If the selction area is L * W < 20, we'll assume you were trying to select whichever
+    # window or output it was inside of to prevent accidental 2px snapshots
+    if [[ "$SELECTION" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]]; then
+      if (( ${BASH_REMATCH[3]} * ${BASH_REMATCH[4]} < 20 )); then
+        click_x="${BASH_REMATCH[1]}"
+        click_y="${BASH_REMATCH[2]}"
+
+        while IFS= read -r rect; do
+          if [[ "$rect" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+) ]]; then
+            rect_x="${BASH_REMATCH[1]}"
+            rect_y="${BASH_REMATCH[2]}"
+            rect_width="${BASH_REMATCH[3]}"
+            rect_height="${BASH_REMATCH[4]}"
+
+            if (( click_x >= rect_x && click_x < rect_x+rect_width && click_y >= rect_y && click_y < rect_y+rect_height )); then
+              SELECTION="${rect_x},${rect_y} ${rect_width}x${rect_height}"
+              break
+            fi
+          fi
+        done <<< "$RECTS"
+      fi
+    fi
+    ;;
+esac
+
+[ -z "$SELECTION" ] && exit 0
+
+grim -g "$SELECTION" - |
   satty --filename - \
     --output-filename "$OUTPUT_DIR/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png" \
     --early-exit \

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -32,7 +32,7 @@ bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-d
 # Screenshots
 bindd = , PRINT, Screenshot of region, exec, omarchy-cmd-screenshot
 bindd = SHIFT, PRINT, Screenshot of window, exec, omarchy-cmd-screenshot window
-bindd = CTRL, PRINT, Screenshot of display, exec, omarchy-cmd-screenshot output
+bindd = CTRL, PRINT, Screenshot of display, exec, omarchy-cmd-screenshot fullscreen
 
 # Screen recordings
 bindd = ALT, PRINT, Screen record a region, exec, omarchy-cmd-screenrecord region

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -36,6 +36,7 @@ github-cli
 gnome-calculator
 gnome-keyring
 gnome-themes-extra
+grim
 gum
 gvfs-mtp
 gvfs-smb
@@ -44,7 +45,6 @@ hyprland
 hyprland-qtutils
 hyprlock
 hyprpicker
-hyprshot
 hyprsunset
 imagemagick
 impala


### PR DESCRIPTION
Since flipping away from the snapshot tool I proposed in #146, there's one piece that I find myself consistently missing and that's that smart region selection. So I've extracted it to re-propose just that bit here.

I hate having to deal with multiple keybinds or menus to make decisions _before_ taking a screenshot when in reality, I may change my mind on the fly. By extracting this one piece, we enable the ability to have Print Screen handle region, window, or output selection without any user prompts, inputs, or finger gymnastics. 

There is technically a decently verbose area we could remove being this bit. It's kind of hefty but serves a decent purpose in that there are occasions where when moving quickly, you'll click a window to snap but technically drag 2-3 pixels and wind up with a 2px snapshot. This insulates against that, and then figures out if the area is too small to be a viable region, what region it was within to determine your intended action.

```
# If the selction area is L * W < 20, we'll assume you were trying to select whichever
# window or output it was inside of to prevent accidental 2px snapshots
if [[ "$SELECTION" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]]; then
  if (( ${BASH_REMATCH[3]} * ${BASH_REMATCH[4]} < 20 )); then
    click_x="${BASH_REMATCH[1]}"
    click_y="${BASH_REMATCH[2]}"

    while IFS= read -r rect; do
      if [[ "$rect" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+) ]]; then
        rect_x="${BASH_REMATCH[1]}"
        rect_y="${BASH_REMATCH[2]}"
        rect_width="${BASH_REMATCH[3]}"
        rect_height="${BASH_REMATCH[4]}"

        if (( click_x >= rect_x && click_x < rect_x+rect_width && click_y >= rect_y && click_y < rect_y+rect_height )); then
          SELECTION="${rect_x},${rect_y} ${rect_width}x${rect_height}"
          break
        fi
      fi
    done <<< "$RECTS"
  fi
fi
```