### PR TITLE
Add missing hyprlock PAM configuration

### DIFF
--- a/default/pam.d/hyprlock
+++ b/default/pam.d/hyprlock
@@ -1,0 +1,5 @@
+# Omarchy PAM fix for Hyprlock (Arch-based)
+auth       include        system-local-login
+account    include        system-local-login
+password   include        system-local-login
+session    include        system-local-login

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -3,6 +3,7 @@ run_logged $OMARCHY_INSTALL/config/theme.sh
 run_logged $OMARCHY_INSTALL/config/branding.sh
 run_logged $OMARCHY_INSTALL/config/git.sh
 run_logged $OMARCHY_INSTALL/config/gpg.sh
+run_logged $OMARCHY_INSTALL/config/hyprlock-pam.sh
 run_logged $OMARCHY_INSTALL/config/timezones.sh
 run_logged $OMARCHY_INSTALL/config/increase-sudo-tries.sh
 run_logged $OMARCHY_INSTALL/config/increase-lockout-limit.sh

--- a/install/config/hyprlock-pam.sh
+++ b/install/config/hyprlock-pam.sh
@@ -1,0 +1,4 @@
+# Setup PAM configuration for Hyprlock screen locker
+sudo mkdir -p /etc/pam.d
+sudo cp ~/.local/share/omarchy/default/pam.d/hyprlock /etc/pam.d/
+sudo chmod 644 /etc/pam.d/hyprlock

--- a/migrations/1761710779.sh
+++ b/migrations/1761710779.sh
@@ -1,0 +1,28 @@
+echo "Setup PAM configuration for Hyprlock screen locker"
+
+# Create the file if it doesn't exist
+if [[ ! -f /etc/pam.d/hyprlock ]]; then
+  sudo mkdir -p /etc/pam.d
+  sudo tee /etc/pam.d/hyprlock >/dev/null <<'EOF'
+# Omarchy PAM fix for Hyprlock (Arch-based)
+auth       include        system-local-login
+account    include        system-local-login
+password   include        system-local-login
+session    include        system-local-login
+EOF
+  sudo chmod 644 /etc/pam.d/hyprlock
+else
+  # File exists, ensure it has the correct entries
+  if ! grep -q "auth.*include.*system-local-login" /etc/pam.d/hyprlock; then
+    echo "auth       include        system-local-login" | sudo tee -a /etc/pam.d/hyprlock >/dev/null
+  fi
+  if ! grep -q "account.*include.*system-local-login" /etc/pam.d/hyprlock; then
+    echo "account    include        system-local-login" | sudo tee -a /etc/pam.d/hyprlock >/dev/null
+  fi
+  if ! grep -q "password.*include.*system-local-login" /etc/pam.d/hyprlock; then
+    echo "password   include        system-local-login" | sudo tee -a /etc/pam.d/hyprlock >/dev/null
+  fi
+  if ! grep -q "session.*include.*system-local-login" /etc/pam.d/hyprlock; then
+    echo "session    include        system-local-login" | sudo tee -a /etc/pam.d/hyprlock >/dev/null
+  fi
+fi


### PR DESCRIPTION
Fixes #2094, #1469

## Problem
Hyprlock fails to authenticate after extended lock periods because `/etc/pam.d/hyprlock` doesn't exist in the current Arch base image. Users get "Authentication Failed" even with correct password and must reboot.

## Root Cause
Upstream Arch recently added `/etc/pam.d/hyprlock` to their hyprlock package (0.8.2-1), but Omarchy's current base predates this addition. Without a PAM policy, hyprlock doesn't know how to authenticate and fails silently.

## Solution
Add the missing PAM configuration file now, rather than waiting for the next Arch rebase. This provides:
- Immediate fix for existing users via migration script
- Proper PAM policy for new installations
- Forward compatibility (when Omarchy rebases to newer Arch, this config will already match upstream)

## Implementation
- **New installs:** Install script copies PAM config during setup
- **Existing users:** Migration script adds/repairs config on upgrade
- **Idempotent:** Safe to run multiple times, handles incomplete configs

## Testing
- Solution discovered and tested by @ItsMick in #2094
- Confirmed working by multiple users in the issue thread
- Migration script tested successfully on Omarchy 3.1.3 dev branch