### PR TITLE
Add support for older printers via gutenprint

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -36,6 +36,7 @@ gnome-calculator
 gnome-keyring
 gnome-themes-extra
 gum
+gutenprint
 gvfs-mtp
 gvfs-smb
 hypridle


### PR DESCRIPTION
In the spirit of extending life of perfectly functional, just a bit older, hardware, gutenprint (previously gimp-print) allows CUPS to work with many older printers: https://gimp-print.sourceforge.io/p_Supported_Printers.php

After installing gutenprint, I was able to successfully find my printer (HP LaserJet 1320) and print a few pages:
<img width="1367" height="395" alt="image" src="https://github.com/user-attachments/assets/97cf5462-357a-4c33-a98d-f813eca4aaed" />

Having out of the box printing experience using older printers and Omarchy would be very pleasant.
However, is gutenprint something that merits joining the base packages, or better to have it as an optional install via walker, or just as it is now - via normal Arch package installation?