### PR TITLE
New neovim plugin solution for auto-loading themes

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -28,6 +28,7 @@ omarchy-restart-waybar
 omarchy-restart-swayosd
 hyprctl reload
 pkill -SIGUSR2 btop
+pkill -SIGUSR1 nvim
 makoctl reload
 
 # Change gnome, browser, vscode themes

--- a/config/nvim/lua/plugins/chameleon.nvim
+++ b/config/nvim/lua/plugins/chameleon.nvim
@@ -1,0 +1,16 @@
+return {
+  {
+    "tahayvr/chameleon.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+      require("chameleon").setup({
+        system = {
+          symlink_path = vim.fn.expand("~/.config/omarchy/current/theme"),
+          debounce_ms = 100,
+          notify = false,
+        },
+      })
+    end,
+  },
+}

--- a/config/nvim/lua/plugins/theme.lua
+++ b/config/nvim/lua/plugins/theme.lua
@@ -1,8 +1,0 @@
-return {
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "tokyonight",
-		},
-	},
-}

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -11,9 +11,6 @@ mkdir -p ~/.config/omarchy/current
 ln -snf ~/.config/omarchy/themes/tokyo-night ~/.config/omarchy/current/theme
 ln -snf ~/.config/omarchy/current/theme/backgrounds/1-scenery-pink-lakeside-sunset-lake-landscape-scenic-panorama-7680x3215-144.png ~/.config/omarchy/current/background
 
-# Set specific app links for current theme
-ln -snf ~/.config/omarchy/current/theme/neovim.lua ~/.config/nvim/lua/plugins/theme.lua
-
 mkdir -p ~/.config/btop/themes
 ln -snf ~/.config/omarchy/current/theme/btop.theme ~/.config/btop/themes/current.theme
 

--- a/themes/catppuccin-latte/neovim.lua
+++ b/themes/catppuccin-latte/neovim.lua
@@ -1,19 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{
-		"catppuccin/nvim",
-		name = "catppuccin",
-		priority = 1000,
-		config = function()
-			require("catppuccin").setup({
-				flavour = "latte", -- other options: "mocha", "frappe", "macchiato"
-			})
-			vim.cmd.colorscheme("catppuccin-latte")
-		end,
-	},
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "catppuccin-latte",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#eff1f5",
+  bg2 = "#e6e8ec",
+  bg3 = "#dde0e5",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#4c4f69",
+  fg2 = "#5c5f77",
+  fg3 = "#6c6f85",
+  -- SELECTION
+  selbg = "#dc8a78",
+  selfg = "#eff1f5",
+  -- COMMENTS
+  comment = "#8c8fa1",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#d20f39",
+  color2 = "#40a02b",
+  color3 = "#df8e1d",
+  color4 = "#1e66f5",
+  color5 = "#ea76cb",
+  color6 = "#179299",
+  -- UI / DECORATIVE
+  uic1 = "#bcc0cc",
 }

--- a/themes/catppuccin/neovim.lua
+++ b/themes/catppuccin/neovim.lua
@@ -1,8 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "catppuccin",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#24273a",
+  bg2 = "#2e3248",
+  bg3 = "#363b52",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#cad3f5",
+  fg2 = "#a5adcb",
+  fg3 = "#8087a2",
+  -- SELECTION
+  selbg = "#f4dbd6",
+  selfg = "#24273a",
+  -- COMMENTS
+  comment = "#5b6078",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#ed8796",
+  color2 = "#a6da95",
+  color3 = "#eed49f",
+  color4 = "#8aadf4",
+  color5 = "#f5bde6",
+  color6 = "#8bd5ca",
+  -- UI / DECORATIVE
+  uic1 = "#494d64",
 }

--- a/themes/everforest/neovim.lua
+++ b/themes/everforest/neovim.lua
@@ -1,10 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{ "neanias/everforest-nvim" },
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "everforest",
-			background = "soft",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#2d353b",
+  bg2 = "#374147",
+  bg3 = "#414b51",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#d3c6aa",
+  fg2 = "#b9ae99",
+  fg3 = "#a09685",
+  -- SELECTION
+  selbg = "#475258",
+  selfg = "#d3c6aa",
+  -- COMMENTS
+  comment = "#8f9a8d",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#e67e80",
+  color2 = "#a7c080",
+  color3 = "#dbbc7f",
+  color4 = "#7fbbb3",
+  color5 = "#d699b6",
+  color6 = "#83c092",
+  -- UI / DECORATIVE
+  uic1 = "#475258",
 }

--- a/themes/gruvbox/neovim.lua
+++ b/themes/gruvbox/neovim.lua
@@ -1,9 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{ "ellisonleao/gruvbox.nvim" },
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "gruvbox",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#282828",
+  bg2 = "#32302f",
+  bg3 = "#3c3836",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#d4be98",
+  fg2 = "#bfa880",
+  fg3 = "#a9916b",
+  -- SELECTION
+  selbg = "#3c3836",
+  selfg = "#d4be98",
+  -- COMMENTS
+  comment = "#928374",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#ea6962",
+  color2 = "#a9b665",
+  color3 = "#d8a657",
+  color4 = "#7daea3",
+  color5 = "#d3869b",
+  color6 = "#89b482",
+  -- UI / DECORATIVE
+  uic1 = "#3c3836",
 }

--- a/themes/kanagawa/neovim.lua
+++ b/themes/kanagawa/neovim.lua
@@ -1,9 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{ "rebelot/kanagawa.nvim" },
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "kanagawa",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#1f1f28",
+  bg2 = "#262630",
+  bg3 = "#2d2d38",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#dcd7ba",
+  fg2 = "#c8c093",
+  fg3 = "#938aa9",
+  -- SELECTION
+  selbg = "#2d4f67",
+  selfg = "#c8c093",
+  -- COMMENTS
+  comment = "#727169",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#c34043",
+  color2 = "#76946a",
+  color3 = "#c0a36e",
+  color4 = "#7e9cd8",
+  color5 = "#957fb8",
+  color6 = "#6a9589",
+  -- UI / DECORATIVE
+  uic1 = "#727169",
 }

--- a/themes/matte-black/neovim.lua
+++ b/themes/matte-black/neovim.lua
@@ -1,9 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-  { "tahayvr/matteblack.nvim", lazy = false, priority = 1000 },
-  {
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "matteblack",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#121212",
+  bg2 = "#1b1b1b",
+  bg3 = "#242424",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#bebebe",
+  fg2 = "#a3a3a3",
+  fg3 = "#8a8a8d",
+  -- SELECTION
+  selbg = "#333333",
+  selfg = "#bebebe",
+  -- COMMENTS
+  comment = "#8a8a8d",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#D35F5F",
+  color2 = "#FFC107",
+  color3 = "#b91c1c",
+  color4 = "#e68e0d",
+  color5 = "#D35F5F",
+  color6 = "#bebebe",
+  -- UI / DECORATIVE
+  uic1 = "#333333",
 }

--- a/themes/nord/neovim.lua
+++ b/themes/nord/neovim.lua
@@ -1,9 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{ "EdenEast/nightfox.nvim" },
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "nordfox",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#2e3440",
+  bg2 = "#343c4a",
+  bg3 = "#3b4252",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#d8dee9",
+  fg2 = "#bfc5cf",
+  fg3 = "#a5abb6",
+  -- SELECTION
+  selbg = "#4c566a",
+  selfg = "#d8dee9",
+  -- COMMENTS
+  comment = "#616e88",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#bf616a",
+  color2 = "#a3be8c",
+  color3 = "#ebcb8b",
+  color4 = "#81a1c1",
+  color5 = "#b48ead",
+  color6 = "#88c0d0",
+  -- UI / DECORATIVE
+  uic1 = "#4c566a",
 }

--- a/themes/osaka-jade/neovim.lua
+++ b/themes/osaka-jade/neovim.lua
@@ -1,9 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	"ribru17/bamboo.nvim",
-	lazy = false,
-	priority = 1000,
-	config = function()
-		require("bamboo").setup({})
-		require("bamboo").load()
-	end,
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#111c18",
+  bg2 = "#182721",
+  bg3 = "#1f322a",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#C1C497",
+  fg2 = "#adb186",
+  fg3 = "#979c75",
+  -- SELECTION
+  selbg = "#23372B",
+  selfg = "#C1C497",
+  -- COMMENTS
+  comment = "#53685B",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#FF5345",
+  color2 = "#549e6a",
+  color3 = "#459451",
+  color4 = "#509475",
+  color5 = "#D2689C",
+  color6 = "#2DD5B7",
+  -- UI / DECORATIVE
+  uic1 = "#23372B",
 }

--- a/themes/ristretto/neovim.lua
+++ b/themes/ristretto/neovim.lua
@@ -1,31 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-  {
-    "gthelding/monokai-pro.nvim",
-    config = function()
-      require("monokai-pro").setup({
-        filter = "ristretto",
-        override = function()
-          return {
-            NonText = { fg = "#948a8b" },
-            MiniIconsGrey = { fg = "#948a8b" },
-	    MiniIconsRed = { fg = "#fd6883" },
-	    MiniIconsBlue = { fg = "#85dacc" },
-	    MiniIconsGreen = { fg = "#adda78" },
-	    MiniIconsYellow = { fg = "#f9cc6c" },
-	    MiniIconsOrange = { fg = "#f38d70" },
-	    MiniIconsPurple = { fg = "#a8a9eb" },
-	    MiniIconsAzure = { fg = "#a8a9eb" },
-	    MiniIconsCyan = { fg = "#85dacc" }, -- same value as MiniIconsBlue for consistency
-          }
-        end,
-      })
-      vim.cmd([[colorscheme monokai-pro]])
-    end,
-  },
-  {
-    "LazyVim/LazyVim",
-    opts = {
-      colorscheme = "monokai-pro",
-    },
-  },
+  -- BACKGROUND LAYERS (dark → lighter).
+  bg1 = "#2c2525",
+  bg2 = "#352d2d",
+  bg3 = "#3d3434",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#e6d9db",
+  fg2 = "#d1bec1",
+  fg3 = "#bca5a8",
+  -- SELECTION
+  selbg = "#403e41",
+  selfg = "#e6d9db",
+  -- COMMENTS
+  comment = "#948a8b",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#fd6883",
+  color2 = "#adda78",
+  color3 = "#f9cc6c",
+  color4 = "#f38d70",
+  color5 = "#a8a9eb",
+  color6 = "#85dacc",
+  -- UI / DECORATIVE
+  uic1 = "#403e41",
 }

--- a/themes/rose-pine/neovim.lua
+++ b/themes/rose-pine/neovim.lua
@@ -1,9 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{ "rose-pine/neovim", name = "rose-pine" },
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "rose-pine-dawn",
-		},
-	},
+  -- BACKGROUND LAYERS (light → lighter).
+  bg1 = "#faf4ed",
+  bg2 = "#f2e9e1",
+  bg3 = "#e9dfd7",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#575279",
+  fg2 = "#797593",
+  fg3 = "#9893a5",
+  -- SELECTION
+  selbg = "#dfdad9",
+  selfg = "#575279",
+  -- COMMENTS
+  comment = "#9893a5",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#b4637a",
+  color2 = "#286983",
+  color3 = "#ea9d34",
+  color4 = "#56949f",
+  color5 = "#907aa9",
+  color6 = "#d7827e",
+  -- UI / DECORATIVE
+  uic1 = "#dfdad9",
 }

--- a/themes/tokyo-night/neovim.lua
+++ b/themes/tokyo-night/neovim.lua
@@ -1,8 +1,25 @@
+-- for reference check https://github.com/tahayvr/chameleon.nvim
 return {
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "tokyonight",
-		},
-	},
+  -- BACKGROUND LAYERS (dark → darker).
+  bg1 = "#1a1b26",
+  bg2 = "#222330",
+  bg3 = "#292a37",
+  -- FOREGROUND LAYERS (bright → muted).
+  fg1 = "#a9b1d6",
+  fg2 = "#8891b2",
+  fg3 = "#69708f",
+  -- SELECTION
+  selbg = "#7aa2f7",
+  selfg = "#1a1b26",
+  -- COMMENTS
+  comment = "#444b6a",
+  -- ACCENT COLORS (syntax + UI)
+  color1 = "#f7768e",
+  color2 = "#9ece6a",
+  color3 = "#e0af68",
+  color4 = "#7aa2f7",
+  color5 = "#ad8ee6",
+  color6 = "#449dab",
+  -- UI / DECORATIVE
+  uic1 = "#32344a",
 }


### PR DESCRIPTION
As we discussed in #346 I moved all the logic for Neovim theme switching to a plugin called "Chameleon".

Now all we need is:

1. Adding the plugin to our nvim plugins folder

```lua
-- ~/.config/nvim/lua/plugins/chameleon.nvim
return {
  {
    "tahayvr/chameleon.nvim",
    lazy = false,
    priority = 1000,
    config = function()
      require("chameleon").setup({
        system = {
          symlink_path = vim.fn.expand("~/.config/omarchy/current/theme"),
          debounce_ms = 100,
          notify = false,
        },
      })
    end,
  },
}
```

2. theme `neovim.lua` files now only need to assign colors to a set of variables. Plugin looks at these variables in the `current/theme` symlink, and colors the theme based on them.

```lua
-- ~/.config/omarchy/themes/matte-black/neovim.lua

-- for reference check https://github.com/tahayvr/chameleon.nvim
return {
  -- BACKGROUND LAYERS (dark → lighter).
  bg1 = "#121212",
  bg2 = "#1b1b1b",
  bg3 = "#242424",
  -- FOREGROUND LAYERS (bright → muted).
  fg1 = "#bebebe",
  fg2 = "#a3a3a3",
  fg3 = "#8a8a8d",
  -- SELECTION
  selbg = "#333333",
  selfg = "#bebebe",
  -- COMMENTS
  comment = "#8a8a8d",
  -- ACCENT COLORS (syntax + UI)
  color1 = "#D35F5F",
  color2 = "#FFC107",
  color3 = "#b91c1c",
  color4 = "#e68e0d",
  color5 = "#D35F5F",
  color6 = "#bebebe",
  -- UI / DECORATIVE
  uic1 = "#333333",
}
```

3. Add SIGUSR command to the `omarchy-theme-set` script

```bash
pkill -SIGUSR1 nvim
```
4. Finally, we can remove the old symlink method that added a theme.lua symlink in the `nvim/lua/plugins` folder.

It works great. Let me know how it goes. 

more info about the config and how the plugin works in the repo: [chameleon.nvim](https://github.com/tahayvr/chameleon.nvim)