### PR TITLE
fix: missing check for uhd graphics

### DIFF
--- a/install/config/hardware/intel.sh
+++ b/install/config/hardware/intel.sh
@@ -2,7 +2,7 @@
 # Check if we have an Intel GPU at all
 if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel'); then
   # HD Graphics and newer uses intel-media-driver
-  if [[ "${INTEL_GPU,,}" =~ "hd graphics"|"xe"|"iris" ]]; then
+  if [[ "${INTEL_GPU,,}" =~ "hd graphics"|"uhd graphics"|"xe"|"iris" ]]; then
     sudo pacman -S --needed --noconfirm intel-media-driver
   elif [[ "${INTEL_GPU,,}" =~ "gma" ]]; then
     # Older generations from 2008 to ~2014-2017 use libva-intel-driver


### PR DESCRIPTION
A user with intel UHD graphics was missing the relevant va-api drivers, despite the script. I guess, the UHD ones are bypassing the checks. Here's the relevant discord thread,

https://discord.com/channels/1390012484194275541/1429445009744330812