### PR TITLE
Make DaVinci Resolve dialog windows only close explicitely.

### DIFF
--- a/default/hypr/apps/davinci-resolve.conf
+++ b/default/hypr/apps/davinci-resolve.conf
@@ -1,0 +1,2 @@
+# Focus floating DaVinci Resolve dialog windows
+windowrule = stayfocused, class:.*[Rr]esolve.*, floating:1


### PR DESCRIPTION
## Summary 
This PR fixes a usability issue where DaVinci Resolve dialog windows cannot be interacted.

### Problem 
DaVinci Resolve dialog windows immediately close without cursor hover due to issues with DaVinci Resolve using XWayland. 

### Solution 
Add specific window rule for `resolve` class floating windows, forcing them to stay open before user closes them with mouse click outside the dialog window or by pressing corresponding UI elements.

**Testing**
- Verified that the dialog windows do not close immediately and work as expected. 
- Verified that the added window rule does not affect overall user experience.

**Related Issue** 
#3062

**Before** 
https://github.com/user-attachments/assets/10d09643-dd67-4110-b243-e6090083f618

**After**
https://github.com/user-attachments/assets/f23659d0-c1f3-465f-aa97-4050750d19be