### PR TITLE
Remove "[AUR]" from Gemini install option in menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -287,7 +287,7 @@ show_install_ai_menu() {
       echo ollama
   )
 
-  case $(menu "Install" "󱚤  Claude Code\n󱚤  Cursor CLI [AUR]\n󱚤  Gemini [AUR]\n󱚤  OpenAI Codex\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
+  case $(menu "Install" "󱚤  Claude Code\n󱚤  Cursor CLI [AUR]\n󱚤  Gemini\n󱚤  OpenAI Codex\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
   *Claude*) install "Claude Code" "claude-code" ;;
   *Cursor*) aur_install "Cursor CLI" "cursor-cli" ;;
   *OpenAI*) install "OpenAI Codex" "openai-codex-bin" ;;


### PR DESCRIPTION
The `gemini-cli` package [was merged into the extra repo](https://archlinux.org/packages/extra/x86_64/gemini-cli/) a week ago. It's no longer in the AUR, so it should no longer be marked as such.