### PR TITLE
When refreshing chromium config, make sure to reinstall google accounts

### DIFF
--- a/bin/omarchy-refresh-chromium
+++ b/bin/omarchy-refresh-chromium
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+CONFIG_FILE="$HOME/.config/chromium-flags.conf"
+INSTALL_GOOGLE_ACCOUNTS=false
+
+# Check if google accounts were installed
+if [[ -f "$CONFIG_FILE" ]] && \
+  grep -q -- "--oauth2-client-id" "$CONFIG_FILE" && \
+  grep -q -- "--oauth2-client-secret" "$CONFIG_FILE"; then
+  INSTALL_GOOGLE_ACCOUNTS=true
+fi
+
+# Refresh the Chromium configuration
+omarchy-refresh-config chromium-flags.conf
+
+# Re-install Google accounts if previously configured
+if [[ "$INSTALL_GOOGLE_ACCOUNTS" == true ]]; then
+  omarchy-install-chromium-google-account
+fi

--- a/migrations/1757021485.sh
+++ b/migrations/1757021485.sh
@@ -1,3 +1,3 @@
 echo "Install Copy URL extension for Chromium"
 
-omarchy-refresh-config chromium-flags.conf
+omarchy-refresh-chromium


### PR DESCRIPTION
The ability to install google accounts was recently added in #1365 and refactored in dac34aa5e0b1d9a8e96f33ed671db58cca4a242b , which in turn edits the `chromium-flags.conf` config. 

However, future migrations of the `chromiumf-flags.conf` (e.g. #1458) will end up undoing the install and causing the end-user to debug the reason why google accounts aren't working anymore. And ultimately, having to run the install again.

To avoid that, we're introducing a `omarchy-refresh-chromium` helper that will ensure to automatically reinstall google accounts if they were present.