### PR TITLE
Fix terminal classes to be compatible with ghostty

### DIFF
--- a/bin/omarchy-launch-about
+++ b/bin/omarchy-launch-about
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec setsid uwsm app -- alacritty --class=Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s'
+exec setsid uwsm app -- "$TERMINAL" --class=omarchy.About -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s'

--- a/bin/omarchy-launch-audio
+++ b/bin/omarchy-launch-audio
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec setsid uwsm app -- "$TERMINAL" --class=omarchy.Wiremix -e wiremix "$@"

--- a/bin/omarchy-launch-bluetooth
+++ b/bin/omarchy-launch-bluetooth
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec setsid uwsm app -- blueberry "$@"

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cmd="$*"
-exec setsid uwsm app -- alacritty --class=Omarchy --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"
+exec setsid uwsm app -- "$TERMINAL" --class=omarchy.Omarchy --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"

--- a/bin/omarchy-launch-wifi
+++ b/bin/omarchy-launch-wifi
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec setsid uwsm app -- "$TERMINAL" --class=Impala -e impala "$@"
+exec setsid uwsm app -- "$TERMINAL" --class=omarchy.Impala -e impala "$@"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -37,11 +37,11 @@ menu() {
 }
 
 terminal() {
-  alacritty --class=Omarchy -e "$@"
+  $TERMINAL --class=omarchy.Omarchy -e "$@"
 }
 
 present_terminal() {
-  omarchy-launch-floating-terminal-with-presentation $1
+  omarchy-launch-floating-terminal-with-presentation "$1"
 }
 
 open_in_editor() {
@@ -178,14 +178,14 @@ show_setup_menu() {
   options="$options\n  Defaults\n󰱔  DNS\n  Security\n  Config"
 
   case $(menu "Setup" "$options") in
-  *Audio*) $TERMINAL --class=Wiremix -e wiremix ;;
+  *Audio*) omarchy-launch-audio ;;
   *Wifi*)
     rfkill unblock wifi
     omarchy-launch-wifi
     ;;
   *Bluetooth*)
     rfkill unblock bluetooth
-    blueberry
+    omarchy-launch-bluetooth
     ;;
   *Power*) show_setup_power_menu ;;
   *Monitors*) open_in_editor ~/.config/hypr/monitors.conf ;;
@@ -291,7 +291,7 @@ show_install_ai_menu() {
   *OpenAI*) aur_install "OpenAI Codex" "openai-codex-bin" ;;
   *Gemini*) aur_install "Gemini" "gemini-cli" ;;
   *Studio*) install "LM Studio" "lmstudio" ;;
-  *Ollama*) install "Ollama" $ollama_pkg ;;
+  *Ollama*) install "Ollama" "$ollama_pkg" ;;
   *Crush*) install "Crush" "crush-bin" ;;
   *opencode*) install "opencode" "opencode" ;;
   *) show_install_menu ;;

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -100,11 +100,11 @@
     "format-disabled": "󰂲",
     "format-connected": "",
     "tooltip-format": "Devices connected: {num_connections}",
-    "on-click": "blueberry"
+    "on-click": "omarchy-launch-bluetooth"
   },
   "pulseaudio": {
     "format": "{icon}",
-    "on-click": "$TERMINAL --class=Wiremix -e wiremix",
+    "on-click": "omarchy-launch-audio",
     "on-click-right": "pamixer -t",
     "tooltip-format": "Playing at {volume}%",
     "scroll-step": 5,

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -3,7 +3,7 @@ windowrule = float, tag:floating-window
 windowrule = center, tag:floating-window
 windowrule = size 800 600, tag:floating-window
 
-windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
+windowrule = tag +floating-window, class:(blueberry.py|omarchy.Impala|omarchy.Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|omarchy.Omarchy|omarchy.About|TUI.float)
 windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open Folder|Save.*Files?|Save.*As|Save|All Files)
 
 # Fullscreen screensaver


### PR DESCRIPTION
This PR updates the class names of several bash terminal commands to
comply with the GTK `Application.id_is_valid` specification, as
described here: https://docs.gtk.org/gio/type_func.Application.id_is_valid.html

These changes ensure that the class names are compatible with ghostty, as this requires class to follow the above requirements, as described here: https://ghostty.org/docs/config/reference#class.

Some of the applications were also moved to `omarchy-launch-*` to make sure they are launched with the correct classes from anywhere.