### PR TITLE
add fix for webapp and browser crash on multi monitor setups

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,4 +7,4 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium-b
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --disable-features=WaylandWpColorManagerV1 --app="$1" "${@:2}"

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -1,6 +1,6 @@
 # Application bindings
 $terminal = uwsm app -- $TERMINAL
-$browser = omarchy-launch-browser
+$browser = omarchy-launch-browser --disable-features=WaylandWpColorManagerV1
 
 bindd = SUPER, return, Terminal, exec, $terminal --working-directory="$(omarchy-cmd-terminal-cwd)"
 bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window


### PR DESCRIPTION
This fixes chromium browsers and webapps crashing when moving them between monitors on multi monitor setups. This affects all chromium based browsers and webapps. Firefox is unaffected. 

Apparently chromium is trying to use some wayland color manager thing, and it breaks. More info in issue linked below. This PR disables that.

Is this the best way, I don't know. This feels more like a temporary workaround. Hopefully it helps for now maybe?


Link to hyprland repo issue:
https://github.com/hyprwm/Hyprland/discussions/11961