### PR TITLE
Replace swapwindow with movewindow

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -16,12 +16,6 @@ bindd = SUPER, RIGHT, Move window focus right, movefocus, r
 bindd = SUPER, UP, Move window focus up, movefocus, u
 bindd = SUPER, DOWN, Move window focus down, movefocus, d
 
-# Move active windows SUPER + CTRL arrow keys
-bindd = SUPER CTRL, LEFT, Move window focus left, movewindow, l
-bindd = SUPER CTRL, RIGHT, Move window focus right, movewindow, r
-bindd = SUPER CTRL, UP, Move window focus up, movewindow, u
-bindd = SUPER CTRL, DOWN, Move window focus down, movewindow, d
-
 # Switch workspaces with SUPER + [1-9]
 bindd = SUPER, code:10, Switch to workspace 1, workspace, 1
 bindd = SUPER, code:11, Switch to workspace 2, workspace, 2
@@ -53,11 +47,11 @@ bindd = SUPER, TAB, Next workspace, workspace, e+1
 bindd = SUPER SHIFT, TAB, Previous workspace, workspace, e-1
 bindd = SUPER CTRL, TAB, Former workspace, workspace, previous
 
-# Swap active window with the one next to it with SUPER + SHIFT + arrow keys
-bindd = SUPER SHIFT, LEFT, Swap window to the left, swapwindow, l
-bindd = SUPER SHIFT, RIGHT, Swap window to the right, swapwindow, r
-bindd = SUPER SHIFT, UP, Swap window up, swapwindow, u
-bindd = SUPER SHIFT, DOWN, Swap window down, swapwindow, d
+# Move active window with the one next to it with SUPER + SHIFT + arrow keys
+bindd = SUPER SHIFT, LEFT, Move window to the left, movewindow, l
+bindd = SUPER SHIFT, RIGHT, Move window to the right, movewindow, r
+bindd = SUPER SHIFT, UP, Move window up, movewindow, u
+bindd = SUPER SHIFT, DOWN, Move window down, movewindow, d
 
 # Cycle through applications on active workspace
 bindd = ALT, TAB, Cycle to next window, cyclenext


### PR DESCRIPTION
~Move active windows around just by using keyboard.~

~We can also move windows with SUPER + left mouse click but having keyboard shortcuts could be more convenient?~

`swapwindow` is limiting when the target direction of workspace does not have a window to swap with. Functionality wise `movewindow` is similar to `swapwindow` with extra functionality to be able to move active window to active workspaces.



