### PR TITLE
feat(omarchy-menu): add npm install helper and GitHub Copilot CLI option to AI menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -73,6 +73,10 @@ aur_install_and_launch() {
   present_terminal "echo 'Installing $1 from AUR...'; yay -S --noconfirm $2 && setsid gtk-launch $3"
 }
 
+npm_install() {
+  present_terminal "echo 'Installing $1 via npm...'; npm install -g $2"
+}
+
 show_learn_menu() {
   case $(menu "Learn" "  Keybindings\n  Omarchy\n  Hyprland\n󰣇  Arch\n  Neovim\n󱆃  Bash") in
   *Keybindings*) omarchy-menu-keybindings ;;
@@ -287,11 +291,12 @@ show_install_ai_menu() {
       echo ollama
   )
 
-  case $(menu "Install" "󱚤  Claude Code\n󱚤  Cursor CLI [AUR]\n󱚤  Gemini [AUR]\n󱚤  OpenAI Codex [AUR]\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
+  case $(menu "Install" "󱚤  Claude Code\n󱚤  Cursor CLI [AUR]\n󱚤  Gemini [AUR]\n󱚤  OpenAI Codex [AUR]\n󱚤  GitHub Copilot CLI [npm]\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
   *Claude*) install "Claude Code" "claude-code" ;;
   *Cursor*) aur_install "Cursor CLI" "cursor-cli" ;;
   *OpenAI*) aur_install "OpenAI Codex" "openai-codex-bin" ;;
   *Gemini*) aur_install "Gemini" "gemini-cli" ;;
+  *Copilot*) npm_install "GitHub Copilot CLI" "@github/copilot" ;;
   *Studio*) install "LM Studio" "lmstudio" ;;
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;


### PR DESCRIPTION
Adds `npm_install` helper for global npm packages and integrates GitHub Copilot CLI into AI tools install menu.

<img width="369" height="562" alt="image" src="https://github.com/user-attachments/assets/c61d7ba2-4ff1-4b32-8c68-154a35e2ce4b" />

Currently Microsoft recommends installing it through npm and the package on AUR is currently outdated & not published by them, so I had to add an `npm_install` function which follows the exact pattern of `install` & `aur_install` where a window is presented with the installation process & no user input needed.
