### PR TITLE
feat(bluetooth): switch desktop integration to bluetui

### DIFF
--- a/bin/omarchy-launch-bluetooth
+++ b/bin/omarchy-launch-bluetooth
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec setsid uwsm app -- "$TERMINAL" --class=Bluetui -e Bluetui "$@"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -185,7 +185,7 @@ show_setup_menu() {
     ;;
   *Bluetooth*)
     rfkill unblock bluetooth
-    blueberry
+    omarchy-launch-bluetooth
     ;;
   *Power*) show_setup_power_menu ;;
   *Monitors*) open_in_editor ~/.config/hypr/monitors.conf ;;

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -100,7 +100,7 @@
     "format-disabled": "󰂲",
     "format-connected": "",
     "tooltip-format": "Devices connected: {num_connections}",
-    "on-click": "blueberry"
+    "on-click": "omarchy-launch-bluetooth"
   },
   "pulseaudio": {
     "format": "{icon}",

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -3,7 +3,7 @@ windowrule = float, tag:floating-window
 windowrule = center, tag:floating-window
 windowrule = size 800 600, tag:floating-window
 
-windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
+windowrule = tag +floating-window, class:(Bluetui|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
 windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files)
 
 # Fullscreen screensaver

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -8,7 +8,7 @@ asdcontrol-git
 avahi
 bash-completion
 bat
-blueberry
+bluetui
 brightnessctl
 btop
 cargo

--- a/migrations/1751134568.sh
+++ b/migrations/1751134568.sh
@@ -1,4 +1,4 @@
-# Turn on bluetooth service so blueberry works out the box
+# Turn on bluetooth service so bluetui works out the box
 echo "Let's turn on Bluetooth service so the controls work"
 if systemctl is-enabled --quiet bluetooth.service && systemctl is-active --quiet bluetooth.service; then
   # Bluetooth is already enabled, nothing to change

--- a/migrations/1759000000.sh
+++ b/migrations/1759000000.sh
@@ -1,0 +1,11 @@
+echo "Replace blueberry with bluetui"
+
+if omarchy-cmd-missing Bluetui; then
+  omarchy-pkg-add bluetui
+fi
+
+if omarchy-pkg-present blueberry; then
+  omarchy-pkg-drop blueberry
+fi
+
+omarchy-refresh-waybar


### PR DESCRIPTION
replace blueberry launchers with a Bluetui runner, ship bluetui in the base packages, and align Hyprland rules and migrations so the Bluetooth UI opens in a consistent terminal interface

author: harshvsri <harshvsri@gmail.com>