### PR TITLE
Fix uwsm-app terminal keybinding regex in migration script

### DIFF
--- a/migrations/1758019332.sh
+++ b/migrations/1758019332.sh
@@ -16,6 +16,6 @@ if grep -q "bindd = SUPER, N, Neovim" ~/.config/hypr/bindings.conf; then
 fi
 
 # Use default terminal for keybinding
-if grep -q "terminal = uwsm app" ~/.config/hypr/bindings.conf; then
-  sed -i '/terminal = uwsm-app -- alacritty/ c\$terminal = uwsm-app -- $TERMINAL' ~/.config/hypr/bindings.conf
+if grep -q "terminal = uwsm[- ]app" ~/.config/hypr/bindings.conf; then
+  sed -i '/terminal = \(uwsm[- ]app\) -- alacritty/ c\$terminal = \1 -- $TERMINAL' ~/.config/hypr/bindings.conf
 fi


### PR DESCRIPTION
The if condition in the migration script was looking for `uwsm app`, but `sed` was then looking for `uwsm-app`.

This migration is concerned with replacing `alacritty` with `$TERMINAL`. Another migration takes care of renaming `uwsm app` to `uwsm-app`. This aims to make both migrations independent of each other by preserving whichever form (`uwsm app` or `uwsm-app`) was present.