### PR TITLE
Update input.conf comment with grp:alt_altgr_toggle 

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -3,7 +3,7 @@
 input {
   # Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
   # kb_layout = us,dk,eu
-  kb_options = compose:caps # ,grp:alts_toggle
+  kb_options = compose:caps # ,grp:alt_altgr_toggle
 
   # Change speed of keyboard repeat
   repeat_rate = 40


### PR DESCRIPTION
This PR will just edit a single comment to point users to a less problematic option for toggling keyboard layouts. No functions are modified, just quality of life improvements for documentation.

Substituting alt_altgr_toggle is the new implementation. alts_toggle currently breaks all lv3 interaction on keyboards that use AltGr + key combinations. This happens because alts_toggle consumes the key press and prevents it to reaching lv3 functionality. This toggle is that safer option and so far retains all original functionality. 

This will also save new users from my painful experience of trying to set up multiple keyboard layouts, latam (my external kb) + us (my thinkpad laptob kb) keyboards.

References: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/548

Example of functioning config:

```
# .config/hypr/input.conf
# See https://wiki.hypr.land/Configuring/Variables/#input
input {
  # Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
  # kb_layout = us,dk,eu
  kb_layout = us,latam
  kb_options = compose:caps,grp:alt_altgr_toggle

  # Change speed of keyboard repeat
  repeat_rate = 40
  repeat_delay = 600

  # Start with numlock on by default
  numlock_by_default = true

  # Increase sensitity for mouse/trackpack (default: 0)
  sensitivity = 0.35

  touchpad {
    # Use natural (inverse) scrolling
    natural_scroll = true

    # Use two-finger clicks for right-click instead of lower-right corner
    clickfinger_behavior = true

    # Control the speed of your scrolling
    scroll_factor = 0.4
  }
}


# Scroll nicely in the terminal
windowrule = scrolltouchpad 1.5, class:(Alacritty|kitty)
windowrule = scrolltouchpad 0.2, class:com.mitchellh.ghostty

# Enable touchpad gestures for changing workspaces
# See https://wiki.hyprland.org/Configuring/Gestures/
# gesture = 3, horizontal, workspace
```