### PR TITLE
add chameleon plugin

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -29,6 +29,7 @@ omarchy-restart-swayosd
 hyprctl reload
 pkill -SIGUSR2 btop
 makoctl reload
+pkill -SIGUSR1 nvim
 
 # Change gnome, browser, vscode themes
 omarchy-theme-set-terminal

--- a/config/nvim/lua/plugins/chameleon.lua
+++ b/config/nvim/lua/plugins/chameleon.lua
@@ -1,0 +1,16 @@
+return {
+  {
+    "tahayvr/chameleon.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+      require("chameleon").setup({
+        system = {
+          symlink_path = vim.fn.expand("~/.config/omarchy/current/theme"),
+          debounce_ms = 100,
+          notify = false,
+        },
+      })
+    end,
+  },
+}


### PR DESCRIPTION
Adds the chameleon plugin to support easy neovim theming using a color palette. 

See [chameleon.nvim](https://github.com/tahayvr/chameleon.nvim) for more info.