### PR TITLE
config/uwsm/env: remove extra trailing / in path

### DIFF
--- a/config/uwsm/env
+++ b/config/uwsm/env
@@ -2,7 +2,7 @@
 
 # Ensure Omarchy bins are in the path
 export OMARCHY_PATH=$HOME/.local/share/omarchy
-export PATH=$OMARCHY_PATH/bin/:$PATH
+export PATH=$OMARCHY_PATH/bin:$PATH
 
 # Set default terminal and editor
 source ~/.config/uwsm/default


### PR DESCRIPTION
I noticed there is an additional traling slash in the bin path set by uwsm

```bash
> which omarchy-cmd-present
/home/<redacted>/.local/share/omarchy/bin//omarchy-cmd-present
```