### PR TITLE
fix: alacrity not supporting emojis

### DIFF
--- a/config/fontconfig/conf.d/01-emoji.conf
+++ b/config/fontconfig/conf.d/01-emoji.conf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>monospace</family>
+    <prefer>
+      <family>Noto Color Emoji</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Noto Color Emoji</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Noto Color Emoji</family>
+    </prefer>
+  </alias>
+</fontconfig>


### PR DESCRIPTION
This project contains noto-fonts-emoji, but it is not properly set. Was added a conf in fontconfig/conf.d