### PR TITLE
Differentiate clipboard screenshot keybinding in utilities.conf

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -30,7 +30,7 @@ bindd = CTRL, F2, Apple Display brightness up, exec, omarchy-cmd-apple-display-b
 bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-display-brightness +60000
 
 # Captures
-bindd = , PRINT, Screenshot, exec, omarchy-cmd-screenshot
+bindd = , PRINT, Screenshot with Editing, exec, omarchy-cmd-screenshot
 bindd = SHIFT, PRINT, Screenshot to Clipboard, exec, omarchy-cmd-screenshot smart clipboard
 bindd = ALT, PRINT, Screenrecording, exec, omarchy-menu screenrecord
 bindd = SUPER, PRINT, Color picking, exec, pkill hyprpicker || hyprpicker -a


### PR DESCRIPTION
Adding a better description to screenshot to clipboard keybinding, so people don't mix them up.