### PR TITLE
Use systemd-resolved's stub resolver

### DIFF
--- a/bin/omarchy-cmd-first-run
+++ b/bin/omarchy-cmd-first-run
@@ -9,6 +9,7 @@ if [[ -f "$FIRST_RUN_MODE" ]]; then
 
   bash "$OMARCHY_PATH/install/first-run/battery-monitor.sh"
   bash "$OMARCHY_PATH/install/first-run/firewall.sh"
+  bash "$OMARCHY_PATH/install/first-run/dns-resolver.sh"
   bash "$OMARCHY_PATH/install/first-run/gnome-theme.sh"
   sudo rm -f /etc/sudoers.d/first-run
 

--- a/default/hypr/apps/steam.conf
+++ b/default/hypr/apps/steam.conf
@@ -1,4 +1,4 @@
-# Float Steam, fullscreen RetroArch
+# Float Steam
 windowrule = float, class:steam
 windowrule = center, class:steam, title:Steam
 windowrule = opacity 1 1, class:steam

--- a/install/first-run/dns-resolver.sh
+++ b/install/first-run/dns-resolver.sh
@@ -1,0 +1,4 @@
+# https://wiki.archlinux.org/title/Systemd-resolved
+echo "Symlink resolved stub-resolv to /etc/resolv.conf"
+
+sudo ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf

--- a/install/preflight/first-run-mode.sh
+++ b/install/preflight/first-run-mode.sh
@@ -5,9 +5,11 @@ touch ~/.local/state/omarchy/first-run.mode
 # Setup sudo-less access for first-run
 sudo tee /etc/sudoers.d/first-run >/dev/null <<EOF
 Cmnd_Alias FIRST_RUN_CLEANUP = /bin/rm -f /etc/sudoers.d/first-run
+Cmnd_Alias SYMLINK_RESOLVED = /usr/bin/ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 $USER ALL=(ALL) NOPASSWD: /usr/bin/ufw
 $USER ALL=(ALL) NOPASSWD: /usr/bin/ufw-docker
 $USER ALL=(ALL) NOPASSWD: /usr/bin/gtk-update-icon-cache
+$USER ALL=(ALL) NOPASSWD: SYMLINK_RESOLVED
 $USER ALL=(ALL) NOPASSWD: FIRST_RUN_CLEANUP
 EOF
 sudo chmod 440 /etc/sudoers.d/first-run


### PR DESCRIPTION
On first run, symlink systemd-resolved's resolver into /etc/resolv.conf
* use first-run script due to chroot restrictions
* add to password-less sudo first-run commands

Matches migration 1754984623