### PR TITLE
update autostart hypridle to log to journald

### DIFF
--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -1,4 +1,4 @@
-exec-once = uwsm app -- hypridle
+exec-once = uwsm app -- sh -c 'hypridle 2>&1 | logger -t hypridle'
 exec-once = uwsm app -- mako
 exec-once = uwsm app -- waybar
 exec-once = uwsm app -- fcitx5


### PR DESCRIPTION
Presently, logs for hypridle are not stored anywhere for debugging. We need a place to log and debug if there are issues with hypridle that persist after a reboot.

See this discussion for more details. This PR will just allow us to gather more details on this random issue that doesn't have a root cause yet.

https://github.com/basecamp/omarchy/discussions/1469