### PR TITLE
Fix HDR omarchy-cmd-screenshot

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -51,30 +51,27 @@ get_rectangles() {
 
 # Select based on mode
 case "$MODE" in
-region)
-  wayfreeze &
-  PID=$!
-  sleep .1
-  SELECTION=$(slurp 2>/dev/null)
-  kill $PID 2>/dev/null
-  ;;
-windows)
-  wayfreeze &
-  PID=$!
-  sleep .1
-  SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
-  kill $PID 2>/dev/null
-  ;;
-fullscreen)
-  SELECTION=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"')
-  ;;
-smart | *)
-  RECTS=$(get_rectangles)
-  wayfreeze &
-  PID=$!
-  sleep .1
-  SELECTION=$(echo "$RECTS" | slurp 2>/dev/null)
-  kill $PID 2>/dev/null
+  region)
+    hyprpicker -r -z >/dev/null 2>&1 & PID=$!
+    sleep .1
+    SELECTION=$(slurp 2>/dev/null)
+    kill $PID 2>/dev/null
+    ;;
+  windows)
+    hyprpicker -r -z >/dev/null 2>&1 & PID=$!
+    sleep .1
+    SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
+    kill $PID 2>/dev/null
+    ;;
+  fullscreen)
+    SELECTION=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"')
+    ;;
+  smart|*)
+    RECTS=$(get_rectangles)
+    hyprpicker -r -z >/dev/null 2>&1 & PID=$!
+    sleep .1
+    SELECTION=$(echo "$RECTS" | slurp 2>/dev/null)
+    kill $PID 2>/dev/null
 
   # If the selection area is L * W < 20, we'll assume you were trying to select whichever
   # window or output it was inside of to prevent accidental 2px snapshots

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -133,7 +133,6 @@ unzip
 usage
 uwsm
 waybar
-wayfreeze
 whois
 wireless-regdb
 wiremix

--- a/migrations/1762156000.sh
+++ b/migrations/1762156000.sh
@@ -1,0 +1,3 @@
+echo "Drop wayfreeze as hyprpicker replaces its function"
+
+omarchy-pkg-drop wayfreeze


### PR DESCRIPTION
### Summary

  - Switch the screenshot command over to hyprpicker so the selection overlay renders correctly on HDR monitors
  - Remove the legacy wayfreeze dependency from the base package manifest
  - Add migration 1762156000.sh to drop wayfreeze installs

### Notes 
- Compatible with [2953](https://github.com/basecamp/omarchy/pull/2953) and [3015](https://github.com/basecamp/omarchy/pull/3015)
- Satty Save as (Ctrl+Shift+S) not working is related to Satty, see: [#332](https://github.com/Satty-org/Satty/issues/332) and [152](https://github.com/Satty-org/Satty/issues/152)