### PR TITLE
Theme support for Cursor

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -30,9 +30,10 @@ hyprctl reload
 pkill -SIGUSR2 btop
 makoctl reload
 
-# Change gnome, browser, vscode themes
+# Change gnome, browser, vscode, cursor themes
 omarchy-theme-set-terminal
 omarchy-theme-set-gnome
 omarchy-theme-set-eza
 omarchy-theme-set-browser
 omarchy-theme-set-vscode
+omarchy-theme-set-cursor

--- a/bin/omarchy-theme-set-cursor
+++ b/bin/omarchy-theme-set-cursor
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Note: We cannot use `jq` to update settings.json because it’s JSONC (allows comments),
+# which jq doesn’t support.
+
+CURSOR_THEME="$HOME/.config/omarchy/current/theme/vscode.json"
+CURSOR_SETTINGS="$HOME/.config/Cursor/User/settings.json"
+CURSOR_SKIP_FLAG="$HOME/.local/state/omarchy/toggles/skip-cursor-theme-changes"
+
+if omarchy-cmd-present cursor && [[ ! -f "$CURSOR_SKIP_FLAG" ]]; then
+  if [[ -f "$CURSOR_THEME" ]]; then
+    theme_name=$(jq -r '.name' "$CURSOR_THEME")
+    extension=$(jq -r '.extension' "$CURSOR_THEME")
+
+    # Install Cursor theme extension
+    if [[ -n "$extension" ]] && ! cursor --list-extensions | grep -Fxq "$extension"; then
+      notify-send "   Installing Cursor theme for $theme_name"
+      cursor --install-extension "$extension" >/dev/null
+    fi
+
+    # Create config file if there isn't already one
+    mkdir -p "$(dirname "$CURSOR_SETTINGS")"
+    if [[ ! -f "$CURSOR_SETTINGS" ]]; then
+      printf '{\n}\n' > "$CURSOR_SETTINGS"
+    fi
+
+    # Create a `workbench.colorTheme` entry in settings.
+    if ! grep -q '"workbench.colorTheme"' "$CURSOR_SETTINGS"; then
+      # Insert `"workbench.colorTheme": "",` immediately after the first `{`
+      # Use sed's first-match range (0,/{/) to only replace the first `{`
+      sed -i --follow-symlinks -E '0,/\{/{s/\{/{\
+  "workbench.colorTheme": "",/}' "$CURSOR_SETTINGS"
+    fi
+
+    # Update theme
+    sed -i --follow-symlinks -E \
+      "s/(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")/\1$theme_name\2/" \
+      "$CURSOR_SETTINGS"
+  else
+    # Remove theme from settings.json when the theme doesn't have cursor support
+    if [[ -f "$CURSOR_SETTINGS" ]]; then
+      sed -i --follow-symlinks -E '/"workbench\.colorTheme"[[:space:]]*:[^,}]*,?/d' "$CURSOR_SETTINGS"
+    fi
+  fi
+fi

--- a/bin/omarchy-theme-set-cursor
+++ b/bin/omarchy-theme-set-cursor
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Call the VSCode theme setter with Cursor-specific parameters
-"$(dirname "$0")/omarchy-theme-set-vscode" cursor "$HOME/.config/Cursor/User/settings.json" "$HOME/.local/state/omarchy/toggles/skip-cursor-theme-changes" Cursor
+omarchy-theme-set-vscode cursor "$HOME/.config/Cursor/User/settings.json" "$HOME/.local/state/omarchy/toggles/skip-cursor-theme-changes" Cursor

--- a/bin/omarchy-theme-set-cursor
+++ b/bin/omarchy-theme-set-cursor
@@ -1,45 +1,4 @@
 #!/bin/bash
 
-# Note: We cannot use `jq` to update settings.json because it’s JSONC (allows comments),
-# which jq doesn’t support.
-
-CURSOR_THEME="$HOME/.config/omarchy/current/theme/vscode.json"
-CURSOR_SETTINGS="$HOME/.config/Cursor/User/settings.json"
-CURSOR_SKIP_FLAG="$HOME/.local/state/omarchy/toggles/skip-cursor-theme-changes"
-
-if omarchy-cmd-present cursor && [[ ! -f "$CURSOR_SKIP_FLAG" ]]; then
-  if [[ -f "$CURSOR_THEME" ]]; then
-    theme_name=$(jq -r '.name' "$CURSOR_THEME")
-    extension=$(jq -r '.extension' "$CURSOR_THEME")
-
-    # Install Cursor theme extension
-    if [[ -n "$extension" ]] && ! cursor --list-extensions | grep -Fxq "$extension"; then
-      notify-send "   Installing Cursor theme for $theme_name"
-      cursor --install-extension "$extension" >/dev/null
-    fi
-
-    # Create config file if there isn't already one
-    mkdir -p "$(dirname "$CURSOR_SETTINGS")"
-    if [[ ! -f "$CURSOR_SETTINGS" ]]; then
-      printf '{\n}\n' > "$CURSOR_SETTINGS"
-    fi
-
-    # Create a `workbench.colorTheme` entry in settings.
-    if ! grep -q '"workbench.colorTheme"' "$CURSOR_SETTINGS"; then
-      # Insert `"workbench.colorTheme": "",` immediately after the first `{`
-      # Use sed's first-match range (0,/{/) to only replace the first `{`
-      sed -i --follow-symlinks -E '0,/\{/{s/\{/{\
-  "workbench.colorTheme": "",/}' "$CURSOR_SETTINGS"
-    fi
-
-    # Update theme
-    sed -i --follow-symlinks -E \
-      "s/(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")/\1$theme_name\2/" \
-      "$CURSOR_SETTINGS"
-  else
-    # Remove theme from settings.json when the theme doesn't have cursor support
-    if [[ -f "$CURSOR_SETTINGS" ]]; then
-      sed -i --follow-symlinks -E '/"workbench\.colorTheme"[[:space:]]*:[^,}]*,?/d' "$CURSOR_SETTINGS"
-    fi
-  fi
-fi
+# Call the VSCode theme setter with Cursor-specific parameters
+"$(dirname "$0")/omarchy-theme-set-vscode" cursor "$HOME/.config/Cursor/User/settings.json" "$HOME/.local/state/omarchy/toggles/skip-cursor-theme-changes" Cursor

--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -3,43 +3,47 @@
 # Note: We cannot use `jq` to update settings.json because it’s JSONC (allows comments),
 # which jq doesn’t support.
 
-VS_CODE_THEME="$HOME/.config/omarchy/current/theme/vscode.json"
-VS_CODE_SETTINGS="$HOME/.config/Code/User/settings.json"
-VS_CODE_SKIP_FLAG="$HOME/.local/state/omarchy/toggles/skip-vscode-theme-changes"
+# Parameters: EDITOR_CMD SETTINGS_PATH SKIP_FLAG EDITOR_NAME
+EDITOR_CMD="${1:-code}"
+SETTINGS_PATH="${2:-$HOME/.config/Code/User/settings.json}"
+SKIP_FLAG="${3:-$HOME/.local/state/omarchy/toggles/skip-vscode-theme-changes}"
+EDITOR_NAME="${4:-VS Code}"
 
-if omarchy-cmd-present code && [[ ! -f "$VS_CODE_SKIP_FLAG" ]]; then
+VS_CODE_THEME="$HOME/.config/omarchy/current/theme/vscode.json"
+
+if omarchy-cmd-present "$EDITOR_CMD" && [[ ! -f "$SKIP_FLAG" ]]; then
   if [[ -f "$VS_CODE_THEME" ]]; then
     theme_name=$(jq -r '.name' "$VS_CODE_THEME")
     extension=$(jq -r '.extension' "$VS_CODE_THEME")
 
-    # Install VS Code theme extension
-    if [[ -n "$extension" ]] && ! code --list-extensions | grep -Fxq "$extension"; then
-      notify-send "   Installing VS Code theme for $theme_name"
-      code --install-extension "$extension" >/dev/null
+    # Install $EDITOR_NAME theme extension
+    if [[ -n "$extension" ]] && ! "$EDITOR_CMD" --list-extensions | grep -Fxq "$extension"; then
+      notify-send "   Installing $EDITOR_NAME theme for $theme_name"
+      "$EDITOR_CMD" --install-extension "$extension" >/dev/null
     fi
 
     # Create config file if there isn't already one
-    mkdir -p "$(dirname "$VS_CODE_SETTINGS")"
-    if [[ ! -f "$VS_CODE_SETTINGS" ]]; then
-      printf '{\n}\n' > "$VS_CODE_SETTINGS"
+    mkdir -p "$(dirname "$SETTINGS_PATH")"
+    if [[ ! -f "$SETTINGS_PATH" ]]; then
+      printf '{\n}\n' > "$SETTINGS_PATH"
     fi
 
-    # Create a `workbench.colorTheme` entry in settings.  
-    if ! grep -q '"workbench.colorTheme"' "$VS_CODE_SETTINGS"; then
+    # Create a `workbench.colorTheme` entry in settings.
+    if ! grep -q '"workbench.colorTheme"' "$SETTINGS_PATH"; then
       # Insert `"workbench.colorTheme": "",` immediately after the first `{`
       # Use sed's first-match range (0,/{/) to only replace the first `{`
       sed -i --follow-symlinks -E '0,/\{/{s/\{/{\
-  "workbench.colorTheme": "",/}' "$VS_CODE_SETTINGS"
+  "workbench.colorTheme": "",/}' "$SETTINGS_PATH"
     fi
 
     # Update theme
     sed -i --follow-symlinks -E \
       "s/(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")/\1$theme_name\2/" \
-      "$VS_CODE_SETTINGS"
+      "$SETTINGS_PATH"
   else
-    # Remove theme from settings.json when the theme doesn't have vscode support
-    if [[ -f "$VS_CODE_SETTINGS" ]]; then
-      sed -i --follow-symlinks -E '/"workbench\.colorTheme"[[:space:]]*:[^,}]*,?/d' "$VS_CODE_SETTINGS"
+    # Remove theme from settings.json when the theme doesn't have $EDITOR_NAME support
+    if [[ -f "$SETTINGS_PATH" ]]; then
+      sed -i --follow-symlinks -E '/"workbench\.colorTheme"[[:space:]]*:[^,}]*,?/d' "$SETTINGS_PATH"
 
     fi
   fi


### PR DESCRIPTION
Just copied `omarchy-theme-set-vscode`. Reading the `vscode.json` file in the themes because VSCode themes will work in Cursor and then omarchy-themes do not need to explicitly add `cursor.json`.