### PR TITLE
feat(catppuccin): use mauve color for hyprland border

### DIFF
--- a/themes/catppuccin/hyprland.conf
+++ b/themes/catppuccin/hyprland.conf
@@ -1,3 +1,3 @@
 general {
-    col.active_border = rgb(c6d0f5)
+    col.active_border = rgb(cba6f7)
 }


### PR DESCRIPTION
this pr use catppuccin mauve as borders color, this is default for most catppuccin mocha style and more comfy to look at