### PR TITLE
Add capslock and numlock colors

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -28,6 +28,8 @@ input-field {
     placeholder_text = Enter Password 󰈷
     check_color = $check_color
     fail_text = <i>$FAIL ($ATTEMPTS)</i>
+    capslock_color = $orange
+    numlock_color = $green
 
     rounding = 0
     shadow_passes = 0


### PR DESCRIPTION
When the capslock key will be pressed, it will be shown in orange; and when the numlock will be pressed, it will be shown in green;

Partial fix for #2884, #2865 and #1770 