### PR TITLE
Feat/enable vim style tiling

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -6,7 +6,7 @@ bindd = SUPER, W, Close active window, killactive,
 bindd = CTRL ALT, DELETE, Close all Windows, exec, omarchy-cmd-close-all-windows
 
 # Control tiling
-bindd = SUPER, J, Toggle split, togglesplit, # dwindle
+bindd = SUPER, S, Toggle split, togglesplit, # dwindle
 bindd = SUPER, P, Pseudo window, pseudo, # dwindle
 bindd = SUPER SHIFT, V, Toggle floating, togglefloating,
 bindd = SHIFT, F11, Force full screen, fullscreen, 0
@@ -17,6 +17,13 @@ bindd = SUPER, LEFT, Move focus left, movefocus, l
 bindd = SUPER, RIGHT, Move focus right, movefocus, r
 bindd = SUPER, UP, Move focus up, movefocus, u
 bindd = SUPER, DOWN, Move focus down, movefocus, d
+
+# Move focus with SUPER + HJKL (VIM-style)
+bindd = SUPER, H, Move focus left, movefocus, l
+bindd = SUPER, L, Move focus right, movefocus, r
+bindd = SUPER, K, Move focus up, movefocus, u
+bindd = SUPER, J, Move focus down, movefocus, d
+
 
 # Switch workspaces with SUPER + [0-9]
 bindd = SUPER, code:10, Switch to workspace 1, workspace, 1
@@ -52,6 +59,12 @@ bindd = SUPER SHIFT, LEFT, Swap window to the left, swapwindow, l
 bindd = SUPER SHIFT, RIGHT, Swap window to the right, swapwindow, r
 bindd = SUPER SHIFT, UP, Swap window up, swapwindow, u
 bindd = SUPER SHIFT, DOWN, Swap window down, swapwindow, d
+
+# Swap active window with the one next to it with SUPER + SHIFT + HJKL (VIM-style)
+bindd = SUPER SHIFT, H, Swap window to the left, swapwindow, l
+bindd = SUPER SHIFT, L, Swap window to the right, swapwindow, r
+bindd = SUPER SHIFT, K, Swap window up, swapwindow, u
+bindd = SUPER SHIFT, J, Swap window down, swapwindow, d
 
 # Cycle through applications on active workspace
 bindd = ALT, TAB, Cycle to next window, cyclenext

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -4,7 +4,7 @@ bindd = SUPER CTRL, E, Emoji picker, exec, omarchy-launch-walker -m symbols
 bindd = SUPER ALT, SPACE, Omarchy menu, exec, omarchy-menu
 bindd = SUPER, ESCAPE, Power menu, exec, omarchy-menu system
 bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system
-bindd = SUPER, K, Show key bindings, exec, omarchy-menu-keybindings
+bindd = SUPER, F1, Show key bindings, exec, omarchy-menu-keybindings
 bindd = , XF86Calculator, Calculator, exec, gnome-calculator
 
 # Aesthetics


### PR DESCRIPTION
This PR requests to add  one commit:
_**feat: add support to vim style tiling**_ 


this config enables:
- SUPER + HJKL to focus on tiles
- SUPER SHIFT + HJKL swap tiles

And change conflicts:
- Show keybindings: from SUPER+K to SUPER+F1
  - F1 was chosen since is the main help menu to navigate through the
    system
- Toggle split: from SUPER+J to SUPER+S