### PR TITLE
bin/omarchy-webapp-install: auto-fetch icons

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -125,9 +125,9 @@ select_best_ico_image() {
   local best_icon=""
   local max_size=0
   
-  # Find all generated PNG files from the ico extraction
+  # Find all generated PNG files from the ico extraction, excluding the target
   for icon_file in "${base_name}"-*.png; do
-    if [[ -f "$icon_file" ]]; then
+    if [[ -f "$icon_file" && "$icon_file" != "$target_png" ]]; then
       # Get the dimensions of the image
       local dimensions
       dimensions=$(magick identify -format "%wx%h" "$icon_file" 2>/dev/null || echo "0x0")
@@ -148,8 +148,12 @@ select_best_ico_image() {
   # If we found a best icon, move it to the target location
   if [[ -n "$best_icon" && -f "$best_icon" ]]; then
     mv "$best_icon" "$target_png"
-    # Clean up the other generated files
-    rm -f "${base_name}"-*.png 2>/dev/null || true
+    # Clean up the other generated files (excluding the target)
+    for file in "${base_name}"-*.png; do
+      if [[ -f "$file" && "$file" != "$target_png" ]]; then
+        rm -f "$file"
+      fi
+    done
     return 0
   fi
   
@@ -168,7 +172,7 @@ download_and_convert() {
     ext="ico"
   fi
   
-  local tmp="${png%.png}.${ext}"
+  local tmp="${png%.png}.tmp.${ext}"
   
   if curl -sfL -o "$tmp" "$url"; then
     # If it's already a PNG, just use it directly


### PR DESCRIPTION
> [!NOTE] 
> Just creating this PR so its documented incase others want to do this themselves until a valid solution is finalized. Close if needed
> 
> feel free to expand upon or correct the code

Add automatic icon discovery and helper utilities to the webapp installer #1682 

- Added URL/icon helper functions (normalize_fetch_url, get_origin, extract_icon_from_html, resolve_icon_url) to locate a site icon when none is provided.
- Added download_and_convert to fetch an icon and attempt conversion to PNG (uses ImageMagick).
- When ICON_REF is blank the script scrapes the target page for link-rel icons, falls back to /favicon.ico, resolves the final URL, downloads and saves the icon under ~/.local/share/applications/icons/.
- When ICON_REF is a URL the script downloads it directly; when it’s a local filename the script uses the file from ICON_DIR.
Improved error handling (download failures print to stderr) and ensured the icon directory exists.

## Tests
I did the following to confirm its working as intended
1)  no icon url with various of my own and well known sites
2)  providing icon url
3)  bad icon url

## Notables
The icons that are extracted from the site dont have any resolution issues from my testing. Im sure theres gonna be a site out there that will or some display that just wont play nicely. But this has been tested on a 3440x1440 & 2880x1800 with default scaling

## Images
<img width="727" height="460" alt="image" src="https://github.com/user-attachments/assets/02d728c1-7cba-44ad-ae02-17d1d69be9c9" />

<img width="720" height="462" alt="image" src="https://github.com/user-attachments/assets/4dc83664-549c-441e-93e8-bc331cb467af" />
