### PR TITLE
fix: corrected initramfs hook ordering.

### DIFF
--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -2,7 +2,7 @@ if command -v limine &>/dev/null; then
   sudo pacman -S --noconfirm --needed limine-snapper-sync limine-mkinitcpio-hook
 
   sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
-HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
+HOOKS=(base udev keyboard autodetect microcode modconf kms keymap consolefont block plymouth encrypt filesystems fsck btrfs-overlayfs)
 EOF
 
   [[ -f /boot/EFI/limine/limine.conf ]] || [[ -f /boot/EFI/BOOT/limine.conf ]] && EFI=true


### PR DESCRIPTION
This fixes #2777.

I believe it was happening because kms was after plymouth in the hooks sequence. The [wiki](https://wiki.archlinux.org/title/Plymouth) says that plymouth relies on kms to display graphics. It also says plymouth should be before encrypt and I kept it that way.