### PR TITLE
feat: (alias) added 'cd -' support

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -8,6 +8,14 @@ alias cd="zd"
 zd() {
   if [ $# -eq 0 ]; then
     builtin cd ~ && return
+  elif [[ "$1" == "-" ]]; then
+    if [[ -n "$OLDPWD" ]]; then
+      builtin cd -
+    else
+      print -u2 "zd: OLDPWD not set"
+      return 1
+    fi
+    return
   elif [ -d "$1" ]; then
     builtin cd "$1"
   else


### PR DESCRIPTION
Mac users coming to Omarchy will likely expect `cd -` to work out of the box — it’s ingrained muscle memory for toggling between `$PWD` and `$OLDPWD`. I personally rely on it heavily, and without this change, `cd -` failed because `zoxide` doesn’t handle the `-` argument.

This patch adds a small, safe branch that delegates `cd -` to the built-in `cd`, restoring standard shell behavior while preserving all existing `zd` functionality.

<img width="816" height="673" alt="screenshot-2025-10-07_20-02-15" src="https://github.com/user-attachments/assets/3e0d03f5-6c53-4c1b-af1c-e7c7e3d3430c" />