### PR TITLE
Add systemd-sleep hook to restore network connectivity after resume

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -16,6 +16,7 @@ run_logged $OMARCHY_INSTALL/config/mimetypes.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/sudoless-asdcontrol.sh
 run_logged $OMARCHY_INSTALL/config/hardware/network.sh
+run_logged $OMARCHY_INSTALL/config/hardware/network-resume.sh
 run_logged $OMARCHY_INSTALL/config/hardware/set-wireless-regdom.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-fkeys.sh
 run_logged $OMARCHY_INSTALL/config/hardware/bluetooth.sh

--- a/install/config/hardware/network-resume.sh
+++ b/install/config/hardware/network-resume.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+sudo mkdir -p /etc/systemd/system-sleep
+
+sudo tee /etc/systemd/system-sleep/omarchy-network-resume >/dev/null <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+restart_service_if_present() {
+  local service="$1"
+
+  if ! systemctl list-unit-files "$service" >/dev/null 2>&1; then
+    return
+  fi
+
+  if systemctl --quiet is-enabled "$service" 2>/dev/null || \
+     systemctl --quiet is-active "$service" 2>/dev/null; then
+    systemctl restart "$service"
+  fi
+}
+
+case "${1:-}" in
+  post)
+    logger -t omarchy-network-resume "Refreshing network stack after resume"
+    restart_service_if_present systemd-networkd.service
+    restart_service_if_present iwd.service
+    ;;
+  *)
+    ;;
+esac
+EOF
+
+sudo chmod +x /etc/systemd/system-sleep/omarchy-network-resume

--- a/migrations/1758111400.sh
+++ b/migrations/1758111400.sh
@@ -1,0 +1,3 @@
+echo "Refresh networking after resume"
+
+bash "$OMARCHY_PATH/install/config/hardware/network-resume.sh"


### PR DESCRIPTION
This PR adds a `systemd-sleep` hook that restarts network services after the system resumes from sleep.

- Restarts `systemd-networkd` and `iwd` services when present and enabled.
- Resolves connectivity issues with captive portals after resume.

I've had the issue of having to fully reboot in order to reconnect to captive portals after suspend for a while now, and restarting network services on resume fixed it for me.

I’m not fully certain if restarting these services is the ideal solution or if there’s a more subtle fix, but I'm open to discussion in order to fix this in the best way possible.