### PR TITLE
Don't outline hidden windows when screenshotting fullscreen apps

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -13,29 +13,34 @@ pkill slurp && exit 0
 MODE="${1:-smart}"
 PROCESSING="${2:-slurp}"
 
+get_active_workspace() {
+  hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id'
+}
+
 get_rectangles() {
-  local active_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id')
-  hyprctl monitors -j | jq -r --arg ws "$active_workspace" '.[] | select(.activeWorkspace.id == ($ws | tonumber)) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"'
-  hyprctl clients -j | jq -r --arg ws "$active_workspace" '.[] | select(.workspace.id == ($ws | tonumber)) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
+  local ws="$1"
+  [[ -z "$ws" ]] && ws=$(get_active_workspace)
+  hyprctl monitors -j | jq -r --arg ws "$ws" '.[] | select(.activeWorkspace.id == ($ws | tonumber)) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"'
+  hyprctl clients -j | jq -r --arg ws "$ws" '.[] | select(.workspace.id == ($ws | tonumber)) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
 }
 
 get_fullscreen_rect() {
   local ws="$1"
-  # Try multiple field shapes for robustness across Hyprland versions:
   hyprctl clients -j | jq -r --arg ws "$ws" '
-    # prefer explicit .fullscreen==true
-    (.[] | select(.workspace.id == ($ws|tonumber) and (.fullscreen == true)) |
-      "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])")
-    //
-    # some versions expose numeric fullscreen state(s)
-    (.[] | select(.workspace.id == ($ws|tonumber) and ((.fullscreen|type=="number") and (.fullscreen==2))) |
-      "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])")
-    //
-    # fallback if a tuple-like fullscreenstate exists (internal/client 0/1/2/3)
-    (.[] | select(.workspace.id == ($ws|tonumber) and (.fullscreenstate? and ((.fullscreenstate[0]==2) or (.fullscreenstate[1]==2)))) |
-      "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])")
-  ' | head -n1
+    first(
+      .[]
+      | select(.workspace.id == ($ws | tonumber))
+      | select(
+          (.fullscreen == true)
+          or ((.fullscreen | type == "number") and (.fullscreen == 2))
+          or (.fullscreenstate? and ((.fullscreenstate[0] == 2) or (.fullscreenstate[1] == 2)))
+        )
+      | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"
+    ) // empty
+  '
 }
+
+ACTIVE_WORKSPACE=$(get_active_workspace 2>/dev/null)
 
 # Select based on mode
 case "$MODE" in
@@ -48,17 +53,16 @@ case "$MODE" in
   windows)
     wayfreeze & PID=$!
     sleep .1
-    SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
+    SELECTION=$(get_rectangles "$ACTIVE_WORKSPACE" | slurp -r 2>/dev/null)
     kill $PID 2>/dev/null
     ;;
   fullscreen)
     SELECTION=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"')
     ;;
   smart|*)
-    RECTS=$(get_rectangles)
-
-    active_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id')
-    FS_RECT=$(get_fullscreen_rect "$active_workspace")
+    active_workspace_local="${ACTIVE_WORKSPACE:-$(get_active_workspace)}"
+    RECTS=$(get_rectangles "$active_workspace_local")
+    [[ -n "$active_workspace_local" ]] && FS_RECT=$(get_fullscreen_rect "$active_workspace_local")
 
     wayfreeze & PID=$!
     sleep .1


### PR DESCRIPTION
When taking a screenshot with a fullscreen window active, slurp outlines all windows on the workspace including those hidden behind the fullscreen app.

**Before:**
<img width="2560" height="1440" alt="screenshot-2025-10-31_12-38-18" src="https://github.com/user-attachments/assets/29b01db4-f25e-41cc-8eb6-5ac862df1e2e" />

<img width="2560" height="1440" alt="screenshot-2025-10-31_12-35-46" src="https://github.com/user-attachments/assets/5943de92-45fd-4a8d-ba4f-1251108569c1" />

<img width="2560" height="1440" alt="screenshot-2025-10-31_12-31-01" src="https://github.com/user-attachments/assets/5ab16c6f-7b6c-4588-a43e-3864e75e9aca" />


**After:**
<img width="2560" height="1440" alt="screenshot-2025-10-31_12-33-25" src="https://github.com/user-attachments/assets/829a94f1-8218-490f-bb65-5ff6bcefd6e0" />

<img width="2560" height="1440" alt="screenshot-2025-10-31_12-40-44" src="https://github.com/user-attachments/assets/e8104259-68af-4730-b15a-f568a7c7b4ed" />

This fix detects fullscreen windows and only passes that window to slurp for outlining, preventing visual clutter while preserving normal outline behavior when no window is fullscreen.