### PR TITLE
Show overlay when changing Apple display brightness

### DIFF
--- a/bin/omarchy-cmd-apple-display-brightness
+++ b/bin/omarchy-cmd-apple-display-brightness
@@ -3,5 +3,12 @@
 if [[ $# -eq 0 ]]; then
   echo "Adjust Apple Display Brightness by passing +5000 or -5000 (or any range from 0-60000)"
 else
-  sudo asdcontrol $(sudo asdcontrol --detect /dev/usb/hiddev* | grep ^/dev/usb/hiddev | cut -d: -f1) -- "$1"
+  DEVICE="$(sudo asdcontrol --detect /dev/usb/hiddev* | grep ^/dev/usb/hiddev | cut -d: -f1)"
+  sudo asdcontrol "$DEVICE" -- "$1" >/dev/null
+  VALUE="$(sudo asdcontrol "$DEVICE" | awk -F= '/BRIGHTNESS=/{print $2+0}')"
+  swayosd-client \
+    --monitor "$(hyprctl monitors -j | jq -r '.[]|select(.focused==true).name')" \
+    --custom-icon display-brightness \
+    --custom-progress "$(awk -v v="$VALUE" 'BEGIN{printf "%.2f", v/60000}')" \
+    --custom-progress-text "$(( VALUE * 100 / 60000 ))%"
 fi


### PR DESCRIPTION
Following up from [#2278](https://github.com/basecamp/omarchy/issues/2278#issuecomment-3377036474)

Now this is my first contribution and I only have one Studio Display so can't test it extensively.

No idea what happens when you don't have an Apple display. No idea what happens when you have multiple. Some else will have to test that :sweat_smile:

I tried to make the UI look as close to native `swayosd` as possible. I know I wasn't crazy when I said I saw it: it's there if you use your keyboard's keys. So on Flow84 you'd see it by Fn+F1 or Fn+F2.