### PR TITLE
fix: universal RAM detection (locale-independent)

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -59,7 +59,7 @@ EOF
 
   # Get system resources
   TOTAL_RAM=$(free -h | awk 'NR==2 {print $2}')
-  TOTAL_RAM_GB=$(awk 'NR==2 {printf "%d", $2/1024/1024}' /proc/meminfo)
+  TOTAL_RAM_GB=$(awk 'NR==1 {printf "%d", $2/1024/1024}' /proc/meminfo)
   TOTAL_CORES=$(nproc)
 
   echo ""


### PR DESCRIPTION
Fixes RAM detection on systems where free output is localized (e.g. Mem.: in Portuguese).
Uses /proc/meminfo for universal compatibility.

**Why**

Prevents bash errors like “esperava operador unário” when TOTAL_RAM_GB is empty.

**Before**
<img width="799" height="595" alt="screenshot-2025-10-19_13-04-40" src="https://github.com/user-attachments/assets/f6b19ef2-573e-42f1-beda-f46bfa0b2861" />

**After**
<img width="333" height="76" alt="image" src="https://github.com/user-attachments/assets/c3870ff9-c3b4-40cb-8155-a99a3da108de" />

