### PR TITLE
fix: typo in everforest theme ghostty.conf

### DIFF
--- a/themes/everforest/ghostty.conf
+++ b/themes/everforest/ghostty.conf
@@ -1,1 +1,1 @@
-theme = Everforest Dark   Hard
+theme = Everforest Dark Hard


### PR DESCRIPTION
Just a couple of extra spaces in the themes/everforest/ghostty.conf file causing the ghostty configuration to fail