### PR TITLE
Use output display or region geometry to record

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -15,7 +15,7 @@ SCOPE="$1"
 AUDIO=$([[ $2 == "audio" ]] && echo "--audio")
 
 start_screenrecording() {
-  filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
+  local filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
 
   if lspci | grep -qi 'nvidia'; then
     wf-recorder $AUDIO -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@" &
@@ -47,7 +47,8 @@ screenrecording_active() {
 if screenrecording_active; then
   stop_screenrecording
 elif [[ "$SCOPE" == "output" ]]; then
-  start_screenrecording
+  output=$(slurp -o) || exit 1
+  start_screenrecording -g "$output"
 else
   region=$(slurp) || exit 1
   start_screenrecording -g "$region"


### PR DESCRIPTION
Adding this PR as a fix for #1858 

The identified issue is when using the hyprctl bindings from default/hypr/bindings/utilities.conf

```
bindd = ALT, PRINT, Screen record a region, exec, omarchy-cmd-screenrecord region
bindd = ALT SHIFT, PRINT, Screen record a region with audio, exec, omarchy-cmd-screenrecord region audio
bindd = CTRL ALT, PRINT, Screen record display, exec, omarchy-cmd-screenrecord output
bindd = CTRL ALT SHIFT, PRINT, Screen record display with audio, exec, omarchy-cmd-screenrecord output audio
```

The call to omarchy-cmd-screenrecord differentiates output versus region as the first parameter used. A conditional is used to identify if the bash script caller is expecting a region or a display output for screen recording. The region handled this as a geometry, first calling slurp, and passing it to wf-recorder or wf-screenrec. The display was calling wf-recorder or wf-screenrec without any geometry flags which had an unexpected response, always attempting to capture the region of the screen allowing no way to capture solely the display.

#### Details for reference

[wf-recorder usage](https://github.com/ammen99/wf-recorder#usage)
- wf-recorder -g "$(slurp)" -- does not include the -o that is needed

[slurp usage reference](https://github.com/emersion/slurp#example-usage)
- note the slurp -o