### PR TITLE
Hide hyperland cursor while typing

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -87,3 +87,8 @@ misc {
     disable_splash_rendering  = true
     focus_on_activate = true
 }
+
+# https://wiki.hypr.land/Configuring/Variables/#cursor
+cursor {
+    hide_on_key_press = true
+}


### PR DESCRIPTION
Set hypr config [`cursor:hide_on_key_press`](https://wiki.hypr.land/Configuring/Variables/#cursor) to true by default, to hide the cursor when you start typing so it is not in the way. I find this a nice quality of life improvement as the cursor never gets in the way when I'm typing. It's also happens to be how macOS behaves.