### PR TITLE
Include `helix` along with `hx` in `bin/omarchy-launch-editor`

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 case "${EDITOR:-nvim}" in
-nvim | vim | nano | micro | hx)
+nvim | vim | nano | micro | hx | helix)
   exec setsid uwsm app -- "$TERMINAL" -e "$EDITOR" "$@"
   ;;
 *)


### PR DESCRIPTION
When [building from source](https://docs.helix-editor.com/install.html), Helix will use the binary name `hx`. When installing from [some package managers](https://docs.helix-editor.com/package-managers.html), Helix will sometimes use the binary name `hx`, `helix` or both.

This change ensures both may be used.