### PR TITLE
chore: better contrast for kanagawa kitty tab colors

### DIFF
--- a/themes/kanagawa/kitty.conf
+++ b/themes/kanagawa/kitty.conf
@@ -22,8 +22,8 @@ url_color                       #72a7bc
 
 #: Tab bar colors
 
-active_tab_foreground           #c8c093
-active_tab_background           #1f1f28
+active_tab_foreground           #1f1f28
+active_tab_background           #c0a36e
 inactive_tab_foreground         #727169
 inactive_tab_background         #1f1f28
 


### PR DESCRIPTION
Provides better contrast for tabs inside of kitty in kanagawa.

After
<img width="980" height="430" alt="image" src="https://github.com/user-attachments/assets/674ee0ee-5b89-4047-b1d7-f75d9f18a458" />


Before

<img width="1302" height="250" alt="image" src="https://github.com/user-attachments/assets/e0a4f2ec-da78-4991-9ea6-f531e432409b" />
