### PR TITLE
fix: use gemini-cli-bin for Gemini installation

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -291,7 +291,7 @@ show_install_ai_menu() {
   *Claude*) install "Claude Code" "claude-code" ;;
   *Cursor*) aur_install "Cursor CLI" "cursor-cli" ;;
   *OpenAI*) aur_install "OpenAI Codex" "openai-codex-bin" ;;
-  *Gemini*) aur_install "Gemini" "gemini-cli" ;;
+  *Gemini*) aur_install "Gemini" "gemini-cli-bin" ;;
   *Studio*) install "LM Studio" "lmstudio" ;;
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;


### PR DESCRIPTION
#### Switched package installation from gemini-cli to gemini-cli-bin.
- The extra repo version is outdated.
- Even though Omarchy menu shows it's installing from AUR, it actually pulls from the extra repo.
<img width="642" height="674" alt="image" src="https://github.com/user-attachments/assets/62df1e7a-0b26-4f84-8224-9de29eb8b915" />
