### PR TITLE
Support environment variables in browser desktop files

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -1,27 +1,22 @@
 #!/bin/bash
 
 default_browser=$(xdg-settings get default-web-browser)
-
 exec_line=$(sed -n 's/^Exec=//p' {~/.local,~/.nix-profile,/usr}/share/applications/"$default_browser" 2>/dev/null | head -n1)
-browser_exec=""
-env_vars=()
-if [[ -n $exec_line ]]; then
-  read -r -a exec_parts <<< "$exec_line"
-  for part in "${exec_parts[@]}"; do
-    if [[ $part == "env" || $part == */env ]]; then
-      continue
-    fi
-    if [[ $part == *=* ]]; then
-      env_vars+=("$part")
-      continue
-    fi
-    browser_exec=$part
-    break
-  done
-fi
 
-if (( ${#env_vars[@]} )) && [[ ${env_vars[0]} != "env" ]]; then
-  env_vars=("env" "${env_vars[@]}")
+browser_exec=""
+env_prefix=()
+
+if [[ -n $exec_line ]]; then
+  read -r -a parts <<< "$exec_line"
+  
+  for part in "${parts[@]}"; do
+    if [[ $part == "env" || $part == */env || ($part == *=* && $part != --*) ]]; then
+      env_prefix+=("$part")
+    else
+      browser_exec=$part
+      break
+    fi
+  done
 fi
 
 if [[ $browser_exec =~ (firefox|zen|librewolf) ]]; then
@@ -30,4 +25,4 @@ else
   private_flag="--incognito"
 fi
 
-exec setsid uwsm-app -- "${env_vars[@]}" "$browser_exec" "${@/--private/$private_flag}"
+exec setsid uwsm-app -- "${env_prefix[@]}" "$browser_exec" "${@/--private/$private_flag}"

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -8,25 +8,21 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*)
 esac
 
 exec_line=$(sed -n 's/^Exec=//p' {~/.local,~/.nix-profile,/usr}/share/applications/"$browser" 2>/dev/null | head -n1)
+
 browser_exec=""
-env_vars=()
+env_prefix=()
+
 if [[ -n $exec_line ]]; then
-  read -r -a exec_parts <<< "$exec_line"
-  for part in "${exec_parts[@]}"; do
-    if [[ $part == "env" || $part == */env ]]; then
-      continue
+  read -r -a parts <<< "$exec_line"
+  
+  for part in "${parts[@]}"; do
+    if [[ $part == "env" || $part == */env || ($part == *=* && $part != --*) ]]; then
+      env_prefix+=("$part")
+    else
+      browser_exec=$part
+      break
     fi
-    if [[ $part == *=* ]]; then
-      env_vars+=("$part")
-      continue
-    fi
-    browser_exec=$part
-    break
   done
 fi
 
-if (( ${#env_vars[@]} )) && [[ ${env_vars[0]} != "env" ]]; then
-  env_vars=("env" "${env_vars[@]}")
-fi
-
-exec setsid uwsm-app -- "${env_vars[@]}" "$browser_exec" --app="$1" "${@:2}"
+exec setsid uwsm-app -- "${env_prefix[@]}" "$browser_exec" --app="$1" "${@:2}"


### PR DESCRIPTION
The launch scripts `omarchy-launch-browser` and `omarchy-launch-webapp` now extract and forward env variables in browser desktop files correctly.

Fixes launching Chrome with custom hardware acceleration flags and similar configurations.

For example this configuration in `google-chrome.desktop` file now correctly works:
```sh
Exec=env LIBVA_DRIVER_NAME=radeonsi /usr/bin/google-chrome-stable --disable-features=WaylandWpColorManagerV1 %U
```

This is often needed on hybrid GPU laptops.