### PR TITLE
fix current working directory if readlink doesn't return a valid directory

### DIFF
--- a/bin/omarchy-cmd-terminal-cwd
+++ b/bin/omarchy-cmd-terminal-cwd
@@ -5,7 +5,12 @@ terminal_pid=$(hyprctl activewindow | awk '/pid:/ {print $2}')
 shell_pid=$(pgrep -P "$terminal_pid" | head -n1)
 
 if [[ -n $shell_pid ]]; then
-  readlink -f "/proc/$shell_pid/cwd" 2>/dev/null || echo "$HOME"
+  found_cwd=$(readlink -f "/proc/$shell_pid/cwd" 2>/dev/null || echo "$HOME")
+  if [[ -d "$found_cwd" ]]; then
+    echo "$found_cwd"
+  else
+    echo "$HOME"
+  fi
 else
   echo "$HOME"
 fi


### PR DESCRIPTION
If the readlink isn't set to a valid directory then alacrity gives an error.

In my case when using Super + Return while Zed Editor is the active window then the readlink returned the same as `/proc/$shell_pid/cwd` which would fail when launching the terminal.

This update makes sure that the directory returned is a valid directory otherwise defaults you to `$HOME`

<img width="488" height="53" alt="image" src="https://github.com/user-attachments/assets/72eff091-6314-428d-91bd-799143ddbd46" />
