### PR TITLE
feat: clear states when relaunching or rebooting from the system menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -451,9 +451,9 @@ show_system_menu() {
   *Lock*) omarchy-lock-screen ;;
   *Screensaver*) omarchy-launch-screensaver force ;;
   *Suspend*) systemctl suspend ;;
-  *Relaunch*) uwsm stop ;;
-  *Restart*) systemctl reboot ;;
-  *Shutdown*) systemctl poweroff ;;
+  *Relaunch*) omarchy-state clear relaunch-required && uwsm stop ;;
+  *Restart*) omarchy-state clear re*-required && systemctl reboot ;;
+  *Shutdown*) omarchy-state clear re*-required && systemctl poweroff ;;
   *) back_to show_main_menu ;;
   esac
 }


### PR DESCRIPTION
This PR clears the relaunch and restart state when restarting manually via the system menu.

Previously, the states only seemed to be cleared when using the ```omarchy-update-restart``` script, causing problems for users choosing to restart at a later time after an update.