### PR TITLE
Update bindings.conf, Super+L for Screen Lock

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -13,6 +13,7 @@ bindd = SUPER, D, Docker, exec, $terminal -e lazydocker
 bindd = SUPER, G, Signal, exec, omarchy-launch-or-focus signal "uwsm app -- signal-desktop"
 bindd = SUPER, O, Obsidian, exec, omarchy-launch-or-focus obsidian "uwsm app -- obsidian -disable-gpu --enable-wayland-ime"
 bindd = SUPER, slash, Passwords, exec, uwsm app -- 1password
+bindd = SUPER, L, Terminal, exec, loginctl lock-session
 
 # If your web app url contains #, type it as ## to prevent hyperland treat it as comments
 bindd = SUPER, A, ChatGPT, exec, omarchy-launch-webapp "https://chatgpt.com"


### PR DESCRIPTION
Mirrors the default Windows shortcut for locking the screen rather than needing to use super+esc, enter. Locking the screen on command is an important function and the consistent UX may be appreciated by migrating Windows users. 