### PR TITLE
Fixes #2036: ghostty needs class names with a dot

### DIFF
--- a/bin/omarchy-launch-wifi
+++ b/bin/omarchy-launch-wifi
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec setsid uwsm app -- "$TERMINAL" --class=Impala -e impala "$@"
+exec setsid uwsm app -- "$TERMINAL" --class=Impala.float --font-size=9 -e impala "$@"

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -5,7 +5,11 @@
   "spacing": 0,
   "height": 26,
   "modules-left": ["custom/omarchy", "hyprland/workspaces"],
-  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator"],
+  "modules-center": [
+    "clock",
+    "custom/update",
+    "custom/screenrecording-indicator"
+  ],
   "modules-right": [
     "group/tray-expander",
     "bluetooth",
@@ -104,7 +108,7 @@
   },
   "pulseaudio": {
     "format": "{icon}",
-    "on-click": "$TERMINAL --class=Wiremix -e wiremix",
+    "on-click": "$TERMINAL --class=Wiremix.float --font-size=9 -e wiremix",
     "on-click-right": "pamixer -t",
     "tooltip-format": "Playing at {volume}%",
     "scroll-step": 5,

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -3,7 +3,7 @@ windowrule = float, tag:floating-window
 windowrule = center, tag:floating-window
 windowrule = size 800 600, tag:floating-window
 
-windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
+windowrule = tag +floating-window, class:(blueberry.py|Impala.float|Wiremix.float|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
 windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files)
 
 # Fullscreen screensaver


### PR DESCRIPTION
Ghostty recently rewrote the complete [GTK application api](https://mitchellh.com/writing/ghostty-gtk-rewrite) in zig, and now it strictly adheres to the [GTK standard](https://docs.gtk.org/gio/type_func.Application.id_is_valid.html), where alacritty does this a little less. Therefore, when Impala or Wiremix are started with only Impala/Wiremix as a class parameter, ghostty ignores these as invalid. GTK classes must be strings with at least one period in it, and they are not allowed to start with one. Without a class set, the Omarchy windowrule does not match anymore and these windows are treated as tiles, not floats. The hard-coded font-size is used to match the alacritty-based Omarchy style but can be omitted to make this dynamic.