### PR TITLE
bug: if uwsm is installed we should cleanup

### DIFF
--- a/migrations/1752292967.sh
+++ b/migrations/1752292967.sh
@@ -1,6 +1,6 @@
 echo "Update to use UWSM and seamless login"
 
-if omarchy-cmd-missing uwsm; then
+if omarchy-cmd-present uwsm; then
   sudo rm -f /etc/systemd/system/getty@tty1.service.d/override.conf
   sudo rmdir /etc/systemd/system/getty@tty1.service.d/ 2>/dev/null || true
 


### PR DESCRIPTION
The current logic will not cleanup because uwsm is installed during the update process