### PR TITLE
Fix typo in bindings.conf comment

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -14,7 +14,7 @@ bindd = SUPER SHIFT, G, Signal, exec, omarchy-launch-or-focus signal "uwsm-app -
 bindd = SUPER SHIFT, O, Obsidian, exec, omarchy-launch-or-focus "^obsidian$" "uwsm-app -- obsidian -disable-gpu --enable-wayland-ime"
 bindd = SUPER SHIFT, SLASH, Passwords, exec, uwsm-app -- 1password
 
-# If your web app url contains #, type it as ## to prevent hyperland treat it as comments
+# If your web app url contains #, type it as ## to prevent hyprland treating it as a comment
 bindd = SUPER SHIFT, A, ChatGPT, exec, omarchy-launch-webapp "https://chatgpt.com"
 bindd = SUPER SHIFT ALT, A, Grok, exec, omarchy-launch-webapp "https://grok.com"
 bindd = SUPER SHIFT, C, Calendar, exec, omarchy-launch-webapp "https://app.hey.com/calendar/weeks/"


### PR DESCRIPTION
Corrected a typo and fixed grammar in the comment regarding web app URLs.  (changed hyperland to hyprland and fixed grammar in the same line)