### PR TITLE
Add Binding to move window out of scratchpad

### DIFF
--- a/bin/omarchy-hyprland-window-move-scratchpad-to-active-workspace
+++ b/bin/omarchy-hyprland-window-move-scratchpad-to-active-workspace
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+monitors=$(hyprctl monitors -j)
+
+# Check if current workspace is special:scratchpad
+special_ws_name=$(echo $monitors | jq -r '.[] | select(.focused) | .specialWorkspace.name')
+if [[ "$special_ws_name" != "special:scratchpad" ]]; then
+  exit 1
+fi
+
+# Get active workspace ID of the focused monitor
+current_ws=$(echo $monitors | jq '.[] | select(.focused) | .activeWorkspace.id')
+
+# Move the focused window to the active workspace
+hyprctl dispatch movetoworkspacesilent "$current_ws"

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -41,6 +41,7 @@ bindd = SUPER SHIFT, code:18, Move window to workspace 9, movetoworkspace, 9
 # Control scratchpad
 bindd = SUPER, S, Toggle scratchpad, togglespecialworkspace, scratchpad
 bindd = SUPER ALT, S, Move window to scratchpad, movetoworkspacesilent, special:scratchpad
+bindd = SUPER SHIFT ALT, S, Move window to current workspace, exec, omarchy-hyprland-window-move-scratchpad-to-active-workspace
 
 # TAB between workspaces
 bindd = SUPER, TAB, Next workspace, workspace, e+1


### PR DESCRIPTION
PR #2669 adds support for special scratchpad workspace. This PR adds binding to move window out of scratchpad workspace if needed.