### PR TITLE
Fix asdcontrol typo

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -4,7 +4,7 @@
 1password-beta
 1password-cli
 alacritty
-asdcontrol-git
+asdcontrol
 avahi
 bash-completion
 bat


### PR DESCRIPTION
`asdcontrol-git` should be `asdcontrol` since the former doesn't exist. 

<img width="1078" height="173" alt="Screenshot_20251009_061441" src="https://github.com/user-attachments/assets/5c7cdd0c-45a8-43aa-9f38-756b5f685629" />
