### PR TITLE
fix: update legibility of bright green color in Osaka Jade Theme

### DIFF
--- a/themes/osaka-jade/alacritty.toml
+++ b/themes/osaka-jade/alacritty.toml
@@ -16,7 +16,7 @@ white   = "#F6F5DD"
 [colors.bright]
 black   = "#53685B"
 red     = "#db9f9c"
-green   = "#143614"
+green   = "#63b07a"
 yellow  = "#E5C736"
 blue    = "#ACD4CF"
 magenta = "#75bbb3"

--- a/themes/osaka-jade/ghostty.conf
+++ b/themes/osaka-jade/ghostty.conf
@@ -17,7 +17,7 @@ palette = 7=#F6F5DD
 # bright colors
 palette = 8=#53685B
 palette = 9=#db9f9c
-palette = 10=#143614
+palette = 10=#63b07a
 palette = 11=#E5C736
 palette = 12=#ACD4CF
 palette = 13=#75bbb3

--- a/themes/osaka-jade/kitty.conf
+++ b/themes/osaka-jade/kitty.conf
@@ -20,7 +20,7 @@ color9  #DB9F9C
 
 # green
 color2  #549E6A
-color10 #143614
+color10 #63b07a
 
 # yellow
 color3  #459451


### PR DESCRIPTION
Bright green color is hard to read on dark backgrounds. Adjusted color value for alacritty, ghostty, and kitty.

Bright green doesn't seem to be common, but it is used in the difftastic tool.