### PR TITLE
Fix cd command if zoxide is missing

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -5,7 +5,7 @@ alias lt='eza --tree --level=2 --long --icons --git'
 alias lta='lt -a'
 alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
 
-if command -v z &> /dev/null; then
+if omarchy-cmd-present z; then
   alias cd="zd"
   zd() {
     if [ $# -eq 0 ]; then


### PR DESCRIPTION
Some `cd ` commands like `cd non-exisiting-directory` results in an error `bash: command not found: z`, it should revert to the builtin `cd` behavior if the `z` (zoxide) package is removed.

The `cd` aliases are now only set up if the `z` (zoxide) package is installed.