### PR TITLE
TTE go fullscreen: --no-eol (tte 0.12.2/0.13.0)

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -18,7 +18,7 @@ hyprctl keyword cursor:invisible true &>/dev/null
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)
   tte -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 240 --canvas-width 0 --canvas-height $(($(tput lines) - 2)) --anchor-canvas c --anchor-text c \
+    --frame-rate 240 --canvas-width 0 --canvas-height 0 --anchor-canvas c --anchor-text c --no-eol \
     "$effect" &
 
   while pgrep -x tte >/dev/null; do


### PR DESCRIPTION
Add new Terminal Text Effects (https://github.com/ChrisBuilds/terminaltexteffects) option "--no-eol" and set "--canvas-height 0" to use the full screen.

"--no-eol" suppresses the trailing newline emitted when an effect animation completes.
"--canvas-height 0" lets TTE match terminal height.

Current TTE version in Arch packages is 0.12.0-1, I believe. The new option will be available in 0.12.2/0.13.0.