### PR TITLE
Quote Hyprland terminal cwd binding in migration

### DIFF
--- a/migrations/1758296526.sh
+++ b/migrations/1758296526.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Quote terminal cwd binding in Hyprland"
+
+HYPR_BINDINGS_FILE="$HOME/.config/hypr/bindings.conf"
+TARGET='bindd = SUPER, return, Terminal, exec, $terminal --working-directory="$(omarchy-cmd-terminal-cwd)"'
+
+if grep -Fq "$TARGET" "$HYPR_BINDINGS_FILE"; then
+  exit 0
+fi
+
+if grep -Fq 'bindd = SUPER, return, Terminal, exec, $terminal --working-directory=$(omarchy-cmd-terminal-cwd)' "$HYPR_BINDINGS_FILE"; then
+  sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal --working-directory=\$(omarchy-cmd-terminal-cwd)|bindd = SUPER, return, Terminal, exec, \$terminal --working-directory="$(omarchy-cmd-terminal-cwd)"|' "$HYPR_BINDINGS_FILE"
+elif grep -Fq 'bindd = SUPER, return, Terminal, exec, $terminal --working-directory $(omarchy-cmd-terminal-cwd)' "$HYPR_BINDINGS_FILE"; then
+  sed -i 's|bindd = SUPER, return, Terminal, exec, \$terminal --working-directory \$(omarchy-cmd-terminal-cwd)|bindd = SUPER, return, Terminal, exec, \$terminal --working-directory="$(omarchy-cmd-terminal-cwd)"|' "$HYPR_BINDINGS_FILE"
+elif grep -Fq 'bindd = SUPER, return, Terminal, exec, $terminal' "$HYPR_BINDINGS_FILE"; then
+  sed -i '/bindd = SUPER, return, Terminal, exec, \$terminal/ s|$| --working-directory="$(omarchy-cmd-terminal-cwd)"|' "$HYPR_BINDINGS_FILE"
+fi


### PR DESCRIPTION
Added a migration that rewrites the Super+Return terminal binding to include the quoted $(omarchy-cmd-terminal-cwd) helper it also handles legacy bindings that lack the helper or omit quotes, while leaving already-migrated configs untouched

Fixes this error when changing to ghostty
<img width="590" height="342" alt="screenshot-2025-09-19_09-08-00" src="https://github.com/user-attachments/assets/7c2f7999-59e5-442b-b7a7-869500a35878" />
