### PR TITLE
Fixes the nvim desktop entry exec command

### DIFF
--- a/applications/nvim.desktop
+++ b/applications/nvim.desktop
@@ -2,7 +2,7 @@
 Name=Neovim
 GenericName=Text Editor
 Comment=Edit text files
-Exec=$TERMINAL --class=nvim --title=nvim -e nvim -- %F
+Exec=sh -c "$TERMINAL --class=nvim --title=nvim -e nvim -- %F"
 Terminal=false
 Type=Application
 Keywords=Text;editor;

--- a/applications/nvim.desktop
+++ b/applications/nvim.desktop
@@ -2,7 +2,7 @@
 Name=Neovim
 GenericName=Text Editor
 Comment=Edit text files
-Exec=sh -c "$TERMINAL --class=nvim --title=nvim -e nvim -- %F"
+Exec=omarchy-launch-editor %F
 Terminal=false
 Type=Application
 Keywords=Text;editor;


### PR DESCRIPTION
The desktop entries doesn't expand any ennvars, so it needs to be executed via the shell.

Edit: It uses `omarchy-launch-editor` instead of `sh`.

resolves #1852