### PR TITLE
Add mouse scroll bindings for window group navigation

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -85,6 +85,10 @@ bindd = SUPER ALT, DOWN, Move window to group on bottom, moveintogroup, d
 bindd = SUPER ALT, TAB, Next window in group, changegroupactive, f
 bindd = SUPER ALT SHIFT, TAB, Previous window in group, changegroupactive, b
 
+# Scroll through a set of grouped windows with SUPER + ALT + scroll
+bindd = SUPER ALT, mouse_down, Next window in group, changegroupactive, f
+bindd = SUPER ALT, mouse_up, Previous window in group, changegroupactive, b
+
 # Activate window in a group by number
 bindd = SUPER ALT, 1, Switch to group window 1, changegroupactive, 1
 bindd = SUPER ALT, 2, Switch to group window 2, changegroupactive, 2


### PR DESCRIPTION
Big fan of the just released tiling groups and believe it's missing the intuitive keybindings to scroll through a set of grouped windows with `SUPER + ALT + <mouse scroll>` like we can use  `SUPER + <mouse scroll>` to scroll through workspaces.