### PR TITLE
Add script to toggle fingerprint as primary sudo authorization

### DIFF
--- a/bin/omarchy-toggle-fingerprint
+++ b/bin/omarchy-toggle-fingerprint
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Toggle fingerprint authentication on/off
+# Usage: ./toggle-fingerprint-auth.sh [on|off]
+
+ACTION=${1:-"toggle"}
+
+SUDO_FILE="/etc/pam.d/sudo"
+POLKIT_FILE="/etc/pam.d/polkit-1"
+BACKUP_SUFFIX=".backup"
+
+enable_fingerprint() {
+    echo "Enabling fingerprint authentication..."
+
+    if ! grep -q "pam_fprintd.so" "$SUDO_FILE"; then
+        sudo cp "$SUDO_FILE" "${SUDO_FILE}${BACKUP_SUFFIX}"
+        sudo tee "$SUDO_FILE" > /dev/null << 'EOF'
+auth    sufficient pam_fprintd.so
+#%PAM-1.0
+auth		include		system-auth
+account		include		system-auth
+session		include		system-auth
+EOF
+    fi
+
+    if ! grep -q "pam_fprintd.so" "$POLKIT_FILE"; then
+        sudo cp "$POLKIT_FILE" "${POLKIT_FILE}${BACKUP_SUFFIX}"
+        sudo tee "$POLKIT_FILE" > /dev/null << 'EOF'
+auth      sufficient pam_fprintd.so
+auth      required pam_unix.so
+account   required pam_unix.so
+password  required pam_unix.so
+session   required pam_unix.so
+EOF
+    fi
+
+    echo "✅ Fingerprint authentication enabled"
+}
+
+disable_fingerprint() {
+    echo "Disabling fingerprint authentication..."
+
+    if grep -q "pam_fprintd.so" "$SUDO_FILE"; then
+        sudo cp "$SUDO_FILE" "${SUDO_FILE}${BACKUP_SUFFIX}"
+        sudo tee "$SUDO_FILE" > /dev/null << 'EOF'
+#%PAM-1.0
+auth		include		system-auth
+account		include		system-auth
+session		include		system-auth
+EOF
+    fi
+
+    if grep -q "pam_fprintd.so" "$POLKIT_FILE"; then
+        sudo cp "$POLKIT_FILE" "${POLKIT_FILE}${BACKUP_SUFFIX}"
+        sudo tee "$POLKIT_FILE" > /dev/null << 'EOF'
+auth      required pam_unix.so
+account   required pam_unix.so
+password  required pam_unix.so
+session   required pam_unix.so
+EOF
+    fi
+
+    echo "❌ Fingerprint authentication disabled"
+}
+
+check_status() {
+    if grep -q "pam_fprintd.so" "$SUDO_FILE" && grep -q "pam_fprintd.so" "$POLKIT_FILE"; then
+        echo "🔐 Fingerprint authentication: ENABLED"
+        return 0
+    else
+        echo "🔓 Fingerprint authentication: DISABLED"
+        return 1
+    fi
+}
+
+case "$ACTION" in
+    "on")
+        enable_fingerprint
+        ;;
+    "off")
+        disable_fingerprint
+        ;;
+    "status")
+        check_status
+        ;;
+    "toggle")
+        if check_status >/dev/null 2>&1; then
+            disable_fingerprint
+        else
+            enable_fingerprint
+        fi
+        ;;
+    *)
+        echo "Usage: $0 [on|off|toggle|status]"
+        echo "  on     - Enable fingerprint authentication"
+        echo "  off    - Disable fingerprint authentication"
+        echo "  toggle - Toggle current state"
+        echo "  status - Show current status"
+        exit 1
+        ;;
+esac
+


### PR DESCRIPTION
When fingerprint is setup it is always the "first" option for authorizing a sudo command which is super annoying when the laptop is in clamshell mode and closed far away. So I added this script to toggle it for that situation, because I still need the fingerprint sometimes and want to be able to bring it back easily. 

This is especially annoying when using the default super+alt+space menu installer then I had no other option but to open up the laptop and use the fingerprint or just run the pacman/yay command directly in the terminal which defeats the whole purpose of that menu then. 