### PR TITLE
Fix class name for Microsoft Edge in browser.conf

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -1,5 +1,5 @@
 # Browser types
-windowrule = tag +chromium-based-browser, class:((google-)?[cC]hrom(e|ium)|[bB]rave-browser|Microsoft-edge|Vivaldi-stable|helium)
+windowrule = tag +chromium-based-browser, class:((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)
 windowrule = tag +firefox-based-browser, class:([fF]irefox|zen|librewolf)
 
 # Force chromium-based browsers into a tile to deal with --app bug


### PR DESCRIPTION
note: I was also considering adding edge web apps to the browser detection, but as chrome web apps weren't there yet, I think it's intended behaviour for web apps to be excluded. https://github.com/patroza/omarchy/pull/1