### PR TITLE
Size `tag:floating-window` relatively, not absolutely

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -1,7 +1,7 @@
 # Floating windows
 windowrule = float, tag:floating-window
 windowrule = center, tag:floating-window
-windowrule = size 800 600, tag:floating-window
+windowrule = size 45% 60%, tag:floating-window
 
 windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
 windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files)


### PR DESCRIPTION
Size `tag:floating-window` relatively, not absolutely

By using percentages, the default size of the `tag:floating-window`
windows look more consistent regardless of screen resolution.

The default of 45% and 60% are selected by simply rounding up to the
nearest 5% using the existing absolute values on a 1080p screen. (800 /
1920 = 41.7%, 600 / 1080 = 55.6%).

---
