### PR TITLE
Revert "fix(presentation-terminal): Ensure consistent ASCII logo alignment (#2260)"

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cmd="$*"
-exec setsid uwsm-app -- alacritty -o font.size=9 --class=Omarchy --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"
+exec setsid uwsm-app -- alacritty --class=Omarchy --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"


### PR DESCRIPTION
Revert "fix(presentation-terminal): Ensure consistent ASCII logo alignment (#2260)"

This reverts commit 6892304277e0045dee15c79d6fa7f02c35b37f62.

While a hard-coded font size of 9 likely is small enough to fix the logo
rendering on a large population of display configurations, it has the
downside of potentially making the update terminal font painfully small
since it ignores the user's configured preferences.

Rather than somewhat arbitrarily drawing a hard-coded line in the sand
(which still doesn't solve the issue for even smaller displays), just
respect the user's preference, allowing them to easily configure a size
that both looks good and doesn't warp the logo.

Signed-off-by: Luke Hsiao <luke@hsiao.dev>

---

## Example of the extremely small size-9 font on some displays

<img width="3652" height="1538" alt="image" src="https://github.com/user-attachments/assets/da726923-5591-4f02-9321-e632b7e11b62" />

Ref: https://github.com/basecamp/omarchy/pull/2260