### PR TITLE
Avoid duplicate web apps windows by updating keybindings to use new launch command

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -16,11 +16,11 @@ bindd = SUPER SHIFT, W, Typora, exec, uwsm-app -- typora
 bindd = SUPER SHIFT, SLASH, Passwords, exec, uwsm-app -- 1password
 
 # If your web app url contains #, type it as ## to prevent hyprland treating it as a comment
-bindd = SUPER SHIFT, A, ChatGPT, exec, omarchy-launch-webapp "https://chatgpt.com"
-bindd = SUPER SHIFT ALT, A, Grok, exec, omarchy-launch-webapp "https://grok.com"
-bindd = SUPER SHIFT, C, Calendar, exec, omarchy-launch-webapp "https://app.hey.com/calendar/weeks/"
-bindd = SUPER SHIFT, E, Email, exec, omarchy-launch-webapp "https://app.hey.com"
-bindd = SUPER SHIFT, Y, YouTube, exec, omarchy-launch-webapp "https://youtube.com/"
+bindd = SUPER SHIFT, A, ChatGPT, exec, omarchy-launch-or-focus-webapp ChatGPT "https://chatgpt.com"
+bindd = SUPER SHIFT ALT, A, Grok, exec, omarchy-launch-or-focus-webapp Grok "https://grok.com"
+bindd = SUPER SHIFT, C, Calendar, exec, omarchy-launch-or-focus-webapp Calendar "https://app.hey.com/calendar/weeks/"
+bindd = SUPER SHIFT, E, Email, exec, omarchy-launch-or-focus-webapp Email "https://app.hey.com"
+bindd = SUPER SHIFT, Y, YouTube, exec, omarchy-launch-or-focus-webapp YouTube "https://youtube.com/"
 bindd = SUPER SHIFT ALT, G, WhatsApp, exec, omarchy-launch-or-focus-webapp WhatsApp "https://web.whatsapp.com/"
 bindd = SUPER SHIFT CTRL, G, Google Messages, exec, omarchy-launch-or-focus-webapp "Google Messages" "https://messages.google.com/web/conversations"
 bindd = SUPER SHIFT, P, Google Photos, exec, omarchy-launch-or-focus-webapp "Google Photos" "https://photos.google.com/"


### PR DESCRIPTION
## Summary

Switch keybindings for several web apps from **`omarchy-launch-webapp`** to **`omarchy-launch-or-focus-webapp`**. If the app already has a window, the binding focuses it; otherwise it launches a new instance. This matches how system apps (Spotify, WhatsApp, Obsidian, etc.) behave and aligns better with user expectations.

## Rationale

My reasoning for this change (idk why it was not implemented already).

* **Predictability & speed:** Keybindings should prioritize fast navigation. Pressing a shortcut should *take you there* - not sometimes open a duplicate. To open up apps we have an equally fast launcher with `SUPER` + `SPACE` 
* **Consistency:** System apps like Spotify already focus existing windows; these web apps should behave the same as having both behaviors at the same time makes it feel more like an oversight rather than a feature.
* **Usage patterns in practice:** ChatGPT, YouTube, Grok, Email, and Calendar are typically revisited as a single active tab rather than needing multiple parallel windows. 
* **Opt-in multiplicity remains:** Launching from Super-Space (or opening links) can still create new instances/windows when desired. It also feels much more intentional.

## Changes

Update `config/hypr/bindings.conf` to use `omarchy-launch-or-focus-webapp`:

```conf
bindd = SUPER SHIFT, A, ChatGPT, exec, omarchy-launch-or-focus-webapp ChatGPT "https://chatgpt.com"
bindd = SUPER SHIFT ALT, A, Grok, exec, omarchy-launch-or-focus-webapp Grok "https://grok.com"
bindd = SUPER SHIFT, C, Calendar, exec, omarchy-launch-or-focus-webapp Calendar "https://app.hey.com/calendar/weeks/"
bindd = SUPER SHIFT, E, Email, exec, omarchy-launch-or-focus-webapp Email "https://app.hey.com"
bindd = SUPER SHIFT, Y, YouTube, exec, omarchy-launch-or-focus-webapp YouTube "https://youtube.com/"
```

## Not included

* **X/Twitter** was ommited since it's unclear to me if both types of windows are differentiated by the **`omarchy-launch-or-focus-webapp`** command.

## Testing

With the modified config in my current setup I just verified that it worked as expected.

1. Ensure no target app window is open; press the binding → **new window opens**.
2. With one window open, press the binding again → **focuses existing window**.
3. Launch via Super-Space or external links → **can still create new instances** when needed.

## Impact/Risks

* Minimal; this aligns behavior with other apps and reduces accidental duplicates.
* Users who truly need multiple windows for these apps can still open them via other entry points.

## Motivation (before/after)

* **Before:** Some bindings focused existing apps; others spawned new windows—unpredictable and “broken” feeling.
* **After:** All listed bindings reliably *focus or launch*, improving flow and muscle memory.


If you deem migrations scripts are necessary let me know and I'll try to produce them :D. I am still unsure on how the development cycle around here works.