### PR TITLE
Add Lutris to Gaming installation menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -299,10 +299,11 @@ show_install_ai_menu() {
 }
 
 show_install_gaming_menu() {
-  case $(menu "Install" "  Steam\n  RetroArch [AUR]\n󰍳  Minecraft") in
+  case $(menu "Install" "  Steam\n  RetroArch [AUR]\n󰍳  Minecraft\n Lutris") in
   *Steam*) present_terminal omarchy-install-steam ;;
   *RetroArch*) aur_install_and_launch "RetroArch" "retroarch retroarch-assets libretro libretro-fbneo" "com.libretro.RetroArch.desktop" ;;
   *Minecraft*) aur_install_and_launch "Minecraft [AUR]" "minecraft-launcher" "minecraft-launcher" ;;
+  *Lutris*) aur_install_and_launch "Lutris" "lutris-git" "lutris-git" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
This PR adds Lutris to the installation menu in the gaming category, as mentioned in #1842. I’ll share more details in the issue on why I think it’s a good fit for Omarchy as a solution for non-Steam games.

I couldn’t figure out which icon font is used, so I left it without an icon for now. If someone knows, I’d be happy to add it so it matches the other options.

Fixes #1842 