### PR TITLE
Align mako font with other apps

### DIFF
--- a/default/mako/core.ini
+++ b/default/mako/core.ini
@@ -5,7 +5,7 @@ outer-margin=20
 padding=10,15
 border-size=2
 max-icon-size=32
-font=sans-serif 14px
+font=Caskaydia Mono Nerd Font
 
 [app-name=Spotify]
 invisible=1


### PR DESCRIPTION
Hello,

Unless I'm missing something, the specified mako font is inconsistent with the rest of omarchy. 
This fixes that :)

<img width="948" height="505" alt="image" src="https://github.com/user-attachments/assets/19bbc5ff-90b6-4406-8c5a-2271f74cfbcb" />
