### PR TITLE
Add resolution responsiveness to Windows VM RDP

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -339,7 +339,7 @@ To stop: omarchy-windows-vm stop"
   # If scale is less than 130%, don't set any scale (use default 100)
 
   # Connect with RDP in fullscreen (auto-detects resolution)
-  xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 +f -grab-keyboard /cert:ignore /title:"Windows VM - Omarchy" /floatbar:sticky:off,default:visible,show:fullscreen $RDP_SCALE
+  xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 +f -grab-keyboard /cert:ignore /title:"Windows VM - Omarchy" /dynamic-resolution /floatbar:sticky:off,default:visible,show:fullscreen $RDP_SCALE
 
   # After RDP closes, stop the container unless --keep-alive was specified
   if [ "$KEEP_ALIVE" = false ]; then


### PR DESCRIPTION
### Description
---
As it stands right now the windows VM launcher launches into xfreerdp in full screen which is fine but if you `super+f` to take it out of full screen mode and into tiling the VM isn't responding to the change in window size. This flag allows the RDP window to respond to window size changes and fit into hyprland more seemlessly. 



### From the manual:
---
```
       /dynamic-resolution
           Send resolution updates when the window is resized
```