### PR TITLE
Add Helium browser to supported browsers list in omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -3,7 +3,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium-browser*) ;;
 *) browser="chromium.desktop" ;;
 esac
 

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -3,7 +3,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi*) ;;
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 


### PR DESCRIPTION
This PR adds Helium browser to the supported browsers list in `omarchy-launch-webapp`.