### PR TITLE
QoL Nit: Render scratchpad workspace slightly differently

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -15,3 +15,8 @@ windowrule = opacity 1 1, class:^(zoom|vlc|mpv|org.kde.kdenlive|com.obsproject.S
 
 # Popped window rounding
 windowrule = rounding 8, tag:pop
+
+# Scratchpad slides in, no gaps or borders to make obvious it's special
+windowrule = opacity 0.95 0.7, onworkspace:special:scratchpad
+workspace = special:scratchpad, gapsout:0, gapsin:0, bordersize:0
+animation = specialWorkspace, 1, 7, default, slidevert


### PR DESCRIPTION
**"Problem"**: I have lots of monitors/workspaces and sometimes I will bring up the scratchpad (which is great), and forget that it's the scratchpad, leading to some weird mistakes on my part

**"Solution"**: Slightly tweak the scratchpad workspace and window rules to remove the gap, borders, opacity - so I can obviously see that it's the scratchpad and not get confused with one of my other 12 workspaces. Plus a nice slide in and out, since why not - another little visual hint that says "hey, this is not your display's workspace".

_Like the title says, **super minor** QoL thing that has helped me, your mileage may vary._

https://github.com/user-attachments/assets/34726c13-0efc-4d0a-ac37-0182ab63c5ce

