### PR TITLE
fix(presentation-terminal): Ensure consistent ASCII logo alignment

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cmd="$*"
-exec setsid uwsm app -- alacritty --class=Omarchy --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"
+exec setsid uwsm app -- alacritty -o font.size=9 --class=Omarchy --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"

--- a/default/hypr/apps/steam.conf
+++ b/default/hypr/apps/steam.conf
@@ -1,4 +1,4 @@
-# Float Steam, fullscreen RetroArch
+# Float Steam
 windowrule = float, class:steam
 windowrule = center, class:steam, title:Steam
 windowrule = opacity 1 1, class:steam


### PR DESCRIPTION
The presentation terminal's ASCII logo, displayed by 'omarchy-show-logo', would misalign if the user had a non-default font size set in their global Alacritty configuration.

This change fixes the issue by explicitly setting the font size to 9 for this specific terminal instance using the  flag.

This approach guarantees correct rendering of the logo without overriding the user's personal font preferences for their regular terminal sessions.

Before (at 14 font size):
<img width="804" height="603" alt="image" src="https://github.com/user-attachments/assets/7da8482b-d6b2-489c-b1f2-fbbbb20d7089" />

After: 
<img width="796" height="596" alt="image" src="https://github.com/user-attachments/assets/155a0e1d-ea0f-41fb-b59d-d8450407bef4" />
