### PR TITLE
switch background-color to window#waybar

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -1,7 +1,6 @@
 @import "../omarchy/current/theme/waybar.css";
 
 * {
-  background-color: @background;
   color: @foreground;
 
   border: none;
@@ -9,6 +8,10 @@
   min-height: 0;
   font-family: 'CaskaydiaMono Nerd Font';
   font-size: 12px;
+}
+
+window#waybar {
+  background-color: @background;
 }
 
 .modules-left {


### PR DESCRIPTION
allows for themes with semi-transparent waybar

with background-color on * the semi-transparency is applied to all elements which doesn't look right with themes that have a semi-transparent waybar