### PR TITLE
Suppress start/stop logs for battery monitor timer 

### DIFF
--- a/config/systemd/user/omarchy-battery-monitor.service
+++ b/config/systemd/user/omarchy-battery-monitor.service
@@ -6,3 +6,4 @@ After=graphical-session.target
 Type=oneshot
 ExecStart=%h/.local/share/omarchy/bin/omarchy-battery-monitor
 Environment=DISPLAY=:0
+LogLevelMax=warning


### PR DESCRIPTION
This change prevents battery monitor start/stop messages from flooding systemd journal with messages like:

```
Sep 21 03:11:55 t systemd[1041]: Starting Omarchy Battery Monitor Check...
Sep 21 03:11:55 t systemd[1041]: Finished Omarchy Battery Monitor Check.
Sep 21 03:12:35 t systemd[1041]: Starting Omarchy Battery Monitor Check...
Sep 21 03:12:35 t systemd[1041]: Finished Omarchy Battery Monitor Check.
```

According to https://github.com/systemd/systemd/issues/9328 and https://github.com/systemd/systemd/issues/9328#issuecomment-1366152202 adding `LogLevelMax=warning` to the service prevents this by applying the log filter to messages about the service (not just from the service). I've confirmed this to work on my test machine.