### PR TITLE
Add tmux theme switching support

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -42,3 +42,8 @@ omarchy-theme-set-obsidian
 
 # Call hook on theme set
 omarchy-hook theme-set "$THEME_NAME"
+
+# Reload tmux to apply new theme (exact same as prefix+r)
+if command -v tmux >/dev/null 2>&1 && tmux list-sessions >/dev/null 2>&1; then
+  tmux source-file ~/.tmux.conf \; display-message "Omarchy theme: $THEME_NAME"
+fi

--- a/themes/catppuccin-latte/tmux.conf
+++ b/themes/catppuccin-latte/tmux.conf
@@ -1,0 +1,23 @@
+# Catppuccin Latte (Light) Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#eff1f5,fg=#4c4f69"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#1e66f5,fg=#eff1f5,bold"
+set -g window-status-style "bg=#ccd0da,fg=#4c4f69"
+
+# Pane borders
+set -g pane-border-style "fg=#dce0e8"
+set -g pane-active-border-style "fg=#1e66f5"
+
+# Message text
+set -g message-style "bg=#ccd0da,fg=#1e66f5"
+
+# Popup styling
+set -g popup-style "bg=#eff1f5,fg=#4c4f69"
+set -g popup-border-style "fg=#1e66f5"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#4c4f69,bg=#eff1f5]%a%l:%M:%S %p#[default] #[fg=#1e66f5]%Y-%m-%d'

--- a/themes/catppuccin/tmux.conf
+++ b/themes/catppuccin/tmux.conf
@@ -1,0 +1,23 @@
+# Catppuccin (Mocha) Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#181824,fg=#cdd6f4"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#89b4fa,fg=#181824,bold"
+set -g window-status-style "bg=#313244,fg=#cdd6f4"
+
+# Pane borders
+set -g pane-border-style "fg=#45475a"
+set -g pane-active-border-style "fg=#89b4fa"
+
+# Message text
+set -g message-style "bg=#313244,fg=#89b4fa"
+
+# Popup styling
+set -g popup-style "bg=#181824,fg=#cdd6f4"
+set -g popup-border-style "fg=#89b4fa"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#cdd6f4,bg=#181824]%a%l:%M:%S %p#[default] #[fg=#89b4fa]%Y-%m-%d'

--- a/themes/everforest/tmux.conf
+++ b/themes/everforest/tmux.conf
@@ -1,0 +1,23 @@
+# Everforest Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#2d353b,fg=#d3c6aa"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#a7c080,fg=#2d353b,bold"
+set -g window-status-style "bg=#374145,fg=#d3c6aa"
+
+# Pane borders
+set -g pane-border-style "fg=#4a555b"
+set -g pane-active-border-style "fg=#a7c080"
+
+# Message text
+set -g message-style "bg=#374145,fg=#a7c080"
+
+# Popup styling
+set -g popup-style "bg=#2d353b,fg=#d3c6aa"
+set -g popup-border-style "fg=#a7c080"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#d3c6aa,bg=#2d353b]%a%l:%M:%S %p#[default] #[fg=#a7c080]%Y-%m-%d'

--- a/themes/flexoki-light/tmux.conf
+++ b/themes/flexoki-light/tmux.conf
@@ -1,0 +1,23 @@
+# Flexoki Light Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#FFFCF0,fg=#100F0F"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#205EA6,fg=#FFFCF0,bold"
+set -g window-status-style "bg=#F2F0E5,fg=#100F0F"
+
+# Pane borders
+set -g pane-border-style "fg=#CECDC3"
+set -g pane-active-border-style "fg=#205EA6"
+
+# Message text
+set -g message-style "bg=#F2F0E5,fg=#205EA6"
+
+# Popup styling
+set -g popup-style "bg=#FFFCF0,fg=#100F0F"
+set -g popup-border-style "fg=#205EA6"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#100F0F,bg=#FFFCF0]%a%l:%M:%S %p#[default] #[fg=#205EA6]%Y-%m-%d'

--- a/themes/gruvbox/tmux.conf
+++ b/themes/gruvbox/tmux.conf
@@ -1,0 +1,23 @@
+# Gruvbox Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#282828,fg=#d4be98"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#d8a657,fg=#282828,bold"
+set -g window-status-style "bg=#3c3836,fg=#d4be98"
+
+# Pane borders
+set -g pane-border-style "fg=#504945"
+set -g pane-active-border-style "fg=#d8a657"
+
+# Message text
+set -g message-style "bg=#3c3836,fg=#d8a657"
+
+# Popup styling
+set -g popup-style "bg=#282828,fg=#d4be98"
+set -g popup-border-style "fg=#d8a657"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#d4be98,bg=#282828]%a%l:%M:%S %p#[default] #[fg=#d8a657]%Y-%m-%d'

--- a/themes/kanagawa/tmux.conf
+++ b/themes/kanagawa/tmux.conf
@@ -1,0 +1,23 @@
+# Kanagawa Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#1f1f28,fg=#dcd7ba"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#7e9cd8,fg=#1f1f28,bold"
+set -g window-status-style "bg=#2a2a37,fg=#dcd7ba"
+
+# Pane borders
+set -g pane-border-style "fg=#54546d"
+set -g pane-active-border-style "fg=#7e9cd8"
+
+# Message text
+set -g message-style "bg=#2a2a37,fg=#7e9cd8"
+
+# Popup styling
+set -g popup-style "bg=#1f1f28,fg=#dcd7ba"
+set -g popup-border-style "fg=#7e9cd8"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#dcd7ba,bg=#1f1f28]%a%l:%M:%S %p#[default] #[fg=#7e9cd8]%Y-%m-%d'

--- a/themes/matte-black/tmux.conf
+++ b/themes/matte-black/tmux.conf
@@ -1,0 +1,23 @@
+# Matte Black Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#1e1e1e,fg=#8a8a8d"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#569cd6,fg=#1e1e1e,bold"
+set -g window-status-style "bg=#2d2d30,fg=#8a8a8d"
+
+# Pane borders
+set -g pane-border-style "fg=#3e3e42"
+set -g pane-active-border-style "fg=#569cd6"
+
+# Message text
+set -g message-style "bg=#2d2d30,fg=#569cd6"
+
+# Popup styling
+set -g popup-style "bg=#1e1e1e,fg=#8a8a8d"
+set -g popup-border-style "fg=#569cd6"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#8a8a8d,bg=#1e1e1e]%a%l:%M:%S %p#[default] #[fg=#569cd6]%Y-%m-%d'

--- a/themes/nord/tmux.conf
+++ b/themes/nord/tmux.conf
@@ -1,0 +1,23 @@
+# Nord Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#2e3440,fg=#d8dee9"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#88c0d0,fg=#2e3440,bold"
+set -g window-status-style "bg=#3b4252,fg=#d8dee9"
+
+# Pane borders
+set -g pane-border-style "fg=#4c566a"
+set -g pane-active-border-style "fg=#88c0d0"
+
+# Message text
+set -g message-style "bg=#3b4252,fg=#88c0d0"
+
+# Popup styling
+set -g popup-style "bg=#2e3440,fg=#d8dee9"
+set -g popup-border-style "fg=#88c0d0"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#d8dee9,bg=#2e3440]%a%l:%M:%S %p#[default] #[fg=#88c0d0]%Y-%m-%d'

--- a/themes/osaka-jade/tmux.conf
+++ b/themes/osaka-jade/tmux.conf
@@ -1,0 +1,23 @@
+# Osaka Jade Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#11221C,fg=#e6d8ba"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#4fd6be,fg=#11221C,bold"
+set -g window-status-style "bg=#1a2e27,fg=#e6d8ba"
+
+# Pane borders
+set -g pane-border-style "fg=#2d4a3e"
+set -g pane-active-border-style "fg=#4fd6be"
+
+# Message text
+set -g message-style "bg=#1a2e27,fg=#4fd6be"
+
+# Popup styling
+set -g popup-style "bg=#11221C,fg=#e6d8ba"
+set -g popup-border-style "fg=#4fd6be"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#e6d8ba,bg=#11221C]%a%l:%M:%S %p#[default] #[fg=#4fd6be]%Y-%m-%d'

--- a/themes/ristretto/tmux.conf
+++ b/themes/ristretto/tmux.conf
@@ -1,0 +1,23 @@
+# Ristretto Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#2c2525,fg=#e6d9db"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#ac7f84,fg=#2c2525,bold"
+set -g window-status-style "bg=#3a3232,fg=#e6d9db"
+
+# Pane borders
+set -g pane-border-style "fg=#524a4a"
+set -g pane-active-border-style "fg=#ac7f84"
+
+# Message text
+set -g message-style "bg=#3a3232,fg=#ac7f84"
+
+# Popup styling
+set -g popup-style "bg=#2c2525,fg=#e6d9db"
+set -g popup-border-style "fg=#ac7f84"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#e6d9db,bg=#2c2525]%a%l:%M:%S %p#[default] #[fg=#ac7f84]%Y-%m-%d'

--- a/themes/rose-pine/tmux.conf
+++ b/themes/rose-pine/tmux.conf
@@ -1,0 +1,23 @@
+# Rose Pine (Dawn) Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#faf4ed,fg=#575279"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#286983,fg=#faf4ed,bold"
+set -g window-status-style "bg=#f2e9e1,fg=#575279"
+
+# Pane borders
+set -g pane-border-style "fg=#dfdad9"
+set -g pane-active-border-style "fg=#286983"
+
+# Message text
+set -g message-style "bg=#f2e9e1,fg=#286983"
+
+# Popup styling
+set -g popup-style "bg=#faf4ed,fg=#575279"
+set -g popup-border-style "fg=#286983"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#575279,bg=#faf4ed]%a%l:%M:%S %p#[default] #[fg=#286983]%Y-%m-%d'

--- a/themes/tokyo-night/tmux.conf
+++ b/themes/tokyo-night/tmux.conf
@@ -1,0 +1,23 @@
+# Tokyo Night Tmux Theme
+# Automatically sourced by ~/.tmux.conf
+
+# Status bar colors
+set -g status-style "bg=#1a1b26,fg=#cdd6f4"
+
+# Active/inactive window styling
+set -g window-status-current-style "bg=#7aa2f7,fg=#1a1b26,bold"
+set -g window-status-style "bg=#24283b,fg=#cdd6f4"
+
+# Pane borders
+set -g pane-border-style "fg=#414868"
+set -g pane-active-border-style "fg=#7aa2f7"
+
+# Message text
+set -g message-style "bg=#24283b,fg=#7aa2f7"
+
+# Popup styling
+set -g popup-style "bg=#1a1b26,fg=#cdd6f4"
+set -g popup-border-style "fg=#7aa2f7"
+
+# Status bar content (keeping user's format, themed colors)
+set -g status-right '#[fg=#cdd6f4,bg=#1a1b26]%a%l:%M:%S %p#[default] #[fg=#7aa2f7]%Y-%m-%d'


### PR DESCRIPTION
This PR adds automatic theme switching for tmux, matching the existing pattern used for terminal emulators (alacritty, kitty, ghostty).

## Changes

**bin/omarchy-theme-set**
- Added tmux reload after theme changes
- Uses `command -v tmux` instead of hardcoded path to work with all installations (pacman, Homebrew, source builds)
- Only reloads if tmux is installed and has active sessions

**themes/*/tmux.conf** (12 files)
- Added tmux theme files for all existing themes
- Follows the same structure as other terminal emulator theme files
- Configures status bar, pane borders, popups, and messages

## User setup

Users add one line to their `~/.tmux.conf`:

```bash
source-file ~/.config/omarchy/current/theme/tmux.conf
```

The symlink at `~/.config/omarchy/current/theme/tmux.conf` points to the active theme, same as alacritty.toml, kitty.conf, etc.

## Implementation notes

The reload mechanism is similar to kitty (`killall -SIGUSR1`) and ghostty (`killall -SIGUSR2`). For tmux, we call `source-file` which is the equivalent of the user's manual reload keybind (typically prefix+r).

Originally tried using `/usr/bin/tmux` directly but that fails for Homebrew installations where tmux lives in `/home/linuxbrew/.linuxbrew/bin/`. Using `command -v` fixes this.

## Testing

Tested on Omarchy with both pacman and Homebrew tmux installations. Theme switching works immediately, tmux displays "Omarchy theme: [theme-name]" on change.

---

**Diff stats:**
- 1 file changed (omarchy-theme-set): +5 lines
- 12 files added (theme tmux.conf files): ~275 lines total