### PR TITLE
Fix theming for Brave and add theming support for helium

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -26,7 +26,6 @@ if omarchy-cmd-present chromium || omarchy-cmd-present helium-browser || omarchy
   if omarchy-cmd-present helium-browser; then
     echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\"}" | tee "/etc/chromium/policies/managed/color.json" >/dev/null
     helium-browser --no-startup-window --refresh-platform-policy
-    fi
   fi
 
   if omarchy-cmd-present brave; then


### PR DESCRIPTION
Theming was broken for Brave and some* browsers

renamed `rgb` to `THEME_RGB_COLOR` since `rgb` was renamed in an earlier commit which broke this functionality.

copied brave theming code to make theming possible for helium
