### PR TITLE
fix: expected .desktop filename for helium

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -3,7 +3,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium-browser*) ;;
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 


### PR DESCRIPTION
According to common sense and Helium browser's spec for .desktop file: [helium.desktop](https://github.com/imputnet/helium-linux/blob/main/package/helium.desktop)

The expected name here should be `helium*` not `helium-browser*`.