### PR TITLE
Hotfix: remove MacBook12,1 model from Mac SPI keyboard support, Add intel_lpss_pci  module for MacBook8,1

### DIFF
--- a/install/config/hardware/fix-apple-spi-keyboard.sh
+++ b/install/config/hardware/fix-apple-spi-keyboard.sh
@@ -5,7 +5,7 @@ if [[ "$product_name" =~ MacBook[89],1|MacBook10,1|MacBookPro13,[123]|MacBookPro
 
   sudo pacman -S --noconfirm --needed macbook12-spi-driver-dkms
   if [[ "$product_name" == "MacBook8,1" ]]; then
-    echo "MODULES=(applespi spi_pxa2xx_platform spi_pxa2xx_pci)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
+    echo "MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform spi_pxa2xx_pci)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
   else
     echo "MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform)" | sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
   fi


### PR DESCRIPTION
- MacBook12,1 model doesn’t exist, so I removed it.
- Added the intel_lpss_pci module to the list for MacBook8,1 models.