### PR TITLE
Add automatic detection of an eduroam network

### DIFF
--- a/install/first-run/wifi.sh
+++ b/install/first-run/wifi.sh
@@ -1,3 +1,24 @@
 if ! ping -c3 -W1 1.1.1.1 >/dev/null 2>&1; then
+
+  INTERFACE=$(iwctl station list | tail -n +5 | awk '{print $2}' | tr -d " \t\n\r")
+  if [[ -z "$INTERFACE" ]]; then
+      notify-send "Error" "No wireless interface found" -u critical
+      exit 1
+  fi
+
+  iwctl station $INTERFACE scan
+  if iwctl station $INTERFACE get-networks | grep -qF "eduroam"; then
+      if ! yay -S --noconfirm geteduroam; then
+          notify-send "Error" "Failed to install geteduroam package" -u critical
+          exit 1
+      fi
+      RESPONSE=$(notify-send --action 'default=Open URL' 'Eduroam Network Detected' 'The eduroam network has been detected. Click here to begin connecting or right click to dismiss.' -u normal -i dialog-information -t 10000)
+      if [[ $RESPONSE == *"default"* ]]; then
+          geteduroam-gui &
+          exit
+      fi
+      yay -R --noconfirm geteduroam
+  fi
+
   notify-send "󰖩    Click to Setup Wi-Fi" "Tab to navigate, Space to select, ? for help." -u critical -t 30000
 fi


### PR DESCRIPTION
Hello! This is my first pull request, so let me know what I can do to improve this, or if it's completely unnecessary. 

I noticed that connecting to eduroam (the default wifi for many institutions worldwide) was unnecessarily difficult to do on Linux. Therefore, I added this small script to the wifi.sh file to detect if eduroam is available and suggest an installation method. 

I first detect the wireless interface using `iwctl`, display an error if none is found, and scan for available networks.
If the "eduroam" network is found, the script installs the `geteduroam` package, prompts the user to launch the authentication GUI, and removes the package if the user dismisses the prompt.

Thank you for taking the time to look at this, and let me know what we can change!

Thank you,
Jack Sovern