### PR TITLE
Hide electron36 and electron37 from walker menu

### DIFF
--- a/applications/hidden/electron36.desktop
+++ b/applications/hidden/electron36.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+Hidden=true

--- a/applications/hidden/electron37.desktop
+++ b/applications/hidden/electron37.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+Hidden=true


### PR DESCRIPTION
like already done for electron34