### PR TITLE
Set default terminal after removing one

### DIFF
--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -13,9 +13,22 @@ fzf_args=(
 )
 
 pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
+TERMINALS=("alacritty" "kitty" "ghostty")
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay
   echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
+
+  # Check if removed package is one of the terminals
+    if [[ " ${TERMINALS[@]} " =~ " $pkg_names " ]]; then
+      for item in "${TERMINALS[@]}"; do
+        if pacman -Qs "$item" >/dev/null; then
+          sed -i "/export TERMINAL=/c\export TERMINAL=$item" ~/.config/uwsm/default
+          gum confirm "Relaunch Hyprland to use new terminal?" && uwsm stop
+          break
+        fi
+      done
+    fi
+
   omarchy-show-done
 fi


### PR DESCRIPTION
The default terminal on **Omarchy** is _Alacritty_, but if you install a new one like _Ghostty_, it will switch automatically as the default one. But when you remove _Ghostty_, you're stuck with no terminal, so that's why I added this short code to check removed pkg If it's terminl it check if for installed one and set it as a default 