### PR TITLE
Hide "Hardware Locality lstopo" from app menu

### DIFF
--- a/applications/hidden/lstopo.desktop
+++ b/applications/hidden/lstopo.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+Hidden=true


### PR DESCRIPTION
By default, we have this Hardware Locality lstopo app in the app launcher, which is unlikely to be useful to the typical user.

This hides it along with the other apps Omarchy intentionally excludes from the menu.

Ref: https://github.com/basecamp/omarchy/issues/1631

---

<img width="758" height="256" alt="image" src="https://github.com/user-attachments/assets/9402e2aa-2f0b-4dde-a693-1443b859d26c" />
