### PR TITLE
Made keybindings menu a little more human readable

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -11,30 +11,44 @@
 # - Map numeric modifier key mask to a textual rendition
 # - Output comma-separated values that the parser can understand
 dynamic_bindings() {
-  hyprctl -j binds | \
-    jq -r '.[] | {modmask, key, keycode, description, dispatcher, arg} | "\(.modmask),\(.key)@\(.keycode),\(.description),\(.dispatcher),\(.arg)"' | \
+  hyprctl -j binds |
+    jq -r '.[] | {modmask, key, keycode, description, dispatcher, arg} | "\(.modmask),\(.key)@\(.keycode),\(.description),\(.dispatcher),\(.arg)"' |
     sed -r \
-        -e 's/null//' \
-        -e 's,~/.local/share/omarchy/bin/,,' \
-        -e 's,uwsm app -- ,,' \
-        -e 's/@0//' \
-        -e 's/,@/,code:/' \
-        -e 's/^0,/,/' \
-        -e 's/^1,/SHIFT,/' \
-        -e 's/^4,/CTRL,/' \
-        -e 's/^5,/SHIFT CTRL,/' \
-        -e 's/^8,/ALT,/' \
-        -e 's/^9,/SHIFT ALT,/' \
-        -e 's/^12,/CTRL ALT,/' \
-        -e 's/^13,/SHIFT CTRL ALT,/' \
-        -e 's/^64,/SUPER,/' \
-        -e 's/^65,/SUPER SHIFT,/' \
-        -e 's/^68,/SUPER CTRL,/' \
-        -e 's/^69,/SUPER SHIFT CTRL,/' \
-        -e 's/^72,/SUPER ALT,/' \
-        -e 's/^73,/SUPER SHIFT ALT,/' \
-        -e 's/^76,/SUPER CTRL ALT,/' \
-        -e 's/^77,/SUPER SHIFT CTRL ALT,/'
+      -e 's/null//' \
+      -e 's,~/.local/share/omarchy/bin/,,' \
+      -e 's,uwsm app -- ,,' \
+      -e 's/@0//' \
+      -e 's/,@/,code:/' \
+      -e 's/,code:10,/,1,/' \
+      -e 's/,code:11,/,2,/' \
+      -e 's/,code:12,/,3,/' \
+      -e 's/,code:13,/,4,/' \
+      -e 's/,code:14,/,5,/' \
+      -e 's/,code:15,/,6,/' \
+      -e 's/,code:16,/,7,/' \
+      -e 's/,code:17,/,8,/' \
+      -e 's/,code:18,/,9,/' \
+      -e 's/,code:19,/,0,/' \
+      -e 's/,code:20,/,-,/' \
+      -e 's/,code:21,/,=,/' \
+      -e 's/^0,/,/' \
+      -e 's/,mouse:272,/,MOUSE LEFT,/' \
+      -e 's/,mouse:273,/,MOUSE RIGHT,/' \
+      -e 's/^1,/SHIFT,/' \
+      -e 's/^4,/CTRL,/' \
+      -e 's/^5,/SHIFT CTRL,/' \
+      -e 's/^8,/ALT,/' \
+      -e 's/^9,/SHIFT ALT,/' \
+      -e 's/^12,/CTRL ALT,/' \
+      -e 's/^13,/SHIFT CTRL ALT,/' \
+      -e 's/^64,/SUPER,/' \
+      -e 's/^65,/SUPER SHIFT,/' \
+      -e 's/^68,/SUPER CTRL,/' \
+      -e 's/^69,/SUPER SHIFT CTRL,/' \
+      -e 's/^72,/SUPER ALT,/' \
+      -e 's/^73,/SUPER SHIFT ALT,/' \
+      -e 's/^76,/SUPER CTRL ALT,/' \
+      -e 's/^77,/SUPER SHIFT CTRL ALT,/'
 }
 
 # Parse and format keybindings
@@ -46,7 +60,7 @@ dynamic_bindings() {
 # - Prints everything in a nicely aligned format.
 parse_bindings() {
   awk -F, '
-{
+  {
     # Combine the modifier and key (first two fields)
     key_combo = $1 " + " $2;
 
@@ -58,36 +72,35 @@ parse_bindings() {
     action = $3;
 
     if (action == "") {
-        # Reconstruct the command from the remaining fields
-        for (i = 4; i <= NF; i++) {
-            action = action $i (i < NF ? "," : "");
-        }
+      # Reconstruct the command from the remaining fields
+      for (i = 4; i <= NF; i++) {
+        action = action $i (i < NF ? "," : "");
+      }
 
-        # Clean up trailing commas, remove leading "exec, ", and trim
-        sub(/,$/, "", action);
-        gsub(/(^|,)[[:space:]]*exec[[:space:]]*,?/, "", action);
-        gsub(/^[ \t]+|[ \t]+$/, "", action);
-        gsub(/[ \t]+/, " ", key_combo);  # Collapse multiple spaces to one
+      # Clean up trailing commas, remove leading "exec, ", and trim
+      sub(/,$/, "", action);
+      gsub(/(^|,)[[:space:]]*exec[[:space:]]*,?/, "", action);
+      gsub(/^[ \t]+|[ \t]+$/, "", action);
+      gsub(/[ \t]+/, " ", key_combo);  # Collapse multiple spaces to one
 
-        # Escape XML entities
-        gsub(/&/, "\\&amp;", action);
-        gsub(/</, "\\&lt;", action);
-        gsub(/>/, "\\&gt;", action);
-        gsub(/"/, "\\&quot;", action);
-        gsub(/'"'"'/, "\\&apos;", action);
+      # Escape XML entities
+      gsub(/&/, "\\&amp;", action);
+      gsub(/</, "\\&lt;", action);
+      gsub(/>/, "\\&gt;", action);
+      gsub(/"/, "\\&quot;", action);
+      gsub(/'"'"'/, "\\&apos;", action);
     }
 
-    if (action != "") {
-        printf "%-35s → %s\n", key_combo, action;
-    }
+  if (action != "") {
+    printf "%-35s → %s\n", key_combo, action;
+  }
 }'
 }
 
 monitor_height=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .height')
 menu_height=$((monitor_height * 40 / 100))
 
-dynamic_bindings | \
-  sort -u | \
-  parse_bindings | \
+dynamic_bindings |
+  sort -u |
+  parse_bindings |
   walker --dmenu --theme keybindings -p 'Keybindings' -w 800 -h "$menu_height"
-

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -2,7 +2,7 @@
 $terminal = uwsm app -- $TERMINAL
 $browser = omarchy-launch-browser
 
-bindd = SUPER, return, Terminal, exec, $terminal --working-directory="$(omarchy-cmd-terminal-cwd)"
+bindd = SUPER, RETURN, Terminal, exec, $terminal --working-directory="$(omarchy-cmd-terminal-cwd)"
 bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window
 bindd = SUPER, B, Browser, exec, $browser
 bindd = SUPER SHIFT, B, Browser (private), exec, $browser --private
@@ -12,7 +12,7 @@ bindd = SUPER, T, Activity, exec, $terminal -e btop
 bindd = SUPER, D, Docker, exec, $terminal -e lazydocker
 bindd = SUPER, G, Signal, exec, omarchy-launch-or-focus signal "uwsm app -- signal-desktop"
 bindd = SUPER, O, Obsidian, exec, omarchy-launch-or-focus obsidian "uwsm app -- obsidian -disable-gpu --enable-wayland-ime"
-bindd = SUPER, slash, Passwords, exec, uwsm app -- 1password
+bindd = SUPER, SLASH, Passwords, exec, uwsm app -- 1password
 
 # If your web app url contains #, type it as ## to prevent hyperland treat it as comments
 bindd = SUPER, A, ChatGPT, exec, omarchy-launch-webapp "https://chatgpt.com"

--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -1,6 +1,6 @@
 # Deprecated bindings file. New installations include everything directly.
 
-bindd = SUPER, return, Terminal, exec, $terminal
+bindd = SUPER, RETURN, Terminal, exec, $terminal
 bindd = SUPER, F, File manager, exec, $fileManager
 bindd = SUPER, B, Web browser, exec, $browser
 bindd = SUPER, M, Music player, exec, $music
@@ -9,7 +9,7 @@ bindd = SUPER, T, Top, exec, $terminal -e btop
 bindd = SUPER, D, Lazy Docker, exec, $terminal -e lazydocker
 bindd = SUPER, G, Messenger, exec, $messenger
 bindd = SUPER, O, Obsidian, exec, obsidian -disable-gpu
-bindd = SUPER, slash, Password manager, exec, $passwordManager
+bindd = SUPER, SLASH, Password manager, exec, $passwordManager
 
 source = ~/.local/share/omarchy/default/hypr/bindings/media.conf
 source = ~/.local/share/omarchy/default/hypr/bindings/tiling.conf

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -10,10 +10,10 @@ bindd = SHIFT, F11, Force full screen, fullscreen, 0
 bindd = ALT, F11, Full width, fullscreen, 1
 
 # Move focus with SUPER + arrow keys
-bindd = SUPER, left, Move focus left, movefocus, l
-bindd = SUPER, right, Move focus right, movefocus, r
-bindd = SUPER, up, Move focus up, movefocus, u
-bindd = SUPER, down, Move focus down, movefocus, d
+bindd = SUPER, LEFT, Move focus left, movefocus, l
+bindd = SUPER, RIGHT, Move focus right, movefocus, r
+bindd = SUPER, UP, Move focus up, movefocus, u
+bindd = SUPER, DOWN, Move focus down, movefocus, d
 
 # Switch workspaces with SUPER + [0-9]
 bindd = SUPER, code:10, Switch to workspace 1, workspace, 1
@@ -39,22 +39,22 @@ bindd = SUPER SHIFT, code:17, Move window to workspace 8, movetoworkspace, 8
 bindd = SUPER SHIFT, code:18, Move window to workspace 9, movetoworkspace, 9
 bindd = SUPER SHIFT, code:19, Move window to workspace 10, movetoworkspace, 10
 
-# Tab between workspaces
+# TAB between workspaces
 bindd = SUPER, TAB, Next workspace, workspace, e+1
 bindd = SUPER SHIFT, TAB, Previous workspace, workspace, e-1
 bindd = SUPER CTRL, TAB, Former workspace, workspace, previous
 
 # Swap active window with the one next to it with SUPER + SHIFT + arrow keys
-bindd = SUPER SHIFT, left, Swap window to the left, swapwindow, l
-bindd = SUPER SHIFT, right, Swap window to the right, swapwindow, r
-bindd = SUPER SHIFT, up, Swap window up, swapwindow, u
-bindd = SUPER SHIFT, down, Swap window down, swapwindow, d
+bindd = SUPER SHIFT, LEFT, Swap window to the left, swapwindow, l
+bindd = SUPER SHIFT, RIGHT, Swap window to the right, swapwindow, r
+bindd = SUPER SHIFT, UP, Swap window up, swapwindow, u
+bindd = SUPER SHIFT, DOWN, Swap window down, swapwindow, d
 
 # Cycle through applications on active workspace
-bindd = ALT, Tab, Cycle to next window, cyclenext
-bindd = ALT SHIFT, Tab, Cycle to prev window, cyclenext, prev
-bindd = ALT, Tab, Reveal active window on top, bringactivetotop
-bindd = ALT SHIFT, Tab, Reveal active window on top, bringactivetotop
+bindd = ALT, TAB, Cycle to next window, cyclenext
+bindd = ALT SHIFT, TAB, Cycle to prev window, cyclenext, prev
+bindd = ALT, TAB, Reveal active window on top, bringactivetotop
+bindd = ALT SHIFT, TAB, Reveal active window on top, bringactivetotop
 
 # Resize active window
 bindd = SUPER, code:20, Expand window left, resizeactive, -100 0    # - key
@@ -63,8 +63,8 @@ bindd = SUPER SHIFT, code:20, Shrink window up, resizeactive, 0 -100
 bindd = SUPER SHIFT, code:21, Expand window down, resizeactive, 0 100
 
 # Scroll through existing workspaces with SUPER + scroll
-bindd = SUPER, mouse_down, Scroll active workspace forward, workspace, e+1
-bindd = SUPER, mouse_up, Scroll active workspace backward, workspace, e-1
+bindd = SUPER, MOUSE_DOWN, Scroll active workspace forward, workspace, e+1
+bindd = SUPER, MOUSE_UP, Scroll active workspace backward, workspace, e-1
 
 # Move/resize windows with mainMod + LMB/RMB and dragging
 bindmd = SUPER, mouse:272, Move window, movewindow

--- a/migrations/1755870033.sh
+++ b/migrations/1755870033.sh
@@ -1,5 +1,5 @@
 echo "Use current terminal shell cwd for new terminal working directories"
 
 if ! grep -q "working-directory" ~/.config/hypr/bindings.conf; then
-  sed -i '/bindd = SUPER, return, Terminal, exec, \$terminal/ s|$| --working-directory=$(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf
+  sed -i '/bindd = SUPER, RETURN, Terminal, exec, \$terminal/ s|$| --working-directory=$(omarchy-cmd-terminal-cwd)|' ~/.config/hypr/bindings.conf
 fi


### PR DESCRIPTION
I started down this trail because I wanted to change what showed up in the SUPER+K menu as code:13 to numbers that were easier for me to read. Then my OCD kicked in an I wanted to standardize capitalization on the modifier keys. I am mifted by slash and return. I cannot get them to change in the menu. I could add a sed but figured it would not hurt to get other eyes on this first. Any ideas why those do not change in the menu with the changes in this PR?