### PR TITLE
chore: better contrast for ristretto kitty conf

### DIFF
--- a/themes/ristretto/kitty.conf
+++ b/themes/ristretto/kitty.conf
@@ -11,15 +11,15 @@ cursor_text_color       #c3b7b8
 
 url_color               #e6d9db
 
-active_border_color     #595959
+active_border_color     #e6d9db
 inactive_border_color   #595959
 bell_border_color       #595959
 
-active_tab_foreground   #e6d9db
-active_tab_background   #2c2525
+active_tab_foreground   #2c2525
+active_tab_background   #f9cc6c
 inactive_tab_foreground #e6d9db
 inactive_tab_background #2c2525
-tab_bar_background      #e6d9db
+tab_bar_background      #2c2525
 
 mark1_foreground        #2c2525
 mark1_background        #404040


### PR DESCRIPTION
Adds better contrast to know in which split and tab you might be in kitty:

<img width="2512" height="1500" alt="image" src="https://github.com/user-attachments/assets/6f549180-601b-4921-830e-02c523e349a6" />

Before:

<img width="2512" height="1500" alt="image" src="https://github.com/user-attachments/assets/4e50d6c9-f827-48d0-b512-09c9b23d740e" />
