### PR TITLE
Add compatibility to different kernel flavours

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $2}')" ]; then
+if [[ "$(pacman -Q $(pacman -Qoq /usr/lib/modules/$(uname -r) | grep -v headers | head -n1) | awk '{print $2}')" != "$(uname -r | sed 's/-[[:alpha:]].*//')" ]]; then
   gum confirm "Linux kernel has been updated. Reboot?" && omarchy-state clear re*-required && sudo reboot now
 
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then


### PR DESCRIPTION
The omarchy-update-restart script fails in the case that there's another linux kernel flavour installed, such as linux-cachyos.

What the change does:
- find out which kernel packages are in use with `pacman -Qoq /usr/lib/modules/$(uname -r)`
- find the currently installed version by passing the above to `pacman -Q`
- pipe the result grep to filter out header packages and take a single line
- awk out the version
- find currently running kernel, filtering out the flavour from `uname -r`
- check if they're the same

Small issue I found is that there might be a way that taking the first line of the output might come up with a different kernel package, but I feel that's impossible since we're finding the currently running one.