### PR TITLE
Fix: include symlinked backgrounds in theme rotation

### DIFF
--- a/bin/omarchy-theme-bg-next
+++ b/bin/omarchy-theme-bg-next
@@ -5,7 +5,7 @@
 BACKGROUNDS_DIR="$HOME/.config/omarchy/current/theme/backgrounds/"
 CURRENT_BACKGROUND_LINK="$HOME/.config/omarchy/current/background"
 
-mapfile -d '' -t BACKGROUNDS < <(find "$BACKGROUNDS_DIR" -type f -print0 | sort -z)
+mapfile -d '' -t BACKGROUNDS < <(find -L "$BACKGROUNDS_DIR" -type f -print0 | sort -z)
 TOTAL=${#BACKGROUNDS[@]}
 
 if [[ $TOTAL -eq 0 ]]; then


### PR DESCRIPTION
Address background rotation skipping images when theme images are stored as symlinks, for example in a stow/dotfiles repo. 

Added -L to the find invocation so the script now follows symbolic links and counts those files. After the change, symlinked backgrounds appear in the rotation as expected.