### PR TITLE
You need 2 to make fullscreen

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -6,7 +6,7 @@ bindd = CTRL ALT, DELETE, Close all Windows, exec, omarchy-cmd-close-all-windows
 bindd = SUPER, J, Toggle split, togglesplit, # dwindle
 bindd = SUPER, P, Pseudo window, pseudo, # dwindle
 bindd = SUPER, T, Toggle floating, togglefloating,
-bindd = SUPER, F, Force full screen, fullscreen, 0
+bindd = SUPER, F, Force full screen, fullscreen, 2
 bindd = SUPER ALT, F, Full width, fullscreen, 1
 
 # Move focus with SUPER + arrow keys


### PR DESCRIPTION
1 is just for the width of the screen to make a full window, so you need to set 2. If not working, you need to remove or comment out the same line in the old `tiling.conf` file