### PR TITLE
feat: tee screensaver automatically loads screen refresh rate

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -16,6 +16,8 @@ trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
 hyprctl keyword cursor:invisible true &>/dev/null
 
 framerate=$(hyprctl monitors -j | jq -r '.[0].refreshRate' | cut -d. -f1)
+# default frame rate set 60
+if [ -z "$framerate" ]; then framerate=60; fi
 
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)


### PR DESCRIPTION
The default 240 will cause high CPU usage during screensaver, and my laptop fan will be noisy, which is not very friendly in the office, and some monitors only have a maximum frame rate of 60 frames per second