### PR TITLE
Add installation option for GitHub Copilot CLI

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -296,6 +296,7 @@ show_install_ai_menu() {
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;
   *opencode*) install "opencode" "opencode" ;;
+  *Copilot*) install "Github Copilot CLI" "github-copilot-cli" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
Added an installation option for the GIthub Copilot CLI under the Install -> AI menu.

https://aur.archlinux.org/packages/github-copilot-cli
https://github.com/features/copilot/cli