### PR TITLE
Fix font menu by using `--width` parameter for `walker`

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -163,7 +163,7 @@ show_theme_menu() {
 }
 
 show_font_menu() {
-  theme=$(menu "Font" "$(omarchy-font-list)" "-w 350" "$(omarchy-font-current)")
+  theme=$(menu "Font" "$(omarchy-font-list)" "--width 350" "$(omarchy-font-current)")
   if [[ "$theme" == "CNCLD" || -z "$theme" ]]; then
     back_to show_style_menu
   else
@@ -318,7 +318,7 @@ show_install_style_menu() {
 }
 
 show_install_font_menu() {
-  case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono" "-w 350") in
+  case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono" "--width 350") in
   *Meslo*) install_font "Meslo LG Mono" "ttf-meslo-nerd" "MesloLGL Nerd Font" ;;
   *Fira*) install_font "Fira Code" "ttf-firacode-nerd" "FiraCode Nerd Font" ;;
   *Victor*) install_font "Victor Code" "ttf-victor-mono-nerd" "VictorMono Nerd Font" ;;


### PR DESCRIPTION
Fix font menu by using `--width` parameter for `walker`

When we call `omarchy-launch-walker` with `-w`, we get the following
error.

    echo -e $'Adwaita Mono\nBerkeley Mono\nBerkeley Mono Variable\nCaskaydiaMono Nerd Font\nCaskaydiaMono Nerd Font Mono\niA Writer Mono S\nIosevka Fixed\nJetBrainsMono Nerd Font\nJetBrainsMono Nerd Font Mono\nJetBrainsMonoNL Nerd Font\nJetBrainsMonoNL Nerd Font Mono\nLiberation Mono\nNimbus Mono PS' | omarchy-launch-walker --dmenu --width 295 --minheight 1 --maxheight 600 -p Font… -w 350 -c 3
    Error parsing option -w

Instead, we now pass `--width`, to properly override the default
`--width 295` for fonts.

Closes: https://github.com/basecamp/omarchy/issues/2404

---
