### PR TITLE
Fix: Alt + Tab keybinding is mapped to two different actions

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -54,7 +54,6 @@ bindd = SUPER SHIFT, DOWN, Swap window down, swapwindow, d
 # Cycle through applications on active workspace
 bindd = ALT, TAB, Cycle to next window, cyclenext
 bindd = ALT SHIFT, TAB, Cycle to prev window, cyclenext, prev
-bindd = ALT, TAB, Reveal active window on top, bringactivetotop
 bindd = ALT SHIFT, TAB, Reveal active window on top, bringactivetotop
 
 # Resize active window

--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -56,7 +56,6 @@ bindd = SUPER SHIFT, DOWN, Swap window down, swapwindow, d
 # Cycle through applications on active workspace
 bindd = ALT, TAB, Cycle to next window, cyclenext
 bindd = ALT SHIFT, TAB, Cycle to prev window, cyclenext, prev
-bindd = ALT, TAB, Reveal active window on top, bringactivetotop
 bindd = ALT SHIFT, TAB, Reveal active window on top, bringactivetotop
 
 # Resize active window


### PR DESCRIPTION
The Alt + Tab keybinding is current mapped to two different actions: `cyclenext` and and `bringactivetotop`.

As the bringactivetotop had two different keybindings: Alt + Tab and Alt + Shift + Tab, I removed the conflicting one.
