### PR TITLE
Fix: omarchy-cmd-screenshot geometry for transformed monitors

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -13,9 +13,23 @@ pkill slurp && exit 0
 MODE="${1:-smart}"
 PROCESSING="${2:-slurp}"
 
+# accounting for portrait/transformed displays
+JQ_MONITOR_GEO='
+  def format_geo:
+    .x as $x | .y as $y |
+    (.width / .scale | floor) as $w |
+    (.height / .scale | floor) as $h |
+    .transform as $t |
+    if $t == 1 or $t == 3 then
+      "\($x),\($y) \($h)x\($w)"
+    else
+      "\($x),\($y) \($w)x\($h)"
+    end;
+'
+
 get_rectangles() {
   local active_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id')
-  hyprctl monitors -j | jq -r --arg ws "$active_workspace" '.[] | select(.activeWorkspace.id == ($ws | tonumber)) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"'
+  hyprctl monitors -j | jq -r --arg ws "$active_workspace" "${JQ_MONITOR_GEO} .[] | select(.activeWorkspace.id == (\$ws | tonumber)) | format_geo"
   hyprctl clients -j | jq -r --arg ws "$active_workspace" '.[] | select(.workspace.id == ($ws | tonumber)) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
 }
 
@@ -34,7 +48,7 @@ case "$MODE" in
     kill $PID 2>/dev/null
     ;;
   fullscreen)
-    SELECTION=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"')
+    SELECTION=$(hyprctl monitors -j | jq -r "${JQ_MONITOR_GEO} .[] | select(.focused == true) | format_geo")
     ;;
   smart|*)
     RECTS=$(get_rectangles)


### PR DESCRIPTION
### Description

Fixes a bug in the `omarchy-cmd-screenshot` script where it fails to correctly capture monitors with a Hyprland `transform` applied (e.g., monitors in portrait mode).

### Problem

For a monitor with a 90-degree rotation (`"transform": 3`), `hyprctl` still reports the landscape dimensions (e.g., `1920x1080`). This causes the script to feed incorrect geometry to `grim`, resulting in a truncated screenshot that only captures a portion of the portrait display, with the rest of the image being empty space.

### Solution

This PR updates the `jq` commands in two locations:
1.  The `get_rectangles` function
2.  The `fullscreen` case

The new `jq` logic now reads the `.transform` value. If the transform is `1` or `3` (a 90 or 270-degree rotation), it correctly swaps the width and height to provide the proper geometry for the capture.