### PR TITLE
force wayland on spotify

### DIFF
--- a/config/spotify-flags.conf
+++ b/config/spotify-flags.conf
@@ -1,0 +1,2 @@
+--enable-features=UseOzonePlatform
+--ozone-platform=wayland


### PR DESCRIPTION
Fix the scaling issue on spotify by adding 
`--enable-features=UseOzonePlatform --ozone-platform=wayland`
edit : use spotify-flags file

Closes #2791