### PR TITLE
New window replaces the current fullscreen or maximized window

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -120,7 +120,7 @@ misc {
     disable_splash_rendering  = true
     focus_on_activate = true
     anr_missed_pings = 3
-    new-window-takes-over-fullscreen = 1
+    new_window_takes_over_fullscreen = 1
 }
 
 # https://wiki.hypr.land/Configuring/Variables/#cursor


### PR DESCRIPTION
Currently if we are in fullscreen or full-width mode and either

1) start a new application OR
2) create a new window of an existing application. Like an incognito window Then those new windows/apps start in the background. There is no indication that something new has been created.

IMHO, if I am opening an application then I want to switch to it. I cannot think of any common use case for having new applications open in the background.

This change will cause new application to replace current application as the fullscreen / fullwidth window  

----------------
Docs: https://wiki.hypr.land/Configuring/Variables/#misc

Option:
new_window_takes_over_fullscreen

Desc:
if there is a fullscreen or maximized window, decide whether a new tiled window opened should replace it, stay behind or disable the fullscreen/maximized state. 0 - behind, 1 - takes over, 2 - unfullscreen/unmaxize [0/1/2]

Type:
int

Default:
0