### PR TITLE
Fix rosé pine light theme for eza

### DIFF
--- a/themes/rose-pine/eza.yml
+++ b/themes/rose-pine/eza.yml
@@ -1,123 +1,121 @@
-# see https://github.com/eza-community/eza-themes/blob/main/themes/rose-pine.yml
+# see https://github.com/eza-community/eza-themes/blob/main/themes/rose-pine-dawn.yml
 
 colourful: true
 
 # Colors are in format of:
 # color/paletteRef (Description) #color code
 
-# Gold (Terminal Yellow) #f6c177
-# Love (Terminal Red) #eb6f92
-# Rose (Terminal Cyan) #ebbcba
-# Base (Primary Background) #191724
-# Iris (Terminal Magenta) #c4a7e7
-# Foam (Terminal Blue) #9ccfd8
-# Pine (Terminal Green)  #31748f
-# Muted (Low Contrast Foreground) #6e6a86
-# Surface (Secondary Background Atop Base) #1f1d2e
-# Overlay (Tertiary Background Atop Surface) #26233a
-# Subtle (Medium Contrast Foreground) #908caa
-# Text (High Contrast Foreground) #e0def4
-# Highlight Low (Low Contrast Highlight) #21202e
-# Highlight Med (Medium Contrast Highlight) #403d52
-# Highlight High (High Contrast Highlight) #524f67
+# Gold (Terminal Yellow) #ea9d34
+# Love (Terminal Red) #b4637a
+# Rose (Terminal Cyan) #d7827e
+# Base (Primary Background) #faf4ed
+# Iris (Terminal Magenta) #907aa9
+# Foam (Terminal Blue) #56949f
+# Pine (Terminal Green)  #286983
+# Text (High contrast foreground) #575279
+# Muted (Low Contrast Foreground) #9893a5
+# Subtle (Medium Contrast Foreground) #797593
+# Highlight Low (Low contrast highlight) #f4ede8
+# Highlight Med (Medium Contrast Highlight) #dfdad9
+# Highlight High (High Contrast Highlight) #cecacd
 
 filekinds:
-  normal: {foreground: "#e0def4"}
-  directory: {foreground: "#9ccfd8"}
-  symlink: {foreground: "#524f67"}
-  pipe: {foreground: "#908caa"}
-  block_device: {foreground: "#ebbcba"}
-  char_device: {foreground: "#f6c177"}
-  socket: {foreground: "#21202e"}
-  special: {foreground: "#c4a7e7"}
-  executable: {foreground: "#c4a7e7"}
-  mount_point: {foreground: "#403d52"}
+  normal: { foreground: "#575279" }
+  directory: { foreground: "#56949f" }
+  symlink: { foreground: "#cecacd" }
+  pipe: { foreground: "#797593" }
+  block_device: { foreground: "#d7827e" }
+  char_device: { foreground: "#ea9d34" }
+  socket: { foreground: "#f4ede8" }
+  special: { foreground: "#907aa9" }
+  executable: { foreground: "#907aa9" }
+  mount_point: { foreground: "#dfdad9" }
 
 perms:
-  user_read: {foreground: "#908caa"}
-  user_write: {foreground: "#403d52"}
-  user_execute_file: {foreground: "#c4a7e7"}
-  user_execute_other: {foreground: "#c4a7e7"}
-  group_read: {foreground: "#908caa"}
-  group_write: {foreground: "#403d52"}
-  group_execute: {foreground: "#c4a7e7"}
-  other_read: {foreground: "#908caa"}
-  other_write: {foreground: "#403d52"}
-  other_execute: {foreground: "#c4a7e7"}
-  special_user_file: {foreground: "#c4a7e7"}
-  special_other: {foreground: "#403d52"}
-  attribute: {foreground: "#908caa"}
+  user_read: { foreground: "#797593" }
+  user_write: { foreground: "#d7827e" }
+  user_execute_file: { foreground: "#907aa9" }
+  user_execute_other: { foreground: "#907aa9" }
+  group_read: { foreground: "#797593" }
+  group_write: { foreground: "#d7827e" }
+  group_execute: { foreground: "#907aa9" }
+  other_read: { foreground: "#797593" }
+  other_write: { foreground: "#d7827e" }
+  other_execute: { foreground: "#907aa9" }
+  special_user_file: { foreground: "#907aa9" }
+  special_other: { foreground: "#d7827e" }
+  attribute: { foreground: "#797593" }
 
 size:
-  major: {foreground: "#908caa"}
-  minor: {foreground: "#9ccfd8"}
-  number_byte: {foreground: "#908caa"}
-  number_kilo: {foreground: "#524f67"}
-  number_mega: {foreground: "#31748f"}
-  number_giga: {foreground: "#c4a7e7"}
-  number_huge: {foreground: "#c4a7e7"}
-  unit_byte: {foreground: "#908caa"}
-  unit_kilo: {foreground: "#31748f"}
-  unit_mega: {foreground: "#c4a7e7"}
-  unit_giga: {foreground: "#c4a7e7"}
-  unit_huge: {foreground: "#9ccfd8"}
+  major: { foreground: "#797593" }
+  minor: { foreground: "#56949f" }
+  number_byte: { foreground: "#797593" }
+  number_kilo: { foreground: "#cecacd" }
+  number_mega: { foreground: "#286983" }
+  number_giga: { foreground: "#907aa9" }
+  number_huge: { foreground: "#907aa9" }
+  unit_byte: { foreground: "#797593" }
+  unit_kilo: { foreground: "#286983" }
+  unit_mega: { foreground: "#907aa9" }
+  unit_giga: { foreground: "#907aa9" }
+  unit_huge: { foreground: "#56949f" }
 
 users:
-  user_you: {foreground: "#f6c177"}
-  user_root: {foreground: "#eb6f92"}
-  user_other: {foreground: "#c4a7e7"}
-  group_yours: {foreground: "#524f67"}
-  group_other: {foreground: "#6e6a86"}
-  group_root: {foreground: "#eb6f92"}
+  user_you: { foreground: "#ea9d34" }
+  user_root: { foreground: "#b4637a" }
+  user_other: { foreground: "#907aa9" }
+  group_yours: { foreground: "#cecacd" }
+  group_other: { foreground: "#9893a5" }
+  group_root: { foreground: "#b4637a" }
 
 links:
-  normal: {foreground: "#9ccfd8"}
-  multi_link_file: {foreground: "#31748f"}
+  normal: { foreground: "#56949f" }
+  multi_link_file: { foreground: "#286983" }
 
 git:
-  new: {foreground: "#9ccfd8"}
-  modified: {foreground: "#f6c177"}
-  deleted: {foreground: "#eb6f92"}
-  renamed: {foreground: "#31748f"}
-  typechange: {foreground: "#c4a7e7"}
-  ignored: {foreground: "#6e6a86"}
-  conflicted: {foreground: "#ebbcba"}
+  new: { foreground: "#56949f" }
+  modified: { foreground: "#ea9d34" }
+  deleted: { foreground: "#b4637a" }
+  renamed: { foreground: "#286983" }
+  typechange: { foreground: "#907aa9" }
+  ignored: { foreground: "#9893a5" }
+  conflicted: { foreground: "#d7827e" }
 
 git_repo:
-  branch_main: {foreground: "#908caa"}
-  branch_other: {foreground: "#c4a7e7"}
-  git_clean: {foreground: "#9ccfd8"}
-  git_dirty: {foreground: "#eb6f92"}
+  branch_main: { foreground: "#797593" }
+  branch_other: { foreground: "#907aa9" }
+  git_clean: { foreground: "#56949f" }
+  git_dirty: { foreground: "#b4637a" }
 
 security_context:
-  colon: {foreground: "#908caa"}
-  user: {foreground: "#9ccfd8"}
-  role: {foreground: "#c4a7e7"}
-  typ: {foreground: "#6e6a86"}
-  range: {foreground: "#c4a7e7"}
+  colon: { foreground: "#797593" }
+  user: { foreground: "#56949f" }
+  role: { foreground: "#907aa9" }
+  typ: { foreground: "#9893a5" }
+  range: { foreground: "#907aa9" }
 
 file_type:
-  image: {foreground: "#f6c177"}
-  video: {foreground: "#eb6f92"}
-  music: {foreground: "#9ccfd8"}
-  lossless: {foreground: "#6e6a86"}
-  crypto: {foreground: "#403d52"}
-  document: {foreground: "#908caa"}
-  compressed: {foreground: "#c4a7e7"}
-  temp: {foreground: "#ebbcba"}
-  compiled: {foreground: "#31748f"}
-  build: {foreground: "#6e6a86"}
-  source: {foreground: "#ebbcba"}
+  image: { foreground: "#ea9d34" }
+  video: { foreground: "#b4637a" }
+  music: { foreground: "#56949f" }
+  lossless: { foreground: "#9893a5" }
+  crypto: { foreground: "#dfdad9" }
+  document: { foreground: "#797593" }
+  compressed: { foreground: "#907aa9" }
+  temp: { foreground: "#d7827e" }
+  compiled: { foreground: "#286983" }
+  build: { foreground: "#9893a5" }
+  source: { foreground: "#d7827e" }
 
-punctuation: {foreground: "#524f67"}
-date: {foreground: "#31748f"}
-inode: {foreground: "#908caa"}
-blocks: {foreground: "#6e6a86"}
-header: {foreground: "#908caa"}
-octal: {foreground: "#9ccfd8"}
-flags: {foreground: "#c4a7e7"}
+punctuation: { foreground: "#cecacd" }
+date: { foreground: "#286983" }
+inode: { foreground: "#797593" }
+blocks: { foreground: "#9893a5" }
+header: { foreground: "#797593" }
+octal: { foreground: "#56949f" }
+flags: { foreground: "#907aa9" }
 
-symlink_path: {foreground: "#9ccfd8"}
-control_char: {foreground: "#31748f"}
-broken_symlink: {foreground: "#eb6f92"}
-broken_path_overlay: {foreground: "#524f67"}
+symlink_path: { foreground: "#56949f" }
+control_char: { foreground: "#286983" }
+broken_symlink: { foreground: "#b4637a" }
+broken_path_overlay: { foreground: "#cecacd" }


### PR DESCRIPTION
Config was actually pulling the dark (default) rosé pine theme which makes eza outputs
hardly readable. Fix is simply copying rosé-pine-*dawn* (light) from the eza themes repo.