### PR TITLE
screensaver: Use the monitor refresh rate

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -15,10 +15,11 @@ trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
 
 hyprctl keyword cursor:invisible true
 
+framerate="${1:-240}"
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)
   tte -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 240 --canvas-width 0 --canvas-height $(($(tput lines) - 1)) --anchor-canvas c --anchor-text c \
+    --frame-rate $framerate --canvas-width 0 --canvas-height $(($(tput lines) - 1)) --anchor-canvas c --anchor-text c \
     "$effect" &
 
   while pgrep -x tte >/dev/null; do

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -15,14 +15,14 @@ fi
 
 focused=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')
 
-for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
+hyprctl monitors -j | jq -r '.[] | "\(.name) \(.refreshRate | ceil)"' | while read -r m r; do
   hyprctl dispatch focusmonitor $m
 
   # FIXME: Find a way to make this generic where we it can work for kitty + ghostty
   hyprctl dispatch exec -- \
     alacritty --class Screensaver \
     --config-file ~/.local/share/omarchy/default/alacritty/screensaver.toml \
-    -e omarchy-cmd-screensaver
+    -e omarchy-cmd-screensaver $r
 done
 
 hyprctl dispatch focusmonitor $focused


### PR DESCRIPTION
When launching, use the refresh rate of each monitor instead of the hardcoded 240.

My selfish motivation is just to stop hearing fans on my laptop, but it makes sense to avoid wasting cycles past the monitor refresh rate.