### PR TITLE
Add more Mac models to SPI keyboard support

### DIFF
--- a/install/config/hardware/fix-apple-spi-keyboard.sh
+++ b/install/config/hardware/fix-apple-spi-keyboard.sh
@@ -1,14 +1,12 @@
 # Detect MacBook models that need SPI keyboard modules
-if [[ "$(cat /sys/class/dmi/id/product_name 2>/dev/null)" =~ MacBook[89],1|MacBook1[02],1|MacBookPro13,[123]|MacBookPro14,[123] ]]; then
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null)"
+if [[ "$product_name" =~ MacBook[89],1|MacBook1[02],1|MacBookPro13,[123]|MacBookPro14,[123] ]]; then
   echo "Detected MacBook with SPI keyboard"
 
   sudo pacman -S --noconfirm --needed macbook12-spi-driver-dkms
-  case "$(cat /sys/class/dmi/id/product_name 2>/dev/null)" in
-    MacBook8,1)
-      echo "MODULES=(applespi spi_pxa2xx_platform spi_pxa2xx_pci)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
-      ;;
-    MacBook9,1|MacBook1[02],1|MacBookPro13,1|MacBookPro13,2|MacBookPro13,3|MacBookPro14,1|MacBookPro14,2|MacBookPro14,3)
-      echo "MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
-      ;;
-  esac
+  if [[ "$product_name" == "MacBook8,1" ]]; then
+    echo "MODULES=(applespi spi_pxa2xx_platform spi_pxa2xx_pci)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
+  else
+    echo "MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
+  fi
 fi

--- a/install/config/hardware/fix-apple-spi-keyboard.sh
+++ b/install/config/hardware/fix-apple-spi-keyboard.sh
@@ -1,7 +1,14 @@
 # Detect MacBook models that need SPI keyboard modules
-if [[ "$(cat /sys/class/dmi/id/product_name 2>/dev/null)" =~ MacBook1[02],1|MacBookPro13,[123]|MacBookPro14,[123] ]]; then
+if [[ "$(cat /sys/class/dmi/id/product_name 2>/dev/null)" =~ MacBook[89],1|MacBook1[02],1|MacBookPro13,[123]|MacBookPro14,[123] ]]; then
   echo "Detected MacBook with SPI keyboard"
 
   sudo pacman -S --noconfirm --needed macbook12-spi-driver-dkms
-  echo "MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
+  case "$(cat /sys/class/dmi/id/product_name 2>/dev/null)" in
+    MacBook8,1)
+      echo "MODULES=(applespi spi_pxa2xx_platform spi_pxa2xx_pci)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
+      ;;
+    MacBook9,1|MacBook1[02],1|MacBookPro13,1|MacBookPro13,2|MacBookPro13,3|MacBookPro14,1|MacBookPro14,2|MacBookPro14,3)
+      echo "MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
+      ;;
+  esac
 fi


### PR DESCRIPTION
Added:

MacBook 8,1
MacBook 9,1

MacBook 8,1 uses slightly different moduels from what I can tell, so I’ve added a case statment.  Please tweak as needed.