### PR TITLE
Add keybinding for locking screen

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -24,6 +24,9 @@ bindd = SUPER CTRL, I, Toggle locking on idle, exec, omarchy-toggle-idle
 # Toggle nightlight
 bindd = SUPER CTRL, N, Toggle nightlight, exec, omarchy-toggle-nightlight
 
+# Lock screen
+bindd = SUPER, L, Lock screen, exec, omarchy-lock-screen
+
 # Control Apple Display brightness
 bindd = CTRL, F1, Apple Display brightness down, exec, omarchy-cmd-apple-display-brightness -5000
 bindd = CTRL, F2, Apple Display brightness up, exec, omarchy-cmd-apple-display-brightness +5000


### PR DESCRIPTION
This is a default keybinding on Ubuntu.
Very often I need a quick screen lock (going for a lunch in office, etc).
I think this might be useful for all, as it promotes good practice to not leave your machine unattended.