### PR TITLE
Add binding to invoke last mako notification

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -18,6 +18,7 @@ bindd = SUPER SHIFT, BACKSPACE, Toggle workspace gaps, exec, omarchy-hyprland-wo
 bindd = SUPER, COMMA, Dismiss last notification, exec, makoctl dismiss
 bindd = SUPER SHIFT, COMMA, Dismiss all notifications, exec, makoctl dismiss --all
 bindd = SUPER CTRL, COMMA, Toggle silencing notifications, exec, makoctl mode -t do-not-disturb && makoctl mode | grep -q 'do-not-disturb' && notify-send "Silenced notifications" || notify-send "Enabled notifications"
+bindd = SUPER ALT, COMMA, Invoke last notification, exec, makoctl invoke
 
 # Toggle idling
 bindd = SUPER CTRL, I, Toggle locking on idle, exec, omarchy-toggle-idle


### PR DESCRIPTION
This additional bind lets the user follow the default action of a notification with a keystroke in the same position `,` as the other notification binds.

The binding is placed in the same section as the other mako / notification bindings.