### PR TITLE
fix(omarchy-pkg-aur-accessible): Add IPv4 fallback for AUR check

### DIFF
--- a/bin/omarchy-pkg-aur-accessible
+++ b/bin/omarchy-pkg-aur-accessible
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-curl -sf --connect-timeout 30 --retry 3 --retry-delay 3 -A "omarchy-update" \
-  "https://aur.archlinux.org/rpc/?v=5&type=info&arg=base" >/dev/null
+AUR_URL="https://aur.archlinux.org/rpc/?v=5&type=info&arg=base"
+CURL_ARGS="-sf --connect-timeout 15 --retry 2 --retry-delay 2 -A omarchy-update"
+
+curl $CURL_ARGS "$AUR_URL" >/dev/null || \
+curl -4 $CURL_ARGS "$AUR_URL" >/dev/null


### PR DESCRIPTION
### Problem

The `omarchy-pkg-aur-accessible` script uses `curl` to check connectivity to the AUR. On networks with "broken" IPv6 configurations (where DNS resolves an IPv6 address but the ISP provides no public route), `curl` defaults to IPv6, times out, and returns an error code.

This causes the main `omarchy-update-system-pkgs` script to assume the AUR is unreachable and skip the `yay` package update.

### Solution

1.  It first attempts the default `curl` connection (allowing IPv6).
2.  If it fails (using `||`), it immediately retries the connection forcing IPv4 (with the `curl -4` flag).