### PR TITLE
fix: mute output when hiding cursor in screensaver

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -13,7 +13,7 @@ exit_screensaver() {
 
 trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
 
-hyprctl keyword cursor:invisible true
+hyprctl keyword cursor:invisible true &>/dev/null
 
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)


### PR DESCRIPTION
Forgot to mute the output of the hyprctl command when hiding the cursor 

It briefly showed "ok" before starting the screensaver

My bad!