### PR TITLE
fix(battery): handle multiple batteries in low-battery notifier

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -5,28 +5,39 @@
 BATTERY_THRESHOLD=10
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
 
-get_battery_percentage() {
-  upower -i "$(upower -e | grep 'BAT')" \
-  | awk -F: '/percentage/ {
-      gsub(/[%[:space:]]/, "", $2);
-      val=$2;
-      printf("%d\n", (val+0.5))
-      exit
-    }'
-}
+get_battery_percentages() {
+  local batteries=($(upower -e | grep 'BAT'))
+  local min_percent=101  # Start higher than 100 to ensure update if discharging found
+  local discharging_found=false
 
-get_battery_state() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}'
+  for bat in "${batteries[@]}"; do
+    local percent=$(upower -i "$bat" | awk -F: '/percentage/ {
+        gsub(/[%[:space:]]/, "", $2);
+        val=$2;
+        printf("%d\n", (val+0.5))
+      }')
+    local state=$(upower -i "$bat" | grep -E "state" | awk '{print $2}')
+
+    if [[ "$state" == "discharging" && "$percent" -lt "$min_percent" ]]; then
+      min_percent="$percent"
+      discharging_found=true
+    fi
+  done
+
+  if [[ "$discharging_found" == true ]]; then
+    echo "$min_percent"
+  else
+    echo "999"  # High value to skip alert
+  fi
 }
 
 send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
 }
 
-BATTERY_LEVEL=$(get_battery_percentage)
-BATTERY_STATE=$(get_battery_state)
+BATTERY_LEVEL=$(get_battery_percentages)
 
-if [[ "$BATTERY_STATE" == "discharging" && "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
+if [[ "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
   if [[ ! -f "$NOTIFICATION_FLAG" ]]; then
     send_notification "$BATTERY_LEVEL"
     touch "$NOTIFICATION_FLAG"


### PR DESCRIPTION
The low-battery notification script fails on multi-battery laptops due to malformed `upower` args from multiple device paths.

**Changes:**
- Loop over batteries to compute min discharging percentage.
- Alert only if below threshold; skip if none discharging.
- No behavior change for single-battery setups.

Code handles edge cases (no batteries, all charging). Tested on simulated dual-battery env.