### PR TITLE
fix: correct typo in command usage (verion -> version)

### DIFF
--- a/bin/omarchy-update-branch
+++ b/bin/omarchy-update-branch
@@ -3,7 +3,7 @@
 set -e
 
 if (($# == 0)); then
-  echo "Usage: omarchy-verion-branch-set [master|dev]"
+  echo "Usage: omarchy-version-branch set [master|dev]"
   exit 1
 fi
 


### PR DESCRIPTION
The command name was misspelled as 'omarchy-verion-branch-set', which caused confusion when using the script. Updated it to 'omarchy-version-branch set' for consistency and correct usage output.