### PR TITLE
Add ncdu to base-packages

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -68,6 +68,7 @@ mariadb-libs
 mise
 mpv
 nautilus
+ncdu
 noto-fonts
 noto-fonts-cjk
 noto-fonts-emoji


### PR DESCRIPTION
ncdu (https://dev.yorhel.nl/ncdu, https://archlinux.org/packages/extra/x86_64/ncdu) is a small (installed size 528.3 KB), well maintained, ncurses application to analyse and manage disk usage.

I believe it fits omarchy and would even suggest to add a keybinding for it.