### PR TITLE
Update omarchy-launch-about to use the default terminal

### DIFF
--- a/bin/omarchy-launch-about
+++ b/bin/omarchy-launch-about
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec setsid uwsm app -- alacritty --class=Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s'
+exec setsid uwsm app -- $TERMINAL --class=Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s'


### PR DESCRIPTION
Ive installed ghostty via "install -> terminal" - which also correctly set it as the "default" (for super+return e.g), also fast-fetch shows ghostty.

The omarchy launch about / button top left still uses alacritty, which doesnt work (for me), since Ive uninstalled it (after switching to ghostty)