### PR TITLE
Remove after install usb installer message

### DIFF
--- a/install/post-install/finished.sh
+++ b/install/post-install/finished.sh
@@ -22,8 +22,6 @@ fi
 
 if sudo test -f /etc/sudoers.d/99-omarchy-installer; then
   sudo rm -f /etc/sudoers.d/99-omarchy-installer &>/dev/null
-  echo
-  echo_in_style "Remember to remove USB installer!"
 fi
 
 # Exit gracefully if user chooses not to reboot


### PR DESCRIPTION
Since in almost all cases, the EFI entries will get positioned above the USB, this notice is not needed.

Enhancement for #2878 