### PR TITLE
Fix keyboard variant detection for Hyprland configuration

### DIFF
--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -2,12 +2,27 @@
 conf="/etc/vconsole.conf"
 hyprconf="$HOME/.config/hypr/input.conf"
 
+# Extract layout and variant if they exist
+layout=""
+variant=""
+
 if grep -q '^XKBLAYOUT=' "$conf"; then
   layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $layout" "$hyprconf"
 fi
 
 if grep -q '^XKBVARIANT=' "$conf"; then
   variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\  kb_variant = $variant" "$hyprconf"
+fi
+
+# Combine layout and variant in the format Hyprland expects
+if [ -n "$layout" ]; then
+  if [ -n "$variant" ]; then
+    # Hyprland expects format like "de(mac)" for layouts with variants
+    kb_layout="${layout}(${variant})"
+  else
+    kb_layout="$layout"
+  fi
+
+  # Insert the kb_layout line before kb_options
+  sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $kb_layout" "$hyprconf"
 fi


### PR DESCRIPTION
- Combine layout and variant in correct format (e.g. de(mac))
- Fixes special characters on German Mac keyboards (e.g. @)
- Maintains backwards compatibility for non-variant layouts

Fixes #1715