### PR TITLE
Add SSH session integration for Ghostty

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -21,4 +21,4 @@ shell-integration-features = no-cursor
 keybind = f11=toggle_fullscreen
 
 # SSH session terminfo
-shell-integration-features = ssh-env,ssh-terminfo
+shell-integration-features = ssh-env

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -19,3 +19,6 @@ shell-integration-features = no-cursor
 
 # Keyboard bindings
 keybind = f11=toggle_fullscreen
+
+# SSH session terminfo
+shell-integration-features = ssh-env,ssh-terminfo


### PR DESCRIPTION
The custom `xterm-ghostty` TERM value in Ghostty can break terminal functionality when connecting via SSH to systems that lack the matching terminfo entry.

```
$ tmux ls
missing or unsuitable terminal: xterm-ghostty
```

To address this we need to enable [shell integration](https://github.com/ghostty-org/ghostty/issues/7608) feature.
