### PR TITLE
Error fallback if terminal was not installed successfully

### DIFF
--- a/bin/omarchy-install-terminal
+++ b/bin/omarchy-install-terminal
@@ -8,12 +8,14 @@ fi
 package="$1"
 
 # Install package
-omarchy-pkg-add $package
+if omarchy-pkg-add $package; then
+  # Set as default terminal
+  echo "Setting $package as new default terminal..."
+  sed -i "/export TERMINAL=/ c\export TERMINAL=$package" ~/.config/uwsm/default
 
-# Set as default terminal
-echo "Setting $package as new default terminal..."
-sed -i "/export TERMINAL=/ c\export TERMINAL=$package" ~/.config/uwsm/default
-
-# Restart is needed for new default to take effect
-echo
-gum confirm "Restart to use new terminal?" && systemctl reboot --no-wall
+  # Restart is needed for new default to take effect
+  echo
+  gum confirm "Restart to use new terminal?" && systemctl reboot --no-wall
+else
+  echo "Failed to install $package"
+fi


### PR DESCRIPTION
If the pkgs.omarchy.org is down, or doesn't have the package (maybe a misspelling got committed or whatever), or in my case...on an ARM VM trying to install ghostty - if it fails, it shouldn't try to set the new default terminal.

<img width="1612" height="1212" alt="CleanShot 2025-10-20 at 07 57 05@2x" src="https://github.com/user-attachments/assets/31fe7b26-5b2a-4bf5-9e6e-7eaf2cf9e7b7" />