### PR TITLE
Make omarchy-menu support $TERMINAL

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -37,7 +37,7 @@ menu() {
 }
 
 terminal() {
-  alacritty --class=Omarchy -e "$@"
+  $TERMINAL --class=Omarchy -e "$@"
 }
 
 present_terminal() {


### PR DESCRIPTION
# Changes
Now that `ghostty` and `kitty` can be used as default instead of `alacritty`, the user configured $TERMINAL should be used in omarchy-menu.

**Note**: The 3 "supported" terminals by omarchy, all handles `--class` (https://ghostty.org/docs/config/reference#class, https://sw.kovidgoyal.net/kitty/invocation/#options) , if new terminal would be added to supported terminals the script may be adapted:

**Reason**:
After setting up `ghostty` i have deleted `alacritty` and `omarchy-menu` was not working anymore