### PR TITLE
feat: make waybar restart less jittery

### DIFF
--- a/bin/omarchy-restart-waybar
+++ b/bin/omarchy-restart-waybar
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-omarchy-restart-app waybar
+if pgrep -x waybar >/dev/null; then
+  # Waybar is running, reload
+  pkill -SIGUSR2 -x waybar
+else
+  # Waybar is not running, launch it
+  setsid uwsm-app -- waybar >/dev/null 2>&1 &
+fi
+


### PR DESCRIPTION
Currently, omarchy-restart-waybar just calls omarchy-restart-app

This kill the process and restarts it. When waybar is killed, Hyprland redraws the app to take the whole space. Waybar is then immediatly restarted, which redraws the app. This makes the top of apps jitter on a waybar restart

This PR fixes this using pkill -SIGUSR2, which tells waybar to reload the config without killing the process. This avoids the aforementioned jitter.