### PR TITLE
Performance tuning

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -18,3 +18,10 @@ if command -v fzf &> /dev/null; then
     source /usr/share/fzf/key-bindings.bash
   fi
 fi
+
+# Performance tuning: Fix for Arch Linux systemd user session file descriptor limit inheritance bug
+# Arch Linux systemd user sessions don't properly inherit global ulimit settings
+# This shell-level workaround ensures file descriptor limits are set correctly
+if [[ $(ulimit -n) -lt 65536 ]] 2>/dev/null; then
+  ulimit -n 65536 2>/dev/null || true
+fi

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -11,6 +11,7 @@ run_logged $OMARCHY_INSTALL/config/detect-keyboard-layout.sh
 run_logged $OMARCHY_INSTALL/config/xcompose.sh
 run_logged $OMARCHY_INSTALL/config/mise-work.sh
 run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
+run_logged $OMARCHY_INSTALL/config/system-performance.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh

--- a/install/config/system-performance.sh
+++ b/install/config/system-performance.sh
@@ -1,0 +1,35 @@
+echo "Configuring kernel performance parameters..."
+sudo mkdir -p /etc/sysctl.d
+
+sudo tee -a /etc/sysctl.d/99-sysctl.conf >/dev/null <<'EOF'
+
+# Network optimizations for Docker, databases, and web applications
+net.core.somaxconn=65536
+net.core.netdev_max_backlog=5000
+net.ipv4.tcp_max_syn_backlog=8192
+net.core.default_qdisc=fq
+net.ipv4.tcp_fastopen=3
+
+# Memory management - slightly reduce swappiness
+vm.swappiness=30
+
+# File system optimizations for development workloads
+fs.inotify.max_user_watches=524288
+fs.file-max=2097152
+
+# Process limits that prevent common development issues
+kernel.pid_max=4194304
+EOF
+
+echo "Configuring systemd resource limits..."
+sudo mkdir -p /etc/systemd/system.conf.d
+sudo tee /etc/systemd/system.conf.d/99-omarchy-limits.conf >/dev/null <<'EOF'
+[Manager]
+DefaultLimitNOFILESoft=65536
+DefaultLimitNOFILE=524288
+DefaultLimitNPROC=32768
+EOF
+
+sudo systemctl daemon-reload
+
+echo "System performance optimizations configured successfully"

--- a/migrations/1758183498.sh
+++ b/migrations/1758183498.sh
@@ -1,0 +1,14 @@
+echo "Apply system performance optimizations for development workloads"
+
+# Apply system performance optimizations for existing installations
+echo "Configuring system performance optimizations..."
+
+# Run the system performance configuration script
+bash $OMARCHY_PATH/install/config/system-performance.sh
+
+# Apply kernel parameters immediately (they will also apply on next boot)
+echo "Applying kernel parameters..."
+sudo sysctl --system >/dev/null 2>&1 || true
+
+echo "System performance optimizations applied successfully"
+echo "Note: Some optimizations may require a logout/login or reboot to take full effect"


### PR DESCRIPTION
# Add Conservative System Performance Optimizations

Adds essential performance tuning for development workloads - fixes common Docker, VS Code, and build issues.

## What it improves:

- **Fixes file watcher errors** in VS Code/webpack (`fs.inotify.max_user_watches=524288`)
- **Prevents PID exhaustion** with containers (`kernel.pid_max=4194304`)
- **Better network performance** for Docker/databases (`somaxconn=65536`, `tcp_fastopen=3`)
- **Proper file descriptor limits** for development tools (`DefaultLimitNOFILE=65536:524288`)
- **Less aggressive swapping** - reduces swap usage when RAM is available (`vm.swappiness=30` vs default 60)

## Implementation:
- Appends settings to existing `/etc/sysctl.d/99-sysctl.conf` (no new files)
- Compatible with existing SSH flakiness configuration
- Conservative settings safe for all system types
- Auto-applied on fresh installs and via migration for existing users
