### PR TITLE
Add elephant config to support !bangs in walker

### DIFF
--- a/config/elephant/websearch.toml
+++ b/config/elephant/websearch.toml
@@ -1,0 +1,4 @@
+[[entries]]
+default = true
+name = "Web Search"
+url = "https://unduck.link?q=%TERM%"


### PR DESCRIPTION
This adds a `websearch.toml` file to change the default websearch query to use `unduck`

This keeps the `default google search` but allows the option to use [`!bangs`](https://raw.githubusercontent.com/T3-Content/unduck/refs/heads/main/src/bang.ts) like in duckduckgo but without the server-side rerouting  (aka its ~~blazingly fast~~ faster than duckduckgo, this should be cached in browser on first call, but it doesn't looks like that is happening)

![2025-10-1902-58-35-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/d88a6aa4-679a-4f41-9a26-5838c85511a3)


~~**Caveat**: This requires the config to be placed in `.config/elephant/` instead of `.config/omarchy/elephant/`, The existing `calc.toml` and `desktopapplications.toml` configs also probably require this.~~ (Fixed in 3.1.0 migration)


