### PR TITLE
Feature: Heroic Games Launcher (for Epic Games) to the Omarchy > Install > Gaming Menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -301,8 +301,9 @@ show_install_ai_menu() {
 }
 
 show_install_gaming_menu() {
-  case $(menu "Install" "  Steam\n  RetroArch [AUR]\n󰍳  Minecraft") in
+  case $(menu "Install" "  Steam\n  Heroic Games Launcher\n  RetroArch [AUR]\n󰍳  Minecraft") in
   *Steam*) present_terminal omarchy-install-steam ;;
+  *"Heroic Games Launcher"*) aur_install_and_launch "Heroic Games Launcher" "heroic-games-launcher" "com.heroicgameslauncher.hgl" ;;
   *RetroArch*) aur_install_and_launch "RetroArch" "retroarch retroarch-assets libretro libretro-fbneo" "com.libretro.RetroArch.desktop" ;;
   *Minecraft*) install_and_launch "Minecraft" "minecraft-launcher" "minecraft-launcher" ;;
   *) show_install_menu ;;


### PR DESCRIPTION
When first installing omarchy i had to find a way to be able to play rocket league or an Epic Games Launcher equivalent for linux. This seemed like the most straight forward option. Heroic can handle as an equivalent for Epic Games, GOG, and Prime games

For more info on the app:
https://heroicgameslauncher.com/

Lutris could also be another option.

https://www.reddit.com/r/linux_gaming/comments/1ipqtel/what_are_the_pros_and_cons_of_lutris_vs_heroic/ 

<img width="501" height="416" alt="image" src="https://github.com/user-attachments/assets/b56e3c76-227e-4a14-8d98-fbee86fceed7" />
