### PR TITLE
VS Code: Apply Omarchy theme during install

### DIFF
--- a/bin/omarchy-install-vscode
+++ b/bin/omarchy-install-vscode
@@ -21,9 +21,6 @@ EOF
 # Ensure VSC's own auto-update feature is turned off
 printf '{\n  "update.mode": "none"\n}\n' > ~/.config/Code/User/settings.json
 
-# Install Neovim extension to LazyVimify the environment
-code --install-extension asvetliakov.vscode-neovim
-
 # Apply Omarchy theme to VSCode
 omarchy-theme-set-vscode
 


### PR DESCRIPTION
Two things:

1. Applies the Omarchy theme during install; current behavior is that the Omarchy theme won't take until the user re-applies it from the Omarchy Menu.
2. This one is a little spicier. It installs the Neovim extension, which will automatically apply LazyVim behavior in VS Code. The idea is to make Omarchy feel more holistic, like there is one way of doing things. Naturally, users can just uninstall the extension right away, or prohibit it from backing up to their account if they aren't using Omarchy on other devices (forbid!).