### PR TITLE
tweak(omarchy-theme-set): only restart waybar if already running

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -24,7 +24,9 @@ ln -nsf "$THEME_PATH" "$CURRENT_THEME_DIR"
 omarchy-theme-bg-next
 
 # Restart components to apply new theme
-omarchy-restart-waybar
+if pgrep -x waybar >/dev/null; then
+  omarchy-restart-waybar
+fi
 omarchy-restart-swayosd
 hyprctl reload
 pkill -SIGUSR2 btop


### PR DESCRIPTION
## Description

This is a PR for #2342.

If we have Waybar toggled off (`super+shift+space`), and then switch themes (`omarchy-set-theme`), waybar will be spawned [here](https://github.com/basecamp/omarchy/blob/master/bin/omarchy-theme-set#L27-L27).

### proposal

We should only restart waybar if it is already running when switching theme.
