### PR TITLE
Fix: Allow passing flags/arguments to omarchy-launch-or-focus-webapp script

### DIFF
--- a/bin/omarchy-launch-or-focus-webapp
+++ b/bin/omarchy-launch-or-focus-webapp
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 if (($# == 0)); then
-  echo "Usage: omarchy-launch-or-focus-webapp [window-pattern] [url]"
+  echo "Usage: omarchy-launch-or-focus-webapp [window-pattern] [url-and-flags...]"
   exit 1
 fi
 
-exec omarchy-launch-or-focus "$1" "omarchy-launch-webapp '$2'"
+WINDOW_PATTERN="$1"
+shift
+LAUNCH_COMMAND="omarchy-launch-webapp $@"
+
+exec omarchy-launch-or-focus "$WINDOW_PATTERN" "$LAUNCH_COMMAND"


### PR DESCRIPTION
What it solves: 
This change addresses the reported issue where the omarchy-launch-or-focus-webapp script failed to correctly process and pass additional flags, such as --profile-directory, to the underlying web app launcher. This resulted in web apps not opening with the intended user profile or configuration. 

How it works: The script is modified to use shift to correctly separate the [window-pattern] from the subsequent arguments ([url] [flags...]). It then passes all remaining arguments as the single launch command to omarchy-launch-or-focus. 

Related Issue: Closes #1977