### PR TITLE
Forward all omarchy-launch-browser args to the exec cmd

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -10,12 +10,9 @@ else
 fi
 
 args=()
-for arg in "$@"; do
-  if [[ $arg == "--private" ]]; then
-    args+=("$private_flag")
-  else
-    args+=("$arg")
-  fi
+for arg; do
+  [[ $arg == "--private" ]] && arg=$private_flag
+  args+=("$arg")
 done
 
 exec setsid uwsm app -- "$browser_exec" "${args[@]}"


### PR DESCRIPTION
Forward all arguments added to `omarchy-launch-browser` to the exec command.

Current implementation does not use any additional args used in the `.desktop` file for the browser. The change allows to add any arguments you may want to use to the browser exec call. 

For example this is useful to work around the issue #2314. The PR fixing it (#2394), does not fix the issue when using `google-chrome-stable`. With this change, you can fix it yourself.

---
**[Not part of the PR changes]**
To fix issue #2314 when using Google Chrome, do this:
1. Copy the .desktop file (to create a personal override): `cp /usr/share/applications/google-chrome.desktop ~/.local/share/applications/`
2. In the desktop file to all the `Exec=` lines add `--disable-features=WaylandWpColorManagerV1` right next to the `/usr/bin/google-chrome-stable` (fixes launching via the desktop entry)
3. Edit `~/.config/hypr/bindings.conf`, add `--disable-features=WaylandWpColorManagerV1` to the `$browser` variable (fixes launching via `Super + B`). Like this:
```sh
$browser = omarchy-launch-browser --disable-features=WaylandWpColorManagerV1
```