### PR TITLE
Added the Option to install Jetbrains

### DIFF
--- a/bin/omarchy-install-jetbrains
+++ b/bin/omarchy-install-jetbrains
@@ -1,0 +1,94 @@
+#!/bin/bash
+if [[ -z "$1" ]]; then
+  echo "What would you like to install?"
+  echo " 0 - Nothing (exit)"
+  echo " 1 - full"
+  echo " 2 - clion"
+  echo " 3 - datagrip"
+  echo " 4 - dataspell"
+  echo " 5 - intellij-idea"
+  echo " 6 - phpstorm"
+  echo " 7 - pycharm"
+  echo " 8 - rider"
+  echo " 9 - webstorm"
+  while true; do
+    read -r -p "Enter the number of your choice: " selection
+    case "$selection" in
+      0)
+        echo "Exiting without installing anything."
+        exit 0
+        ;;
+      1) set -- full; break ;;
+      2) set -- clion; break ;;
+      3) set -- datagrip; break ;;
+      4) set -- dataspell; break ;;
+      5) set -- intellij-idea; break ;;
+      6) set -- phpstorm; break ;;
+      7) set -- pycharm; break ;;
+      8) set -- rider; break ;;
+      9) set -- webstorm; break ;;
+      *)
+        echo "Invalid option. Please enter a number from 0 to 9."
+        ;;
+    esac
+  done
+fi
+
+case "$1" in
+full)
+  echo -e "Installing everything...\n"
+  yay -S --noconfirm clion clion-jre datagrip datagrip-jre dataspell dataspell-jre intellij-idea-ultimate-edition \
+      phpstorm phpstorm-jre pycharm rider webstorm webstorm-jre
+  sudo updatedb
+  omarchy-show-done
+  ;;
+clion)
+  echo -e "Installing CLion...\n"
+  yay -S --noconfirm clion clion-jre
+  sudo updatedb
+  omarchy-show-done
+  ;;
+datagrip)
+  echo -e "Installing DataGrip...\n"
+  yay -S --noconfirm datagrip datagrip-jre
+  sudo updatedb
+  omarchy-show-done
+  ;;
+dataspell)
+  echo -e "Installing DataSpell...\n"
+  yay -S --noconfirm dataspell dataspell-jre
+  sudo updatedb
+  omarchy-show-done
+  ;;
+intellij-idea)
+  echo -e "Installing IntelliJ IDEA...\n"
+  yay -S --noconfirm intellij-idea-ultimate-edition
+  sudo updatedb
+  omarchy-show-done
+  ;;
+phpstorm)
+  echo -e "Installing PhpStorm...\n"
+  yay -S --noconfirm phpstorm phpstorm-jre
+  sudo updatedb
+  omarchy-show-done
+  ;;
+pycharm)
+  echo -e "Installing PyCharm...\n"
+  yay -S --noconfirm pycharm
+  sudo updatedb
+  omarchy-show-done
+  ;;
+rider)
+  echo -e "Installing Rider...\n"
+  yay -S --noconfirm rider
+  sudo updatedb
+  omarchy-show-done
+  ;;
+webstorm)
+  echo -e "Installing WebStorm...\n"
+  yay -S --noconfirm webstorm webstorm-jre
+  sudo updatedb
+  omarchy-show-done
+  ;;
+esac
+  

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -259,8 +259,9 @@ show_install_service_menu() {
 }
 
 show_install_editor_menu() {
-  case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Emacs") in
+  case $(menu "Install" "  VSCode\n JetBrains Suite\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Emacs") in
   *VSCode*) install_and_launch "VSCode" "visual-studio-code-bin" "code" ;;
+  *JetBrains*) present_terminal omarchy-install-jetbrains  ;;
   *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
   *Zed*) install_and_launch "Zed" "zed" "dev.zed.Zed" ;;
   *Sublime*) aur_install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;


### PR DESCRIPTION
I assume that a good chunk of devs use the JetBrains Suite.

The thing is, if you don't know that it not only requires the package but also the runtime, you spend unnecessary time to find what you're looking for. So I tried to fix this, and that is the solution. I hope you like it and merge it.

It basically asks the user what he wants to install (accepts a number) and then does its thing. :-)