### PR TITLE
Allow interaction with first Android Studio dialog ("Send usage statistics") by adjusting JetBrains window rules

### DIFF
--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -5,6 +5,5 @@ windowrule = size 50% 50%, class:(.*jetbrains.*)$, title:^$
 windowrule = noinitialfocus, class:^(.*jetbrains.*)$, title:^\\s$
 
 # Allow dialogs (like "Send usage statistics") to be focusable and clickable
-windowrulev2 = unset,nofocus,class:^(.*jetbrains.*)$,title:^$
-windowrulev2 = unset,noinitialfocus,class:^(.*jetbrains.*)$,title:^$
-
+windowrule = unset,nofocus,class:^(.*jetbrains.*)$,title:^$
+windowrule = unset,noinitialfocus,class:^(.*jetbrains.*)$,title:^$


### PR DESCRIPTION
### Summary
This PR fixes a usability issue where the first Android Studio dialog (“Send usage statistics” / “Don’t send”) cannot be interacted with under Omarchy.

### Problem
Omarchy’s JetBrains window rules (`nofocus` and `noinitialfocus`) currently apply to all windows with empty or space-only titles.  
Android Studio’s first dialog has an empty title, so focus and click events are blocked, making the buttons unresponsive.

### Solution
Add exceptions for dialogs with empty titles, allowing them to receive focus and input:

```
windowrulev2 = unset,nofocus,class:^(.*jetbrains.*)$,title:^$
windowrulev2 = unset,noinitialfocus,class:^(.*jetbrains.*)$,title:^$
```
Existing rules for title:^\s$ (single space) remain, preserving tab-dragging behavior in JetBrains IDEs.

**Testing**
Verified that the “Send usage statistics” dialog is now clickable.

Tab-dragging behavior in JetBrains IDEs remains unaffected.
Tested across Android Studio and IntelliJ IDEA on Omarchy 3.0.1 with Hyprland.

**Related Issue**
https://github.com/basecamp/omarchy/issues/2898

**Before** 
 
![bug_3](https://github.com/user-attachments/assets/6aa0df60-b784-45a8-8e95-dde8f81bfe5d)
![bug](https://github.com/user-attachments/assets/89839ba8-6cf6-47cf-9291-e9c17d31db74)
![bug_1](https://github.com/user-attachments/assets/28d8a4e7-b89c-4a9c-9c4c-835acb1ce55e)

**After**

![fix_4](https://github.com/user-attachments/assets/b16b8ec8-30a0-4776-8834-4a23125c3da9)
![fix_5](https://github.com/user-attachments/assets/2ab6c540-cc3e-4ca5-8f84-8c2c4ebd1f88)

![fix_2](https://github.com/user-attachments/assets/ef7d0576-ee91-4ec1-b2c8-7ff5e462c5a4)
![fix_3](https://github.com/user-attachments/assets/ef7043d1-dcc7-44a5-baf5-20739916ca7a)

![fix_6](https://github.com/user-attachments/assets/8f834348-fb25-4adb-8b88-3cbf1e4026ab)
![fix](https://github.com/user-attachments/assets/d78c285f-e5c5-47a3-af37-e8e7dabe7fcb)
![fix_1](https://github.com/user-attachments/assets/04570674-423c-4ed4-a0bb-ac5fe5e39f4d)
