### PR TITLE
Use AAC audio codec for screen recordings

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -62,7 +62,7 @@ start_screenrecording() {
   # Merge audio tracks into one - separate tracks only play one at a time in most players
   [[ "$AUDIO" == "true" ]] && audio_args="-a default_output|default_input"
 
-  gpu-screen-recorder -w "$@" -f 60 -c mp4 -o "$filename" $audio_args &
+  gpu-screen-recorder -w "$@" -f 60 -c mp4 $audio_args -ac aac -o "$filename" &
   toggle_screenrecording_indicator
 }
 


### PR DESCRIPTION
AAC provides better cross-platform compatibility compared to Opus (the default codec for `gpu-screen-recorder`) when using MP4 containers. While Opus is supported in MP4, compatibility varies across different media players and platforms.

In testing, screen recordings with Opus codec sent to Windows users played without audio in Windows Media Player, while recordings with AAC codec worked immediately without issues. 

AAC ensures recordings are playable out-of-the-box across all platforms without requiring recipients of Omarchy screen recordings to install additional codecs or use alternative media players.