### PR TITLE
Fix: Low Battery notification returning empty value on reboot

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -11,19 +11,6 @@ send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
 }
 
-#!/bin/bash
-
-# Designed to be run by systemd timer every 30 seconds and alerts if battery is low
-
-BATTERY_THRESHOLD=10
-NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
-BATTERY_LEVEL=$(omarchy-battery-remaining)
-BATTERY_STATE=$(upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}')
-
-send_notification() {
-  notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
-}
-
 if [[ -n "$BATTERY_LEVEL" && "$BATTERY_LEVEL" =~ ^[0-9]+$ ]]; then
   if [[ $BATTERY_STATE == "discharging" && $BATTERY_LEVEL -le $BATTERY_THRESHOLD ]]; then
     if [[ ! -f $NOTIFICATION_FLAG ]]; then


### PR DESCRIPTION
This is based off the bug fix in Issue #2886.

Upon reboot, a notification pops up:
<img width="559" height="251" alt="image" src="https://github.com/user-attachments/assets/bf4a7832-69aa-443b-a2de-c7360b8d3197" />

The issue is that no matter your charge level, this notification pops up and returns an empty value, most likely because the line: `BATTERY_LEVEL=$(omarchy-battery-remaining)` is an empty value on reboot.

The code given in Issue #2886 fixed it for @data-davey and I when we added the following code in `bin/omarchy-battery-monitor`:
<img width="933" height="166" alt="image" src="https://github.com/user-attachments/assets/5e92c4d9-a778-49b9-b90f-418329e1a823" />
