### PR TITLE
Improve theme-set-vscode to support jsonc and respect symlinks

### DIFF
--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Note: We cannot use `jq` to update settings.json because it’s JSONC (allows comments),
+# which jq doesn’t support.
+
 VS_CODE_THEME="$HOME/.config/omarchy/current/theme/vscode.json"
 VS_CODE_SETTINGS="$HOME/.config/Code/User/settings.json"
 VS_CODE_SKIP_FLAG="$HOME/.local/state/omarchy/toggles/skip-vscode-theme-changes"
@@ -15,12 +18,29 @@ if omarchy-cmd-present code && [[ ! -f "$VS_CODE_SKIP_FLAG" ]]; then
       code --install-extension "$extension" >/dev/null
     fi
 
-    # Update theme in settings.json
-    jq -n --arg t "$theme_name" '(input? // {}) | .["workbench.colorTheme"] = $t' "$VS_CODE_SETTINGS" >"${VS_CODE_SETTINGS}.new"
+    # Create config file if there isn't already one
+    mkdir -p "$(dirname "$VS_CODE_SETTINGS")"
+    if [[ ! -f "$VS_CODE_SETTINGS" ]]; then
+      printf '{\n}\n' > "$VS_CODE_SETTINGS"
+    fi
+
+    # Create a `workbench.colorTheme` entry in settings.  
+    if ! grep -q '"workbench.colorTheme"' "$VS_CODE_SETTINGS"; then
+      # Insert `"workbench.colorTheme": "",` immediately after the first `{`
+      # Use sed's first-match range (0,/{/) to only replace the first `{`
+      sed -i --follow-symlinks -E '0,/\{/{s/\{/{\
+  "workbench.colorTheme": "",/}' "$VS_CODE_SETTINGS"
+    fi
+
+    # Update theme
+    sed -i --follow-symlinks -E \
+      "s/(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")/\1$theme_name\2/" \
+      "$VS_CODE_SETTINGS"
   else
     # Remove theme from settings.json when the theme doesn't have vscode support
-    jq 'del(.["workbench.colorTheme"])' "$VS_CODE_SETTINGS" >"${VS_CODE_SETTINGS}.new"
-  fi
+    if [[ -f "$VS_CODE_SETTINGS" ]]; then
+      sed -i --follow-symlinks -E '/"workbench\.colorTheme"[[:space:]]*:[^,}]*,?/d' "$VS_CODE_SETTINGS"
 
-  mv "${VS_CODE_SETTINGS}.new" "$VS_CODE_SETTINGS"
+    fi
+  fi
 fi


### PR DESCRIPTION
Improvements to the VS Code theme setup script to support

* Config files with comments, e.g. https://github.com/basecamp/omarchy/issues/1733
* Maintain symlinks 

Jsonc is tricky to parse, so there are edge cases that might not work -- but they should be fairly uncommon.  