### PR TITLE
Kill correct screensaver process when locking screen  

### DIFF
--- a/bin/omarchy-lock-screen
+++ b/bin/omarchy-lock-screen
@@ -9,4 +9,4 @@ if pgrep -x "1password" >/dev/null; then
 fi
 
 # Avoid running screensaver when locked
-pkill -f "$TERMINAL --class Screensaver"
+pkill -f "alacritty --class Screensaver"


### PR DESCRIPTION
/bin/omarchy-launch-screensaver uses alacritty and /bin/omarchy-lock-screen uses $TERMINAL