### PR TITLE
Add progressbar trough color variable for swayosd

### DIFF
--- a/config/swayosd/style.css
+++ b/config/swayosd/style.css
@@ -23,6 +23,10 @@ progressbar {
   border-radius: 0;
 }
 
+trough {
+  background-color: @trough;
+}
+
 progress {
   background-color: @progress;
 }

--- a/themes/catppuccin-latte/swayosd.css
+++ b/themes/catppuccin-latte/swayosd.css
@@ -3,3 +3,4 @@
 @define-color label #4c4f69;
 @define-color image #4c4f69;
 @define-color progress #4c4f69;
+@define-color trough #9ea0af;

--- a/themes/catppuccin/swayosd.css
+++ b/themes/catppuccin/swayosd.css
@@ -3,3 +3,4 @@
 @define-color label #cad3f5;
 @define-color image #cad3f5;
 @define-color progress #cad3f5;
+@define-color trough #777d98;

--- a/themes/everforest/swayosd.css
+++ b/themes/everforest/swayosd.css
@@ -3,4 +3,4 @@
 @define-color label #d3c6aa;
 @define-color image #d3c6aa;
 @define-color progress #d3c6aa;
-
+@define-color trough #807e73;

--- a/themes/flexoki-light/swayosd.css
+++ b/themes/flexoki-light/swayosd.css
@@ -3,3 +3,4 @@
 @define-color label #100F0F;
 @define-color image #100F0F;
 @define-color progress #100F0F;
+@define-color trough #888680;

--- a/themes/gruvbox/swayosd.css
+++ b/themes/gruvbox/swayosd.css
@@ -3,4 +3,4 @@
 @define-color label #ebdbb2;
 @define-color image #ebdbb2;
 @define-color progress #ebdbb2;
-
+@define-color trough #8a826d;

--- a/themes/kanagawa/swayosd.css
+++ b/themes/kanagawa/swayosd.css
@@ -3,4 +3,4 @@
 @define-color label #dcd7ba;
 @define-color image #dcd7ba;
 @define-color progress #dcd7ba;
-
+@define-color trough #7e7b71;

--- a/themes/matte-black/swayosd.css
+++ b/themes/matte-black/swayosd.css
@@ -3,4 +3,4 @@
 @define-color label #8A8A8D;
 @define-color image #8A8A8D;
 @define-color progress #8A8A8D;
-
+@define-color trough #4E4E50;

--- a/themes/nord/swayosd.css
+++ b/themes/nord/swayosd.css
@@ -3,4 +3,4 @@
 @define-color label #D8DEE9;
 @define-color image #D8DEE9;
 @define-color progress #D8DEE9;
-
+@define-color trough #838995;

--- a/themes/osaka-jade/swayosd.css
+++ b/themes/osaka-jade/swayosd.css
@@ -3,3 +3,4 @@
 @define-color label #C0C396;
 @define-color image #C0C396;
 @define-color progress #C0C396;
+@define-color trough #697359;

--- a/themes/ristretto/swayosd.css
+++ b/themes/ristretto/swayosd.css
@@ -3,3 +3,4 @@
 @define-color label #c3b7b8;
 @define-color image #c3b7b8;
 @define-color progress #c3b7b8;
+@define-color trough #786e6f;

--- a/themes/rose-pine/swayosd.css
+++ b/themes/rose-pine/swayosd.css
@@ -3,4 +3,4 @@
 @define-color label #575279;
 @define-color image #575279;
 @define-color progress #575279;
-
+@define-color trough #a9a3b3;

--- a/themes/tokyo-night/swayosd.css
+++ b/themes/tokyo-night/swayosd.css
@@ -3,4 +3,4 @@
 @define-color label #a9b1d6;
 @define-color image #a9b1d6;
 @define-color progress #a9b1d6;
-
+@define-color trough #62667e;


### PR DESCRIPTION
Currently swayosd progressbar has a gray background (called `trough` in swayosd) in every theme and it doesn't always look great.

This change makes `trough` themeable and adds trough colors for all default themes. The default colors are generated as midpoints between previously defined background and progress colors.

Attached are before and after examples for cobalt2 theme. Extra themes will need to define `@trough` in swayosd.css, or the progressbar will appear with the same background as the window background.

<img width="419" height="111" alt="image" src="https://github.com/user-attachments/assets/a63baf09-2390-47bc-9bbc-9cfb4846e15c" />
<img width="419" height="111" alt="image" src="https://github.com/user-attachments/assets/c7544f5a-8409-4d6d-a968-2efe09245919" />
