### PR TITLE
feat: Keybinding to switch to the next theme

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -11,6 +11,7 @@ bindd = , XF86Calculator, Calculator, exec, gnome-calculator
 bindd = SUPER SHIFT, SPACE, Toggle top bar, exec, omarchy-toggle-waybar
 bindd = SUPER CTRL, SPACE, Next background in theme, exec, omarchy-theme-bg-next
 bindd = SUPER SHIFT CTRL, SPACE, Pick new theme, exec, omarchy-menu theme
+bindd = SUPER SHIFT CTRL, N, Toggle next theme, exec, omarchy-theme-next
 bindd = SUPER, BACKSPACE, Toggle window transparency, exec, hyprctl dispatch setprop "address:$(hyprctl activewindow -j | jq -r '.address')" opaque toggle
 
 # Notifications


### PR DESCRIPTION
Bind SUPER + SHIFT + CTRL + N to toggle the next theme.

As per the hotkey is concerned LEFT or W could be used as an alt to N.
PS : Previous theme functionality could be added if required (would require a custom omarchy-theme-previous script).