### PR TITLE
Clarify error message when no web apps have been selected in the WebApp Remove menu

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -30,7 +30,7 @@ else
 fi
 
 if [[ ${#APP_NAMES[@]} -eq 0 ]]; then
-  echo "You must provide web app names."
+  echo "You must select at least one web app to remove."
   exit 1
 fi
 


### PR DESCRIPTION
Resolves slightly obscure error when user doesn't see the small `x toggle` text (#2295)