### PR TITLE
Add Hyprland Window Grouping (Stacking) Support

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -5,6 +5,7 @@ source = ~/.local/share/omarchy/default/hypr/autostart.conf
 source = ~/.local/share/omarchy/default/hypr/bindings/media.conf
 source = ~/.local/share/omarchy/default/hypr/bindings/tiling.conf
 source = ~/.local/share/omarchy/default/hypr/bindings/utilities.conf
+source = ~/.local/share/omarchy/default/hypr/bindings/grouping.conf
 source = ~/.local/share/omarchy/default/hypr/envs.conf
 source = ~/.local/share/omarchy/default/hypr/looknfeel.conf
 source = ~/.local/share/omarchy/default/hypr/input.conf

--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -14,3 +14,4 @@ bindd = SUPER, slash, Password manager, exec, $passwordManager
 source = ~/.local/share/omarchy/default/hypr/bindings/media.conf
 source = ~/.local/share/omarchy/default/hypr/bindings/tiling.conf
 source = ~/.local/share/omarchy/default/hypr/bindings/utilities.conf
+source = ~/.local/share/omarchy/default/hypr/bindings/grouping.conf

--- a/default/hypr/bindings/grouping.conf
+++ b/default/hypr/bindings/grouping.conf
@@ -1,0 +1,61 @@
+# Grouping / Stacking
+
+group {
+  # https://wiki.hypr.land/Configuring/Variables/#groupbar
+  auto_group = false             # new windows join the focused unlocked group
+  groupbar {
+    #  https://wiki.hypr.land/Configuring/Variables/#groupbar
+    height = 15
+    font_size = 12
+    font_weight_active = bold
+    gradients = true
+  }
+}
+
+# Key bindings for Stacking / Grouping windows
+# Base combination for this is CONTROL + ALT
+
+# Start/stop a group for the focused window (creates a tabbed stack)
+bindd = SUPER ALT, RETURN, start grouping, togglegroup
+
+# Unstack
+bindd = SUPER ALT, U, Unstack focused window, moveoutofgroup
+
+# Lock the group
+bindd = SUPER ALT,       L, Lock the active group, lockactivegroup, toggle
+bindd = SUPER ALT SHIFT, L, Lock all groups,       lockgroups, toogle
+
+# Add the focused window into a neighboring group's stack
+bindd = SUPER ALT, LEFT , Stack into left group,  moveintogroup, l
+bindd = SUPER ALT, RIGHT, Stack into right group, moveintogroup, r
+bindd = SUPER ALT, UP   , Stack into up group,    moveintogroup, u
+bindd = SUPER ALT, DOWN , Stack into down group,  moveintogroup, d
+
+# Cycle tabs inside the stack, or use the index
+bindd = SUPER ALT      , TAB      , Next tab in group,     changegroupactive, f
+bindd = SUPER ALT SHIFT, TAB      , Previous tab in group, changegroupactive, b
+bindd = SUPER ALT      , Page_Up  , Next tab in group,     changegroupactive, f
+bindd = SUPER ALT      , Page_Down, Next tab in group,     changegroupactive, b
+bindd = SUPER ALT      , code:10  , 1st in group,          changegroupactive, 1
+bindd = SUPER ALT      , code:11  , 2nd in group,          changegroupactive, 2
+bindd = SUPER ALT      , code:12  , 3rd in group,          changegroupactive, 3
+bindd = SUPER ALT      , code:13  , 4th in group,          changegroupactive, 4
+bindd = SUPER ALT      , code:14  , 5th in group,          changegroupactive, 5
+bindd = SUPER ALT      , code:15  , 6th in group,          changegroupactive, 6
+bindd = SUPER ALT      , code:16  , 7th in group,          changegroupactive, 7
+bindd = SUPER ALT      , code:17  , 8th in group,          changegroupactive, 8
+bindd = SUPER ALT      , code:18  , 9th in group,          changegroupactive, 9
+bindd = SUPER ALT      , code:19  , 10th in group,         changegroupactive, 10
+
+# Toogle actrive group
+bindd = SUPER ALT CTRL,       TAB, Next group,     togglegroup, f
+bindd = SUPER ALT CTRL SHIFT, TAB, Previous group, togglegroup, b
+
+# Reorder within the stack
+bindd = SUPER ALT CTRL, LEFT , Swap tab forward,  movegroupwindow
+bindd = SUPER ALT CTRL, RIGHT, Swap tab backward, movegroupwindow, b
+
+# If there is a group in the direction, will move the active window to it.
+# If there isn't, will move outside the current group
+bindd = SUPER ALT SHIFT, LEFT , Move window or group left,  movewindoworgroup, l
+bindd = SUPER ALT SHIFT, RIGHT, Move window or group right, movewindoworgroup, r


### PR DESCRIPTION
### **Summary**
Adds window grouping functionality to Hyprland, similar to tmux tabs but for GUI windows. For users who prefer keeping related windows together in one workspace rather than spreading them across multiple workspaces, this provides tabbed stacks with easy navigation.

### **Keybindings (SUPER + ALT modifier)**

**Basic Operations:**
- `SUPER + ALT + RETURN` - Create/remove group for focused window
- `SUPER + ALT + U` - Unstack focused window

**Locking:**
- `SUPER + ALT + L` - Lock/unlock active group
- `SUPER + ALT + SHIFT + L` - Lock/unlock all groups

**Stacking:**
- `SUPER + ALT + ←/→/↑/↓` - Add focused window to neighboring group

**Navigation:**
- `SUPER + ALT + TAB` - Next tab in group
- `SUPER + ALT + SHIFT + TAB` - Previous tab in group
- `SUPER + ALT + Page Up/Down` - Alternative tab navigation
- `SUPER + ALT + 1-0` - Jump to 1st-10th tab

**Group Management:**
- `SUPER + ALT + CTRL + TAB` - Next group
- `SUPER + ALT + CTRL + SHIFT + TAB` - Previous group

**Advanced:**
- `SUPER + ALT + CTRL + ←/→` - Reorder tabs within group
- `SUPER + ALT + SHIFT + ←/→` - Move window/group in direction
