### PR TITLE
elephant: Remove elephant-files from base packages

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -27,7 +27,6 @@ elephant-bluetooth
 elephant-calc
 elephant-clipboard
 elephant-desktopapplications
-elephant-files
 elephant-menus
 elephant-providerlist
 elephant-runner

--- a/migrations/1761044056.sh
+++ b/migrations/1761044056.sh
@@ -1,0 +1,5 @@
+echo "Drop elephant-files"
+
+if omarchy-pkg-present elephant-files; then
+  omarchy-pkg-drop elephant-files
+fi


### PR DESCRIPTION
The functionality is interesting, but the implementation is too resource-
intensive. Several users have reported issues such as Chrome becoming
unresponsive or general system slowness related to I/O or memory usage.

The files provider currently indexes all non-hidden, non-VCS directories in the home directory. [1]

It also maintains a map of md5 -> (path, changed_time). [2]

On my system:

    $ fd . ~/ --ignore-vcs --type directory | wc -l
    698078

The default inotify watch limit in Omarchy is 524,288. Any system with more
dirs than that will run out of available inotify watches for other
applications, leading to performance degradation.

Additionally, the map alone would consume approximately 6 GB of memory in my
case.

Another expensive operation is `stat`-ing every file and directory in the
filesystem whenever anything is removed. [3]

[1] https://github.com/abenz1267/elephant/blob/v2.3.2/internal/providers/files/setup.go#L59  
[2] https://github.com/abenz1267/elephant/blob/v2.3.2/internal/providers/files/setup.go#L133  
[3] https://github.com/abenz1267/elephant/blob/v2.3.2/internal/providers/files/setup.go#L87
