### PR TITLE
Waybar battery indicator: show capacity and remaining time when charging or discharging

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -78,16 +78,16 @@
   },
   "battery": {
     "format": "{capacity}% {icon}",
-    "format-discharging": "{icon}",
-    "format-charging": "{icon}",
+    "format-discharging": "{capacity}% {icon}",
+    "format-charging": "{capacity}% {icon}",
     "format-plugged": "",
     "format-icons": {
       "charging": ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"],
       "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
     },
     "format-full": "󰂅",
-    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
-    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%\n{time}",
+    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%\n{time}",
     "interval": 5,
     "on-click": "omarchy-menu power",
     "states": {


### PR DESCRIPTION
When charging or discharging show the current capacity in % left to the battery icon. Additionally in the tooltip show the remaining time until full discharge or charge. Other battery states are kept unchanged.

This is an enhancement worthy of adding to the default waybar config. It helps with knowing the battery state, personally I was missing knowing how much time I have left when on battery.