### PR TITLE
Expanded mime types for better out-of-the-box experience

### DIFF
--- a/install/config/mimetypes.sh
+++ b/install/config/mimetypes.sh
@@ -33,3 +33,15 @@ xdg-mime default mpv.desktop video/x-ms-asf
 xdg-mime default mpv.desktop video/x-ogm+ogg
 xdg-mime default mpv.desktop video/x-theora+ogg
 xdg-mime default mpv.desktop application/ogg
+
+# Open audio files with mpv
+xdg-mime default mpv.desktop audio/mpeg
+xdg-mime default mpv.desktop audio/x-wav
+xdg-mime default mpv.desktop audio/ogg
+xdg-mime default mpv.desktop audio/flac
+xdg-mime default mpv.desktop audio/aac
+xdg-mime default mpv.desktop audio/x-m4a
+xdg-mime default mpv.desktop audio/mp4
+
+# Open text files with nvim
+xdg-mime default nvim.desktop text/plain

--- a/install/config/mimetypes.sh
+++ b/install/config/mimetypes.sh
@@ -45,3 +45,20 @@ xdg-mime default mpv.desktop audio/mp4
 
 # Open text files with nvim
 xdg-mime default nvim.desktop text/plain
+
+# Open subtitles with nvim
+xdg-mime default nvim.desktop text/x-microdvd
+xdg-mime default nvim.desktop text/x-srt
+
+# Open markdown and code files with nvim
+xdg-mime default nvim.desktop text/markdown
+xdg-mime default nvim.desktop text/x-python
+xdg-mime default nvim.desktop text/x-javascript
+xdg-mime default nvim.desktop application/json
+xdg-mime default nvim.desktop text/csv
+
+# Open archives with pcmanfm
+xdg-mime default pcmanfm.desktop application/zip
+xdg-mime default pcmanfm.desktop application/x-tar
+xdg-mime default pcmanfm.desktop application/gzip
+xdg-mime default pcmanfm.desktop application/x-7z-compressed


### PR DESCRIPTION
Hey Omarchy team! 👋 As another small contribution to make Omarchy feel even more "ready to rock" right after install, I've added to the MIME type defaults in `install/config/mimetypes.sh`. This builds on the existing setup (like images with imv and videos with mpv) by adding sensible handlers for a few more common file types. 

Nothing groundbreaking, just some quality-of-life tweaks to save users a bit of manual config. 

#### What's New?
- **Audio Files**: Now open with mpv (e.g., MP3, WAV, OGG, FLAC)
- **Basic Text Files**: Default to nvim for quick editing (text/plain).
- **Subtitles**: Also nvim (e.g., SRT, MicroDVD).
- **Markdown & Code Files**: nvim again (Markdown, Python, JS, JSON, CSV)
- **Archives**: Handled by pcmanfm (ZIP, TAR, GZIP, 7Z)

#### Files Changed
- `install/config/mimetypes.sh` (added some lines of `xdg-mime` commands under new comment blocks)

#### Testing Notes
- Run the installer and check defaults: e.g., `xdg-mime query default text/markdown` should return `nvim.desktop`.
- No conflicts with other scripts; refreshes via `omarchy-refresh-applications` as before.

Thanks for checking it out and I'm looking forward to making more contributions.
