### PR TITLE
feat: Add MANPAGER environment variable for nvim

### DIFF
--- a/default/bash/envs
+++ b/default/bash/envs
@@ -1,3 +1,4 @@
 # Editor used by CLI
 export SUDO_EDITOR="$EDITOR"
 export BAT_THEME=ansi
+export MANPAGER='nvim +Man!'


### PR DESCRIPTION
This pull request makes a small configuration improvement by setting the manual page viewer to use `nvim` with the `+Man!` option. This enhances the experience of viewing man pages in the terminal by introducing syntax highlighting, table of contents Location List navigation via `gO`, and more.