### PR TITLE
Fix small browser pop-ups not floating under hyprland

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -6,6 +6,7 @@ windowrule = size 800 600, tag:floating-window
 windowrule = tag +floating-window, class:(blueberry.py|Impala|Wiremix|org.gnome.NautilusPreviewer|com.gabm.satty|Omarchy|About|TUI.float)
 windowrule = tag +floating-window, class:(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), title:^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to open.*|[C|c]hoose.*)
 windowrule = float, class:org.gnome.Calculator
+windowrule = float,condition:size<900x1000,class:((google-)?[cC]hrom(e|ium)|[bB]rave-browser|Microsoft-edge|Vivaldi-stable|helium|[fF]irefox|zen|librewolf)
 
 # Fullscreen screensaver
 windowrule = fullscreen, class:Screensaver


### PR DESCRIPTION
The previous rule matched specific window titles like “Sign In – Google Accounts – Brave”, which failed when browsers changed titles after mapping or used different ones. This caused login dialogs to tile instead of floating. This update uses a size-based condition that floats any small browser window, ensuring consistent behavior across Brave, Chrome, Chromium, Edge, Vivaldi, Helium, Firefox, Zen, and LibreWolf.