### PR TITLE
Set waybar battery icon color according to warning and critical thresholds

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -72,3 +72,11 @@ tooltip {
 #custom-screenrecording-indicator.active {
   color: #a55555;
 }
+
+#battery.warning {
+  color: orange;
+}
+
+#battery.critical {
+  color: red;
+}


### PR DESCRIPTION
Give minimal visual feedback about the battery state by changing the waybar battery icon color according to the current battery state.

- Normal (no color change)
- Warning (orange)
- Critical (red)
