### PR TITLE
Use QT6, drop QT5, update "kvantum-qt5" to "kvantum"

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -89,6 +89,7 @@ power-profiles-daemon
 python-gobject
 python-poetry-core
 python-terminaltexteffects
+qt5-wayland
 qt6-wayland
 ripgrep
 satty

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -52,7 +52,7 @@ inetutils
 iwd
 jq
 kdenlive
-kvantum-qt5
+kvantum
 lazydocker
 lazygit
 less
@@ -89,7 +89,7 @@ power-profiles-daemon
 python-gobject
 python-poetry-core
 python-terminaltexteffects
-qt5-wayland
+qt6-wayland
 ripgrep
 satty
 signal-desktop

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -35,7 +35,6 @@ pipewire
 pipewire-alsa
 pipewire-jack
 pipewire-pulse
-qt5-remoteobjects
 qt6-wayland
 sassc
 snapper


### PR DESCRIPTION
Package changements:
- use QT6 version of `kvantum` instead of `kvantum-qt`
- drop QT5 for QT6 (up-to-date and better wayland integration)
in order to remove unnecessary dependencies of old packages.