### PR TITLE
added gnome-disk-utility to base-packages

### DIFF
--- a/default/hypr/apps/steam.conf
+++ b/default/hypr/apps/steam.conf
@@ -1,4 +1,4 @@
-# Float Steam, fullscreen RetroArch
+# Float Steam
 windowrule = float, class:steam
 windowrule = center, class:steam, title:Steam
 windowrule = opacity 1 1, class:steam

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -68,6 +68,7 @@ mariadb-libs
 mise
 mpv
 nautilus
+gnome-disk-utility
 noto-fonts
 noto-fonts-cjk
 noto-fonts-emoji


### PR DESCRIPTION
Added gnome-disk-utility next to nautilus in install/omarchy-base-packages.

Since I installed i have been somewhat frustrated to see this error message when i clicked "Open in Disks" from Nautilus.
![image](https://github.com/user-attachments/assets/1344f8e8-aa69-4e06-8bb6-a5780620189e)

As I'm a Linux Newb, I assume i'm not the only one going through this.

Just today my question on the Omacom Discord was answered by @pooparoo and i figured the Powers That Be would be happy to have this installed from scratch also.
