### PR TITLE
Add window theme to Ghostty config

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -7,6 +7,7 @@ font-style = Regular
 font-size = 9
 
 # Window
+window-theme = ghostty
 window-padding-x = 14
 window-padding-y = 14
 confirm-close-surface=false


### PR DESCRIPTION
Adds `window-theme = ghostty` to `omarchy/config/ghostty/config`, so that the current Ghostty theme is applied to the tab bar.

The Ghostty documentation for the setting is here: https://ghostty.org/docs/config/reference#window-theme. 

Without the option:

<img width="3440" height="1440" alt="screenshot-2025-09-25_20-11-51" src="https://github.com/user-attachments/assets/f3632ffe-b2ba-4754-b2ac-0bd4efc1309c" />

With the option:

<img width="3440" height="1440" alt="screenshot-2025-09-25_20-17-15" src="https://github.com/user-attachments/assets/ae34020b-7b67-4a4f-865b-f0594e4ff241" />



