### PR TITLE
Disable Trackpad While Typing - w/ device & timeout TUI config

### DIFF
--- a/bin/omarchy-disable-trackpad-while-typing
+++ b/bin/omarchy-disable-trackpad-while-typing
@@ -1,0 +1,429 @@
+#!/bin/bash
+
+# Disable trackpad while typing using sysfs inhibit mechanism
+# Also enable trackpad on window focus change for smooth window switching
+# Optimized for efficiency - minimal operations per keypress
+
+# Read timeout from environment variable set in Hyprland config, or use default
+TIMEOUT="${OMARCHY_TRACKPAD_DWT_TIMEOUT:-1.5}"
+PID_FILE="/tmp/dwt-timeout-pid"
+CANCEL_TIMEOUT="/tmp/dwt-cancel-timeout"
+SCRIPT_PID_FILE="/tmp/dwt-script-pid"
+
+main() {
+  # Check if already running and kill old instances (e.g., from previous Hyprland session)
+  if [ -f "$SCRIPT_PID_FILE" ]; then
+    old_pid=$(cat "$SCRIPT_PID_FILE" 2>/dev/null)
+    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+      # Kill the entire process group (negative PID kills process group)
+      # This ensures all subprocesses (evtest, socat, timeout jobs) are killed
+      kill -- -"$old_pid" 2>/dev/null || {
+        # Fallback: kill children then parent if process group kill fails
+        pkill -P "$old_pid" 2>/dev/null
+        kill "$old_pid" 2>/dev/null
+      }
+      sleep 0.5
+    fi
+    # Remove old PID file
+    rm -f "$SCRIPT_PID_FILE"
+  fi
+
+  # Run in own process group so we can kill entire tree later
+  # This makes $$ equal to the process group ID
+  set -m
+
+  # Store our PID (which is also our PGID due to set -m)
+  echo $$ >"$SCRIPT_PID_FILE"
+
+  # Detect if running interactively (not in background from autostart)
+  if [ -t 1 ]; then
+    INTERACTIVE=true
+  else
+    INTERACTIVE=false
+  fi
+
+  # Helper function for conditional output
+  log_info() {
+    $INTERACTIVE && echo "$@"
+  }
+
+  # Keyboard device - REQUIRED environment variable
+  if [ -z "${OMARCHY_TRACKPAD_DWT_KEYBOARD:-}" ]; then
+    echo "Error: OMARCHY_TRACKPAD_DWT_KEYBOARD environment variable not set"
+    echo "Run omarchy-disable-trackpad-while-typing-tui to configure your keyboard device"
+    exit 1
+  fi
+
+  KEYBOARD_DEVICE="$OMARCHY_TRACKPAD_DWT_KEYBOARD"
+  if [ ! -c "$KEYBOARD_DEVICE" ]; then
+    echo "Error: Keyboard device $KEYBOARD_DEVICE not found"
+    echo "Run omarchy-disable-trackpad-while-typing-tui to configure available devices"
+    exit 1
+  fi
+  log_info "Using keyboard: $KEYBOARD_DEVICE"
+
+  # Configuration for instant trackpad enable - array of keys
+  INSTANT_ENABLE_KEYS=(
+    "ESCAPE"
+    "LEFTCTRL" "RIGHTCTRL"
+    "LEFTALT" "RIGHTALT"
+    "LEFTSHIFT" "RIGHTSHIFT"
+    "LEFTMETA" "RIGHTMETA"
+    "ESC" # For escape sequences like ^[ from keyd remapped keys
+    "TAB"
+    "FN" # Might not work on all keyboards (firmware dependent)
+    "DELETE" "BACKSPACE"
+    "UP" "DOWN" "LEFT" "RIGHT"
+    "ENTER" "RETURN"
+  )
+
+  # Trackpad device - REQUIRED environment variable
+  if [ -z "${OMARCHY_TRACKPAD_DWT_TRACKPAD:-}" ]; then
+    echo "Error: OMARCHY_TRACKPAD_DWT_TRACKPAD environment variable not set"
+    echo "Run omarchy-disable-trackpad-while-typing-tui to configure your trackpad device"
+    exit 1
+  fi
+
+  # Convert trackpad device path to sysfs path
+  TRACKPAD_EVENT=$(basename "$OMARCHY_TRACKPAD_DWT_TRACKPAD")
+  TRACKPAD_SYSFS=""
+
+  for input_dev in /sys/class/input/input*/event*; do
+    if [ "$(basename "$input_dev")" = "$TRACKPAD_EVENT" ]; then
+      TRACKPAD_SYSFS=$(dirname "$input_dev")
+      break
+    fi
+  done
+
+  if [ -z "$TRACKPAD_SYSFS" ]; then
+    echo "Error: Trackpad device $OMARCHY_TRACKPAD_DWT_TRACKPAD not found"
+    echo "Run omarchy-disable-trackpad-while-typing-tui to configure available devices"
+    exit 1
+  fi
+
+  log_info "Found trackpad at: $TRACKPAD_SYSFS"
+  log_info "Device name: $(cat "$TRACKPAD_SYSFS/name")"
+
+  # Find the inhibited file for the trackpad
+  if [ -f "$TRACKPAD_SYSFS/inhibited" ]; then
+    TRACKPAD_FILE="$TRACKPAD_SYSFS/inhibited"
+  elif [ -f "$TRACKPAD_SYSFS/device/inhibited" ]; then
+    TRACKPAD_FILE="$TRACKPAD_SYSFS/device/inhibited"
+  else
+    echo "Error: Cannot find inhibited file for trackpad"
+    echo "Trackpad may not support the inhibit mechanism"
+    exit 1
+  fi
+
+  # Check that we have permission (script should be run with sudo)
+  if [ ! -w "$TRACKPAD_FILE" ] && [ "$EUID" -ne 0 ]; then
+    echo "Error: No permission to control trackpad"
+    echo "This script must be run with sudo"
+    exit 1
+  fi
+
+  # Simple trackpad control functions
+  disable_trackpad() {
+    echo 1 >"$TRACKPAD_FILE" 2>/dev/null
+  }
+
+  enable_trackpad() {
+    echo 0 >"$TRACKPAD_FILE" 2>/dev/null
+  }
+
+  log_info "Monitoring keyboard: $KEYBOARD_DEVICE"
+  log_info "Monitoring Hyprland window focus changes"
+  log_info "Trackpad will be disabled while typing (timeout: ${TIMEOUT}s)"
+  log_info "Trackpad will be enabled on window focus change"
+  log_info "Press Escape or any modifier key to instantly enable trackpad"
+  log_info "Press Ctrl+C to stop"
+
+  # Get Hyprland instance signature
+  ACTUAL_UID="${SUDO_UID:-$(id -u)}"
+
+  if [ -z "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
+    HYPRLAND_INSTANCE_SIGNATURE=$(ls /run/user/$ACTUAL_UID/hypr/ 2>/dev/null | sort -r | head -1)
+  fi
+
+  # Start window focus monitor in background using socat
+  if [ -n "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
+    (
+      # dwt-focus-monitor: Monitor Hyprland window focus changes
+      sudo -u "${SUDO_USER:-$USER}" HYPRLAND_INSTANCE_SIGNATURE="$HYPRLAND_INSTANCE_SIGNATURE" socat -u UNIX-CONNECT:/run/user/$ACTUAL_UID/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock - | while read -r line; do
+        if echo "$line" | grep -q "activewindow>>"; then
+          log_info "Window focus changed - enabling trackpad"
+          enable_trackpad
+          # Signal timeout cancellation
+          touch "$CANCEL_TIMEOUT"
+        fi
+      done
+    ) &
+    FOCUS_MONITOR_PID=$!
+  else
+    FOCUS_MONITOR_PID=""
+  fi
+
+  # Function to cleanup on exit
+  cleanup() {
+    log_info "Cleaning up..."
+    enable_trackpad
+    [ -n "$FOCUS_MONITOR_PID" ] && kill $FOCUS_MONITOR_PID 2>/dev/null
+    rm -f "$PID_FILE" "$CANCEL_TIMEOUT" "$SCRIPT_PID_FILE"
+    exit 0
+  }
+
+  trap cleanup SIGINT SIGTERM
+
+  # Get all window focus movement keybindings at startup
+  log_info "Reading Hyprland keybindings for window focus movement..."
+  FOCUS_BINDINGS=""
+  if [ -n "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
+    # Get all bindings and parse the structured format
+    focus_commands="movefocus|movewindow|workspace|movetoworkspace|focuswindow|swapwindow|moveworkspacetomonitor|focusmonitor"
+
+    # Parse hyprctl binds structured output
+    modmask=""
+    key=""
+    dispatcher=""
+
+    while IFS= read -r line; do
+      if echo "$line" | grep -q "modmask:"; then
+        modmask=$(echo "$line" | sed 's/.*modmask: //')
+      elif echo "$line" | grep -q "key:"; then
+        key=$(echo "$line" | sed 's/.*key: //')
+      elif echo "$line" | grep -q "dispatcher:"; then
+        dispatcher=$(echo "$line" | sed 's/.*dispatcher: //')
+
+        # If this is a focus-related dispatcher, convert modmask to modifier names
+        if echo "$dispatcher" | grep -qE "^($focus_commands)$"; then
+          modifiers=""
+          # Convert modmask bits to modifier names (Hyprland modmask format)
+          [ $((modmask & 1)) -ne 0 ] && modifiers="${modifiers}SHIFT_"
+          [ $((modmask & 2)) -ne 0 ] && modifiers="${modifiers}CAPS_"
+          [ $((modmask & 4)) -ne 0 ] && modifiers="${modifiers}CTRL_"
+          [ $((modmask & 8)) -ne 0 ] && modifiers="${modifiers}ALT_"
+          [ $((modmask & 64)) -ne 0 ] && modifiers="${modifiers}SUPER_"
+
+          # Remove trailing underscore and create binding
+          modifiers=$(echo "$modifiers" | sed 's/_$//')
+          if [ -n "$modifiers" ]; then
+            binding="${modifiers}+${key}"
+          else
+            binding="$key"
+          fi
+
+          FOCUS_BINDINGS="$FOCUS_BINDINGS $binding"
+        fi
+
+        # Reset for next binding
+        modmask=""
+        key=""
+        dispatcher=""
+      fi
+    done < <(sudo -u "${SUDO_USER:-$USER}" HYPRLAND_INSTANCE_SIGNATURE="$HYPRLAND_INSTANCE_SIGNATURE" hyprctl binds 2>/dev/null)
+  fi
+
+  log_info "Detected focus movement bindings:$FOCUS_BINDINGS"
+
+  # Track modifier key states for efficient combo detection
+  CTRL_HELD=false
+  ALT_HELD=false
+  SHIFT_HELD=false
+  SUPER_HELD=false
+
+  # Function to check if current modifier+key combo is a focus movement binding
+  is_focus_binding() {
+    local key="$1"
+    local current_combo=""
+
+    # Build current modifier combination in Hyprland order (matches the binding output)
+    $SHIFT_HELD && current_combo="${current_combo}SHIFT_"
+    $CTRL_HELD && current_combo="${current_combo}CTRL_"
+    $ALT_HELD && current_combo="${current_combo}ALT_"
+    $SUPER_HELD && current_combo="${current_combo}SUPER_"
+
+    # Remove trailing underscore and add key
+    current_combo=$(echo "$current_combo" | sed 's/_$//')
+    [ -n "$current_combo" ] && current_combo="${current_combo}+${key}"
+    [ -z "$current_combo" ] && current_combo="$key"
+
+    # Check if this combo matches any focus binding
+    echo "$FOCUS_BINDINGS" | grep -q "\<$current_combo\>"
+  }
+
+  # Export the function for use in subshells
+  export -f log_info
+  export INTERACTIVE
+
+  # Monitor keyboard with evtest
+  evtest "$KEYBOARD_DEVICE" | while read -r line; do
+    # Track all modifier key states and check for instant enable on press
+    if echo "$line" | grep -q "KEY_LEFTMETA.*value 1\|KEY_RIGHTMETA.*value 1"; then
+      SUPER_HELD=true
+      if echo "$line" | grep -q "KEY_LEFTMETA.*value 1"; then
+        log_info "LEFT_META pressed - enabling trackpad instantly"
+      else
+        log_info "RIGHT_META pressed - enabling trackpad instantly"
+      fi
+      enable_trackpad
+      touch "$CANCEL_TIMEOUT"
+      continue
+    elif echo "$line" | grep -q "KEY_LEFTMETA.*value 0\|KEY_RIGHTMETA.*value 0"; then
+      SUPER_HELD=false
+      continue
+    elif echo "$line" | grep -q "KEY_LEFTCTRL.*value 1\|KEY_RIGHTCTRL.*value 1"; then
+      CTRL_HELD=true
+      if echo "$line" | grep -q "KEY_LEFTCTRL.*value 1"; then
+        log_info "LEFT_CTRL pressed - enabling trackpad instantly"
+      else
+        log_info "RIGHT_CTRL pressed - enabling trackpad instantly"
+      fi
+      enable_trackpad
+      touch "$CANCEL_TIMEOUT"
+      continue
+    elif echo "$line" | grep -q "KEY_LEFTCTRL.*value 0\|KEY_RIGHTCTRL.*value 0"; then
+      CTRL_HELD=false
+      continue
+    elif echo "$line" | grep -q "KEY_LEFTALT.*value 1\|KEY_RIGHTALT.*value 1"; then
+      ALT_HELD=true
+      if echo "$line" | grep -q "KEY_LEFTALT.*value 1"; then
+        log_info "LEFT_ALT pressed - enabling trackpad instantly"
+      else
+        log_info "RIGHT_ALT pressed - enabling trackpad instantly"
+      fi
+      enable_trackpad
+      touch "$CANCEL_TIMEOUT"
+      continue
+    elif echo "$line" | grep -q "KEY_LEFTALT.*value 0\|KEY_RIGHTALT.*value 0"; then
+      ALT_HELD=false
+      continue
+    elif echo "$line" | grep -q "KEY_LEFTSHIFT.*value 1\|KEY_RIGHTSHIFT.*value 1"; then
+      SHIFT_HELD=true
+      if echo "$line" | grep -q "KEY_LEFTSHIFT.*value 1"; then
+        log_info "LEFT_SHIFT pressed - enabling trackpad instantly"
+      else
+        log_info "RIGHT_SHIFT pressed - enabling trackpad instantly"
+      fi
+      enable_trackpad
+      touch "$CANCEL_TIMEOUT"
+      continue
+    elif echo "$line" | grep -q "KEY_LEFTSHIFT.*value 0\|KEY_RIGHTSHIFT.*value 0"; then
+      SHIFT_HELD=false
+      continue
+    fi
+
+    # Look for key press events (value 1 = press)
+    if echo "$line" | grep -q "EV_KEY.*value 1"; then
+      # Skip modifier keys (already handled above)
+      if echo "$line" | grep -qE "(KEY_LEFT(SHIFT|CTRL|ALT|META)|KEY_RIGHT(SHIFT|CTRL|ALT|META)|KEY_COMPOSE)"; then
+        continue
+      fi
+
+      # Extract the key name from evtest output
+      key_name=$(echo "$line" | sed -n 's/.*(\(KEY_[^)]*\)).*/\1/p')
+      if [ -n "$key_name" ]; then
+        # Convert KEY_* to the format used in Hyprland binds (remove KEY_ prefix)
+        hypr_key=$(echo "$key_name" | sed 's/^KEY_//')
+
+        # Check for instant enable keys (Escape or any modifier)
+        for enable_key in "${INSTANT_ENABLE_KEYS[@]}"; do
+          if [ "$hypr_key" = "$enable_key" ]; then
+            log_info "$enable_key pressed - enabling trackpad instantly"
+            enable_trackpad
+            touch "$CANCEL_TIMEOUT"
+            continue 2 # Continue outer loop
+          fi
+        done
+
+        # Check if any modifier is held + key pressed (modifier chord)
+        if $CTRL_HELD || $ALT_HELD || $SHIFT_HELD || $SUPER_HELD; then
+          log_info "Modifier chord detected: $hypr_key - enabling trackpad"
+          enable_trackpad
+          touch "$CANCEL_TIMEOUT"
+          continue
+        fi
+
+        # Check if this is a focus movement binding ONLY when modifiers are held
+        # (Focus movement requires modifier combinations, not plain key presses)
+        if $CTRL_HELD || $ALT_HELD || $SHIFT_HELD || $SUPER_HELD; then
+          if is_focus_binding "$hypr_key" || is_focus_binding "$(echo "$hypr_key" | tr '[:upper:]' '[:lower:]')"; then
+            log_info "Focus movement binding detected: $hypr_key - enabling trackpad"
+            enable_trackpad
+            # Cancel any running timeout
+            touch "$CANCEL_TIMEOUT"
+            continue
+          fi
+        fi
+      fi
+
+      log_info "Key pressed - disabling trackpad"
+      disable_trackpad
+
+      # Clean up any existing cancel signal and kill existing timeout
+      rm -f "$CANCEL_TIMEOUT"
+      [ -f "$PID_FILE" ] && kill $(cat "$PID_FILE") 2>/dev/null
+
+      # Start simple timeout with cancellation check
+      (
+        # dwt-timeout: Re-enable trackpad after typing timeout
+        # Calculate iterations based on timeout (0.1s increments)
+        iterations=$(awk "BEGIN {print int($TIMEOUT * 10)}" 2>/dev/null || echo 15)
+        for ((i = 1; i <= iterations; i++)); do
+          sleep 0.1
+          [ -f "$CANCEL_TIMEOUT" ] && {
+            log_info "Timeout cancelled"
+            rm -f "$PID_FILE" "$CANCEL_TIMEOUT"
+            exit 0
+          }
+        done
+        log_info "Re-enabling trackpad after timeout"
+        enable_trackpad
+        rm -f "$PID_FILE"
+      ) &
+      echo $! >"$PID_FILE"
+    fi
+  done
+}
+
+# Show help if requested
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Disable trackpad while typing using sysfs inhibit mechanism. Enables trackpad
+on window focus changes for smooth window switching.
+
+REQUIRED ENVIRONMENT VARIABLES:
+    OMARCHY_TRACKPAD_DWT_KEYBOARD    Keyboard device path (e.g., /dev/input/event1)
+    OMARCHY_TRACKPAD_DWT_TRACKPAD    Trackpad device path (e.g., /dev/input/event2)
+
+OPTIONAL ENVIRONMENT VARIABLES:
+    OMARCHY_TRACKPAD_DWT_TIMEOUT     Timeout in seconds before re-enabling trackpad (default: 1.5)
+
+FEATURES:
+    • Disables trackpad while typing with configurable timeout
+    • Instantly enables trackpad on modifier keys (Ctrl, Alt, Shift, Super, Esc)
+    • Enables trackpad on window focus changes (Hyprland integration)
+    • Detects focus movement key bindings and enables trackpad accordingly
+
+EXAMPLES:
+    $(basename "$0")                                    # Start with default settings
+    OMARCHY_TRACKPAD_DWT_TIMEOUT=2.0 $(basename "$0")   # Use 2 second timeout
+
+NOTES:
+    • Script will auto-detect input devices and prompt to set the trigger (keyboard)
+      and target to disable (trackpad/mouse).
+    • Though designed to disable large trackpads on laptops while using the
+      internal keyboard, it can be used to disable any input device (e.g.,
+      external mouse) while typing on a specified trigger (keyboard). This
+      could be useful in a pair programming scenario where there are multiple
+      sets of input devices and you want to control which one is active based on
+      typing activity, for example.
+    • For keyd users, keyboard device is usually /dev/input/event3 if no external keyboards are attached
+    • Press Ctrl+C to stop the script
+
+EOF
+  exit 0
+fi
+
+main "$@"

--- a/bin/omarchy-disable-trackpad-while-typing
+++ b/bin/omarchy-disable-trackpad-while-typing
@@ -77,60 +77,68 @@ main() {
     "ENTER" "RETURN"
   )
 
-  # Trackpad device(s) - REQUIRED environment variable
-  # Can be a single device or multiple colon-separated devices (e.g., event6:event7)
-  if [ -z "${OMARCHY_TRACKPAD_DWT_TRACKPAD:-}" ]; then
-    echo "Error: OMARCHY_TRACKPAD_DWT_TRACKPAD environment variable not set"
-    echo "Run omarchy-disable-trackpad-while-typing-tui to configure your trackpad device"
-    exit 1
-  fi
+  # Initialize trackpad devices and return array of sysfs inhibited file paths
+  initialize_trackpad_devices() {
+    local -n files_ref=$1  # Reference to TRACKPAD_FILES array
 
-  # Split by colons to handle multiple devices (e.g., Magic Trackpad with multiple interfaces)
-  IFS=':' read -ra TRACKPAD_DEVICES <<< "$OMARCHY_TRACKPAD_DWT_TRACKPAD"
-  TRACKPAD_FILES=()
+    # Trackpad device(s) - REQUIRED environment variable
+    # Can be a single device or multiple colon-separated devices (e.g., event6:event7)
+    if [ -z "${OMARCHY_TRACKPAD_DWT_TRACKPAD:-}" ]; then
+      echo "Error: OMARCHY_TRACKPAD_DWT_TRACKPAD environment variable not set"
+      echo "Run omarchy-disable-trackpad-while-typing-tui to configure your trackpad device"
+      exit 1
+    fi
 
-  for device_path in "${TRACKPAD_DEVICES[@]}"; do
-    TRACKPAD_EVENT=$(basename "$device_path")
-    TRACKPAD_SYSFS=""
+    # Split by colons to handle multiple devices (e.g., Magic Trackpad with multiple interfaces)
+    IFS=':' read -ra TRACKPAD_DEVICES <<< "$OMARCHY_TRACKPAD_DWT_TRACKPAD"
 
-    # Find sysfs path for this event device
-    for input_dev in /sys/class/input/input*/event*; do
-      if [ "$(basename "$input_dev")" = "$TRACKPAD_EVENT" ]; then
-        TRACKPAD_SYSFS=$(dirname "$input_dev")
-        break
+    for device_path in "${TRACKPAD_DEVICES[@]}"; do
+      TRACKPAD_EVENT=$(basename "$device_path")
+      TRACKPAD_SYSFS=""
+
+      # Find sysfs path for this event device
+      for input_dev in /sys/class/input/input*/event*; do
+        if [ "$(basename "$input_dev")" = "$TRACKPAD_EVENT" ]; then
+          TRACKPAD_SYSFS=$(dirname "$input_dev")
+          break
+        fi
+      done
+
+      if [ -z "$TRACKPAD_SYSFS" ]; then
+        echo "Error: Trackpad device $device_path not found"
+        echo "Run omarchy-disable-trackpad-while-typing-tui to configure available devices"
+        exit 1
       fi
+
+      log_info "Found trackpad at: $TRACKPAD_SYSFS"
+      log_info "Device name: $(cat "$TRACKPAD_SYSFS/name")"
+
+      # Find the inhibited file for this trackpad
+      TRACKPAD_FILE=""
+      if [ -f "$TRACKPAD_SYSFS/inhibited" ]; then
+        TRACKPAD_FILE="$TRACKPAD_SYSFS/inhibited"
+      elif [ -f "$TRACKPAD_SYSFS/device/inhibited" ]; then
+        TRACKPAD_FILE="$TRACKPAD_SYSFS/device/inhibited"
+      else
+        echo "Error: Cannot find inhibited file for trackpad $TRACKPAD_EVENT"
+        echo "Trackpad may not support the inhibit mechanism"
+        exit 1
+      fi
+
+      # Check that we have permission (script should be run with sudo)
+      if [ ! -w "$TRACKPAD_FILE" ] && [ "$EUID" -ne 0 ]; then
+        echo "Error: No permission to control trackpad"
+        echo "This script must be run with sudo"
+        exit 1
+      fi
+
+      files_ref+=("$TRACKPAD_FILE")
     done
+  }
 
-    if [ -z "$TRACKPAD_SYSFS" ]; then
-      echo "Error: Trackpad device $device_path not found"
-      echo "Run omarchy-disable-trackpad-while-typing-tui to configure available devices"
-      exit 1
-    fi
-
-    log_info "Found trackpad at: $TRACKPAD_SYSFS"
-    log_info "Device name: $(cat "$TRACKPAD_SYSFS/name")"
-
-    # Find the inhibited file for this trackpad
-    TRACKPAD_FILE=""
-    if [ -f "$TRACKPAD_SYSFS/inhibited" ]; then
-      TRACKPAD_FILE="$TRACKPAD_SYSFS/inhibited"
-    elif [ -f "$TRACKPAD_SYSFS/device/inhibited" ]; then
-      TRACKPAD_FILE="$TRACKPAD_SYSFS/device/inhibited"
-    else
-      echo "Error: Cannot find inhibited file for trackpad $TRACKPAD_EVENT"
-      echo "Trackpad may not support the inhibit mechanism"
-      exit 1
-    fi
-
-    # Check that we have permission (script should be run with sudo)
-    if [ ! -w "$TRACKPAD_FILE" ] && [ "$EUID" -ne 0 ]; then
-      echo "Error: No permission to control trackpad"
-      echo "This script must be run with sudo"
-      exit 1
-    fi
-
-    TRACKPAD_FILES+=("$TRACKPAD_FILE")
-  done
+  # Initialize trackpad devices
+  TRACKPAD_FILES=()
+  initialize_trackpad_devices TRACKPAD_FILES
 
   # Trackpad control functions that handle multiple devices
   disable_trackpad() {
@@ -188,17 +196,22 @@ main() {
 
   trap cleanup SIGINT SIGTERM
 
-  # Get all window focus movement keybindings at startup
-  log_info "Reading Hyprland keybindings for window focus movement..."
-  FOCUS_BINDINGS=""
-  if [ -n "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
+  # Parse Hyprland keybindings to detect focus movement commands
+  parse_hyprland_focus_bindings() {
+    local bindings=""
+
+    if [ -z "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
+      echo "$bindings"
+      return
+    fi
+
     # Get all bindings and parse the structured format
-    focus_commands="movefocus|movewindow|workspace|movetoworkspace|focuswindow|swapwindow|moveworkspacetomonitor|focusmonitor"
+    local focus_commands="movefocus|movewindow|workspace|movetoworkspace|focuswindow|swapwindow|moveworkspacetomonitor|focusmonitor"
 
     # Parse hyprctl binds structured output
-    modmask=""
-    key=""
-    dispatcher=""
+    local modmask=""
+    local key=""
+    local dispatcher=""
 
     while IFS= read -r line; do
       if echo "$line" | grep -q "modmask:"; then
@@ -210,7 +223,7 @@ main() {
 
         # If this is a focus-related dispatcher, convert modmask to modifier names
         if echo "$dispatcher" | grep -qE "^($focus_commands)$"; then
-          modifiers=""
+          local modifiers=""
           # Convert modmask bits to modifier names (Hyprland modmask format)
           [ $((modmask & 1)) -ne 0 ] && modifiers="${modifiers}SHIFT_"
           [ $((modmask & 2)) -ne 0 ] && modifiers="${modifiers}CAPS_"
@@ -220,13 +233,14 @@ main() {
 
           # Remove trailing underscore and create binding
           modifiers=$(echo "$modifiers" | sed 's/_$//')
+          local binding
           if [ -n "$modifiers" ]; then
             binding="${modifiers}+${key}"
           else
             binding="$key"
           fi
 
-          FOCUS_BINDINGS="$FOCUS_BINDINGS $binding"
+          bindings="$bindings $binding"
         fi
 
         # Reset for next binding
@@ -235,8 +249,13 @@ main() {
         dispatcher=""
       fi
     done < <(sudo -u "${SUDO_USER:-$USER}" HYPRLAND_INSTANCE_SIGNATURE="$HYPRLAND_INSTANCE_SIGNATURE" hyprctl binds 2>/dev/null)
-  fi
 
+    echo "$bindings"
+  }
+
+  # Get all window focus movement keybindings at startup
+  log_info "Reading Hyprland keybindings for window focus movement..."
+  FOCUS_BINDINGS=$(parse_hyprland_focus_bindings)
   log_info "Detected focus movement bindings:$FOCUS_BINDINGS"
 
   # Track modifier key states for efficient combo detection
@@ -244,6 +263,17 @@ main() {
   ALT_HELD=false
   SHIFT_HELD=false
   SUPER_HELD=false
+
+  # Helper to check if any modifier key is currently held
+  any_modifier_held() {
+    $CTRL_HELD || $ALT_HELD || $SHIFT_HELD || $SUPER_HELD
+  }
+
+  # Helper to enable trackpad and cancel any pending timeout
+  enable_trackpad_and_cancel_timeout() {
+    enable_trackpad
+    touch "$CANCEL_TIMEOUT"
+  }
 
   # Function to check if current modifier+key combo is a focus movement binding
   is_focus_binding() {
@@ -269,62 +299,37 @@ main() {
   export -f log_info
   export INTERACTIVE
 
+  # Helper function to handle modifier key press/release
+  handle_modifier_key() {
+    local line="$1"
+    local key_name="$2"
+    local held_var="$3"
+
+    # Check for press (value 1)
+    if echo "$line" | grep -q "KEY_LEFT${key_name}.*value 1\|KEY_RIGHT${key_name}.*value 1"; then
+      eval "$held_var=true"
+      if echo "$line" | grep -q "KEY_LEFT${key_name}.*value 1"; then
+        log_info "LEFT_${key_name} pressed - enabling trackpad instantly"
+      else
+        log_info "RIGHT_${key_name} pressed - enabling trackpad instantly"
+      fi
+      enable_trackpad_and_cancel_timeout
+      return 0
+    # Check for release (value 0)
+    elif echo "$line" | grep -q "KEY_LEFT${key_name}.*value 0\|KEY_RIGHT${key_name}.*value 0"; then
+      eval "$held_var=false"
+      return 0
+    fi
+    return 1
+  }
+
   # Monitor keyboard with evtest
   evtest "$KEYBOARD_DEVICE" | while read -r line; do
     # Track all modifier key states and check for instant enable on press
-    if echo "$line" | grep -q "KEY_LEFTMETA.*value 1\|KEY_RIGHTMETA.*value 1"; then
-      SUPER_HELD=true
-      if echo "$line" | grep -q "KEY_LEFTMETA.*value 1"; then
-        log_info "LEFT_META pressed - enabling trackpad instantly"
-      else
-        log_info "RIGHT_META pressed - enabling trackpad instantly"
-      fi
-      enable_trackpad
-      touch "$CANCEL_TIMEOUT"
-      continue
-    elif echo "$line" | grep -q "KEY_LEFTMETA.*value 0\|KEY_RIGHTMETA.*value 0"; then
-      SUPER_HELD=false
-      continue
-    elif echo "$line" | grep -q "KEY_LEFTCTRL.*value 1\|KEY_RIGHTCTRL.*value 1"; then
-      CTRL_HELD=true
-      if echo "$line" | grep -q "KEY_LEFTCTRL.*value 1"; then
-        log_info "LEFT_CTRL pressed - enabling trackpad instantly"
-      else
-        log_info "RIGHT_CTRL pressed - enabling trackpad instantly"
-      fi
-      enable_trackpad
-      touch "$CANCEL_TIMEOUT"
-      continue
-    elif echo "$line" | grep -q "KEY_LEFTCTRL.*value 0\|KEY_RIGHTCTRL.*value 0"; then
-      CTRL_HELD=false
-      continue
-    elif echo "$line" | grep -q "KEY_LEFTALT.*value 1\|KEY_RIGHTALT.*value 1"; then
-      ALT_HELD=true
-      if echo "$line" | grep -q "KEY_LEFTALT.*value 1"; then
-        log_info "LEFT_ALT pressed - enabling trackpad instantly"
-      else
-        log_info "RIGHT_ALT pressed - enabling trackpad instantly"
-      fi
-      enable_trackpad
-      touch "$CANCEL_TIMEOUT"
-      continue
-    elif echo "$line" | grep -q "KEY_LEFTALT.*value 0\|KEY_RIGHTALT.*value 0"; then
-      ALT_HELD=false
-      continue
-    elif echo "$line" | grep -q "KEY_LEFTSHIFT.*value 1\|KEY_RIGHTSHIFT.*value 1"; then
-      SHIFT_HELD=true
-      if echo "$line" | grep -q "KEY_LEFTSHIFT.*value 1"; then
-        log_info "LEFT_SHIFT pressed - enabling trackpad instantly"
-      else
-        log_info "RIGHT_SHIFT pressed - enabling trackpad instantly"
-      fi
-      enable_trackpad
-      touch "$CANCEL_TIMEOUT"
-      continue
-    elif echo "$line" | grep -q "KEY_LEFTSHIFT.*value 0\|KEY_RIGHTSHIFT.*value 0"; then
-      SHIFT_HELD=false
-      continue
-    fi
+    handle_modifier_key "$line" "META" "SUPER_HELD" && continue
+    handle_modifier_key "$line" "CTRL" "CTRL_HELD" && continue
+    handle_modifier_key "$line" "ALT" "ALT_HELD" && continue
+    handle_modifier_key "$line" "SHIFT" "SHIFT_HELD" && continue
 
     # Look for key press events (value 1 = press)
     if echo "$line" | grep -q "EV_KEY.*value 1"; then
@@ -343,28 +348,24 @@ main() {
         for enable_key in "${INSTANT_ENABLE_KEYS[@]}"; do
           if [ "$hypr_key" = "$enable_key" ]; then
             log_info "$enable_key pressed - enabling trackpad instantly"
-            enable_trackpad
-            touch "$CANCEL_TIMEOUT"
+            enable_trackpad_and_cancel_timeout
             continue 2 # Continue outer loop
           fi
         done
 
         # Check if any modifier is held + key pressed (modifier chord)
-        if $CTRL_HELD || $ALT_HELD || $SHIFT_HELD || $SUPER_HELD; then
+        if any_modifier_held; then
           log_info "Modifier chord detected: $hypr_key - enabling trackpad"
-          enable_trackpad
-          touch "$CANCEL_TIMEOUT"
+          enable_trackpad_and_cancel_timeout
           continue
         fi
 
         # Check if this is a focus movement binding ONLY when modifiers are held
         # (Focus movement requires modifier combinations, not plain key presses)
-        if $CTRL_HELD || $ALT_HELD || $SHIFT_HELD || $SUPER_HELD; then
+        if any_modifier_held; then
           if is_focus_binding "$hypr_key" || is_focus_binding "$(echo "$hypr_key" | tr '[:upper:]' '[:lower:]')"; then
             log_info "Focus movement binding detected: $hypr_key - enabling trackpad"
-            enable_trackpad
-            # Cancel any running timeout
-            touch "$CANCEL_TIMEOUT"
+            enable_trackpad_and_cancel_timeout
             continue
           fi
         fi

--- a/bin/omarchy-disable-trackpad-while-typing
+++ b/bin/omarchy-disable-trackpad-while-typing
@@ -77,58 +77,72 @@ main() {
     "ENTER" "RETURN"
   )
 
-  # Trackpad device - REQUIRED environment variable
+  # Trackpad device(s) - REQUIRED environment variable
+  # Can be a single device or multiple colon-separated devices (e.g., event6:event7)
   if [ -z "${OMARCHY_TRACKPAD_DWT_TRACKPAD:-}" ]; then
     echo "Error: OMARCHY_TRACKPAD_DWT_TRACKPAD environment variable not set"
     echo "Run omarchy-disable-trackpad-while-typing-tui to configure your trackpad device"
     exit 1
   fi
 
-  # Convert trackpad device path to sysfs path
-  TRACKPAD_EVENT=$(basename "$OMARCHY_TRACKPAD_DWT_TRACKPAD")
-  TRACKPAD_SYSFS=""
+  # Split by colons to handle multiple devices (e.g., Magic Trackpad with multiple interfaces)
+  IFS=':' read -ra TRACKPAD_DEVICES <<< "$OMARCHY_TRACKPAD_DWT_TRACKPAD"
+  TRACKPAD_FILES=()
 
-  for input_dev in /sys/class/input/input*/event*; do
-    if [ "$(basename "$input_dev")" = "$TRACKPAD_EVENT" ]; then
-      TRACKPAD_SYSFS=$(dirname "$input_dev")
-      break
+  for device_path in "${TRACKPAD_DEVICES[@]}"; do
+    TRACKPAD_EVENT=$(basename "$device_path")
+    TRACKPAD_SYSFS=""
+
+    # Find sysfs path for this event device
+    for input_dev in /sys/class/input/input*/event*; do
+      if [ "$(basename "$input_dev")" = "$TRACKPAD_EVENT" ]; then
+        TRACKPAD_SYSFS=$(dirname "$input_dev")
+        break
+      fi
+    done
+
+    if [ -z "$TRACKPAD_SYSFS" ]; then
+      echo "Error: Trackpad device $device_path not found"
+      echo "Run omarchy-disable-trackpad-while-typing-tui to configure available devices"
+      exit 1
     fi
+
+    log_info "Found trackpad at: $TRACKPAD_SYSFS"
+    log_info "Device name: $(cat "$TRACKPAD_SYSFS/name")"
+
+    # Find the inhibited file for this trackpad
+    TRACKPAD_FILE=""
+    if [ -f "$TRACKPAD_SYSFS/inhibited" ]; then
+      TRACKPAD_FILE="$TRACKPAD_SYSFS/inhibited"
+    elif [ -f "$TRACKPAD_SYSFS/device/inhibited" ]; then
+      TRACKPAD_FILE="$TRACKPAD_SYSFS/device/inhibited"
+    else
+      echo "Error: Cannot find inhibited file for trackpad $TRACKPAD_EVENT"
+      echo "Trackpad may not support the inhibit mechanism"
+      exit 1
+    fi
+
+    # Check that we have permission (script should be run with sudo)
+    if [ ! -w "$TRACKPAD_FILE" ] && [ "$EUID" -ne 0 ]; then
+      echo "Error: No permission to control trackpad"
+      echo "This script must be run with sudo"
+      exit 1
+    fi
+
+    TRACKPAD_FILES+=("$TRACKPAD_FILE")
   done
 
-  if [ -z "$TRACKPAD_SYSFS" ]; then
-    echo "Error: Trackpad device $OMARCHY_TRACKPAD_DWT_TRACKPAD not found"
-    echo "Run omarchy-disable-trackpad-while-typing-tui to configure available devices"
-    exit 1
-  fi
-
-  log_info "Found trackpad at: $TRACKPAD_SYSFS"
-  log_info "Device name: $(cat "$TRACKPAD_SYSFS/name")"
-
-  # Find the inhibited file for the trackpad
-  if [ -f "$TRACKPAD_SYSFS/inhibited" ]; then
-    TRACKPAD_FILE="$TRACKPAD_SYSFS/inhibited"
-  elif [ -f "$TRACKPAD_SYSFS/device/inhibited" ]; then
-    TRACKPAD_FILE="$TRACKPAD_SYSFS/device/inhibited"
-  else
-    echo "Error: Cannot find inhibited file for trackpad"
-    echo "Trackpad may not support the inhibit mechanism"
-    exit 1
-  fi
-
-  # Check that we have permission (script should be run with sudo)
-  if [ ! -w "$TRACKPAD_FILE" ] && [ "$EUID" -ne 0 ]; then
-    echo "Error: No permission to control trackpad"
-    echo "This script must be run with sudo"
-    exit 1
-  fi
-
-  # Simple trackpad control functions
+  # Trackpad control functions that handle multiple devices
   disable_trackpad() {
-    echo 1 >"$TRACKPAD_FILE" 2>/dev/null
+    for file in "${TRACKPAD_FILES[@]}"; do
+      echo 1 >"$file" 2>/dev/null
+    done
   }
 
   enable_trackpad() {
-    echo 0 >"$TRACKPAD_FILE" 2>/dev/null
+    for file in "${TRACKPAD_FILES[@]}"; do
+      echo 0 >"$file" 2>/dev/null
+    done
   }
 
   log_info "Monitoring keyboard: $KEYBOARD_DEVICE"

--- a/bin/omarchy-disable-trackpad-while-typing-tui
+++ b/bin/omarchy-disable-trackpad-while-typing-tui
@@ -219,6 +219,10 @@ select_trackpad() {
   local devices=()
   local names=()
 
+  # Group devices by physical hardware + name to collect all sibling interfaces
+  declare -A device_groups
+  declare -A device_info
+
   # Find all pointer devices (trackpad, touchpad, mouse)
   for input_dev in /sys/class/input/input*; do
     if [ -r "$input_dev/name" ]; then
@@ -234,7 +238,20 @@ select_trackpad() {
 
           # Only include devices that are mice, touchpads, or trackpads
           if echo "$device_props" | grep -q "ID_INPUT_MOUSE=1\|ID_INPUT_TOUCHPAD=1"; then
-            # Determine device type from properties and name
+            # Get the physical device path (USB device path without interface number)
+            # DEVPATH looks like: /devices/.../usb3/3-1/3-1:1.0/0003:05AC:0265.0015/input/input23/event6
+            # We want up to the USB device: /devices/.../usb3/3-1
+            devpath=$(echo "$device_props" | grep "^DEVPATH=" | cut -d= -f2)
+
+            # Extract physical device path (remove interface and everything after)
+            # This removes the :1.0, :1.1 interface numbers and HID device part
+            phys_device=$(echo "$devpath" | sed 's|:[0-9]\+\.[0-9]\+/.*||')
+
+            # Create unique key: physical_device + device_name
+            # This groups multiple interfaces from same physical device together
+            unique_key="${phys_device}::${device_name}"
+
+            # Determine device type
             device_type="pointer"
             if echo "$device_props" | grep -q "ID_INPUT_TOUCHPAD=1"; then
               if echo "$device_name" | grep -qi "trackpad"; then
@@ -246,19 +263,41 @@ select_trackpad() {
               device_type="mouse"
             fi
 
-            # Check if this is an internal (SPI) or external (USB/BT) device
+            # Check if internal or external
             bus_type="external"
             if echo "$device_props" | grep -q "ID_PATH.*spi"; then
               bus_type="internal"
             fi
 
-            devices+=("$event_path")
-            names+=("$device_name ($event_name, $device_type, $bus_type)")
-            break
+            # Collect all event devices for this unique key
+            if [ -z "${device_groups[$unique_key]:-}" ]; then
+              device_groups[$unique_key]="$event_path"
+              device_info[$unique_key]="$device_name|$event_name|$device_type|$bus_type"
+            else
+              # Append to existing group (colon-separated)
+              device_groups[$unique_key]="${device_groups[$unique_key]}:$event_path"
+              # Collect event names (will format later)
+              current_info="${device_info[$unique_key]}"
+              current_events=$(echo "$current_info" | cut -d'|' -f2)
+              device_info[$unique_key]="$device_name|${current_events}+${event_name}|$device_type|$bus_type"
+            fi
           fi
+          break
         fi
       done
     fi
+  done
+
+  # Convert to arrays for selection and format display names
+  for key in "${!device_groups[@]}"; do
+    devices+=("${device_groups[$key]}")
+    # Format: "Device Name (event1 + event2, type, bus)"
+    info="${device_info[$key]}"
+    dev_name=$(echo "$info" | cut -d'|' -f1)
+    events=$(echo "$info" | cut -d'|' -f2 | sed 's/+/ + /g')
+    dev_type=$(echo "$info" | cut -d'|' -f3)
+    bus_type=$(echo "$info" | cut -d'|' -f4)
+    names+=("$dev_name ($events, $dev_type, $bus_type)")
   done
 
   if [ ${#devices[@]} -eq 0 ]; then

--- a/bin/omarchy-disable-trackpad-while-typing-tui
+++ b/bin/omarchy-disable-trackpad-while-typing-tui
@@ -147,6 +147,60 @@ setup_sudo() {
   rm -f "$TEMP_FILE"
 }
 
+# Generic function to display device selection menu
+select_device_from_menu() {
+  local -n devices_ref=$1    # Array of device paths (nameref)
+  local -n names_ref=$2      # Array of display names (nameref)
+  local device_type=$3       # Description (e.g., "keyboard", "pointer device")
+  local default_pattern=$4   # Pattern to match for default (e.g., "internal")
+  local prompt_msg=$5        # Custom prompt message (optional)
+
+  if [ ${#devices_ref[@]} -eq 0 ]; then
+    error "No ${device_type}s found!"
+    exit 1
+  elif [ ${#devices_ref[@]} -eq 1 ]; then
+    success "Found one ${device_type}: ${names_ref[0]}" >&2
+    echo "${devices_ref[0]}"
+  else
+    # Find the default choice based on pattern
+    local default_choice=""
+    for i in "${!names_ref[@]}"; do
+      if echo "${names_ref[$i]}" | grep -q "$default_pattern"; then
+        default_choice=$((i + 1))
+        break
+      fi
+    done
+
+    # Show menu
+    if [ -n "$prompt_msg" ]; then
+      info "$prompt_msg" >&2
+    else
+      info "Found multiple ${device_type}s. Please select one:" >&2
+    fi
+    echo "" >&2
+    for i in "${!names_ref[@]}"; do
+      echo "$((i + 1))) ${names_ref[$i]}" >&2
+    done
+
+    # Get user selection
+    while true; do
+      if [ -n "$default_choice" ]; then
+        read -p "Enter number [default: $default_choice]: " choice
+        choice=${choice:-$default_choice}
+      else
+        read -p "Enter number: " choice
+      fi
+
+      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#devices_ref[@]}" ]; then
+        echo "${devices_ref[$((choice - 1))]}"
+        break
+      else
+        error "Invalid choice, please enter 1-${#devices_ref[@]}" >&2
+      fi
+    done
+  fi
+}
+
 select_keyboard() {
   local keyboards=()
   local names=()
@@ -175,44 +229,7 @@ select_keyboard() {
     fi
   done
 
-  if [ ${#keyboards[@]} -eq 0 ]; then
-    error "No keyboard devices found!"
-    exit 1
-  elif [ ${#keyboards[@]} -eq 1 ]; then
-    success "Found one keyboard: ${names[0]}" >&2
-    echo "${keyboards[0]}"
-  else
-    # Find the internal keyboard index (1-based for display)
-    local default_choice=""
-    for i in "${!names[@]}"; do
-      if echo "${names[$i]}" | grep -q "internal"; then
-        default_choice=$((i + 1))
-        break
-      fi
-    done
-
-    info "Found multiple keyboards. Please select one:" >&2
-    echo "" >&2
-    for i in "${!names[@]}"; do
-      echo "$((i + 1))) ${names[$i]}" >&2
-    done
-
-    while true; do
-      if [ -n "$default_choice" ]; then
-        read -p "Enter number [default: $default_choice]: " choice
-        choice=${choice:-$default_choice}
-      else
-        read -p "Enter number: " choice
-      fi
-
-      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#keyboards[@]}" ]; then
-        echo "${keyboards[$((choice - 1))]}"
-        break
-      else
-        error "Invalid choice, please enter 1-${#keyboards[@]}" >&2
-      fi
-    done
-  fi
+  select_device_from_menu keyboards names "keyboard" "internal" "Found multiple keyboards. Please select one:"
 }
 
 select_trackpad() {
@@ -300,44 +317,7 @@ select_trackpad() {
     names+=("$dev_name ($events, $dev_type, $bus_type)")
   done
 
-  if [ ${#devices[@]} -eq 0 ]; then
-    error "No pointer devices found!"
-    exit 1
-  elif [ ${#devices[@]} -eq 1 ]; then
-    success "Found one pointer device: ${names[0]}" >&2
-    echo "${devices[0]}"
-  else
-    # Find the internal trackpad index (1-based for display)
-    local default_choice=""
-    for i in "${!names[@]}"; do
-      if echo "${names[$i]}" | grep -q "trackpad.*internal"; then
-        default_choice=$((i + 1))
-        break
-      fi
-    done
-
-    info "Found multiple pointer devices. Please select one to disable while typing:" >&2
-    echo "" >&2
-    for i in "${!names[@]}"; do
-      echo "$((i + 1))) ${names[$i]}" >&2
-    done
-
-    while true; do
-      if [ -n "$default_choice" ]; then
-        read -p "Enter number [default: $default_choice]: " choice
-        choice=${choice:-$default_choice}
-      else
-        read -p "Enter number: " choice
-      fi
-
-      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#devices[@]}" ]; then
-        echo "${devices[$((choice - 1))]}"
-        break
-      else
-        error "Invalid choice, please enter 1-${#devices[@]}" >&2
-      fi
-    done
-  fi
+  select_device_from_menu devices names "pointer device" "trackpad.*internal" "Found multiple pointer devices. Please select one to disable while typing:"
 }
 
 select_timeout() {

--- a/bin/omarchy-disable-trackpad-while-typing-tui
+++ b/bin/omarchy-disable-trackpad-while-typing-tui
@@ -389,8 +389,8 @@ write_config() {
   local trackpad="$2"
   local timeout="$3"
 
-  # Check if config already exists in input.conf
-  if grep -q "OMARCHY_TRACKPAD_DWT_KEYBOARD" "$INPUT_CONF" 2>/dev/null; then
+  # Check if config already exists in input.conf (not commented out)
+  if grep -q '^\s*env = OMARCHY_TRACKPAD_DWT_KEYBOARD' "$INPUT_CONF" 2>/dev/null; then
     echo "" >&2
     warn "Existing DWT configuration found in input.conf"
     echo "" >&2

--- a/bin/omarchy-disable-trackpad-while-typing-tui
+++ b/bin/omarchy-disable-trackpad-while-typing-tui
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# Interactive TUI setup for trackpad disable-while-typing
+
+set -euo pipefail
+
+# Define logging functions
+info() { echo -e "\033[34m[INFO]\033[0m $*"; }
+success() { echo -e "\033[32m[SUCCESS]\033[0m $*"; }
+warn() { echo -e "\033[33m[WARN]\033[0m $*"; }
+error() { echo -e "\033[31m[ERROR]\033[0m $*"; }
+
+# Configuration files
+REAL_USER="${SUDO_USER:-$USER}"
+REAL_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
+DWT_SCRIPT="$REAL_HOME/.local/share/omarchy/bin/omarchy-disable-trackpad-while-typing"
+SUDOERS_FILE="/etc/sudoers.d/omarchy-trackpad-dwt"
+INPUT_CONF="$REAL_HOME/.config/hypr/input.conf"
+AUTOSTART_CONF="$REAL_HOME/.config/hypr/autostart.conf"
+
+main() {
+  clear
+  echo "═══════════════════════════════════"
+  echo "Trackpad Disable-While-Typing Setup"
+  echo "═══════════════════════════════════"
+  echo "" >&2
+
+  # Step 1: Install dependencies
+  info "Step 1: Checking dependencies..."
+  install_dependencies
+
+  # Step 2: Setup passwordless sudo
+  echo "" >&2
+  info "Step 2: Setting up passwordless sudo..."
+  setup_sudo
+
+  # Step 3: Select keyboard device
+  echo "" >&2
+  info "Step 3: Select your keyboard device"
+  KEYBOARD_DEVICE=$(select_keyboard)
+
+  # Step 4: Select trackpad device
+  echo "" >&2
+  info "Step 4: Select your trackpad device"
+  TRACKPAD_DEVICE=$(select_trackpad)
+
+  # Step 5: Choose timeout
+  echo "" >&2
+  info "Step 5: Choose timeout duration"
+  TIMEOUT=$(select_timeout)
+
+  # Step 6: Write configuration
+  echo "" >&2
+  info "Step 6: Writing configuration..."
+  write_config "$KEYBOARD_DEVICE" "$TRACKPAD_DEVICE" "$TIMEOUT"
+
+  # Final instructions
+  echo "" >&2
+  echo    "═════════════════════════"
+  success "Setup complete!"
+  echo    "═════════════════════════"
+  echo "" >&2
+  info "The following configuration has been added to your input.conf:"
+  echo "" >&2
+  echo "  env = OMARCHY_TRACKPAD_DWT_KEYBOARD,$KEYBOARD_DEVICE"
+  echo "  env = OMARCHY_TRACKPAD_DWT_TRACKPAD,$TRACKPAD_DEVICE"
+  echo "  env = OMARCHY_TRACKPAD_DWT_TIMEOUT,$TIMEOUT"
+  echo "" >&2
+
+  # Offer to relaunch Hyprland
+  warn "Hyprland needs to be relaunched before the changes will take effect."
+  echo "" >&2
+  read -p "Relaunch now? [y/N]: " -n 1 -r
+  echo "" >&2
+
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    info "Relaunching Hyprland..."
+    # Get the actual user's UID for their session bus
+    REAL_UID=$(id -u "$REAL_USER")
+    # Run as the real user with their session bus address
+    sudo -u "$REAL_USER" DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$REAL_UID/bus" bash -c "$REAL_HOME/.local/share/omarchy/bin/omarchy-state clear relaunch-required && uwsm stop"
+  else
+    info "Skipping relaunch. To relaunch later, use Super+Esc → Relaunch"
+  fi
+
+  echo "" >&2
+  info "To remove this configuration later:"
+  echo "  - Remove the env lines from ~/.config/hypr/input.conf"
+  echo "  - Remove the exec-once line from ~/.config/hypr/autostart.conf"
+  echo "  - Run: sudo rm /etc/sudoers.d/omarchy-trackpad-dwt"
+}
+
+install_dependencies() {
+  local deps_needed=false
+
+  if ! command -v evtest &>/dev/null; then
+    deps_needed=true
+    info "Installing evtest..."
+    sudo pacman -S --noconfirm evtest || error "Failed to install evtest"
+  fi
+
+  if ! command -v socat &>/dev/null; then
+    deps_needed=true
+    info "Installing socat..."
+    sudo pacman -S --noconfirm socat || error "Failed to install socat"
+  fi
+
+  if ! $deps_needed; then
+    success "All dependencies are already installed"
+  else
+    success "Dependencies installed"
+  fi
+}
+
+setup_sudo() {
+  # Check if script exists
+  if [ ! -f "$DWT_SCRIPT" ]; then
+    error "Script not found: $DWT_SCRIPT"
+    info "Please install Omarchy first"
+    exit 1
+  fi
+
+  # Create sudoers rule with environment variable preservation
+  USERNAME="${SUDO_USER:-$USER}"
+  RULE="Defaults:$USERNAME env_keep += \"OMARCHY_TRACKPAD_DWT_KEYBOARD OMARCHY_TRACKPAD_DWT_TRACKPAD OMARCHY_TRACKPAD_DWT_TIMEOUT HYPRLAND_INSTANCE_SIGNATURE\"
+  $USERNAME ALL=(ALL) NOPASSWD: $DWT_SCRIPT"
+
+  # Create temporary file with proper permissions
+  TEMP_FILE=$(mktemp)
+  echo "$RULE" > "$TEMP_FILE"
+
+  # Validate the sudoers syntax
+  if ! visudo -c -f "$TEMP_FILE" &>/dev/null; then
+    error "Invalid sudoers syntax"
+    rm -f "$TEMP_FILE"
+    exit 1
+  fi
+
+  # Install the sudoers file
+  if sudo install -m 0440 "$TEMP_FILE" "$SUDOERS_FILE"; then
+    success "Passwordless sudo configured"
+  else
+    error "Failed to install sudoers rule"
+    rm -f "$TEMP_FILE"
+    exit 1
+  fi
+
+  rm -f "$TEMP_FILE"
+}
+
+select_keyboard() {
+  local keyboards=()
+  local names=()
+
+  # Find all keyboard devices
+  for input_dev in /sys/class/input/input*; do
+    if [ -r "$input_dev/name" ]; then
+      device_name=$(cat "$input_dev/name")
+      if echo "$device_name" | grep -qi "keyboard\|keyd" && \
+         ! echo "$device_name" | grep -qi "mouse\|touchpad\|trackpad"; then
+        for event_dev in "$input_dev"/event*; do
+          if [ -e "$event_dev" ]; then
+            event_path="/dev/input/$(basename "$event_dev")"
+            event_name=$(basename "$event_dev")
+            # Check if this is an internal (SPI) or external (USB/BT) device
+            bus_type="external"
+            if udevadm info --query=property "$event_path" 2>/dev/null | grep -q "ID_PATH.*spi"; then
+              bus_type="internal"
+            fi
+            keyboards+=("$event_path")
+            names+=("$device_name ($event_name, $bus_type)")
+            break
+          fi
+        done
+      fi
+    fi
+  done
+
+  if [ ${#keyboards[@]} -eq 0 ]; then
+    error "No keyboard devices found!"
+    exit 1
+  elif [ ${#keyboards[@]} -eq 1 ]; then
+    success "Found one keyboard: ${names[0]}" >&2
+    echo "${keyboards[0]}"
+  else
+    # Find the internal keyboard index (1-based for display)
+    local default_choice=""
+    for i in "${!names[@]}"; do
+      if echo "${names[$i]}" | grep -q "internal"; then
+        default_choice=$((i + 1))
+        break
+      fi
+    done
+
+    info "Found multiple keyboards. Please select one:" >&2
+    echo "" >&2
+    for i in "${!names[@]}"; do
+      echo "$((i + 1))) ${names[$i]}" >&2
+    done
+
+    while true; do
+      if [ -n "$default_choice" ]; then
+        read -p "Enter number [default: $default_choice]: " choice
+        choice=${choice:-$default_choice}
+      else
+        read -p "Enter number: " choice
+      fi
+
+      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#keyboards[@]}" ]; then
+        echo "${keyboards[$((choice - 1))]}"
+        break
+      else
+        error "Invalid choice, please enter 1-${#keyboards[@]}" >&2
+      fi
+    done
+  fi
+}
+
+select_trackpad() {
+  local trackpads=()
+  local names=()
+
+  # Find all trackpad devices
+  for input_dev in /sys/class/input/input*; do
+    if [ -r "$input_dev/name" ]; then
+      device_name=$(cat "$input_dev/name")
+      if echo "$device_name" | grep -qi "trackpad\|touchpad"; then
+        for event_dev in "$input_dev"/event*; do
+          if [ -e "$event_dev" ]; then
+            event_path="/dev/input/$(basename "$event_dev")"
+            event_name=$(basename "$event_dev")
+            # Check if this is an internal (SPI) or external (USB/BT) device
+            bus_type="external"
+            if udevadm info --query=property "$event_path" 2>/dev/null | grep -q "ID_PATH.*spi"; then
+              bus_type="internal"
+            fi
+            trackpads+=("$event_path")
+            names+=("$device_name ($event_name, $bus_type)")
+            break
+          fi
+        done
+      fi
+    fi
+  done
+
+  if [ ${#trackpads[@]} -eq 0 ]; then
+    error "No trackpad devices found!"
+    exit 1
+  elif [ ${#trackpads[@]} -eq 1 ]; then
+    success "Found one trackpad: ${names[0]}" >&2
+    echo "${trackpads[0]}"
+  else
+    # Find the internal trackpad index (1-based for display)
+    local default_choice=""
+    for i in "${!names[@]}"; do
+      if echo "${names[$i]}" | grep -q "internal"; then
+        default_choice=$((i + 1))
+        break
+      fi
+    done
+
+    info "Found multiple trackpads. Please select one:" >&2
+    echo "" >&2
+    for i in "${!names[@]}"; do
+      echo "$((i + 1))) ${names[$i]}" >&2
+    done
+
+    while true; do
+      if [ -n "$default_choice" ]; then
+        read -p "Enter number [default: $default_choice]: " choice
+        choice=${choice:-$default_choice}
+      else
+        read -p "Enter number: " choice
+      fi
+
+      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#trackpads[@]}" ]; then
+        echo "${trackpads[$((choice - 1))]}"
+        break
+      else
+        error "Invalid choice, please enter 1-${#trackpads[@]}" >&2
+      fi
+    done
+  fi
+}
+
+select_timeout() {
+  local show_menu=true
+
+  while true; do
+    if $show_menu; then
+      echo "" >&2
+      echo "Select disable-while-typing timeout:" >&2
+      echo "" >&2
+      echo "1) 0.5 seconds (very short)" >&2
+      echo "2) 1.0 seconds (short)" >&2
+      echo "3) 1.5 seconds (default)" >&2
+      echo "4) 2.0 seconds (long)" >&2
+      echo "5) 3.0 seconds (very long)" >&2
+      echo "6) Custom" >&2
+      echo "" >&2
+    fi
+    show_menu=true
+
+    read -p "Enter number [default: 3]: " choice
+    # Default to 3 if empty
+    choice=${choice:-3}
+
+    case $choice in
+      1) echo "0.5"; break ;;
+      2) echo "1.0"; break ;;
+      3) echo "1.5"; break ;;
+      4) echo "2.0"; break ;;
+      5) echo "3.0"; break ;;
+      6)
+        echo "" >&2
+        read -p "Enter custom timeout in seconds (e.g., 1.75): " custom
+        if [[ ! "$custom" =~ ^[0-9]+\.?[0-9]*$ ]]; then
+          echo "" >&2
+          error "Invalid number" >&2
+          # Menu will be re-shown on next loop
+        elif (( $(echo "$custom > 10" | awk '{print ($1 > 10)}') )); then
+          echo "" >&2
+          error "Timeout cannot exceed 10 seconds" >&2
+          # Menu will be re-shown on next loop
+        else
+          echo "$custom"
+          break
+        fi
+        ;;
+      *)
+        echo "" >&2
+        error "Invalid choice" >&2
+        # Menu will be re-shown on next loop
+        ;;
+    esac
+  done
+}
+
+write_config() {
+  local keyboard="$1"
+  local trackpad="$2"
+  local timeout="$3"
+
+  # Check if config already exists in input.conf
+  if grep -q "OMARCHY_TRACKPAD_DWT_KEYBOARD" "$INPUT_CONF" 2>/dev/null; then
+    echo "" >&2
+    warn "Existing DWT configuration found in input.conf"
+    echo "" >&2
+    read -p "Replace existing configuration? [Y/n]: " -n 1 -r
+    echo "" >&2
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+      echo "" >&2
+      info "Keeping existing configuration"
+      exit 0
+    fi
+
+    # Replace existing config lines in-place
+    sed -i "s|^env = OMARCHY_TRACKPAD_DWT_KEYBOARD,.*|env = OMARCHY_TRACKPAD_DWT_KEYBOARD,$keyboard|" "$INPUT_CONF"
+    sed -i "s|^env = OMARCHY_TRACKPAD_DWT_TRACKPAD,.*|env = OMARCHY_TRACKPAD_DWT_TRACKPAD,$trackpad|" "$INPUT_CONF"
+    sed -i "s|^env = OMARCHY_TRACKPAD_DWT_TIMEOUT,.*|env = OMARCHY_TRACKPAD_DWT_TIMEOUT,$timeout|" "$INPUT_CONF"
+  else
+    # First time setup - add comment and config
+    {
+      echo ""
+      echo "# Trackpad disable-while-typing (configured by omarchy-disable-trackpad-while-typing-tui)"
+      echo "env = OMARCHY_TRACKPAD_DWT_KEYBOARD,$keyboard"
+      echo "env = OMARCHY_TRACKPAD_DWT_TRACKPAD,$trackpad"
+      echo "env = OMARCHY_TRACKPAD_DWT_TIMEOUT,$timeout"
+    } >> "$INPUT_CONF"
+  fi
+
+  # Handle autostart.conf - only add if it doesn't exist
+  local autostart_added=false
+  if ! grep -q "omarchy-disable-trackpad-while-typing" "$AUTOSTART_CONF" 2>/dev/null; then
+    # First time setup - add comment and exec-once
+    {
+      echo ""
+      echo "# Trackpad disable-while-typing"
+      echo "exec-once = sudo $DWT_SCRIPT"
+    } >> "$AUTOSTART_CONF"
+    autostart_added=true
+  fi
+
+  if $autostart_added; then
+    success "Configuration written to ~/.config/hypr/input.conf and ~/.config/hypr/autostart.conf"
+  else
+    success "Configuration written to ~/.config/hypr/input.conf"
+  fi
+}
+
+# Show usage
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  cat << EOF
+Usage: $(basename "$0")
+
+Interactive setup for Trackpad disable-while-typing feature.
+This script will guide you through:
+  1. Installing required dependencies
+  2. Setting up passwordless sudo
+  3. Selecting your keyboard and trackpad devices
+  4. Choosing a timeout duration
+  5. Writing the configuration
+
+The script requires sudo access and will prompt when needed.
+EOF
+  exit 0
+fi
+
+# Check if we need sudo and re-run with it if necessary
+if [ "$EUID" -ne 0 ]; then
+  info "This script requires sudo access"
+  info "Re-running with sudo..."
+  exec sudo "$0" "$@"
+fi
+
+main "$@"

--- a/bin/omarchy-disable-trackpad-while-typing-tui
+++ b/bin/omarchy-disable-trackpad-while-typing-tui
@@ -38,9 +38,9 @@ main() {
   info "Step 3: Select your keyboard device"
   KEYBOARD_DEVICE=$(select_keyboard)
 
-  # Step 4: Select trackpad device
+  # Step 4: Select pointer device (trackpad/mouse) to disable while typing
   echo "" >&2
-  info "Step 4: Select your trackpad device"
+  info "Step 4: Select pointer device to disable while typing"
   TRACKPAD_DEVICE=$(select_trackpad)
 
   # Step 5: Choose timeout
@@ -216,49 +216,68 @@ select_keyboard() {
 }
 
 select_trackpad() {
-  local trackpads=()
+  local devices=()
   local names=()
 
-  # Find all trackpad devices
+  # Find all pointer devices (trackpad, touchpad, mouse)
   for input_dev in /sys/class/input/input*; do
     if [ -r "$input_dev/name" ]; then
       device_name=$(cat "$input_dev/name")
-      if echo "$device_name" | grep -qi "trackpad\|touchpad"; then
-        for event_dev in "$input_dev"/event*; do
-          if [ -e "$event_dev" ]; then
-            event_path="/dev/input/$(basename "$event_dev")"
-            event_name=$(basename "$event_dev")
+
+      for event_dev in "$input_dev"/event*; do
+        if [ -e "$event_dev" ]; then
+          event_path="/dev/input/$(basename "$event_dev")"
+          event_name=$(basename "$event_dev")
+
+          # Check device properties using udevadm
+          device_props=$(udevadm info --query=property "$event_path" 2>/dev/null)
+
+          # Only include devices that are mice, touchpads, or trackpads
+          if echo "$device_props" | grep -q "ID_INPUT_MOUSE=1\|ID_INPUT_TOUCHPAD=1"; then
+            # Determine device type from properties and name
+            device_type="pointer"
+            if echo "$device_props" | grep -q "ID_INPUT_TOUCHPAD=1"; then
+              if echo "$device_name" | grep -qi "trackpad"; then
+                device_type="trackpad"
+              else
+                device_type="touchpad"
+              fi
+            elif echo "$device_props" | grep -q "ID_INPUT_MOUSE=1"; then
+              device_type="mouse"
+            fi
+
             # Check if this is an internal (SPI) or external (USB/BT) device
             bus_type="external"
-            if udevadm info --query=property "$event_path" 2>/dev/null | grep -q "ID_PATH.*spi"; then
+            if echo "$device_props" | grep -q "ID_PATH.*spi"; then
               bus_type="internal"
             fi
-            trackpads+=("$event_path")
-            names+=("$device_name ($event_name, $bus_type)")
+
+            devices+=("$event_path")
+            names+=("$device_name ($event_name, $device_type, $bus_type)")
             break
           fi
-        done
-      fi
+        fi
+      done
     fi
   done
 
-  if [ ${#trackpads[@]} -eq 0 ]; then
-    error "No trackpad devices found!"
+  if [ ${#devices[@]} -eq 0 ]; then
+    error "No pointer devices found!"
     exit 1
-  elif [ ${#trackpads[@]} -eq 1 ]; then
-    success "Found one trackpad: ${names[0]}" >&2
-    echo "${trackpads[0]}"
+  elif [ ${#devices[@]} -eq 1 ]; then
+    success "Found one pointer device: ${names[0]}" >&2
+    echo "${devices[0]}"
   else
     # Find the internal trackpad index (1-based for display)
     local default_choice=""
     for i in "${!names[@]}"; do
-      if echo "${names[$i]}" | grep -q "internal"; then
+      if echo "${names[$i]}" | grep -q "trackpad.*internal"; then
         default_choice=$((i + 1))
         break
       fi
     done
 
-    info "Found multiple trackpads. Please select one:" >&2
+    info "Found multiple pointer devices. Please select one to disable while typing:" >&2
     echo "" >&2
     for i in "${!names[@]}"; do
       echo "$((i + 1))) ${names[$i]}" >&2
@@ -272,11 +291,11 @@ select_trackpad() {
         read -p "Enter number: " choice
       fi
 
-      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#trackpads[@]}" ]; then
-        echo "${trackpads[$((choice - 1))]}"
+      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#devices[@]}" ]; then
+        echo "${devices[$((choice - 1))]}"
         break
       else
-        error "Invalid choice, please enter 1-${#trackpads[@]}" >&2
+        error "Invalid choice, please enter 1-${#devices[@]}" >&2
       fi
     done
   fi

--- a/bin/omarchy-disable-trackpad-while-typing-tui
+++ b/bin/omarchy-disable-trackpad-while-typing-tui
@@ -94,16 +94,27 @@ install_dependencies() {
 
   if ! command -v evtest &>/dev/null; then
     deps_needed=true
+    echo
     info "Installing evtest..."
-    sudo pacman -S --noconfirm evtest || error "Failed to install evtest"
+    if sudo pacman -S --noconfirm evtest &>/dev/null; then
+      success "evtest installed"
+    else
+      error "Failed to install evtest"
+    fi
   fi
 
   if ! command -v socat &>/dev/null; then
     deps_needed=true
+    echo
     info "Installing socat..."
-    sudo pacman -S --noconfirm socat || error "Failed to install socat"
+    if sudo pacman -S --noconfirm socat &>/dev/null; then
+      success "socat installed"
+    else
+      error "Failed to install socat"
+    fi
   fi
 
+  echo
   if ! $deps_needed; then
     success "All dependencies are already installed"
   else

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -190,12 +190,20 @@ show_setup_menu() {
   *Power*) show_setup_power_menu ;;
   *Monitors*) open_in_editor ~/.config/hypr/monitors.conf ;;
   *Keybindings*) open_in_editor ~/.config/hypr/bindings.conf ;;
-  *Input*) open_in_editor ~/.config/hypr/input.conf ;;
+  *Input*) show_setup_input_menu ;;
   *Defaults*) open_in_editor ~/.config/uwsm/default ;;
   *DNS*) present_terminal omarchy-setup-dns ;;
   *Security*) show_setup_security_menu ;;
   *Config*) show_setup_config_menu ;;
   *) show_main_menu ;;
+  esac
+}
+
+show_setup_input_menu() {
+  case $(menu "Input Setup" "  Disable on Typing\n  Config Input Opts") in
+  *Disable*) present_terminal omarchy-disable-trackpad-while-typing-tui ;;
+  *Config*) open_in_editor ~/.config/hypr/input.conf ;;
+  *) show_setup_menu ;;
   esac
 }
 

--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -34,3 +34,20 @@ windowrule = scrolltouchpad 0.2, class:com.mitchellh.ghostty
 # Enable touchpad gestures for changing workspaces
 # See https://wiki.hyprland.org/Configuring/Gestures/
 # gesture = 3, horizontal, workspace
+
+# Trackpad: Disable While Typing (DWT) setup script
+# This enables automatic trackpad disabling while typing to prevent accidental
+# cursor movement which is a particuarly annoying issue on MacBooks and other
+# laptops with large trackpads running Linux.
+#
+# To use this feature:
+# 1. Open Omarchy Menu (Super+Alt+Space) → Setup → Input → Disable on Typing
+#    (or run directly: omarchy-disable-trackpad-while-typing-tui)
+# 2. Follow the interactive setup to configure your devices
+# 3. You have to restart hyprland before the changes take effect. The TUI
+#    prompts you to offer this.
+#
+# The script ONLY runs if both keyboard and trackpad devices are configured
+# env = OMARCHY_TRACKPAD_DWT_KEYBOARD,/dev/input/event1  # REQUIRED - your keyboard device
+# env = OMARCHY_TRACKPAD_DWT_TRACKPAD,/dev/input/event2  # REQUIRED - your trackpad device
+# env = OMARCHY_TRACKPAD_DWT_TIMEOUT,1.5                 # Optional - timeout in seconds (default: 1.5)


### PR DESCRIPTION
# Trackpad Disable-While-Typing Feature

## TL;DR; 

Disable your trackpad for 1.5s by default when you press a key (configurable up to 10 seconds). Designed for MacBook keyboards and trackpads since the linux palm rejection is horrible compared to macOS, mac laptops have _huge_ trackpads _and_ hyprland changes window focus on cursor movement, not click, so you end up typing in the wrong window A LOT.

Try it out with a super easy installer (and uninstaller) detailed in this gist: https://gist.github.com/jondkinney/24c28043f54cdfa9891084c7e4e7b9a9

## Overview

Adds disable-while-typing (DWT) functionality for trackpads and mice on MacBooks and other devices. This prevents accidental cursor movements and clicks while typing by temporarily disabling pointer devices when keyboard input is detected.

## Features

### Smart Device Detection

- **Automatic device discovery** - Detects all keyboards and pointer devices (trackpads, touchpads, mice)
- **Internal vs external identification** - Distinguishes between built-in (SPI) and external (USB/Bluetooth) devices
- **Multi-interface handling** - Automatically groups and disables multiple interfaces from the same physical device (e.g., Magic Trackpad's event6 + event7)
- **Deduplication** - Prevents duplicate entries for devices with multiple interfaces while allowing different functional interfaces to be shown separately

### Interactive Setup (TUI)

- **Guided configuration wizard** (`omarchy-disable-trackpad-while-typing-tui`)
- Smart defaults that auto-select internal devices (just press Enter)
- Configurable timeout (0.5s to 10s, default 1.5s)
- Automatic passwordless sudo configuration
- Option to relaunch Hyprland immediately after setup

### Intelligent Behavior

- **Instant re-enable triggers:**
  - Modifier keys (Ctrl, Alt, Shift, Super, Esc)
  - Window focus changes (Hyprland integration)
  - Detected focus movement keybindings
- **Configurable timeout** for re-enabling after typing stops
- **Multiple device support** - Handles devices with multiple event interfaces (both disabled simultaneously)

### Seamless Integration

- **Automatic startup** via Hyprland autostart
- **Clean restarts** - Kills previous instances before starting new ones (handles Hyprland relaunches gracefully)
- **Environment variable preservation** through sudo
- **Live configuration updates** - Changes to timeout take effect after Hyprland relaunch

## Setup Process

1. **Run the setup TUI from the Omarchy Menu, or directly via the script name:**

   ```bash
   omarchy-disable-trackpad-while-typing-tui
   ```

2. **Follow the interactive prompts:**
   - Step 1: Dependencies check (evtest, socat)
   - Step 2: Passwordless sudo configuration
   - Step 3: Select keyboard device (defaults to internal)
   - Step 4: Select pointer device to disable (defaults to internal trackpad)
   - Step 5: Choose timeout duration (default 1.5s)

3. **Relaunch Hyprland** (prompted at the end, or manually with `Super+Esc -> Relaunch` or the new binding `Super+Ctrl+Shift+R`)

https://github.com/user-attachments/assets/0f5895ad-91ec-4729-bec5-1a3f173e50ac

## How It Works

### Configuration

- **Environment variables** stored in `~/.config/hypr/input.conf`:
  - `OMARCHY_TRACKPAD_DWT_KEYBOARD` - Keyboard device to monitor
  - `OMARCHY_TRACKPAD_DWT_TRACKPAD` - Pointer device(s) to disable (colon-separated for multiple interfaces)
  - `OMARCHY_TRACKPAD_DWT_TIMEOUT` - Re-enable delay in seconds

- **Autostart entry** in `~/.config/hypr/autostart.conf`:
  ```bash
  exec-once = sudo /home/user/.local/share/omarchy/bin/omarchy-disable-trackpad-while-typing
  ```

### Runtime Behavior

1. **On Hyprland startup**, the script runs via autostart
2. **Checks for existing instances** and kills them (handles stale PIDs from previous sessions)
3. **Monitors keyboard events** using `evtest`
4. **Disables trackpad** when typing detected
5. **Re-enables trackpad** after timeout OR on instant-enable triggers
6. **Monitors Hyprland window focus** to enable trackpad during window switching

### Process Management

- Stores PID in `/tmp/dwt-script-pid`
- On startup, kills any process with existing PID to prevent conflicts
- Ensures clean transitions when Hyprland relaunches
- Automatically spawns background processes for focus monitoring and timeout handling

## Files Added

- `bin/omarchy-disable-trackpad-while-typing` - Main DWT script
- `bin/omarchy-disable-trackpad-while-typing-tui` - Interactive setup wizard

## Files Modified

- `bin/omarchy-menu` - "Config Options" uses `open_in_editor` to load the
  input.conf file (as before), and adds "Disable on Typing" menu option to
  launch the TUI for device selection and timeout configuration.
- `.config/hypr/bindings.conf` - Added `Super+Ctrl+Shift+R` keybinding to relaunch Hyprland
- `.config/hypr/input.conf` - Environment variables added by TUI (user-modified)
- `.config/hypr/autostart.conf` - Autostart entry added by TUI (user-modified)

## Technical Details

### Device Detection

Uses `udevadm` to query device properties:

- `ID_INPUT_MOUSE=1` - Identifies mice
- `ID_INPUT_TOUCHPAD=1` - Identifies trackpads/touchpads
- `ID_PATH` - Determines if internal (SPI) or external (USB/Bluetooth)
- `DEVPATH` - Used to group multiple interfaces from same physical device

### Trackpad Control

Uses sysfs `inhibited` mechanism:

- `/sys/class/input/inputX/inhibited` (or `.../device/inhibited`)
- Write `1` to disable, `0` to enable
- Requires sudo permissions (handled via passwordless sudo configuration)

### Multiple Interface Support

Devices like Magic Trackpad expose multiple event interfaces (e.g., event6 for touchpad, event7 for gestures). The system:

1. Detects interfaces from same physical device via DEVPATH
2. Groups them if they share the same name
3. Stores as colon-separated paths: `/dev/input/event6:/dev/input/event7`
4. Disables/enables all interfaces simultaneously

## Configuration Changes

To modify timeout after initial setup:

1. Edit `~/.config/hypr/input.conf`
2. Change `OMARCHY_TRACKPAD_DWT_TIMEOUT` value
3. Relaunch Hyprland (`Super+Ctrl+Shift+R`)

Or re-run the TUI to reconfigure everything.

## Removal

To remove this feature:

1. Remove env lines from `~/.config/hypr/input.conf`
2. Remove exec-once line from `~/.config/hypr/autostart.conf`
3. Run: `sudo rm /etc/sudoers.d/omarchy-trackpad-dwt`
4. Kill running process: `sudo pkill -f omarchy-disable-trackpad-while-typing`