### PR TITLE
Fix auto-generated everforest obsidian theme readability issues

### DIFF
--- a/bin/omarchy-theme-set-obsidian
+++ b/bin/omarchy-theme-set-obsidian
@@ -258,38 +258,30 @@ extract_theme_data() {
     fi
   done
 
-  # Sort by distance and get the closest color for code background
-  local -a closest_to_bg
-  readarray -t closest_to_bg < <(printf '%s\n' "${bg_distances[@]}" | sort -n | head -1 | cut -d: -f2)
-
   # All background variations use the same as primary background
   local bg_primary_alt="$bg_color"
   local bg_secondary="$bg_color"
   local bg_secondary_alt="$bg_color"
 
-  # Code block background uses the closest different color
-  local code_bg="${closest_to_bg[0]}"
-
-  # If no different color available, create a subtle variant for code blocks
-  if [ -z "$code_bg" ]; then
-    read -r r g b <<<"$(hex_to_rgb "$bg_color")"
-    if [ $bg_brightness -gt 127 ]; then
-      r=$((r - 10))
-      g=$((g - 10))
-      b=$((b - 10))
-    else
-      r=$((r + 15))
-      g=$((g + 15))
-      b=$((b + 15))
-    fi
-    [ $r -lt 0 ] && r=0
-    [ $r -gt 255 ] && r=255
-    [ $g -lt 0 ] && g=0
-    [ $g -gt 255 ] && g=255
-    [ $b -lt 0 ] && b=0
-    [ $b -gt 255 ] && b=255
-    code_bg=$(printf "#%02x%02x%02x" "$r" "$g" "$b")
+  # Generate code background color that will contrast with foreground text
+  read -r r g b <<<"$(hex_to_rgb "$bg_color")"
+  if [ $bg_brightness -gt 127 ]; then
+    r=$((r - 10))
+    g=$((g - 10))
+    b=$((b - 10))
+  else
+    r=$((r + 15))
+    g=$((g + 15))
+    b=$((b + 15))
   fi
+  [ $r -lt 0 ] && r=0
+  [ $r -gt 255 ] && r=255
+  [ $g -lt 0 ] && g=0
+  [ $g -gt 255 ] && g=255
+  [ $b -lt 0 ] && b=0
+  [ $b -gt 255 ] && b=255
+  code_bg=$(printf "#%02x%02x%02x" "$r" "$g" "$b")
+
 
   # Find closest color to foreground for code block text
   local code_fg=""


### PR DESCRIPTION
## Summary

This PR updates the dynamic Obsidian theme logic to prevent menu icons and text from being unreadable due to contrast issues.

## More Details

When using the "Omarchy" theme in Obsidian with the `everforest` theme, the sidebar, title bar, and tab items are unreadable due to a low color contrast with the background.

To fix this, I have added in some very basic color contrast checking that ensures the text color (which defaults to the `$border_color`) can be read on top of the background color. If these values do _not_ have a decent contrast ratio, I set the two CSS variables responsible for the text (`--text-muted` and `--text-faint`) to the `foreground` color that comes from the Alacritty config file. Note that, in doing this, we keep the border color the same, since some themes are expecting their borders to not stand out from the background (like in the case of `everforest`, for example).

This fix does **NOT** impact the following:

- The ability to create custom `obsidian.css` files for themes
- Attempting to create a valid `$border_color` if one does not exist (though we _do_ check this new value for contrast issues)
- Any themes that both had a sufficiently contrasting `$border_color` and used the automatic Obsidian theme generation code

Happy to chat more about this if needed 👍

<details><summary>**Before**</summary>
<p>

<img width="2517" height="2805" alt="screenshot-2025-10-22_20-41-58" src="https://github.com/user-attachments/assets/6552856c-a288-4c54-9aaf-bf114438b287" />


</p>
</details> 

<details><summary>**After**</summary>
<p>

<img width="2517" height="2805" alt="screenshot-2025-10-22_20-42-41" src="https://github.com/user-attachments/assets/c1373019-f314-44fd-ac5b-1383564b79ea" />


</p>
</details> 