### PR TITLE
Update utilities.conf with keyboard shortcuts for zooming in and out on the display

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -44,5 +44,5 @@ bindd = SUPER CTRL, T, Show time, exec, notify-send "    $(date +"%A %H:%M  �
 bindd = SUPER CTRL, B, Show battery remaining, exec, notify-send "󰁹    Battery is at $(omarchy-battery-remaining)%"
 
 # Zoom in-out
-bindd = SUPER SHIFT, Z, exec, hyprctl keyword cursor:zoom_factor $(awk "BEGIN {print $(hyprctl getoption cursor:zoom_factor | grep 'float:' | awk '{print $2}') + 1.0}")
-bindd = SUPER SHIFT ALT, Z, exec, hyprctl keyword cursor:zoom_factor 1
+bindd = SUPER SHIFT, Z, Zoom in, exec, hyprctl keyword cursor:zoom_factor $(awk "BEGIN {print $(hyprctl getoption cursor:zoom_factor | grep 'float:' | awk '{print $2}') + 1.0}")
+bindd = SUPER SHIFT ALT, Z, Zoom to default, exec, hyprctl keyword cursor:zoom_factor 1


### PR DESCRIPTION
`Super+Shift+Z` to zoom in on the display, and `Super+Shift+Alt+Z` to return the display to the default 100% zoom.