### PR TITLE
Add Helium to chromium-based browser windowrule (follow-up to #1945)

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -1,5 +1,5 @@
 # Browser types
-windowrule = tag +chromium-based-browser, class:([cC]hrom(e|ium)|[bB]rave-browser|Microsoft-edge|Vivaldi-stable)
+windowrule = tag +chromium-based-browser, class:([cC]hrom(e|ium)|[bB]rave-browser|Microsoft-edge|Vivaldi-stable|helium)
 windowrule = tag +firefox-based-browser, class:([fF]irefox|zen|librewolf)
 
 # Force chromium-based browsers into a tile to deal with --app bug


### PR DESCRIPTION
This PR adds Helium to the Hyprland window tagging rule for Chromium-based browsers.

Context:
- PR #1945 added Helium support to `omarchy-launch-webapp`