### PR TITLE
fix(screenrecord): avoid slurp execution when scope is 'output'

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -106,18 +106,7 @@ if screenrecording_active; then
 elif [[ "$SCOPE" == "output" ]]; then
   [[ "$WEBCAM" == "true" ]] && start_webcam_overlay
 
-  if ! output=$(slurp -o -f "%o"); then
-    [[ "$WEBCAM" == "true" ]] && cleanup_webcam
-    exit 1
-  fi
-
-  if [[ -z "$output" ]]; then
-    notify-send "Error" "Could not detect monitor" -u critical
-    [[ "$WEBCAM" == "true" ]] && cleanup_webcam
-    exit 1
-  fi
-
-  start_screenrecording "$output"
+  start_screenrecording "screen"
 else
   [[ "$WEBCAM" == "true" ]] && start_webcam_overlay
 


### PR DESCRIPTION
### Summary
This PR fixes a UX issue where selecting **"Display" (output mode)** in the Omarchy screen recording menu
still required manually selecting a region with `slurp`.

### Problem
Previously, the `"output"` variable in `omarchy-cmd-screenrecord` invoked:`slurp -o -f "%o"` which caused slurp to run even when the user requested to record the full display. This behavior was inconsistent with the "output" option’s intended purpose.
[omarchy-cmd-screenrecord:109](https://github.com/basecamp/omarchy/blob/master/bin/omarchy-cmd-screenrecord#L109)

### Fix
The slurp call has been removed for "output", and replaced with:
```bash
start_screenrecording "screen"
```
This ensures that "Display" mode records the active monitor directly via gpu-screen-recorder.

### Testing notes
Tested under Hyprland + Waybar (v0.14.0)
The fix works reliably when using the current Waybar workaround under ~/.config/waybar/config.jsonc:

```json
"custom/screenrecording-indicator": {
  "on-click": "setsid bash -c 'omarchy-cmd-screenrecord output'", #<-- workaround
  "exec": "$OMARCHY_PATH/default/waybar/indicators/screen-recording.sh",
  "signal": 8,
  "return-type": "json"
}
```
This workaround is required until Waybar supports detached execution for on-click commands
(see: https://github.com/Alexays/Waybar/issues/4608)


__This PR is independent of the Waybar behavior and corrects logic within the script itself. The workaround above is mentioned only for reproducibility and testing consistency.__

## Refs:
### Related Omarchy discussions:
https://github.com/basecamp/omarchy/issues/2706 -> Screen recording fails on hybrid Intel+NVIDIA
https://github.com/basecamp/omarchy/issues/2656 -> Stop Recording icon always showing on waybar

### Related Waybar discussions:
https://github.com/Alexays/Waybar/issues/4608 -> Waybar issue about detached on-click 
