### PR TITLE
systemd-resolvconf has been added to support wg-quick out of the box

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -129,3 +129,4 @@ xournalpp
 yaru-icon-theme
 yay
 zoxide
+systemd-resolvconf


### PR DESCRIPTION
wg-quick relies on the resolvconf. The recommended solution for arch linux seems to be using systemd-resolvconf

I was troubleshooting and found [this](https://superuser.com/questions/1500691/usr-bin-wg-quick-line-31-resolvconf-command-not-found-wireguard-debian) thread about  it.

It worked perfectly.