### PR TITLE
Fix DPI issue on VLC on high DPI monitors with QT_SCALE_FACTOR

### DIFF
--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -5,6 +5,8 @@
 
 # Optimized for retina-class 2x displays, like 13" 2.8K, 27" 5K, 32" 6K.
 env = GDK_SCALE,2
+env = QT_SCALE_FACTOR,2.0
+
 monitor=,preferred,auto,auto
 
 # Good compromise for 27" or 32" 4K monitors (but fractional!)


### PR DESCRIPTION
Added QT_SCALE_FACTOR environment variable for scaling on high DPI display. Without it, VLC UI  is ridiculously small.

# WARNING

This actually then break OBS Studio UI... everything becomes too big... unsure how I should proceed to have both OBS and VLC working as expected.