### PR TITLE
Fix: adjust battery monitor logic to prevent warning on every boot

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -11,7 +11,7 @@ send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
 }
 
-if [[ $BATTERY_STATE == "discharging" && $BATTERY_LEVEL -le $BATTERY_THRESHOLD ]]; then
+if [[ $BATTERY_STATE == "discharging" && $BATTERY_LEVEL -le $BATTERY_THRESHOLD && "$BATTERY_LEVEL" != "" ]]; then
   if [[ ! -f $NOTIFICATION_FLAG ]]; then
     send_notification $BATTERY_LEVEL
     touch $NOTIFICATION_FLAG


### PR DESCRIPTION
Several users reported that the “Time to charge!” battery warning appears on every boot, even when the battery is not low.

This issue occurs because omarchy-battery-remaining returns an empty value early in the boot process.
This patch adds a simple check to skip sending the notification if the returned value is empty.