### PR TITLE
Prompt adornment in Nix env.

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -1,6 +1,6 @@
 add_newline = true
 command_timeout = 200
-format = "[$directory$git_branch$git_status]($style)$character"
+format = "[$directory$git_branch$git_status$nix_shell]($style)$character"
 
 [character]
 error_symbol = "[✗](bold cyan)"
@@ -30,3 +30,9 @@ stashed    = ""
 staged     = ""
 renamed    = ""
 deleted    = ""
+
+[nix_shell]
+format = '$symbol [$name(@$pkg_version)]($style) '
+style  = "cyan"
+symbol = "[](blue)"
+heuristic = true


### PR DESCRIPTION
Helpful indicator that you are working in a Nix shell env.
<img width="664" height="250" alt="image" src="https://github.com/user-attachments/assets/3b81fc4a-ab3f-4151-a5ff-610ddad2ce1d" />

Not shown - when the package version is set, it will render as such: `shell-name@1.2.3`