### PR TITLE
feat: disabled screensaver in power-saver mode to save battery

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -5,6 +5,11 @@ if ! command -v tte &>/dev/null; then
   exit 1
 fi
 
+# Exit early if we are using power-saver
+if [[ "$(powerprofilesctl get)" == "power-saver" ]]; then 
+  exit 1
+fi
+
 # Exit early if screensave is already running
 pgrep -f "alacritty --class Screensaver" && exit 0
 

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -451,7 +451,15 @@ show_update_password_menu() {
 }
 
 show_system_menu() {
-  case $(menu "System" "  Lock\n󱄄  Screensaver\n󰤄  Suspend\n󰜉  Restart\n󰐥  Shutdown") in
+  current_power_mode=$(powerprofilesctl get)
+
+  options="  Lock\n"
+  if [[ "$current_power_mode" != "power-saver" ]]; then
+    options+="󱄄  Screensaver\n"
+  fi
+  options+="󰤄  Suspend\n󰜉  Restart\n󰐥  Shutdown"
+
+  case $(menu "System" "$options") in
   *Lock*) omarchy-lock-screen ;;
   *Screensaver*) omarchy-launch-screensaver force ;;
   *Suspend*) systemctl suspend ;;


### PR DESCRIPTION
## Description:

Disabled screensaver in power-saver mode to save battery by:
1. Early exit in `omarchy-launch-screensaver` when in `power-saver` mode.
2. Hiding the screensaver option from the "System" menu.

Demo:

https://github.com/user-attachments/assets/d17b8398-e99b-4f5a-aafc-1fe534273f0e

Addresses: #1256 