### PR TITLE
Add alias for caffeinate command

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -26,6 +26,7 @@ alias ....='cd ../../..'
 # Tools
 alias d='docker'
 alias r='rails'
+alias caffeinate="systemd-inhibit sleep infinity"
 n() { if [ "$#" -eq 0 ]; then nvim .; else nvim "$@"; fi; }
 
 # Git


### PR DESCRIPTION
MacOS has this cool utility command, so instead of installing a new package, let's use this alias!