### PR TITLE
Add binding for tiled full screen toggle

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -7,6 +7,7 @@ bindd = SUPER, J, Toggle split, togglesplit, # dwindle
 bindd = SUPER, P, Pseudo window, pseudo, # dwindle
 bindd = SUPER, T, Toggle floating, togglefloating,
 bindd = SUPER, F, Force full screen, fullscreen, 0
+bindd = SUPER CTRL, F, Tiled full screen, fullscreenstate, 0 2
 bindd = SUPER ALT, F, Full width, fullscreen, 1
 
 # Move focus with SUPER + arrow keys


### PR DESCRIPTION
This is niche, but you might like it. Binds Super + Ctrl + F to force-tile a fullscreen app. It works nice for things including running games in a tile or watching YouTube in a pip tile without needing to configure these apps specifically to do so.

<img width="2818" height="1586" alt="image" src="https://github.com/user-attachments/assets/78de4e09-ffe4-4724-8f53-e019d092445f" />
