### PR TITLE
Add interactive calendar tooltip to Waybar clock

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -61,7 +61,8 @@
   "clock": {
     "format": "{:L%A %H:%M}",
     "format-alt": "{:L%d %B W%V %Y}",
-    "locale": "en_GB.UTF-8", // week start on Monday
+    // "locale": "en_GB.UTF-8", // force locale to start week on Monday
+                                // sudo localectl set-locale LC_TIME=en_GB.UTF-8 && sudo locale-gen
     "tooltip-format": "<tt><small>{calendar}</small></tt>",
     "calendar": {
       "mode": "month",


### PR DESCRIPTION
## Summary
- Added interactive calendar tooltip to Waybar clock module
- Tooltip displays current month with color-coded calendar elements
- Middle click switches between month and year view
- Mouse wheel scrolls through months and years
- Week numbers displayed on the right side

## Details
The clock module now has an interactive calendar tooltip with:
- **Month headers**: Beige/cream colored
- **Days**: Light pink text
- **Week numbers**: Cyan with bold formatting (right side)
- **Weekdays**: Yellow/gold headers
- **Today's date**: Pink with underline and bold

Configuration implemented using Waybar Clock module documentation:
https://github.com/Alexays/Waybar/wiki/Module:-Clock#style

More info about setting locale vars:
https://github.com/Alexays/Waybar/discussions/3072#discussioncomment-8952079

Month view:
<img width="208" height="165" alt="image" src="https://github.com/user-attachments/assets/b15d2a30-b951-4a0a-ba49-1ab9bd3c7f41" />

Year view:
<img width="526" height="497" alt="image" src="https://github.com/user-attachments/assets/eee03f1d-6c6c-41fc-b86b-bab198c6970a" />
