### PR TITLE
Float and size Calculator

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -6,6 +6,10 @@ windowrule = size 800 600, tag:floating-window
 windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
 windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open Folder|Save.*Files?|Save.*As|Save|All Files)
 
+# Calculator
+windowrule = tag +floating-window, class:org.gnome.Calculator, title:Calculator
+windowrule = maxsize 360 616, class:org.gnome.Calculator, title:Calculator
+
 # Fullscreen screensaver
 windowrule = fullscreen, class:Screensaver
 

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -5,10 +5,7 @@ windowrule = size 800 600, tag:floating-window
 
 windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
 windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open Folder|Save.*Files?|Save.*As|Save|All Files)
-
-# Calculator
-windowrule = tag +floating-window, class:org.gnome.Calculator, title:Calculator
-windowrule = maxsize 360 616, class:org.gnome.Calculator, title:Calculator
+windowrule = float, class:org.gnome.Calculator
 
 # Fullscreen screensaver
 windowrule = fullscreen, class:Screensaver


### PR DESCRIPTION
When tiled, the calculator looks goofy. This will float it and limit its size to make it look a bit better. 

<img width="1403" height="1121" alt="image" src="https://github.com/user-attachments/assets/1f3baaec-3b37-4f8a-ace3-6d7adf6049af" />
