### PR TITLE
Feature chromium srvc

### DIFF
--- a/config/systemd/user/chrome-graceful-shutdown.service
+++ b/config/systemd/user/chrome-graceful-shutdown.service
@@ -1,0 +1,56 @@
+[Unit]
+Description=Graceful Chromium-based browser shutdown
+Documentation=https://wiki.archlinux.org/title/Systemd/User
+DefaultDependencies=no
+Before=wayland-session-shutdown.target
+PartOf=wayland-session@.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+# Gracefully shutdown Chrome/Chromium/Brave and other chromium-based browsers
+ExecStop=/usr/bin/sh -c ' \
+    browsers="chrome chromium brave vivaldi opera"; \
+    running_browsers=""; \
+    for browser in $browsers; do \
+        if pgrep -f "^/.*/$browser( |$)" >/dev/null 2>&1; then \
+            printf "Sending SIGTERM to %s...\\n" "$browser"; \
+            pkill -15 -f "^/.*/$browser( |$)"; \
+            running_browsers="$running_browsers $browser"; \
+        fi; \
+    done; \
+    if [ -n "$running_browsers" ]; then \
+        timeout=10; \
+        while [ $timeout -gt 0 ]; do \
+            all_stopped=1; \
+            for browser in $running_browsers; do \
+                if pgrep -f "^/.*/$browser( |$)" >/dev/null 2>&1; then \
+                    all_stopped=0; \
+                    break; \
+                fi; \
+            done; \
+            if [ $all_stopped -eq 1 ]; then \
+                printf "All browsers shutdown gracefully\\n"; \
+                exit 0; \
+            fi; \
+            sleep 1; \
+            timeout=$((timeout - 1)); \
+        done; \
+        printf "Timeout reached, force terminating remaining browsers...\\n"; \
+        for browser in $running_browsers; do \
+            if pgrep -f "^/.*/$browser( |$)" >/dev/null 2>&1; then \
+                printf "Force killing %s\\n" "$browser"; \
+                pkill -9 -f "^/.*/$browser( |$)" 2>/dev/null; \
+            fi; \
+        done; \
+    fi \
+'
+TimeoutStopSec=15
+# Reduce noise in logs for normal operations
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=wayland-session@.target

--- a/migrations/1760974946.sh
+++ b/migrations/1760974946.sh
@@ -1,0 +1,11 @@
+
+#!/usr/bin/env bash
+
+echo "Enable chrome gracefull shutdown service"
+
+set -e
+
+if [[ ! -f ~/.local/share/omarchy/config/systemd/user/chrome-graceful-shutdown.service ]]; then
+  cp ~/.local/share/omarchy/config/systemd/user/chrome-graceful-shutdown.service ~/.config/systemd/user/
+  systemctl --user enable --now chrome-graceful-shutdown.service || true
+fi


### PR DESCRIPTION
## Fix: Chromium-based browsers not shutting down correctly on Hyprland exit

### Problem

When logging out or shutting down the system, Chrome/Chromium shows "didn't shut down correctly" 
warnings because browsers are terminated abruptly (SIGKILL) instead of gracefully (SIGTERM).

### Solution

Added systemd user service that hooks into uwsm's `wayland-session-shutdown.target` to 
gracefully shutdown Chromium-based browsers before compositor exits.

Added service copy and enable script to migrations(needs testing)

### Changes

- Added `chrome-graceful-shutdown.service` to handle browser shutdown
- Supports Chrome, Chromium, Brave, Vivaldi, Opera
- 10-second grace period before force-kill
- Integrated with uwsm's session management

### Testing

- [x] Tested on Omarchy with uwsm 0.24.1
- [x] Chrome no longer shows crash warnings after Reboot or Log out
- [x] Browser Session state preserved correctly
- [x] Works with multiple browsers simultaneously (at least 2)
- [x] Works when browsers are closed(running in background) or when shutdown is triggered when browsers are running
- [ ] Testing with more browsers (only tested with chrome and chromium simultaneously)
- [ ] Testing migrations script it should copy and enable the service

### Installation

- To manually install it need to copy chrome-graceful-shutdown.service file to `~/.config/systemd/user/` and enable and start the service 

```bash
systemctl --user enable chrome-graceful-shutdown.service
systemctl --user start chrome-graceful-shutdown.service
```