### PR TITLE
feat: add relaunch-required and reboot-required to waybar

### DIFF
--- a/bin/omarchy-reboot-required
+++ b/bin/omarchy-reboot-required
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Get reboot state file
+if [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
+  echo "Omarchy needs to reboot"
+  exit 0
+else
+  echo "No reboot required"
+  exit 1
+fi

--- a/bin/omarchy-relaunch-required
+++ b/bin/omarchy-relaunch-required
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Get reboot state file, no need to relaunch if we restart
+if [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
+  echo "Omarchy needs to reboot"
+  exit 1
+fi
+
+# Get relaunch state file
+if [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
+  echo "Hyprland needs a relaunch"
+  exit 0
+else
+  echo "No relaunch required"
+  exit 1
+fi

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -8,6 +8,8 @@ elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then
 
 elif [ -f "$HOME/.local/state/omarchy/relaunch-required" ]; then
   gum confirm "Updates require Hyprland relaunch. Ready?" && omarchy-state clear re*-required && uwsm stop
+else
+  omarchy-update-available-reset
 fi
 
 for file in "$HOME"/.local/state/omarchy/restart-*-required; do

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -5,7 +5,7 @@
   "spacing": 0,
   "height": 26,
   "modules-left": ["custom/omarchy", "hyprland/workspaces"],
-  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator"],
+  "modules-center": ["clock", "custom/update", "custom/reboot-required", "custom/relaunch-required", "custom/screenrecording-indicator"],
   "modules-right": [
     "group/tray-expander",
     "bluetooth",
@@ -50,6 +50,22 @@
     "tooltip-format": "Omarchy update available",
     "signal": 7,
     "interval": 3600
+  },
+
+  "custom/reboot-required": {
+    "format": "󰜉",
+    "exec": "omarchy-reboot-required",
+    "on-click": "omarchy-launch-floating-terminal-with-presentation omarchy-update-restart",
+    "tooltip-format": "Omarchy needs to reboot",
+    "signal": 7
+  },
+
+  "custom/relaunch-required": {
+    "format": "",
+    "exec": "omarchy-relaunch-required",
+    "on-click": "omarchy-launch-floating-terminal-with-presentation omarchy-update-restart",
+    "tooltip-format": "Hyprland needs to relaunch",
+    "signal": 7
   },
 
   "cpu": {

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -38,6 +38,8 @@
 #pulseaudio,
 #custom-omarchy,
 #custom-screenrecording-indicator,
+#custom-relaunch-required,
+#custom-reboot-required,
 #custom-update {
   min-width: 12px;
   margin: 0 7.5px;
@@ -51,6 +53,7 @@ tooltip {
   padding: 2px;
 }
 
+#custom-relaunch-required,
 #custom-update {
   font-size: 10px;
 }

--- a/migrations/1758455816.sh
+++ b/migrations/1758455816.sh
@@ -1,0 +1,3 @@
+echo "Add relaunch-required and reboot-required indicator to waybar"
+
+gum confirm "Replace current Waybar config (backup will be made)?" && omarchy-refresh-waybar


### PR DESCRIPTION
This PR adds icons to waybar if a relaunch or a restart is required

When updating, it gives you the option to restart (or relaunch) right away.

If you say no to defer the restart, you never got any other reminder and the states weren't cleared.

This reminds the user that a restart (or relaunch) is pending and they can choose to proceed at a convenient time for them