### PR TITLE
Fix omarchy-theme-set-vscode

### DIFF
--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -41,7 +41,7 @@ if omarchy-cmd-present "$EDITOR_CMD" && [[ ! -f "$SKIP_FLAG" ]]; then
   else
     # Remove theme from settings.json when the theme doesn't have $EDITOR_NAME support
     if [[ -f "$SETTINGS_PATH" ]]; then
-      sed -i --follow-symlinks -E '/"workbench\.colorTheme"[[:space:]]*:[^,}]*,?/d' "$SETTINGS_PATH"
+      sed -i --follow-symlinks -E 's/\"workbench\.colorTheme\"[[:space:]]*:[^,}]*,?//' "$SETTINGS_PATH"
     fi
   fi
 fi


### PR DESCRIPTION
If it doesn't find a vscode theme, `omarchy-theme-set-vscode` will remove the complete line, this includes the `{` at the start, which leads to a corrupt `settings.json`  and all vscode settings become invalidated. This also stops theming to happen again on vscode since it can no longer find the starting brace.

Changed the sed command to find and replace with blank/nothing instead of deleting the whole line