### PR TITLE
Update Helium browser in omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -3,7 +3,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium.desktop*) ;;
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 


### PR DESCRIPTION
The correct name for helium is `helium.desktop` instead of `helium-desktop`.
I updated the `omarchy-launch-webapp` command to launch helium correctly if it is set to your default browser.

see https://github.com/basecamp/omarchy/pull/1945#discussion_r2401957283

<img width="908" height="224" alt="image" src="https://github.com/user-attachments/assets/ce1a82db-0dd8-4473-a08d-4e542a7e45bb" />
