### PR TITLE
Fix: hard-coded binding for changegroupactive

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -93,8 +93,8 @@ bindd = SUPER ALT, mouse_down, Next window in group, changegroupactive, f
 bindd = SUPER ALT, mouse_up, Previous window in group, changegroupactive, b
 
 # Activate window in a group by number
-bindd = SUPER ALT, 1, Switch to group window 1, changegroupactive, 1
-bindd = SUPER ALT, 2, Switch to group window 2, changegroupactive, 2
-bindd = SUPER ALT, 3, Switch to group window 3, changegroupactive, 3
-bindd = SUPER ALT, 4, Switch to group window 4, changegroupactive, 4
-bindd = SUPER ALT, 5, Switch to group window 5, changegroupactive, 5
+bindd = SUPER ALT, code:10, Switch to group window 1, changegroupactive, 1
+bindd = SUPER ALT, code:11, Switch to group window 2, changegroupactive, 2
+bindd = SUPER ALT, code:12, Switch to group window 3, changegroupactive, 3
+bindd = SUPER ALT, code:13, Switch to group window 4, changegroupactive, 4
+bindd = SUPER ALT, code:14, Switch to group window 5, changegroupactive, 5


### PR DESCRIPTION
Changed default bindings for switching to a window in a group. The original values did not respect different keyboard layouts.

This change only makes these bindings more consistent with other default bindings that rely on numeric keys. 