### PR TITLE
Add system language option to update menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -387,13 +387,14 @@ show_remove_menu() {
 }
 
 show_update_menu() {
-  case $(menu "Update" " Omarchy\n  Config\n󰸌  Extra Themes\n  Process\n󰇅  Hardware\n  Firmware\n  Password\n  Timezone\n  Time") in
+  case $(menu "Update" " Omarchy\n  Config\n󰸌  Extra Themes\n  Process\n󰇅  Hardware\n  Firmware\n  Password\n  Language\n  Timezone\n  Time") in
   *Omarchy*) present_terminal omarchy-update ;;
   *Config*) show_update_config_menu ;;
   *Themes*) present_terminal omarchy-theme-update ;;
   *Process*) show_update_process_menu ;;
   *Hardware*) show_update_hardware_menu ;;
   *Firmware*) present_terminal omarchy-update-firmware ;;
+  *Language*) present_terminal omarchy-update-language ;;
   *Timezone*) present_terminal omarchy-tz-select ;;
   *Time*) present_terminal omarchy-update-time ;;
   *Password*) show_update_password_menu ;;

--- a/bin/omarchy-update-language
+++ b/bin/omarchy-update-language
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Select a locale to enable
+selected=$(
+    grep -E '^[#]?[[:alnum:]_]+\.[[:alnum:]_-]+' /etc/locale.gen | \
+    sed 's/^#//' | \
+    gum filter --height 20 --header "Select locale to enable"
+) || exit 1
+
+# Comment out all locales and uncomment the chosen one to ensure Waybar displays time correctly
+sudo sed -i 's/^[^#]/#&/; s|^#\s*'"$selected"'|'"$selected"'|' /etc/locale.gen
+
+sudo locale-gen
+
+default_lang=${selected%% *}
+echo "System language is now set to $default_lang"
+echo "LANG=$default_lang" | sudo tee /etc/locale.conf >/dev/null
+
+# Restart waybar with new LANG
+env LANG="$default_lang" omarchy-restart-waybar


### PR DESCRIPTION
This PR adds a system language change option to the update menu, similar to the existing timezone option. When a new language is selected, Waybar restarts automatically to apply it immediately.

I’m not entirely sure if a full reboot or additional steps are required for the change to fully take effect, but this makes the option visible and functional in the menu.