### PR TITLE
Add TZ environment variable for timezone-aware applications

### DIFF
--- a/default/bash/envs
+++ b/default/bash/envs
@@ -1,3 +1,4 @@
 # Editor used by CLI
 export SUDO_EDITOR="$EDITOR"
 export BAT_THEME=ansi
+export TZ="$(timedatectl show -p Timezone --value)"


### PR DESCRIPTION
This PR adds the TZ environment variable to ensure timezone-aware applications display the correct local time instead of UTC.

## Problem
- Waybar clock format `{:L%A %H:%M}` displays UTC time instead of local time in some systems where TZ env variable is not defined
- Applications launched from shell don't inherit system timezone without TZ variable
- Users have to hardcode timezone in application configs as workaround

More details about the problem here https://github.com/basecamp/omarchy/issues/2170 

## Solution  
- Dynamically set TZ environment variable based on system timezone via `timedatectl`
- Added to `default/bash/envs` so it's available in all bash sessions
- Works globally for all users without hardcoding timezone values

## Testing
- Verified TZ variable is set correctly: `echo $TZ` shows system timezone
- Waybar clock now displays local time with `:L` locale operator
- Applications launched from shell inherit correct timezone

Fixes #2170