### PR TITLE
Add hooks for system actions

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -28,6 +28,8 @@ if [[ -n "$font_name" && "$font_name" != "CNCLD" ]]; then
     omarchy-restart-waybar
     omarchy-restart-swayosd
     omarchy-restart-walker
+
+    omarchy-hook font-set "$font_name"
   else
     echo "Font '$font_name' not found."
     exit 1

--- a/bin/omarchy-hook
+++ b/bin/omarchy-hook
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: omarchy-hook [name] [args...]"
+  exit 1
+fi
+
+HOOK=$1
+HOOK_PATH="$HOME/.config/omarchy/hooks/$1"
+shift
+
+if [[ -f $HOOK_PATH ]]; then
+  bash "$HOOK_PATH" "$@"
+fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -39,3 +39,6 @@ omarchy-theme-set-browser
 omarchy-theme-set-vscode
 omarchy-theme-set-cursor
 omarchy-theme-set-obsidian
+
+# Call hook on theme set
+omarchy-hook theme-set "$THEME_NAME"

--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -5,4 +5,5 @@ set -e
 omarchy-update-available-reset
 omarchy-update-system-pkgs
 omarchy-migrate
+omarchy-hook post-update
 omarchy-update-restart

--- a/config/omarchy/hooks/font-set.sample
+++ b/config/omarchy/hooks/font-set.sample
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This hook is called with the snake-cased name of the font that has just been set.
+# To put it into use, remove .sample from the name.
+
+# Example: Show the name of the theme that was just set.
+# notify-send "New font" "Your new font is $1"

--- a/config/omarchy/hooks/post-update.sample
+++ b/config/omarchy/hooks/post-update.sample
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This hook is called after an Omarchy system update has been performed.
+# To put it into use, remove .sample from the name.
+
+# Example: Show notification after the system has been updated.
+# notify-send "Update Performed" "Your system is now up to date"

--- a/config/omarchy/hooks/theme-set.sample
+++ b/config/omarchy/hooks/theme-set.sample
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This hook is called with the snake-cased name of the theme that has just been set.
+# To put it into use, remove .sample from the name.
+
+# Example: Show the name of the theme that was just set.
+# notify-send "New theme" "Your new theme is $1"


### PR DESCRIPTION
Adds three hooks for theme set, font set, and post update. Users and extension creators can use this to run custom code on system changes. These work like git hooks, and they live in `~/.config/omarchy/hooks`. Rename to remove .sample to make them active.