### PR TITLE
Increase Application Not Responding delay

### DIFF
--- a/config/hypr/looknfeel.conf
+++ b/config/hypr/looknfeel.conf
@@ -21,3 +21,12 @@ dwindle {
     # Avoid overly wide single-window layouts on wide screens
     # single_window_aspect_ratio = 1 1
 }
+
+# https://wiki.hypr.land/Configuring/Variables/#misc
+misc {
+    # Enable or disable the ANR dialog
+    enable_anr_dialog = true
+    # Delay before showing Not Responding dialog
+    anr_missed_pings = 10
+  }
+


### PR DESCRIPTION
Issue: When an application hangs temporarily, the Application Not Responding dialog appears, asking if you want to wait or terminate the application.  The default is to show the dialog when just one ping is missed.  This causes the dialog to appear while games load levels, or sometimes a window will dim momentarily while the dialog appears and disappears almost instantaneously.  This harms user experience and causes unnecessary google searches to solve it.

Fix: Include the `anr_missed_pings` setting and set to 10 instead of the default of 1. Also provide an easy way to disable the dialog all together `enable_anr_dialog = true` right in the config files.

I feel that this is a more useful default while also exposing the setting more conveniently to the user.