### PR TITLE
fix(hyprland): match Brave portal dialogs in floating-window rule

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -4,7 +4,7 @@ windowrule = center, tag:floating-window
 windowrule = size 800 600, tag:floating-window
 
 windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
-windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to open.*|.*Permission.*|.*Choose application.*)
+windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to open.*|Choose application.*)
 windowrule = float, class:org.gnome.Calculator
 
 # Fullscreen screensaver


### PR DESCRIPTION
Brave on Wayland uses xdg-desktop-portal-gtk for permission and file dialogs. These windows use website-based titles (e.g. "chatgpt.com wants to open") instead of "Open File" or "Save File", so they were not matched by the floating-window rule. This commit expands the title regex to include those patterns, ensuring Brave dialogs float properly.