### PR TITLE
Make omarchy-launch-editor check that setted $EDITOR exists

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-case "${EDITOR:-nvim}" in
+omarchy-cmd-present "$EDITOR" || EDITOR=nvim
+
+case "$EDITOR" in
 nvim | vim | nano | micro | hx | helix)
   exec setsid uwsm-app -- "$TERMINAL" -e "$EDITOR" "$@"
   ;;


### PR DESCRIPTION
Fixes #1955 

Check that $EDITOR is a real command and back up to nvim if it's not.