### PR TITLE
Added Modules so the Surface Laptop 5 built-in Keyboard Works at Login

### DIFF
--- a/install/config/hardware/fix-surface5-keyboard.sh
+++ b/install/config/hardware/fix-surface5-keyboard.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Enable early Surface Laptop 5 keyboard/I²C/HID modules so the built-in keyboard works at the greeter.
+
+set -euo pipefail
+
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null || echo '')"
+sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || echo '')"
+
+# Target only Surface Laptop 5
+if [[ "$sys_vendor" == "Microsoft Corporation" ]] && [[ "$product_name" == "Surface Laptop 5" ]]; then
+  echo "Detected Microsoft Surface Laptop 5 — enabling early keyboard modules"
+
+  # Working module set verified on Surface Laptop 5
+  echo 'MODULES=(btrfs crc-itu-t usbhid hid-generic pinctrl_tigerlake intel_lpss_pci
+  8250_dw surface_gpe surface_hotplug surface_aggregator_registry
+  surface_aggregator_hub surface_aggregator surface_hid_core surface_hid
+  surface_kbd xhci_hcd hid_multitouch)' \
+  | sudo tee /etc/mkinitcpio.conf.d/surface5_kbd_modules.conf >/dev/null
+fi


### PR DESCRIPTION
On my Surface Laptop 5, the built-in keyboard doesn’t work at the login screen, but it starts working normally after logging in. I added some modules to '/etc/mkinitcpio.conf' and it fixed the issue for me. I also found a few people on the Omarchy Discord reporting the same issue, so this seems reproducible on other Surface 5 systems.

Steps to reproduce the original problem: 
        1. Boot Omarchy on a Surface Laptop 5.
        2. At the password login screen, the keyboard doesn’t respond.
        3. After logging in (using an external keyboard), the built-in keyboard works normally.

Here’s the module list that worked for my setup:

MODULES=(btrfs crc-itu-t usbhid hid-generic pinctrl_tigerlake intel_lpss_pci
         8250_dw surface_gpe surface_hotplug surface_aggregator_registry
         surface_aggregator_hub surface_aggregator surface_hid_core surface_hid
         surface_kbd xhci_hcd hid_multitouch)

After looking through the Omarchy repository, I noticed there’s a similar hardware-specific fix for MacBook SPI keyboards. I used that script as a reference and, with some AI assistance, created a matching patch for the Surface Laptop 5. 

The patch is implemented as:

omarchy/install/config/hardware/fix-surface5-keyboard.sh

It mirrors the style of fix-apple-spi-keyboard.sh and just writes a mkinitcpio drop-in file.