### PR TITLE
Adding key bindings for screen lock and suspend to RAM

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -42,3 +42,8 @@ bindd = SUPER CTRL, S, Share, exec, omarchy-menu share
 # Waybar-less information
 bindd = SUPER CTRL, T, Show time, exec, notify-send "    $(date +"%A %H:%M  —  %d %B W%V %Y")"
 bindd = SUPER CTRL, B, Show battery remaining, exec, notify-send "󰁹    Battery is at $(omarchy-battery-remaining)%"
+
+# Lock Screen
+bindd = SUPER ALT, L, Lock screen, exec, omarchy-lock-screen
+# Suspend to RAM
+bindd = SUPER ALT, S, Suspend machine, exec, systemctl suspend


### PR DESCRIPTION
I have added two new key bindings that I think are very helpful for everyone.

1. Lock the screen
SUPER ALT L  locks the screen

This feature is helpful for all people who work in an office where there is a need of locking and unlocking the machine several times a day. Having a shortcut for this should be in the standard key bindings imho.

2. Suspend the machine to RAM (aka Sleep mode)
SUPER ALT S suspends to RAM (put the machine to sleep mode)

This feature is helpful for people who'd like to put their machine to sleep mode when the work is done or when they leave the desk for a longer time period. I think this is superior to shutting the machine down, because the start up time is much quicker, when the machine needs to be used again. Also, all the open apps are there again instantly. I think this should be part of the standard key bindings as well.
