### PR TITLE
Add theming support for VSCodium

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -37,5 +37,6 @@ omarchy-theme-set-terminal
 omarchy-theme-set-gnome
 omarchy-theme-set-browser
 omarchy-theme-set-vscode
+omarchy-theme-set-vscodium
 omarchy-theme-set-cursor
 omarchy-theme-set-obsidian

--- a/bin/omarchy-theme-set-vscodium
+++ b/bin/omarchy-theme-set-vscodium
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Call the VSCode theme setter with VSCodium-specific parameters
+omarchy-theme-set-vscode codium "$HOME/.config/VSCodium/User/settings.json" "$HOME/.local/state/omarchy/toggles/skip-codium-theme-changes" VSCodium


### PR DESCRIPTION
Just copied omarchy-theme-set-cursor. Reading the vscode.json file in the themes because VSCode themes will work in VSCodium