### PR TITLE
chore: run shellcheck on install/iso.sh

### DIFF
--- a/install/iso.sh
+++ b/install/iso.sh
@@ -1,14 +1,7 @@
 # Called by Omarchy ISO setup before starting configurator and archinstall
+# shellcheck shell=bash
 
-source "$OMARCHY_INSTALL/preflight/set-size-vars.sh"
-source "$OMARCHY_INSTALL/helpers/logo.sh"
-source "$OMARCHY_INSTALL/preflight/gum.sh"
-source "$OMARCHY_INSTALL/helpers/tail-log-output.sh"
-source "$OMARCHY_INSTALL/helpers/trap-errors.sh"
-
-source $OMARCHY_INSTALL/helpers/chroot.sh
-source $OMARCHY_INSTALL/helpers/logo.sh
-source $OMARCHY_INSTALL/helpers/gum.sh
-source $OMARCHY_INSTALL/helpers/errors.sh
-source $OMARCHY_INSTALL/helpers/logging.sh
-source $OMARCHY_INSTALL/helpers/layout.sh
+source "$OMARCHY_INSTALL/helpers/chroot.sh"
+source "$OMARCHY_INSTALL/helpers/errors.sh"
+source "$OMARCHY_INSTALL/helpers/presentation.sh"
+source "$OMARCHY_INSTALL/helpers/logging.sh"


### PR DESCRIPTION
I was reading the source and noticed these `gum.sh`, `logo.sh`, and `layout.sh` where combined into this `presentation.sh` in https://github.com/basecamp/omarchy/commit/5372393211373c1601ad257bc6f85d5cc237f36c which wasn't reflected in `iso.sh`.

The preflight scripts like `set-size-vars.sh` seemed to have been introduced in https://github.com/basecamp/omarchy/commit/8651f6d8b0f3bd03eba7d556fd07327c69360623 without any corresponding source and I couldn't find any existing/deleted/generated files with these names. Maybe that changed missed some untracked files?

At any rate, this makes shellcheck happy for this file.

Worth noting I didn't test this.