### PR TITLE
Surface: enable built-in keyboard at LUKS

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -30,3 +30,4 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-t2.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh

--- a/install/config/hardware/fix-surface-keyboard.sh
+++ b/install/config/hardware/fix-surface-keyboard.sh
@@ -1,0 +1,23 @@
+# Detect Surface devices which require additional modules for the keyboard to work.
+# Module list derived from Chris McLeod's manual install instructions
+# https://chrismcleod.dev/blog/installing-arch-linux-with-secure-boot-on-a-microsoft-surface-laptop-studio/
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null)"
+if [[ "$product_name" =~ Surface ]]; then
+  echo "Detected Surface Device"
+
+  # Modules already exist in the rootfs for the default kernel.
+  if [[ "$product_name" != "Surface Laptop 3" ]]; then
+    echo "Untested Surface Device: $product_name, additional modules may be required for your device."
+  fi
+
+  echo "Attempting to autodetect required pinctrl module"
+  pinctrl_module=$(lsmod | grep pinctrl_ | cut -f 1 -d" ")
+  if [[ -z "$pinctrl_module" ]]; then
+    echo "Failed to autodetect pinctrl module."
+  else
+    echo "Detected pinctrl module: $pinctrl_module"
+  fi
+
+  echo "MODULES=(${pinctrl_module} surface_aggregator surface_aggregator_registry surface_aggregator_hub surface_hid_core surface_hid surface_kbd intel_lpss_pci 8250_dw)" | sudo tee /etc/mkinitcpio.conf.d/surface_device_modules.conf >/dev/null
+
+fi


### PR DESCRIPTION
Derives the list of required modules for the installer from Chris McLeod's manual installation steps. His instructions say to use the surface-linux kernel however the default kernel has the right set of modules already (as noted by the fact that the right modules are loaded for the keyboard to work during the install and after the LUKS unlock screen).

I only have a Surface Laptop 3 to test this on but based on the guide where Chris is using a newer laptop and the only difference is the pinctrl module which I attempt to autodetect I think it should "just" work for others but definitely "use at your own risk".