### PR TITLE
Add MeteorJS to JavaScript install options

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -64,6 +64,10 @@ deno)
   echo -e "Installing Deno...\n"
   mise use -g deno@latest
   ;;
+meteor)
+  echo -e "Installing Meteor...\n"
+  curl https://install.meteor.com/ | sh
+  ;;
 go)
   echo -e "Installing Go...\n"
   mise use --global go@latest

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -348,10 +348,11 @@ show_install_development_menu() {
 }
 
 show_install_javascript_menu() {
-  case $(menu "Install" "  Node.js\n  Bun\n  Deno") in
+  case $(menu "Install" "  Node.js\n  Bun\n  Deno\n☄ Meteor") in
   *Node*) present_terminal "omarchy-install-dev-env node" ;;
   *Bun*) present_terminal "omarchy-install-dev-env bun" ;;
   *Deno*) present_terminal "omarchy-install-dev-env deno" ;;
+  *Meteor*) present_terminal "omarchy-install-dev-env meteor" ;;
   *) show_install_development_menu ;;
   esac
 }


### PR DESCRIPTION
A quick addition to add [MeteorJS](https://www.meteor.com/) as an installation option under JavaScript.
You can install MeteorJS either via NPM or via a curl. The second option is still favorite for many and the easiest one. Functionality wise, there isn't a difference.
https://docs.meteor.com/about/install.html