### PR TITLE
Add fullscreen border color support to all themes

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -3,6 +3,7 @@
 # Variables
 $activeBorderColor = rgba(33ccffee) rgba(00ff99ee) 45deg
 $inactiveBorderColor = rgba(595959aa)
+$fullscreenBorderColor = rgba(ffd700ee)
 
 # https://wiki.hyprland.org/Configuring/Variables/#general
 general {
@@ -134,3 +135,6 @@ env = GUM_CONFIRM_SELECTED_FOREGROUND,0     # Black
 env = GUM_CONFIRM_SELECTED_BACKGROUND,2     # Green
 env = GUM_CONFIRM_UNSELECTED_FOREGROUND,0   # Black
 env = GUM_CONFIRM_UNSELECTED_BACKGROUND,8   # Dark grey
+
+# Fullscreen windows get distinct border color to indicate covered windows
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1

--- a/themes/catppuccin-latte/hyprland.conf
+++ b/themes/catppuccin-latte/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(1e66f5)
+$fullscreenBorderColor = rgba(D20F39ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/catppuccin/hyprland.conf
+++ b/themes/catppuccin/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(c6d0f5)
+$fullscreenBorderColor = rgba(F38BA8ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/everforest/hyprland.conf
+++ b/themes/everforest/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(d3c6aa)
+$fullscreenBorderColor = rgba(e67e80ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/flexoki-light/hyprland.conf
+++ b/themes/flexoki-light/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgba(205EA6ee)
+$fullscreenBorderColor = rgba(CE5D97ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/gruvbox/hyprland.conf
+++ b/themes/gruvbox/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(a89984)
+$fullscreenBorderColor = rgba(fb4934ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/kanagawa/hyprland.conf
+++ b/themes/kanagawa/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(dcd7ba)
+$fullscreenBorderColor = rgba(ffa066ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/matte-black/hyprland.conf
+++ b/themes/matte-black/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(8A8A8D)
+$fullscreenBorderColor = rgba(FFC107ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/nord/hyprland.conf
+++ b/themes/nord/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(D8DEE9)
+$fullscreenBorderColor = rgba(EBCB8Bee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/osaka-jade/hyprland.conf
+++ b/themes/osaka-jade/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(71CEAD)
+$fullscreenBorderColor = rgba(FF5345ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/ristretto/hyprland.conf
+++ b/themes/ristretto/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(e6d9db)
+$fullscreenBorderColor = rgba(fd6883ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/rose-pine/hyprland.conf
+++ b/themes/rose-pine/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(575279)
+$fullscreenBorderColor = rgba(f6c177ee)
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor

--- a/themes/tokyo-night/hyprland.conf
+++ b/themes/tokyo-night/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgba(33ccffee) rgba(00ff99ee) 45deg
+$fullscreenBorderColor = rgba(f7768eee) rgba(ff9e64ee) 45deg
+
+windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1
 
 general {
     col.active_border = $activeBorderColor


### PR DESCRIPTION
This PR adds distinct border colors for fullscreen/maximized windows (SUPER+ALT+F) to provide visual feedback when windows are covering others.

## Changes
- Added `$fullscreenBorderColor` variable to all 12 themes
- Added `windowrulev2 = bordercolor $fullscreenBorderColor, fullscreen:1` rule
- Each theme uses high-contrast accent colors from its palette
- Tokyo-night maintains gradient style (pink-to-orange vs cyan-to-green)

## Rationale
When a window is maximized, it can be hard to tell if other windows are underneath. The distinct border color provides immediate visual feedback that the window is in fullscreen mode.

## Testing
Tested across multiple themes by toggling SUPER+ALT+F. Each theme shows obvious color contrast between normal and fullscreen borders.