### PR TITLE
Scale with the right monitor

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -327,7 +327,7 @@ To stop: omarchy-windows-vm stop"
     "$LIFECYCLE"
 
   # Detect display scale from Hyprland
-  HYPR_SCALE=$(hyprctl monitors -j | jq -r '.[0].scale')
+  HYPR_SCALE=$(hyprctl monitors -j | jq -r '.[] | select (.focused == true) | .scale')
   SCALE_PERCENT=$(echo "$HYPR_SCALE" | awk '{print int($1 * 100)}')
 
   RDP_SCALE=""


### PR DESCRIPTION
`omarchy-windows-vm` take the first monitor from `hyprtctl monitors` instead of the active one.

This PR choose the active monitor instead.