### PR TITLE
fix: improve catppuccin-latte group background colors

### DIFF
--- a/themes/catppuccin-latte/hyprland.conf
+++ b/themes/catppuccin-latte/hyprland.conf
@@ -1,4 +1,7 @@
 $activeBorderColor = rgb(1e66f5)
+$text = rgb(4c4f69)
+$surface0 = rgb(ccd0da)
+$base = rgb(eff1f5)
 
 general {
     col.active_border = $activeBorderColor
@@ -6,4 +9,12 @@ general {
 
 group {
     col.border_active = $activeBorderColor
+
+    groupbar {
+        text_color = $text
+        text_color_inactive = $text
+
+        col.active = $surface0
+        col.inactive = $base
+    }
 }


### PR DESCRIPTION
Hello,

In this PR, I am trying to improve catpuccin-late theme for Hyprland groups:

- Improves contrast
- Make the colors consistent with the theme

**Before**

<img width="1915" height="98" alt="image" src="https://github.com/user-attachments/assets/a871f429-5508-4f58-97c1-26f642bd8f65" />

See how the background colors of the group is not from catpuccin-late color palettes and also that the inactive group text is almost unreadable.

**After**

<img width="1910" height="93" alt="image" src="https://github.com/user-attachments/assets/377155ae-5f6e-461c-bb39-596bd5869089" />