### PR TITLE
Fix ls when not using eza

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -1,5 +1,5 @@
 # File system
-if command -v eza &> /dev/null; then
+if omarchy-cmd-present eza; then
   alias ls='eza -lh --group-directories-first --icons=auto'
   alias lsa='ls -a'
   alias lt='eza --tree --level=2 --long --icons --git'


### PR DESCRIPTION
The `ls` command results in an error `bash: command not found: eza`, instead of it reverting to the builtin `ls` if the `eza` package is removed.

The `ls` aliases are now only set if the `eza` package is installed.