### PR TITLE
Faster pacman calls: added --needed flag where it was missing for consistency

### DIFF
--- a/bin/omarchy-install-steam
+++ b/bin/omarchy-install-steam
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "Now pick dependencies matching your graphics card"
-sudo pacman -Syu --noconfirm steam
+sudo pacman -Syu --noconfirm --needed steam
 setsid gtk-launch steam >/dev/null 2>&1 &

--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -29,7 +29,7 @@ if [ -n "$(lspci | grep -i 'nvidia')" ]; then
   fi
 
   # force package database refresh
-  sudo pacman -Syu --noconfirm
+  sudo pacman -Syu --noconfirm --needed
 
   # Install packages
   PACKAGES_TO_INSTALL=(

--- a/install/preflight/pacman.sh
+++ b/install/preflight/pacman.sh
@@ -7,5 +7,5 @@ if [[ -n ${OMARCHY_ONLINE_INSTALL:-} ]]; then
   sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist /etc/pacman.d/mirrorlist
 
   # Refresh all repos
-  sudo pacman -Syu --noconfirm
+  sudo pacman -Syu --noconfirm --needed
 fi

--- a/migrations/1751134561.sh
+++ b/migrations/1751134561.sh
@@ -5,5 +5,5 @@ omarchy-refresh-pacman-mirrorlist
 if ! grep -q "omarchy" /etc/pacman.conf; then
   sudo sed -i '/^\[core\]/i [omarchy]\nSigLevel = Optional TrustAll\nServer = https:\/\/pkgs.omarchy.org\/$arch\n' /etc/pacman.conf
   sudo systemctl restart systemd-timesyncd
-  sudo pacman -Syu --noconfirm
+  sudo pacman -Syu --noconfirm --needed
 fi

--- a/migrations/1754515289.sh
+++ b/migrations/1754515289.sh
@@ -1,4 +1,4 @@
 echo "Update and restart Walker to resolve stuck Omarchy menu"
 
-sudo pacman -Syu --noconfirm walker-bin
+sudo pacman -Syu --noconfirm --needed walker-bin
 omarchy-restart-walker

--- a/migrations/1755795450.sh
+++ b/migrations/1755795450.sh
@@ -1,3 +1,3 @@
 echo "Ensure latest uwsm is installed"
 
-sudo pacman -Syu --noconfirm uwsm
+sudo pacman -Syu --noconfirm --needed uwsm

--- a/migrations/1756360552.sh
+++ b/migrations/1756360552.sh
@@ -4,4 +4,4 @@ sudo cp /etc/pacman.conf /etc/pacman.conf.bak
 sudo sed -i '/\[omarchy\]/,+2 d' /etc/pacman.conf
 sudo sed -i '/\[chaotic-aur\]/,+2 d' /etc/pacman.conf
 sudo bash -c 'echo -e "\n[omarchy]\nSigLevel = Optional TrustAll\nServer = https://pkgs.omarchy.org/\$arch" >> /etc/pacman.conf'
-sudo pacman -Syu --noconfirm
+sudo pacman -Syu --noconfirm --needed


### PR DESCRIPTION
My first pull request to Omarchy 🎉! Thank you for this project and this gift to the community.

The pacman `--needed` command/flag tells the Arch Linux package manager to only install packages if they are not already present or if the installed version is older than the one available. This should speed things up in cases where the latest package is already installed. 

The flag `--needed` was already present in quite a few places, but not consistently throughout all scripts.

Let me know what you think and hoping I can contribute more in the future.

