### PR TITLE
Add Godot to Install Editor Menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -259,13 +259,14 @@ show_install_service_menu() {
 }
 
 show_install_editor_menu() {
-  case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Emacs") in
+  case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Emacs\n  Godot") in
   *VSCode*) install_and_launch "VSCode" "visual-studio-code-bin" "code" ;;
   *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
   *Zed*) install_and_launch "Zed" "zed" "dev.zed.Zed" ;;
   *Sublime*) aur_install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;
   *Helix*) install "Helix" "helix" ;;
   *Emacs*) install "Emacs" "emacs-wayland" && systemctl --user enable --now emacs.service ;;
+  *Godot*) install_and_launch "Godot" "godot" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
Let's make it easy to get started with game development using Godot on Omarchy!

This change will make it quick and easy to install the latest version of Godot via the install editor menu. Since most developers use (or at least start with) GDScript, I think it makes sense for the non-mono version to be the default place to start.

https://github.com/user-attachments/assets/a8255f76-00c4-449c-b1e4-06dab33b8831