### PR TITLE
Fix Neovim .desktop file to open files from GUI file manager

### DIFF
--- a/applications/nvim.desktop
+++ b/applications/nvim.desktop
@@ -2,7 +2,7 @@
 Name=Neovim
 GenericName=Text Editor
 Comment=Edit text files
-Exec=$TERMINAL --class=nvim --title=nvim -e nvim -- %F
+Exec=sh -c "$TERMINAL --class=nvim --title=nvim -e nvim -- %F"
 Terminal=false
 Type=Application
 Keywords=Text;editor;


### PR DESCRIPTION
Previously, Neovim could only be launched from a terminal, and opening files
from a GUI file manager failed. This change updates the .desktop file to use
`sh -c` with $TERMINAL, allowing files to be opened directly from the GUI.
