### PR TITLE
Add custom walker-based share picker with monitor descriptions

### DIFF
--- a/bin/omarchy-hyprland-share-picker
+++ b/bin/omarchy-hyprland-share-picker
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+ALLOW_TOKEN=false
+[[ "$1" == "--allow-token" ]] && ALLOW_TOKEN=true
+
+output_selection() {
+  local type="$1"
+  local value="$2"
+
+  echo -n "[SELECTION]"
+  [[ "$ALLOW_TOKEN" == "true" ]] && echo -n "r"
+  echo "/${type}:${value}"
+  exit 0
+}
+
+show_screen_tab() {
+  local options=()
+  local connectors=()
+
+  while IFS='|' read -r connector desc width height; do
+    local friendly_name=$(sed -E 's/ (0x[0-9A-F]+|[A-Z0-9]{10,})$//' <<<"$desc")
+    options+=("$friendly_name (${width}x${height}) - $connector")
+    connectors+=("$connector")
+  done < <(hyprctl monitors -j 2>/dev/null | jq -r '.[] | "\(.name)|\(.description)|\(.width)|\(.height)"' 2>/dev/null)
+
+  local selected=$(printf '%s\n' "${options[@]}" | walker --dmenu -w 350 -p "Share Screen…" 2>/dev/null)
+
+  for i in "${!options[@]}"; do
+    [[ "${options[$i]}" == "$selected" ]] && output_selection "screen" "${connectors[$i]}"
+  done
+
+  exit 1
+}
+
+show_window_tab() {
+  [[ -z "$XDPH_WINDOW_SHARING_LIST" ]] && exit 1
+
+  local options=()
+  local ids=()
+  local rolling="$XDPH_WINDOW_SHARING_LIST"
+
+  while [[ -n "$rolling" && "$rolling" == *"[HC>]"* ]]; do
+    local id="${rolling%%\[HC>\]*}"
+    rolling="${rolling#*\[HC>\]}"
+
+    local class="${rolling%%\[HT>\]*}"
+    rolling="${rolling#*\[HT>\]}"
+
+    local title="${rolling%%\[HE>\]*}"
+    rolling="${rolling#*\[HE>\]}"
+
+    rolling="${rolling#*\[HA>\]}"
+
+    if [[ -n "$id" && -n "$title" ]]; then
+      options+=("$title")
+      ids+=("$id")
+    fi
+  done
+
+  local selected=$(printf '%s\n' "${options[@]}" | walker --dmenu -w 350 -p "Share Window…" 2>/dev/null)
+
+  for i in "${!options[@]}"; do
+    [[ "${options[$i]}" == "$selected" ]] && output_selection "window" "${ids[$i]}"
+  done
+
+  exit 1
+}
+
+show_region_tab() {
+  local geometry=$(slurp -f "%o %x %y %w %h" 2>/dev/null)
+
+  if [[ -n "$geometry" ]]; then
+    read -r output x y w h <<<"$geometry"
+    output_selection "region" "${output}@${x},${y},${w},${h}"
+  fi
+
+  exit 1
+}
+
+main_menu() {
+  local choice=$(printf "Screen\nWindow\nRegion" | walker --dmenu --theme dmenu_250 -p "Share…" 2>/dev/null)
+
+  case "$choice" in
+  Screen) show_screen_tab ;;
+  Window) show_window_tab ;;
+  Region) show_region_tab ;;
+  *) exit 1 ;;
+  esac
+}
+
+main_menu

--- a/default/hypr/xdph.conf
+++ b/default/hypr/xdph.conf
@@ -1,0 +1,3 @@
+screencopy {
+  custom_picker_binary = ~/.local/share/omarchy/bin/omarchy-hyprland-share-picker
+}

--- a/migrations/1759852695.sh
+++ b/migrations/1759852695.sh
@@ -1,0 +1,3 @@
+echo "Install custom share picker"
+
+cp -f $OMARCHY_PATH/default/hypr/xdph.conf ~/.config/hypr/xdph.conf


### PR DESCRIPTION
  ## Problem

  The current Qt-based `hyprland-share-picker` has several issues that don't align with Omarchy's design:

  1. **Generic labels**: Shows "Screen 0", "Screen 1", "Screen 2" instead of actual monitor names, making it hard to identify which monitor to share on multi-monitor setups
  2. **Takes half the screen**: The Qt dialog is unnecessarily large and intrusive
  3. **Doesn't support themes**: Uses Qt's default styling which looks out of place in Omarchy
  4. **No keyboard navigation**: In a keyboard-centric system like Omarchy, you can't search or quickly select with the keyboard

  ## Solution

  This PR adds a custom walker-based share picker that:

  - **Shows friendly monitor names** from Hyprland descriptions
  - **Compact and themeable** - Uses walker's dmenu mode, integrates with Omarchy themes
  - **Fully keyboard-driven** - Search and select with keyboard, matching Omarchy's workflow
  - **Supports all features** - Screen/Window/Region selection with restore token support

  ### Before (Qt picker)
 
<img width="2560" height="1600" alt="screenshot-2025-10-07_20-20-41" src="https://github.com/user-attachments/assets/a7ae2443-baae-462a-974d-e56a73d09d0f" />


  ### After (Walker picker)

<img width="2540" height="1528" alt="screenshot-2025-10-07_20-14-30" src="https://github.com/user-attachments/assets/0d9e3472-12a6-4e8f-b943-c9fd3f74afe9" />

<img width="2540" height="1528" alt="screenshot-2025-10-07_20-15-33" src="https://github.com/user-attachments/assets/4fc6e597-788d-4019-be09-767968d75649" />

<img width="2540" height="1528" alt="screenshot-2025-10-07_20-16-12" src="https://github.com/user-attachments/assets/d7b365c6-f0b9-4b40-b94a-c074bf705668" />




  ## Implementation

  - **Script**: `bin/omarchy-hyprland-share-picker` - Custom picker using walker
  - **Config**: `default/hypr/xdph.conf` - Configures xdg-desktop-portal-hyprland
  - **Migration**: Copies config to `~/.config/hypr/xdph.conf`

  ## Benefits

  1. **No extra dependencies** - Uses `hyprctl`
  2. **Omarchy consistency** - Matches walker-based design language
  3. **Better UX** - Searchable, keyboard-driven, clear monitor identification

  ## Context

  PR #144 proposed a similar wofi-based picker but was closed

  The Qt picker comes from upstream `xdg-desktop-portal-hyprland`

