### PR TITLE
Add window rule for xdg-desktop-portal-gtk dialogs

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -13,4 +13,4 @@ windowrule = opacity 1 0.97, tag:firefox-based-browser
 windowrule = opacity 1.0 1.0, initialTitle:((?i)(?:[a-z0-9-]+\.)*youtube\.com_/|app\.zoom\.us_/wc/home)
 
 # Float, center, and set size (800x600) for xdg-desktop-portal-gtk dialogs (e.g., Brave permission popups)
-windowrulev2 = float,center,size 800 600,class:^(xdg-desktop-portal-gtk)$
+windowrule = float,center,size 800 600,class:^(xdg-desktop-portal-gtk)$


### PR DESCRIPTION
Problem

- Brave pop-ups (like permission requests, “Open with” dialogs, or file pickers) on Wayland/Hyprland are not treated as floating windows.
- Instead, they appear tiled like normal windows.
- The reason: Brave often delegates these pop-ups to xdg-desktop-portal-gtk, so Hyprland sees them as separate apps, not transient dialogs.
- This leads to poor UX: dialogs are mixed with tiled windows, not visually distinct or centered.

Solution

- Add a Hyprland window rule targeting xdg-desktop-portal-gtk.
- The rule makes them:
- Float → always on top of tiled windows
- Fixed size (800×600) → consistent and usable window dimensions

Outcome

- Brave pop-ups now behave like proper dialogs.
- UX is much cleaner: dialogs are visually separate, centered, and a consistent size.
- Also works for other apps using portal dialogs (Flatpak apps, GTK apps on Wayland).