### PR TITLE
fix(portal): match additional 'Choose Export Directory' dialogs

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -4,7 +4,7 @@ windowrule = center, tag:floating-window
 windowrule = size 800 600, tag:floating-window
 
 windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
-windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to open.*|Choose application.*)
+windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to open.*|[C|c]hoose.*)
 windowrule = float, class:org.gnome.Calculator
 
 # Fullscreen screensaver


### PR DESCRIPTION
Some applications (e.g. Aether) use xdg-desktop-portal-gtk to open folder chooser dialogs titled "Choose Export Directory" or similar. These were not matched by the previous floating-window regex, causing them to tile instead of float.

This change expands the title regex to include "Choose …" patterns, ensuring these dialogs float and center properly in Hyprland