### PR TITLE
fix removal of webapps that use additional handler (Zoom)

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -6,7 +6,7 @@ DESKTOP_DIR="$HOME/.local/share/applications/"
 if [ "$#" -eq 0 ]; then
   # Find all web apps
   while IFS= read -r -d '' file; do
-    if grep -q '^Exec=.*omarchy-launch-webapp.*' "$file"; then
+    if grep -q '^Exec=.*\(omarchy-launch-webapp\|omarchy-webapp-handler\).*' "$file"; then
       WEB_APPS+=("$(basename "${file%.desktop}")")
     fi
   done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0)


### PR DESCRIPTION
Issue: Currently when removing webapps via the Omarchy menu, omarchy-webapp-remove does not list Zoom for removal. This is due to Zoom.desktop utilizing omarchy-webapp-handler-zoom as opposed to omarchy-launch-webapp.

Fix: Adjusts omarchy-webapp-remove to also locate webapps that utilize a omarchy-webapp-handler* script