### PR TITLE
optional: add 'cd -' and move functional aliases to functions file

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -8,6 +8,14 @@ alias cd="zd"
 zd() {
   if [ $# -eq 0 ]; then
     builtin cd ~ && return
+  elif [[ "$1" == "-" ]]; then
+    if [[ -n "$OLDPWD" ]]; then
+      builtin cd -
+    else
+      print -u2 "zd: OLDPWD not set"
+      return 1
+    fi
+    return
   elif [ -d "$1" ]; then
     builtin cd "$1"
   else

--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -5,26 +5,6 @@ alias lt='eza --tree --level=2 --long --icons --git'
 alias lta='lt -a'
 alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
 alias cd="zd"
-zd() {
-  if [ $# -eq 0 ]; then
-    builtin cd ~ && return
-  elif [[ "$1" == "-" ]]; then
-    if [[ -n "$OLDPWD" ]]; then
-      builtin cd -
-    else
-      print -u2 "zd: OLDPWD not set"
-      return 1
-    fi
-    return
-  elif [ -d "$1" ]; then
-    builtin cd "$1"
-  else
-    z "$@" && printf "\U000F17A9 " && pwd || echo "Error: Directory not found"
-  fi
-}
-open() {
-  xdg-open "$@" >/dev/null 2>&1 &
-}
 
 # Directories
 alias ..='cd ..'
@@ -34,7 +14,6 @@ alias ....='cd ../../..'
 # Tools
 alias d='docker'
 alias r='rails'
-n() { if [ "$#" -eq 0 ]; then nvim .; else nvim "$@"; fi; }
 
 # Git
 alias g='git'

--- a/default/bash/functions
+++ b/default/bash/functions
@@ -65,3 +65,30 @@ img2png() {
     -define png:exclude-chunk=all \
     "${1%.*}.png"
 }
+
+# Mapping of zd opt-outs to stay with cd builtin
+zd() {
+  if [ $# -eq 0 ]; then
+    builtin cd ~ && return
+  elif [[ "$1" == "-" ]]; then
+    if [[ -n "$OLDPWD" ]]; then
+      builtin cd -
+    else
+      print -u2 "zd: OLDPWD not set"
+      return 1
+    fi
+    return
+  elif [ -d "$1" ]; then
+    builtin cd "$1"
+  else
+    z "$@" && printf "\U000F17A9 " && pwd || echo "Error: Directory not found"
+  fi
+}
+
+# Open xdg-open session
+open() {
+  xdg-open "$@" >/dev/null 2>&1 &
+}
+
+# Open nvim shortcut
+n() { if [ "$#" -eq 0 ]; then nvim .; else nvim "$@"; fi; }


### PR DESCRIPTION
Please see #2299 first, specifically this comment:
https://github.com/basecamp/omarchy/pull/2299/files#r2412387383

This PR moves all functional aliases out of `default/bash/aliases` to `default/bash/functions` and also introduces support for `cd -` as described in the description of #2299.