### PR TITLE
Avoid migrations issues as experienced in #2546

### DIFF
--- a/bin/omarchy-pkg-add
+++ b/bin/omarchy-pkg-add
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if omarchy-pkg-missing "$@"; then
-  sudo pacman -S --noconfirm --needed "$@" || exit 1
+  sudo pacman -Sy --noconfirm --needed "$@" || exit 1
 fi
 
 for pkg in "$@"; do


### PR DESCRIPTION
I tried to run `omarchy-update`, then elephant was not found

I noticed I could not install elephant manually on pacman without `-Sy`.
Without this, installing 3.1.1 was giving me errors about file not found on the repository.

This may fix #2546
