### PR TITLE
Fix screensaver animation offset between effects

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -18,8 +18,8 @@ hyprctl keyword cursor:invisible true &>/dev/null
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)
   tte -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 240 --canvas-width 0 --canvas-height $(($(tput lines) - 2)) --anchor-canvas c --anchor-text c \
-    "$effect" &
+    --frame-rate 240 --canvas-width 0 --canvas-height 0 --anchor-canvas c --anchor-text c \
+    --no-eol "$effect" &
 
   while pgrep -x tte >/dev/null; do
     if read -n 1 -t 3 || ! screensaver_in_focus; then


### PR DESCRIPTION
## Problem
The screensaver animations were offsetting upward after each effect completed.

## Solution
- Added `--no-eol` flag to the `tte` command to suppress the trailing newline emitted after each animation
- Changed canvas height from `$(tput lines) - 2` to `0` for automatic terminal height detection

## Testing
Verified that animations now transition cleanly without offset between effects.