### PR TITLE
Fix: add US fallback for non-US keyboard layouts in Hyprland

### DIFF
--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -2,12 +2,29 @@
 conf="/etc/vconsole.conf"
 hyprconf="$HOME/.config/hypr/input.conf"
 
-if grep -q '^XKBLAYOUT=' "$conf"; then
-  layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $layout" "$hyprconf"
-fi
+default="us"
+# Extract the primary keyboard layout (XKBLAYOUT) from vconsole.conf.
+# We use grep to find the line, cut to get the value after '=', and tr to remove quotes.
+layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
 
-if grep -q '^XKBVARIANT=' "$conf"; then
-  variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\  kb_variant = $variant" "$hyprconf"
+# Extract the keyboard variant (XKBVARIANT) from vconsole.conf.
+# This might be empty if no specific variant is used for the chosen layout.
+variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
+
+if [ "$layout" != "$default" ]; then
+    kb_layout="$default,$layout"
+    kb_variant=",$variant"
+    kb_options="grp:alt_shift_toggle"
+else
+    kb_layout="$layout"
+    kb_variant="$variant"
+    kb_options=""
 fi
+sed -i "/^[[:space:]]*kb_layout *=/d" "$hyprconf"
+sed -i "/^[[:space:]]*kb_variant *=/d" "$hyprconf"
+sed -i "/^[[:space:]]*kb_options *=/d" "$hyprconf"
+
+echo "kb_layout = $kb_layout" >> "$hyprconf"
+
+[ -n "$kb_variant" ] && echo "kb_variant = $kb_variant" >> "$hyprconf"
+[ -n "$kb_options" ] && echo "kb_options = $kb_options" >> "$hyprconf"


### PR DESCRIPTION
**Description:**
This pull request addresses the installation issue where users selecting a non-US keyboard layout during installation would find their Hyprland system "bricked" due to a lack of a working input method for system shortcuts and text editing (especially in nvim which is the default editor).

**Problem Addressed (Fixes #2054):**
Previously, if a user chose a keyboard layout like `ru` or any other non-US layout, the Hyprland configuration would only include that single layout. This led to a situation where essential system shortcuts (which often rely on a `us` layout interpretation) would not function, and users would be unable to type effectively in applications like nvim (the default editor), making it impossible to even enter insert mode or modify configuration files.

**Solution:**
This script modification ensures that:
1.  If the detected keyboard layout from `/etc/vconsole.conf` is anything other than `us`, the `us` layout is prepended to the `kb_layout` variable (e.g., `us,ru`).
2.  The `kb_options` are set to `grp:alt_shift_toggle` to allow users to easily switch between `us` and their chosen layout (e.g., Russian) using `Alt+Shift`.
3.  If the detected layout *is* `us`, the configuration remains simple, setting only `kb_layout = us` without additional options.
4.  Existing `kb_layout`, `kb_variant`, and `kb_options` lines are removed before appending new ones to prevent duplication and ensure a clean configuration update.

This fix prevents the system from becoming unusable for non-US keyboard users, providing a reliable fallback to the `us` layout when needed for system interactions and ensuring a smooth user experience.

**Testing:**
*   Tested with `XKBLAYOUT="ru"` in `/etc/vconsole.conf`: `kb_layout` correctly set to `us,ru`, and `kb_options` to `grp:alt_shift_toggle`.
*   Tested with `XKBLAYOUT="us"` in `/etc/vconsole.conf`: `kb_layout` correctly set to `us`, and `kb_options` remained 