### PR TITLE
Fix Matte Black theme ghostty and vscode configs

### DIFF
--- a/themes/matte-black/ghostty.conf
+++ b/themes/matte-black/ghostty.conf
@@ -1,3 +1,12 @@
+background = #121212
+foreground = #BEBEBE
+
+cursor-color = #EAEAEA
+cursor-text = #121212
+
+selection-background = #333333
+selection-foreground = #EAEAEA
+
 # normal colors
 palette = 0=#333333
 palette = 1=#D35F5F

--- a/themes/matte-black/vscode.json
+++ b/themes/matte-black/vscode.json
@@ -1,4 +1,4 @@
 {
-  "name": "MatteBlack",
+  "name": "Matte Black",
   "extension": "TahaYVR.matteblack"
 }


### PR DESCRIPTION
I missed some important values in the Matte Black Ghostty theme (BG, FG, Cursor,...)