### PR TITLE
added command line options to run omarchy-update non-interactively

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -4,15 +4,36 @@ set -e
 
 trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR
 
-gum style --border normal --border-foreground 6 --padding "1 2" --margin "1 0" \
-  "Ready to update Omarchy?" \
-  "" \
-  "• You cannot stop the update once you start!" \
-  "• Make sure you're not on battery power or have sufficient charge"
 
-if ! gum confirm --default=false "Continue with update?"; then
-  echo "Update cancelled"
-  exit 0
+OPTIND=1 #reset in case getopts has been used previously
+
+interactive=1
+
+while getopts ":y" opt; do
+  case "$opt" in
+    y)
+       interactive=0
+       ;;
+    \?)
+       echo "invalid option: -${OPTARG}" >&2
+       exit 1
+       ;;
+  esac
+done
+
+shift $((OPTIND-1)) #clear all processed options
+
+if [[ "$interactive" -eq 1 ]]; then
+  gum style --border normal --border-foreground 6 --padding "1 2" --margin "1 0" \
+    "Ready to update Omarchy?" \
+    "" \
+    "• You cannot stop the update once you start!" \
+    "• Make sure you're not on battery power or have sufficient charge"
+
+  if ! gum confirm --default=false "Continue with update?"; then
+    echo "Update cancelled"
+    exit 0
+  fi
 fi
 
 omarchy-snapshot create || [ $? -eq 127 ]


### PR DESCRIPTION
I my opinion it should be possible to run omarchy-update without the interactive reminder at the start. To that end I added the command-line option "-y" (for "yes") for non-interactive mode which skips the initial gum dialog. This is implemented using the  getopts utility.