### PR TITLE
Update Zed install to include Omazed (theme sync package) install and setup

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -262,7 +262,7 @@ show_install_editor_menu() {
   case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Emacs") in
   *VSCode*) install_and_launch "VSCode" "visual-studio-code-bin" "code" ;;
   *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
-  *Zed*) install_and_launch "Zed" "zed" "dev.zed.Zed" ;;
+  *Zed*) present_terminal "echo 'Installing Zed...'; sudo pacman -S --noconfirm zed && yay -S --noconfirm omazed && omazed setup && setsid gtk-launch dev.zed.Zed" ;;
   *Sublime*) aur_install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;
   *Helix*) install "Helix" "helix" ;;
   *Emacs*) install "Emacs" "emacs-wayland" && systemctl --user enable --now emacs.service ;;


### PR DESCRIPTION
This PR adds automatic installation of [Omazed](https://github.com/APS6/omazed).

PS: This is my first time making a PR.

Omazed is a lightweight Bash + systemd package that:

- Automatically syncs Zed’s theme with your current Omarchy theme.
- Includes the 11 default Omarchy themes.
- Generates custom Zed themes from Alacritty configs on the fly (fast with bash).

As a Zed user myself I wanted to make the experience better for everyone and not just me. Since theme switching for all apps was previously considered out of scope in #719,  I decided to make a separate, opt-in package. The goal was to keep it as **lightweight** and **easy to set up** as possible.

### How it works

- A systemd service uses inotify-tools to watch the current Omarchy theme.
- On change, it runs a simple Bash script to update Zed’s theme.
- Resource usage is very low (about 5 MB of memory in my testing):
<img width="482" height="34" alt="omazed in btop. using only 5MB memory" src="https://github.com/user-attachments/assets/f506a1a6-b866-425a-a583-1b83368a7308" />

To make the install simple I added the package to **AUR** so that everything can be setup **in seconds** with `yay -S omazed && omazed setup`

### Demo
Video of theme sync in action, including external themes:
https://github.com/user-attachments/assets/4266c939-d992-4551-b87f-d8feddc78572

Auto-generated Sakura theme (from Alacritty) in Zed:
<img width="1921" height="1177" alt="Automatically generated sakura theme" src="https://github.com/user-attachments/assets/c168adef-3cf8-4fef-b2da-c8edb4da0864" />

### Change in this PR

The Zed installer entry now also installs and sets up Omazed:
`*Zed*) present_terminal "echo 'Installing Zed...'; sudo pacman -S --noconfirm zed && yay -S --noconfirm omazed && omazed setup && setsid gtk-launch dev.zed.Zed" ;;`

That's it! Omazed handles everything else.

This way, users who choose Zed from the Omarchy installer get theme sync out of the box. Omarchy itself carries **no extra burden** since Omazed is fetched from the AUR.

Omazed is **MIT-licensed and open source**, so changes or improvements can be made freely.

### Proposal
To make Omazed even lighter, I’d like to propose either:
- A file that always contains the current theme name (not a symlink), so I can drop the inotify-tools dependency and switch to systemd.path, or
- Even better, a way to hook into omarchy-theme-set directly, removing the need for file watching entirely.
