### PR TITLE
Update Exec command to allow browsing next/previous image

### DIFF
--- a/applications/imv.desktop
+++ b/applications/imv.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Image Viewer
-Exec=imv %F
+Exec=sh -c 'imv "$(dirname %f)"/*'
 Icon=imv
 Type=Application
 MimeType=image/png;image/jpeg;image/jpg;image/gif;image/bmp;image/webp;image/tiff;image/x-xcf;image/x-portable-pixmap;image/x-xbitmap;


### PR DESCRIPTION
This change updates the `Exec` line in the `imv.desktop` file to load all images in the current directory instead of just the single file opened via double-click in a file manager like Nautilus.

Currently, when opening an image by double-clicking in Nautilus, only the selected file is passed to `imv`.  
This prevents users from navigating to the next/previous image in the same folder using the arrow keys.  

By adjusting the `Exec` command, `imv` will receive all images in the directory, allowing proper navigation.

```ini
Exec=sh -c 'imv "$(dirname %f)"/*'
```