### PR TITLE
disable update checks in VS Code on install, now creating target dir

### DIFF
--- a/bin/omarchy-install-vscode
+++ b/bin/omarchy-install-vscode
@@ -3,7 +3,7 @@
 echo "Installing VSCode..."
 omarchy-pkg-add visual-studio-code-bin
 
-mkdir -p ~/.vscode
+mkdir -p ~/.vscode ~/.config/Code/User
 
 cat > ~/.vscode/argv.json << 'EOF'
 // This configuration file allows you to pass permanent command line arguments to VS Code.

--- a/migrations/1760974946.sh
+++ b/migrations/1760974946.sh
@@ -1,0 +1,21 @@
+echo "Turn off VSCode's own auto-update feature (we rely on pacman)"
+
+# Note: We cannot use `jq` to update settings.json because it’s JSONC (allows comments),
+# which jq doesn’t support.
+
+VS_CODE_SETTINGS="$HOME/.config/Code/User/settings.json"
+
+# If VSCode is installed, ensure that the "update.mode" setting is set to "none"
+if omarchy-cmd-present code; then
+  mkdir -p "$(dirname "$VS_CODE_SETTINGS")"
+
+  if [[ ! -f "$VS_CODE_SETTINGS" ]]; then
+    # If settings.json doesn't exist, create it with just the update.mode setting
+    printf '{\n  "update.mode": "none"\n}\n' > "$VS_CODE_SETTINGS"
+ elif ! grep -q '"update.mode"' "$VS_CODE_SETTINGS"; then
+    # Insert "update.mode": "none", immediately after the first "{"
+    # Use sed's first-match range (0,/{/) to only replace the first "{
+    sed -i --follow-symlinks -E '0,/\{/{s/\{/{\
+  "update.mode": "none",/}' "$VS_CODE_SETTINGS"
+  fi
+fi


### PR DESCRIPTION
On installing VS Code on a fresh omarchy 3.1.0, I noticed I messed up my first PR #1730 as I forgot to create the settings dir before writing into it; also re-added the migration from the first PR so it runs for anyone who installed VS Code on 3.1.0 already