### PR TITLE
Create a wiremix configuration to display GoXLRMini names

### DIFF
--- a/default/wiremix/wiremix.toml
+++ b/default/wiremix/wiremix.toml
@@ -1,0 +1,6 @@
+# Configuration reference: https://github.com/tsowell/wiremix/blob/05a40ca2a147ce3e015802acc62b2e7bb3711bde/wiremix.toml#L141
+[[names.overrides]]
+types     = [ "endpoint" ]
+property  = "node:node.nick"
+value     = "GoXLRMini"
+templates = [ "{node:node.description}" ]


### PR DESCRIPTION
Suggested solution for #1988 

GoXLRMini device reports generic name for individual audio devices (Chat, Game, Music, Sample, etc). This patch allows the endpoint device name to be displayed uniquely "GoXLR Game" in the Wiremix playback tab instead of only as "GoXLRMini."

**Before**

<img width="2560" height="1440" alt="screenshot-2025-09-26_13-25-56" src="https://github.com/user-attachments/assets/3f794330-3cd2-4615-925e-57e78c936241" />

**After**

<img width="2560" height="1440" alt="screenshot-2025-09-26_13-25-36" src="https://github.com/user-attachments/assets/580be93a-b301-43d2-bf49-c81c44857525" />


This may relate to other audio devices that can also be configured over time.

### Wiremix configuration reference

https://crates.io/crates/wiremix#names