### PR TITLE
Fix Chromium 141 crash by adding --new-window flag

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,4 +7,4 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium-b
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --new-window --app="$1" "${@:2}"


### PR DESCRIPTION
## Problem
Chromium 141.0.7390.107 on Arch Linux crashes with `SIGTRAP` when launching webapps via `omarchy-launch-webapp`.
```bash
$ omarchy-launch-webapp "https://mail.google.com/mail/u/0/"
[68678:68678:1019/144947.816988:ERROR:components/dbus/xdg/request.cc:169] Request ended (non-user cancelled).
[1]    68678 trace trap (core dumped)  /usr/bin/chromium --app=https://...
```

## Root Cause
The `--app` flag alone triggers a crash in Chromium 141.x. Coredump analysis shows consistent `SIGTRAP` (Signal 5) crashes on startup.

## Solution
Add `--new-window` flag before `--app` in `bin/omarchy-launch-webapp`. This workaround resolves the crash without affecting webapp functionality.

## Testing
✅ Tested successfully with:
- Chromium 141.0.7390.107 on Arch Linux
- Multiple webapps (Gmail, Calendar, etc.)
- Hyprland (Wayland) environment

## Notes
- This issue is already acknowledged in `default/hypr/apps/browser.conf` comment: "Force chromium-based browsers into a tile to deal with --app bug"
- The migration script `migrations/1755507891.sh` migrates old desktop files but doesn't include the `--new-window` fix
- This change affects all Chromium-based browsers in the supported list

## Changes
- Modified `bin/omarchy-launch-webapp` to add `--new-window` before `--app`