### PR TITLE
Fixed problematic default scaling in hyprland

### DIFF
--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -3,17 +3,17 @@
 # Format: monitor = [port], resolution, position, scale
 # You must relaunch Hyprland after changing any envs (use Super+Esc, then Relaunch)
 
-# Optimized for retina-class 2x displays, like 13" 2.8K, 27" 5K, 32" 6K.
-env = GDK_SCALE,2
+# Straight 1x setup for low-resolution displays like 1080p or 1440p
+env = GDK_SCALE,1
 monitor=,preferred,auto,auto
+
+# Optimized for retina-class 2x displays, like 13" 2.8K, 27" 5K, 32" 6K.
+# env = GDK_SCALE,2
+# monitor=,preferred,auto,auto
 
 # Good compromise for 27" or 32" 4K monitors (but fractional!)
 # env = GDK_SCALE,1.75
 # monitor=,preferred,auto,1.666667
-
-# Straight 1x setup for low-resolution displays like 1080p or 1440p
-# env = GDK_SCALE,1
-# monitor=,preferred,auto,1
 
 # Example for Framework 13 w/ 6K XDR Apple display
 # monitor = DP-5, 6016x3384@60, auto, 2


### PR DESCRIPTION
Updated hyprland's monitor config to default to 1080p instead of 2k to fix general issues on low-res displays and inside Virtual Machines like VirtualBox.

The current config shipped with the iso makes the hyprland windows scale to 2k instead of 1080p, which results in broken scaling inside a terminal or application, which prevents alot of functionality on non-1080p displays and especially Virtual Machines like VirtualBox, where you have to trick around to get a working display resolution to install GuestBox Additions.

This is a fix for https://github.com/basecamp/omarchy/issues/2144 and also additionally resolves a temp workaround posted in the discussion: https://github.com/basecamp/omarchy/discussions/176