### PR TITLE
feat: remember waybar hidden status through restart

### DIFF
--- a/bin/omarchy-toggle-waybar
+++ b/bin/omarchy-toggle-waybar
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-if pgrep -x waybar >/dev/null; then
-  pkill -x waybar
+waybar_config_file="${XDG_CONFIG_HOME:-$HOME/.config}/waybar/config.jsonc"
+is_bar_hidden=$(grep -m1 '"start_hidden"' "$waybar_config_file" | grep -oE '(true|false)')
+
+if [ "$is_bar_hidden" = "true" ]; then
+  sed -i '0,/"start_hidden": *true/s//"start_hidden": false/' "$waybar_config_file"
+elif [ "$is_bar_hidden" = "false" ]; then
+  sed -i '0,/"start_hidden": *false/s//"start_hidden": true/' "$waybar_config_file"
 else
-  uwsm-app -- waybar >/dev/null 2>&1 &
+  exit 1
 fi
+
+omarchy-restart-waybar

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -2,6 +2,7 @@
   "reload_style_on_change": true,
   "layer": "top",
   "position": "top",
+  "start_hidden": false,
   "spacing": 0,
   "height": 26,
   "modules-left": ["custom/omarchy", "hyprland/workspaces"],

--- a/migrations/1761292867.sh
+++ b/migrations/1761292867.sh
@@ -1,0 +1,5 @@
+echo "Allow Waybar to remember if it's hidden after a restart"
+
+if ! grep -q "start_hidden" ~/.config/waybar/config.jsonc; then
+  omarchy-refresh-waybar
+fi


### PR DESCRIPTION
Currently, if waybar is toggled using ```omarchy-toggle-waybar```, its state is reset when waybar is restarted, which occurs ofter in Omarchy (i.e. changing themes, updating).

This fixes the problem using the start_hidden option in waybar's config file.

```omarchy-toggle-waybar``` now changes the config and restarts waybar, persisting the bar's hidden state

