### PR TITLE
Disable wall messages on shutdown/reboot

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -453,8 +453,8 @@ show_system_menu() {
   *Screensaver*) omarchy-launch-screensaver force ;;
   *Suspend*) systemctl suspend ;;
   *Relaunch*) omarchy-state clear relaunch-required && sudo systemctl restart sddm ;;
-  *Restart*) omarchy-state clear re*-required && systemctl reboot ;;
-  *Shutdown*) omarchy-state clear re*-required && systemctl poweroff ;;
+  *Restart*) omarchy-state clear re*-required && systemctl reboot --no-wall ;;
+  *Shutdown*) omarchy-state clear re*-required && systemctl poweroff --no-wall ;;
   *) back_to show_main_menu ;;
   esac
 }


### PR DESCRIPTION
This PR hides the brief flash of broadcast messages during shutdown/reboot by adding the `--no-wall` option to the `systemctl` commands.

More info: https://man.archlinux.org/man/systemctl.1.en#:~:text=%2D%2Dno%2Dwall,off%20and%20reboot.