### PR TITLE
Fix screen recording for multiple display setups

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -47,7 +47,7 @@ screenrecording_active() {
 if screenrecording_active; then
   stop_screenrecording
 elif [[ "$SCOPE" == "output" ]]; then
-  start_screenrecording
+  start_screenrecording -o "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')"
 else
   region=$(slurp) || exit 1
   start_screenrecording -g "$region"


### PR DESCRIPTION
Fixes #1301

ISSUE: Screen recording a display on a multiple display setup currently fails due to the output to be recorded not being specified.

FIX: Pull name of focused monitor from hyprctl and set output flag of wf-recorder / wl-screenrec