### PR TITLE
Fix browser launching for flatpak

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 default_browser=$(xdg-settings get default-web-browser)
-browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
 
-if [[ $browser_exec =~ (firefox|zen|librewolf) ]]; then
+if [[ $default_browser =~ (firefox|zen|librewolf) ]]; then
   private_flag="--private-window"
 else
   private_flag="--incognito"
 fi
 
-exec setsid uwsm app -- "$browser_exec" "${@/--private/$private_flag}"
+exec setsid uwsm app -- "$default_browser" "${@/--private/$private_flag}"


### PR DESCRIPTION
fixes #2037
This makes the browser launch script work for all desktop entry files.