### PR TITLE
Adds omarchy-cyclenext and bindings for custom cycling

### DIFF
--- a/bin/omarchy-cyclenext
+++ b/bin/omarchy-cyclenext
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+STATE_FILE="/tmp/hypr_alt_tab_state"
+
+case "$1" in
+    "start")
+        # Check if currently fullscreen
+        FULLSCREEN=$(hyprctl activewindow -j | jq -r '.fullscreen')
+
+        if [ "$FULLSCREEN" = "1" ] || [ "$FULLSCREEN" = "2" ]; then
+            # Store state and exit fullscreen
+            echo "$FULLSCREEN" > "$STATE_FILE"
+            hyprctl dispatch fullscreen "$FULLSCREEN"
+        fi
+
+        hyprctl dispatch cyclenext
+        ;;
+
+    "cycle")
+        # Cycle through windows based on direction flag or cyclenext by default
+        if [[ "$2" =~ ^(u|d|l|r)$ ]]; then
+            hyprctl dispatch movefocus $2
+        else
+            hyprctl dispatch cyclenext
+        fi
+        ;;
+
+    "finish")
+        # Only restore fullscreen if we came from a fullscreen state
+        if [ -f "$STATE_FILE" ]; then
+            FULLSCREEN=$(cat "$STATE_FILE")
+            hyprctl dispatch fullscreen "$FULLSCREEN"
+            rm -f "$STATE_FILE"
+        fi
+        
+        hyprctl dispatch bringactivetotop
+        ;;
+esac

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -51,9 +51,19 @@ bindd = SUPER SHIFT, up, Swap window up, swapwindow, u
 bindd = SUPER SHIFT, down, Swap window down, swapwindow, d
 
 # Cycle through applications on active workspace
-bindd = ALT, Tab, Cycle to next window, cyclenext
+bindd = ALT, Tab, Switch Windows, exec, ~/.config/hypr/scripts/alt-tab start
+bind = ALT, Tab, submap, alttab
+submap = alttab
+bind = ALT, Tab, exec, ~/.config/hypr/scripts/alt-tab cycle
+bindti = ALT, right, exec, ~/.config/hypr/scripts/alt-tab cycle r
+bindti = ALT, left, exec, ~/.config/hypr/scripts/alt-tab cycle l
+bindti = ALT, down, exec, ~/.config/hypr/scripts/alt-tab cycle d
+bindti = ALT, up, exec, ~/.config/hypr/scripts/alt-tab cycle u
+bindrti = ALT, Alt_L, exec, ~/.config/hypr/scripts/alt-tab finish
+bindrti = ALT, Alt_L, submap, reset
+submap = reset
+
 bindd = ALT SHIFT, Tab, Cycle to prev window, cyclenext, prev
-bindd = ALT, Tab, Reveal active window on top, bringactivetotop
 bindd = ALT SHIFT, Tab, Reveal active window on top, bringactivetotop
 
 # Resize active window


### PR DESCRIPTION
I like to run some apps in fullscreen mode in the same workspace, but that makes it hard to cycle through tiles when you are looking for a specific one. This changes the ALT+tab binding to temporarily leave fullscreen so you can cycle through the tiles, and upon releasing ALT it will focus on the selected tile and go back to fullscreen.


https://github.com/user-attachments/assets/46ca5ee5-1a54-421c-8b94-51507822abd4



