### PR TITLE
Add Super+Shift+~ keybinding to move workspace between monitors

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -47,6 +47,9 @@ bindd = SUPER, TAB, Next workspace, workspace, e+1
 bindd = SUPER SHIFT, TAB, Previous workspace, workspace, e-1
 bindd = SUPER CTRL, TAB, Former workspace, workspace, previous
 
+# Move workspace between monitors
+bindd = SUPER SHIFT, grave, Move workspace to next monitor, movecurrentworkspacetomonitor, +1
+
 # Swap active window with the one next to it with SUPER + SHIFT + arrow keys
 bindd = SUPER SHIFT, LEFT, Swap window to the left, swapwindow, l
 bindd = SUPER SHIFT, RIGHT, Swap window to the right, swapwindow, r


### PR DESCRIPTION
This adds a keybinding for moving the currently focused workspace to the other monitor:

- **Super + Shift + ~** → Move workspace to the next display

This matches the existing Super + Shift pattern used for workspace management and improves
multi-monitor workflow efficiency, especially when docking or switching setups.

Tested locally on a multi-monitor configuration. No changes to existing behavior for users
without multiple displays.
