### PR TITLE
Include all shell-integration-features options together

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -17,11 +17,11 @@ gtk-toolbar-style = flat
 # Cursor styling
 cursor-style = "block"
 cursor-style-blink = false
-shell-integration-features = no-cursor
+
+# Cursor styling + SSH session terminfo
+# (all shell integration options must be passed together)
+shell-integration-features = no-cursor,ssh-env
 
 # Keyboard bindings
 keybind = shift+insert=paste_from_clipboard
 keybind = control+insert=copy_to_clipboard
-
-# SSH session terminfo
-shell-integration-features = ssh-env


### PR DESCRIPTION
Ghostty will only use the last `shell-integration-features` line found in the config, so multiple options need to be presented as a comma-separated list. Including them on separate lines meant that only the `ssh-env` option was getting set, causing the `no-cursor` option to be ignored. This prevented the cursor from going into the `block` style.