### PR TITLE
any browser in webapp bindings

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -2,13 +2,16 @@
 
 browser=$(xdg-settings get default-web-browser)
 
-case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | chromium*)
-  app_cmd=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1)
+webapp_browsers="google-chrome brave-browser microsoft-edge opera vivaldi chromium"
+
+resolve_exec() {
+  sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$1 2>/dev/null | head -1
+}
+
+if echo "$webapp_browsers" | grep -qw "${browser%%.*}"; then
+  app_cmd=$(resolve_exec "$browser")
   exec setsid uwsm app -- "$app_cmd" --app="$1" "${@:2}"
-  ;;
-firefox*)
-  exec setsid uwsm app -- firefox "$1" "${@:2}"
-  ;;
-*) ;;
-esac
+else
+  app_cmd=$(resolve_exec "$browser")
+  exec setsid uwsm app -- "$app_cmd" "$1" "${@:2}"
+fi

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -3,8 +3,12 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi*) ;;
-*) browser="chromium.desktop" ;;
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | chromium*)
+  app_cmd=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1)
+  exec setsid uwsm app -- "$app_cmd" --app="$1" "${@:2}"
+  ;;
+firefox*)
+  exec setsid uwsm app -- firefox "$1" "${@:2}"
+  ;;
+*) ;;
 esac
-
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"


### PR DESCRIPTION
Firefox (and other browsers that doesn't support webapp) users have a bad exp when changing browser in ./config/hypr/bindings because it doesn't change the omarchy-launch-webapp flow. 

When uninstalling omarchy-chromium even worse. The bindings start returning errors.

This PR checks the default browser and if it's not on the webapp supported list, it opens the link from the parameter normally in a new tab. 
**The user just change the default browser and the bindings are now in the browser of choice!**