### PR TITLE
Fix placeholder position and adjust fail text on lock screen

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -22,12 +22,12 @@ input-field {
     outer_color = $outer_color
     outline_thickness = 4
 
-    font_family = CaskaydiaMono Nerd Font
+    font_family = CaskaydiaMono Nerd Font Propo
     font_color = $font_color
 
-    placeholder_text =   Enter Password 󰈷 
+    placeholder_text = Enter Password 󰈷
     check_color = $check_color
-    fail_text = <i>$PAMFAIL ($ATTEMPTS)</i>
+    fail_text = <i>$FAIL ($ATTEMPTS)</i>
 
     rounding = 0
     shadow_passes = 0

--- a/migrations/1759270604.sh
+++ b/migrations/1759270604.sh
@@ -1,0 +1,3 @@
+echo "Fix placeholder position and adjust fail text"
+
+omarchy-refresh-hyprlock


### PR DESCRIPTION
This PR fixes the horizontal alignment of the placeholder text on the lock screen by switching to the proportional variant of Cascadia (which also removes the need to pad the text with extra whitespace).

I also changed the fail message source from `$PAMFAIL`, which only shows password-related failure messages, to `$FAIL`, which shows both password and fingerprint related failure messages.

Placeholder text before:
<img width="1920" height="1080" alt="placeholder before" src="https://github.com/user-attachments/assets/a1880b1e-590b-4178-8be0-10fdd3ab8e8a" />

Placeholder text after:
<img width="1920" height="1080" alt="placeholder after" src="https://github.com/user-attachments/assets/e17541e4-2bd3-4d00-a1c0-dd9f577c0893" />

Fail text before:

https://github.com/user-attachments/assets/dfda2102-a153-4cc3-80da-4ae4e614696d

Fail text after:

https://github.com/user-attachments/assets/8de10ba9-4f58-4174-9357-ec1c83a36982

