### PR TITLE
Add tmux themes

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -36,3 +36,14 @@ omarchy-theme-set-gnome
 omarchy-theme-set-eza
 omarchy-theme-set-browser
 omarchy-theme-set-vscode
+
+# Reload tmux theme if running
+if command -v tmux &>/dev/null && tmux list-sessions &>/dev/null 2>&1; then
+  TMUX_CONF="$HOME/.config/tmux/tmux.conf"
+  if [ -f "$TMUX_CONF" ]; then
+    tmux source-file "$TMUX_CONF" &>/dev/null || true
+    tmux list-clients -F '#{client_name}' 2>/dev/null | while IFS= read -r client; do
+      tmux refresh-client -t "$client" &>/dev/null || true
+    done
+  fi
+fi

--- a/themes/catppuccin-latte/tmux.conf
+++ b/themes/catppuccin-latte/tmux.conf
@@ -1,0 +1,20 @@
+# ============================================================================
+# Catppuccin Latte Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/catppuccin-latte/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/catppuccin-latte/tmux/palettes/latte.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/catppuccin-latte/tmux/status.sh"               # Force icons
+#run-shell "bash ~/.config/omarchy/themes/catppuccin-latte/tmux/status-no-icons.sh" # Force no-icon
+

--- a/themes/catppuccin-latte/tmux/status-no-icons.sh
+++ b/themes/catppuccin-latte/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr%bin/env bash
+
+source ~/.config/omarchy/themes/catppuccin-latte/tmux/palettes/latte.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Catppuccin Latte palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[blue]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[blue]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[blue]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[blue]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[blue]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[blue]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[blue]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[blue]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[blue]}]#W #F #[fg=${PALETTE[blue]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/catppuccin-latte/tmux/status.sh
+++ b/themes/catppuccin-latte/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/catppuccin-latte/tmux/palettes/latte.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Catppuccin Latte palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[blue]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[blue]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[blue]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] 󰌌 #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[blue]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[blue]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[blue]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[blue]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[blue]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[blue]}]#W #F #[fg=${PALETTE[blue]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/catppuccin-latte/tmux/theme.sh
+++ b/themes/catppuccin-latte/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/catppuccin-latte/tmux/palettes/latte.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Catppuccin Latte palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[blue]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[blue]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[blue]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[blue]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[blue]}"

--- a/themes/catppuccin/tmux.conf
+++ b/themes/catppuccin/tmux.conf
@@ -1,0 +1,19 @@
+# ============================================================================
+# Catppuccin Macchiato Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/palettes/macchiato.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/status.sh"
+# run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/status-no-icons.sh" 

--- a/themes/catppuccin/tmux/status-no-icons.sh
+++ b/themes/catppuccin/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/catppuccin/tmux/palettes/macchiato.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Catppuccin palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[magenta]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[magenta]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[magenta]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[magenta]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#W #F #[fg=${PALETTE[magenta]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/catppuccin/tmux/status.sh
+++ b/themes/catppuccin/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/catppuccin/tmux/palettes/macchiato.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Catppuccin palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[magenta]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[magenta]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[magenta]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] 󰌌 #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[magenta]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#W #F #[fg=${PALETTE[magenta]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/catppuccin/tmux/theme.sh
+++ b/themes/catppuccin/tmux/theme.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/catppuccin/tmux/palettes/macchiato.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Catppuccin palette not loaded. Colors may not display correctly."
+fi
+
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[magenta]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[magenta]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[magenta]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[magenta]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[magenta]}"

--- a/themes/everforest/tmux.conf
+++ b/themes/everforest/tmux.conf
@@ -1,0 +1,19 @@
+# ============================================================================
+# Everforest Dark Hard Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/everforest/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/everforest/tmux/palettes/dark-hard.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/everforest/tmux/status.sh"               # Force icons
+#run-shell "bash ~/.config/omarchy/themes/everforest/tmux/status-no-icons.sh" # Force no-icon
+

--- a/themes/everforest/tmux/status-no-icons.sh
+++ b/themes/everforest/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/everforest/tmux/palettes/dark-hard.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Everforest Dark Hard palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[aqua]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[aqua]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[aqua]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[aqua]},bold] #S #[fg=${PALETTE[aqua]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[aqua]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[aqua]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[green]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[green]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[green]}]#W #F #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg5]},nobold,noitalics,nounderscore] #[fg=${PALETTE[green]},bg=${PALETTE[bg5]}]#I #[fg=${PALETTE[green]},bg=${PALETTE[bg5]},nobold,noitalics,nounderscore] #[fg=${PALETTE[green]},bg=${PALETTE[bg5]}]#W #F #[fg=${PALETTE[bg5]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/everforest/tmux/status.sh
+++ b/themes/everforest/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/everforest/tmux/palettes/dark-hard.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Everforest Dark Hard palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[aqua]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[aqua]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[aqua]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[aqua]},bold] 󰌌 #S #[fg=${PALETTE[aqua]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[aqua]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[aqua]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[green]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[green]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[green]}]#W #F #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg5]},nobold,noitalics,nounderscore] #[fg=${PALETTE[green]},bg=${PALETTE[bg5]}]#I #[fg=${PALETTE[green]},bg=${PALETTE[bg5]},nobold,noitalics,nounderscore] #[fg=${PALETTE[green]},bg=${PALETTE[bg5]}]#W #F #[fg=${PALETTE[bg5]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/everforest/tmux/theme.sh
+++ b/themes/everforest/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/everforest/tmux/palettes/dark-hard.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Everforest Dark Hard palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[green]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[green]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[green]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[green]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[green]}"

--- a/themes/gruvbox/tmux.conf
+++ b/themes/gruvbox/tmux.conf
@@ -1,0 +1,19 @@
+# ============================================================================
+# Gruvbox Dark Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/gruvbox/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/gruvbox/tmux/palettes/dark.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/gruvbox/tmux/status.sh"               # Force icons
+#run-shell "bash ~/.config/omarchy/themes/gruvbox/tmux/status-no-icons.sh" # Force no-icon
+

--- a/themes/gruvbox/tmux/status-no-icons.sh
+++ b/themes/gruvbox/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/gruvbox/tmux/palettes/dark.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Gruvbox Dark palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[yellow_bright]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[yellow_bright]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[yellow_bright]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green_bright]},bold] #S #[fg=${PALETTE[green_bright]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg1]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg1]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg1]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg1]}] ${TIME_FORMAT} #[fg=${PALETTE[yellow_bright]},bg=${PALETTE[bg1]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg2]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg2]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg2]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg2]}]#W #F #[fg=${PALETTE[bg2]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]}]#W #F #[fg=${PALETTE[yellow_bright]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/gruvbox/tmux/status.sh
+++ b/themes/gruvbox/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/gruvbox/tmux/palettes/dark.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Gruvbox Dark palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[yellow_bright]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[yellow_bright]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[yellow_bright]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green_bright]},bold] 󰌌 #S #[fg=${PALETTE[green_bright]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg1]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg1]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg1]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg1]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[yellow_bright]},bg=${PALETTE[bg1]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg2]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg2]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg2]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg2]}]#W #F #[fg=${PALETTE[bg2]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[yellow_bright]}]#W #F #[fg=${PALETTE[yellow_bright]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/gruvbox/tmux/theme.sh
+++ b/themes/gruvbox/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/gruvbox/tmux/palettes/dark.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Gruvbox Dark palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[yellow_bright]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[bg2]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[yellow_bright]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[bg2]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[blue_bright]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[yellow_bright]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[yellow_bright]}"

--- a/themes/kanagawa/tmux.conf
+++ b/themes/kanagawa/tmux.conf
@@ -1,0 +1,18 @@
+# ============================================================================
+# Kanagawa Wave Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/kanagawae/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/kanagawa/tmux/palettes/wave.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/kanagawa/tmux/status.sh"               # Force icons
+#run-shell "bash ~/.config/omarchy/themes/kanagawa/tmux/status-no-icons.sh" # Force no-icon

--- a/themes/kanagawa/tmux/status-no-icons.sh
+++ b/themes/kanagawa/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/kanagawa/tmux/palettes/wave.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Kanagawa Wave palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[purple]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[purple]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[purple]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[cyan]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[cyan]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#W #F #[fg=${PALETTE[purple]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/kanagawa/tmux/status.sh
+++ b/themes/kanagawa/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/kanagawa/tmux/palettes/wave.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Kanagawa Wave palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[purple]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[purple]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[purple]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] 󰌌 #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[cyan]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[cyan]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#W #F #[fg=${PALETTE[purple]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/kanagawa/tmux/theme.sh
+++ b/themes/kanagawa/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/kanagawa/tmux/palettes/wave.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Kanagawa Wave palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[purple]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[purple]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[blue]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[purple]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[purple]}"

--- a/themes/matte-black/tmux.conf
+++ b/themes/matte-black/tmux.conf
@@ -1,0 +1,20 @@
+# ============================================================================
+# Matte Black Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/matte-black/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/matte-black/tmux/palettes/matte-black.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/matte-black/tmux/status.sh"               # Force icons
+#run-shell "bash ~/.config/omarchy/themes/matte-black/tmux/status-no-icons.sh" # Force no-icon
+
+

--- a/themes/matte-black/tmux/status-no-icons.sh
+++ b/themes/matte-black/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/matte-black/tmux/palettes/matte-black.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Matte Black palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[purple]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[purple]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[purple]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[orange]},bold] #S #[fg=${PALETTE[orange]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[amber]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[amber]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#W #F #[fg=${PALETTE[purple]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/matte-black/tmux/status.sh
+++ b/themes/matte-black/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/matte-black/tmux/palettes/matte-black.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Matte Black palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[purple]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[purple]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[purple]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[orange]},bold] 󰌌 #S #[fg=${PALETTE[orange]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[amber]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[amber]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[purple]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[purple]}]#W #F #[fg=${PALETTE[purple]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/matte-black/tmux/theme.sh
+++ b/themes/matte-black/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/matte-black/tmux/palettes/matte-black.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Matte Black palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[purple]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[purple]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[blue]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[purple]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[purple]}"

--- a/themes/nord/tmux.conf
+++ b/themes/nord/tmux.conf
@@ -1,0 +1,19 @@
+# ============================================================================
+# Nord Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/nord/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/nord/tmux/palettes/nord.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/nord/tmux/status.sh"              # Force icons
+#run-shell "bash ~/.config/omarchy/themes/nord/tmux/status-no-icons.sh" # Force no-icon
+

--- a/themes/nord/tmux/status-no-icons.sh
+++ b/themes/nord/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/nord/tmux/palettes/nord.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Nord palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[cyan]}]#[bg=${PALETTE[black]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[cyan]}]#[fg=${PALETTE[black]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[cyan]},bg=${PALETTE[black]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[black]},bg=${PALETTE[blue]},bold] #S #[fg=${PALETTE[blue]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[brightblack]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]#[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}] ${DATE_FORMAT} #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore]#[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}] ${TIME_FORMAT} #[fg=${PALETTE[cyan]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore]#[fg=${PALETTE[black]},bg=${PALETTE[cyan]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[black]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore] #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}]#I #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore] #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}]#W #F #[fg=${PALETTE[brightblack]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[black]},bg=${PALETTE[cyan]},nobold,noitalics,nounderscore] #[fg=${PALETTE[black]},bg=${PALETTE[cyan]}]#I #[fg=${PALETTE[black]},bg=${PALETTE[cyan]},nobold,noitalics,nounderscore] #[fg=${PALETTE[black]},bg=${PALETTE[cyan]}]#W #F #[fg=${PALETTE[cyan]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/nord/tmux/status.sh
+++ b/themes/nord/tmux/status.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/nord/tmux/palettes/nord.sh
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[cyan]}]#[bg=${PALETTE[black]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[cyan]}]#[fg=${PALETTE[black]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[cyan]},bg=${PALETTE[black]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[black]},bg=${PALETTE[blue]},bold] 󰌌 #S #[fg=${PALETTE[blue]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[brightblack]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]#[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore]#[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[cyan]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore]#[fg=${PALETTE[black]},bg=${PALETTE[cyan]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[black]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore] #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}]#I #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]},nobold,noitalics,nounderscore] #[fg=${PALETTE[white]},bg=${PALETTE[brightblack]}]#W #F #[fg=${PALETTE[brightblack]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[black]},bg=${PALETTE[cyan]},nobold,noitalics,nounderscore] #[fg=${PALETTE[black]},bg=${PALETTE[cyan]}]#I #[fg=${PALETTE[black]},bg=${PALETTE[cyan]},nobold,noitalics,nounderscore] #[fg=${PALETTE[black]},bg=${PALETTE[cyan]}]#W #F #[fg=${PALETTE[cyan]},bg=${PALETTE[black]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/nord/tmux/theme.sh
+++ b/themes/nord/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/nord/tmux/palettes/nord.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Nord palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[black]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[cyan]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[black]},fg=${PALETTE[white]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[brightblack]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[cyan]}"
+tmux set -g display-panes-colour "${PALETTE[black]}"
+tmux set -g display-panes-active-colour "${PALETTE[brightblack]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[cyan]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[cyan]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[cyan]}"

--- a/themes/osaka-jade/tmux.conf
+++ b/themes/osaka-jade/tmux.conf
@@ -1,0 +1,18 @@
+j ============================================================================
+# Osaka Jade Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/osaka-jade/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/osaka-jade/tmux/palettes/jade.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/osaka-jade/tmux/status.sh"
+# run-shell "bash ~/.config/omarchy/themes/osaka-jade/tmux/status-no-icons.sh" 

--- a/themes/osaka-jade/tmux/status-no-icons.sh
+++ b/themes/osaka-jade/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/osaka-jade/tmux/palettes/jade.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Osaka Jade Latte palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[teal]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[teal]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[teal]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[teal]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#W #F #[fg=${PALETTE[teal]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/osaka-jade/tmux/status.sh
+++ b/themes/osaka-jade/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/osaka-jade/tmux/palettes/jade.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Osaka Jade Latte palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[teal]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[teal]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[teal]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] 󰌌 #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[teal]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#W #F #[fg=${PALETTE[teal]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/osaka-jade/tmux/theme.sh
+++ b/themes/osaka-jade/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/osaka-jade/tmux/palettes/jade.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Osaka Jade Latte palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[teal]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[teal]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[teal]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[teal]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[teal]}"

--- a/themes/ristretto/tmux.conf
+++ b/themes/ristretto/tmux.conf
@@ -1,0 +1,18 @@
+# ============================================================================
+# Ristretto Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/ristretto/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/ristretto/tmux/palettes/ristretto.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/ristretto/tmux/status.sh"
+# run-shell "bash ~/.config/omarchy/themes/ristretto/tmux/status-no-icons.sh" 

--- a/themes/ristretto/tmux/status-no-icons.sh
+++ b/themes/ristretto/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/ristretto/tmux/palettes/ristretto.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Ristretto palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[teal]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[teal]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[teal]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[teal]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#W #F #[fg=${PALETTE[teal]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/ristretto/tmux/status.sh
+++ b/themes/ristretto/tmux/status.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/ristretto/tmux/palettes/ristretto.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Ristretto palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[teal]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[teal]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[teal]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] 󰌌 #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[teal]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[teal]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[teal]}]#W #F #[fg=${PALETTE[teal]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/ristretto/tmux/theme.sh
+++ b/themes/ristretto/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/ristretto/tmux/palettes/ristretto.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Ristretto palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[teal]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[teal]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[teal]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[teal]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[teal]}"

--- a/themes/rose-pine/tmux.conf
+++ b/themes/rose-pine/tmux.conf
@@ -1,0 +1,18 @@
+# ============================================================================
+# Rose Pine Dawn Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/rose-pine/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/rose-pine/tmux/palettes/dawn.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/rose-pine/tmux/status.sh"
+# run-shell "bash ~/.config/omarchy/themes/rose-pine/tmux/status-no-icons.sh" 

--- a/themes/rose-pine/tmux/status-no-icons.sh
+++ b/themes/rose-pine/tmux/status-no-icons.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/rose-pine/tmux/palettes/dawn.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Rose Pine Dawn Latte palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[rose]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[rose]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[rose]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[green]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[rose]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[rose]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[rose]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[rose]}]#W #F #[fg=${PALETTE[rose]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[rose]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[gold]}"
+
+#+----------+
+#+ Messages +
+#+----------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[rose]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[rose]}"

--- a/themes/rose-pine/tmux/status.sh
+++ b/themes/rose-pine/tmux/status.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/rose-pine/tmux/palettes/dawn.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Rose Pine Dawn Latte palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[rose]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[rose]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[rose]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] 󰌌 #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[green]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[rose]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[rose]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[rose]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[rose]}]#W #F #[fg=${PALETTE[rose]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[rose]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[gold]}"
+
+#+----------+
+#+ Messages +
+#+----------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[rose]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[rose]}"

--- a/themes/rose-pine/tmux/theme.sh
+++ b/themes/rose-pine/tmux/theme.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/rose-pine/tmux/palettes/dawn.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Rose Pine Dawn Latte palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[teal]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[bg]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+--- Windows ---+
+tmux set -g window-status-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[fg_dark]}"
+tmux set -g window-status-current-style "bg=${PALETTE[teal]},fg=${PALETTE[bg]},bold"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[teal]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[teal]}"
+
+#+----------+
+#+ Messages +
+#+----------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[teal]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[teal]}"

--- a/themes/tokyo-night/tmux.conf
+++ b/themes/tokyo-night/tmux.conf
@@ -1,0 +1,18 @@
+# ============================================================================
+# Tokyo Night Tmux Theme
+# ============================================================================
+# This theme supports both icon and no-icon variants.
+#
+# Comment/uncomment the status bar lines below.
+# Then reload: tmux source ~/.config/tmux/tmux.conf or Prefix + R
+# ============================================================================
+
+# Load theme base and colors
+run-shell "bash ~/.config/omarchy/themes/tokyo-night/tmux/theme.sh"
+run-shell "bash ~/.config/omarchy/themes/tokyo-night/tmux/palettes/night.sh"
+
+# Uncomment ONE of the lines below to force a specific variant:
+# ------------------------------------------------------------
+
+run-shell "bash ~/.config/omarchy/themes/tokyo-night/tmux/status.sh"
+# run-shell "bash ~/.config/omarchy/themes/tokyo-night/tmux/status-no-icons.sh" 

--- a/themes/tokyo-night/tmux/status-no-icons.sh
+++ b/themes/tokyo-night/tmux/status-no-icons.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/tokyo-night/tmux/palettes/night.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Tokyo Night palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[magenta]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[magenta]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[magenta]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] ${TIME_FORMAT} #[fg=${PALETTE[magenta]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#W #F #[fg=${PALETTE[magenta]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/tokyo-night/tmux/status.sh
+++ b/themes/tokyo-night/tmux/status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/tokyo-night/tmux/palettes/night.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Tokyo Night palette not loaded. Colors may not display correctly."
+fi
+
+DATE_FORMAT=$(tmux show-environment -g THEME_DATE_FORMAT 2>/dev/null | cut -d= -f2-)
+TIME_FORMAT=$(tmux show-environment -g THEME_TIME_FORMAT 2>/dev/null | cut -d= -f2-)
+
+DATE_FORMAT=${DATE_FORMAT:-"%Y-%m-%d"}
+TIME_FORMAT=${TIME_FORMAT:-"%H:%M"}
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_output_prefix "#[fg=${PALETTE[magenta]}]#[bg=${PALETTE[bg]}]#[nobold]#[noitalics]#[nounderscore]#[bg=${PALETTE[magenta]}]#[fg=${PALETTE[bg]}]"
+tmux set -g @prefix_highlight_output_suffix ""
+tmux set -g @prefix_highlight_copy_mode_attr "fg=${PALETTE[magenta]},bg=${PALETTE[bg]},bold"
+
+#+--------+
+#+ Status +  
+#+--------+
+#+--- Bars ---+
+tmux set -g status-left "#[fg=${PALETTE[bg]},bg=${PALETTE[green]},bold] 󰌌 #S #[fg=${PALETTE[green]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g status-right "#{prefix_highlight}#[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰃭 ${DATE_FORMAT} #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}] 󰥔 ${TIME_FORMAT} #[fg=${PALETTE[magenta]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore]#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},bold] #H "
+
+#+--- Windows ---+
+tmux set -g window-status-format "#[fg=${PALETTE[bg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#I #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]},nobold,noitalics,nounderscore] #[fg=${PALETTE[fg]},bg=${PALETTE[bg_highlight]}]#W #F #[fg=${PALETTE[bg_highlight]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-current-format "#[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#I #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]},nobold,noitalics,nounderscore] #[fg=${PALETTE[bg]},bg=${PALETTE[magenta]}]#W #F #[fg=${PALETTE[magenta]},bg=${PALETTE[bg]},nobold,noitalics,nounderscore]"
+tmux set -g window-status-separator ""

--- a/themes/tokyo-night/tmux/theme.sh
+++ b/themes/tokyo-night/tmux/theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+source ~/.config/omarchy/themes/tokyo-night/tmux/palettes/night.sh
+
+if [ ${#PALETTE[@]} -eq 0 ]; then
+  echo "Warning: Tokyo Night palette not loaded. Colors may not display correctly."
+fi
+
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+tmux set -g @prefix_highlight_fg "${PALETTE[bg]}"
+tmux set -g @prefix_highlight_bg "${PALETTE[blue]}"
+
+#+---------+
+#+ Options +
+#+---------+
+tmux set -g status-interval 1
+tmux set -g status on
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Layout ---+
+tmux set -g status-justify left
+
+#+--- Colors ---+
+tmux set -g status-style "bg=${PALETTE[bg]},fg=${PALETTE[fg]}"
+
+#+-------+
+#+ Panes +
+#+-------+
+tmux set -g pane-border-style "bg=default,fg=${PALETTE[fg_gutter]}"
+tmux set -g pane-active-border-style "bg=default,fg=${PALETTE[blue]}"
+tmux set -g display-panes-colour "${PALETTE[bg]}"
+tmux set -g display-panes-active-colour "${PALETTE[fg_gutter]}"
+
+#+------------+
+#+ Clock Mode +
+#+------------+
+tmux setw -g clock-mode-colour "${PALETTE[blue]}"
+
+#+----------+
+#+ Messages +
+#+---------+
+tmux set -g message-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[blue]}"
+tmux set -g message-command-style "bg=${PALETTE[bg_highlight]},fg=${PALETTE[blue]}"


### PR DESCRIPTION
# Add Native Tmux Theme Support

## Overview

This PR adds native tmux theming support for all 11 Omarchy themes, providing automatic theme synchronization for tmux users.

## What This Adds

Tmux theme configurations for:
- Catppuccin (Macchiato)
- Catppuccin Latte
- Everforest
- Gruvbox
- Kanagawa
- Matte Black
- Nord
- Osaka Jade
- Ristretto
- Rose Pine
- Tokyo Night

## Key Features

### 1. **Automatic Theme Sync**
When users run `omarchy set <theme>`, tmux automatically updates to match (if running).

### 2. **Opt-in by Design**
- No dependencies or forced configuration
- Users who don't use tmux won't see any changes
- Simple one-line setup in `~/.config/tmux/tmux.conf`:
  ```bash
  source-file ~/.config/omarchy/current/theme/tmux.conf
  ```

### 3. **Icon Flexibility**
Supports both Nerd Font icons (default) and plain ASCII variants:
```bash
# ~/.config/omarchy/themes<theme>/tmux.conf
# Load theme base and colors
run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/theme.sh"
run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/palettes/macchiato.sh"

# Uncomment ONE of the lines below to force a specific variant:
# ------------------------------------------------------------
run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/status.sh"
# run-shell "bash ~/.config/omarchy/themes/catppuccin/tmux/status-no-icons.sh" 


```

### 4. **Consistent Design**
- Follows the same patterns as other Omarchy theme components (alacritty, kitty, btop, etc.)
- Each theme directory contains a `tmux.conf` that sources theme files
- Status bar designs match each theme's aesthetic

## Why Tmux?

Tmux is widely used in the Linux community for:
- **Session persistence** - maintain your environment across terminal restarts
- **Detachable sessions** - long-running tasks continue even when disconnected
- **Remote development** - essential for SSH workflows
- **Workflow flexibility** - splits, windows, and session management

Many Omarchy users already use or want to use tmux alongside Hyprland's tiling capabilities.

## Implementation

### File Structure
```
themes/<theme>/
├── tmux.conf              # Theme entry point
└── tmux/
    ├── theme.sh           # Base tmux settings
    ├── status.sh          # Status bar with icons
    ├── status-no-icons.sh # Status bar without icons
    └── palettes/
        └── <variant>.sh   # Color palette
```

### Auto-reload on Theme Switch
Modified `bin/theme-set` to reload tmux configurations when switching themes:
- Only runs if tmux is installed and has active sessions
- Completely silent if tmux is not running
- Refreshes all active clients automatically

## Testing

Tested on all 11 themes with:
- ✅ Single tmux session
- ✅ Multiple tmux sessions
- ✅ Icon and no-icon variants
- ✅ Theme switching while tmux is running
- ✅ No errors when tmux is not installed/running

### Gif 
[![Design-sem-nome.gif](https://i.postimg.cc/tCtmDqCZ/Design-sem-nome.gif)](https://postimg.cc/zVvjG1h8)

## Impact

- **For non-tmux users**: Zero impact - files are included but never loaded
- **For tmux users**: Seamless theme integration with automatic updates
- **Maintenance**: Follows existing theme patterns, easy to maintain alongside other components

---

This PR makes tmux a first-class optional component in Omarchy, maintaining theme consistency for users who choose to use it.