### PR TITLE
fix: clean chrome caches

### DIFF
--- a/migrations/1758436992.sh
+++ b/migrations/1758436992.sh
@@ -3,11 +3,20 @@
 
 set -e
 
+browser=$(xdg-settings get default-web-browser)
+
+case $browser in
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium-browser*) ;;
+*) browser="chromium.desktop" ;;
+esac
+
+BROWSER=${browser%.desktop}
+
 # Directories to remove
 CACHE_DIRS=(
-    "$HOME/.config/google-chrome/GrShaderCache"
-    "$HOME/.config/google-chrome/ShaderCache"
-    "$HOME/.config/google-chrome/Default/GPUCache"
+    "$HOME/.config/$BROWSER/GrShaderCache"
+    "$HOME/.config/$BROWSER/ShaderCache"
+    "$HOME/.config/$BROWSER/Default/GPUCache"
 )
 
 for dir in "${CACHE_DIRS[@]}"; do


### PR DESCRIPTION
This PR addresses the issue where Chromium and Chrome appear completely gray/black-and-white on Omarchy after recent updates. The bug was related to GPU rendering and cached shader data, causing themes and colors to malfunction.

https://github.com/basecamp/omarchy/issues/2272#issuecomment-3382870635