### PR TITLE
Restore normal Caps Lock behaviour by removing default compose:caps

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -3,7 +3,7 @@
 input {
   # Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
   # kb_layout = us,dk,eu
-  kb_options = compose:caps # ,grp:alts_toggle
+  kb_options = # ,grp:alts_toggle
 
   # Change speed of keyboard repeat
   repeat_rate = 40

--- a/default/hypr/input.conf
+++ b/default/hypr/input.conf
@@ -3,7 +3,7 @@ input {
     kb_layout = us
     kb_variant =
     kb_model =
-    kb_options = compose:caps
+    kb_options =
     kb_rules =
 
     follow_mouse = 1


### PR DESCRIPTION
Decided to remove default compose:caps because of 2 reasons:

1. **Consistency:** Mismatch between log in screen and system. Caps Lock works normally on log in screen, then switches to compose inside of the system.

2. **User experience:** As DHH said on X: "Omarchy wasn't built to win over existing linux users, It was built to grow the pie. To attract people on Windows and Mac who love computers to the joy of Hyprland..." 

Caps Lock on Win and Mac does not work compose by default, This can be confusing for users coming from those systems, while it’s easy for experienced Linux users to re-enable if they prefer.