### PR TITLE
Configure VSCode/Cursor to use gnome-libsecret password store

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -73,6 +73,14 @@ aur_install_and_launch() {
   present_terminal "echo 'Installing $1 from AUR...'; yay -S --noconfirm $2 && setsid gtk-launch $3"
 }
 
+install_and_launch_vscode() {
+  present_terminal "echo 'Installing VSCode...'; sudo pacman -S --noconfirm visual-studio-code-bin && bash ~/.local/share/omarchy/install/config/editor-argv.sh vscode && setsid gtk-launch code"
+}
+
+install_and_launch_cursor() {
+  present_terminal "echo 'Installing Cursor...'; sudo pacman -S --noconfirm cursor-bin && bash ~/.local/share/omarchy/install/config/editor-argv.sh cursor && setsid gtk-launch cursor"
+}
+
 show_learn_menu() {
   case $(menu "Learn" "  Keybindings\n  Omarchy\n  Hyprland\n󰣇  Arch\n  Neovim\n󱆃  Bash") in
   *Keybindings*) omarchy-menu-keybindings ;;
@@ -260,8 +268,8 @@ show_install_service_menu() {
 
 show_install_editor_menu() {
   case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Emacs") in
-  *VSCode*) install_and_launch "VSCode" "visual-studio-code-bin" "code" ;;
-  *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
+  *VSCode*) install_and_launch_vscode ;;
+  *Cursor*) install_and_launch_cursor ;;
   *Zed*) install_and_launch "Zed" "zed" "dev.zed.Zed" ;;
   *Sublime*) aur_install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;
   *Helix*) install "Helix" "helix" ;;

--- a/install/config/editor-argv.sh
+++ b/install/config/editor-argv.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Configure VSCode-based editors to use gnome-libsecret as the password store
+# Usage: editor-argv.sh <editor-name>
+# Example: editor-argv.sh vscode
+
+set -e
+
+EDITOR_NAME="${1:-vscode}"
+EDITOR_DIR="${EDITOR_NAME,,}"  # Convert to lowercase
+ARGV_FILE="$HOME/.${EDITOR_DIR}/argv.json"
+
+# Create the editor directory if it doesn't exist
+mkdir -p "$HOME/.${EDITOR_DIR}"
+
+# Check if file exists and already has password-store configured
+if [[ -f "$ARGV_FILE" ]] && grep -q '"password-store"[[:space:]]*:[[:space:]]*"gnome-libsecret"' "$ARGV_FILE"; then
+  echo "${EDITOR_NAME} password-store already configured correctly"
+  exit 0
+fi
+
+# If file exists but doesn't have password-store, add it using sed
+if [[ -f "$ARGV_FILE" ]]; then
+  # Add comma to the last property before closing brace (if it doesn't already have one)
+  sed -i '/^[[:space:]]*}[[:space:]]*$/!{/[^,]$/s/$/,/}' "$ARGV_FILE"
+
+  # Add the password-store setting before the closing brace
+  sed -i '/^[[:space:]]*}[[:space:]]*$/i\
+\
+	// Omarchy default password store\
+	"password-store": "gnome-libsecret"' "$ARGV_FILE"
+
+  echo "Added password-store setting to existing ${EDITOR_NAME} argv.json"
+  exit 0
+fi
+
+# Create new argv.json with password-store setting
+cat >"$ARGV_FILE" <<'EOF'
+{
+	// Omarchy default password store
+	"password-store": "gnome-libsecret"
+}
+EOF
+
+echo "Configured ${EDITOR_NAME} to use gnome-libsecret password store"

--- a/migrations/1759862313.sh
+++ b/migrations/1759862313.sh
@@ -1,0 +1,5 @@
+echo "Configure VSCode and Cursor to use gnome-libsecret password store"
+
+# Only configure if the editor is installed
+[[ -d ~/.vscode ]] && bash $OMARCHY_PATH/install/config/editor-argv.sh vscode
+[[ -d ~/.cursor ]] && bash $OMARCHY_PATH/install/config/editor-argv.sh cursor


### PR DESCRIPTION
Fixes #1015. This PR adds automatic configuration of the password-store setting for VSCode and Cursor editors to use gnome-libsecret (GNOME Keyring) for storing credentials.

### Changes

1. **New unified configuration script** (editor-argv.sh)
   - Configures the `~/.vscode/argv.json` or `~/.cursor/argv.json` file
   - Handles three scenarios:
     - File doesn't exist: creates it with the password-store setting
     - File exists without password-store: adds the setting using sed
     - File already configured: skips (idempotent)

2. **Updated omarchy-menu** (omarchy-menu)
   - Added `install_and_launch_vscode()` and `install_and_launch_cursor()` functions
   - Automatically runs the configuration script after installing VSCode or Cursor
   - Updated `show_install_editor_menu()` to use the new install functions

3. **Migration for existing users** (1759862313.sh)
   - Runs the configuration script for VSCode and Cursor if they're already installed
   - Only configures editors that exist on the system
