### PR TITLE
fix: use xdg-terminal-exec in TUI installer for terminal compatibility

### DIFF
--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -43,7 +43,7 @@ cat >"$DESKTOP_FILE" <<EOF
 Version=1.0
 Name=$APP_NAME
 Comment=$APP_NAME
-Exec=\$TERMINAL --class=$APP_CLASS -e $APP_EXEC
+Exec=xdg-terminal-exec --app-id=$APP_CLASS -e $APP_EXEC
 Terminal=false
 Type=Application
 Icon=$ICON_PATH


### PR DESCRIPTION
Replace hardcoded --class flag with xdg-terminal-exec --app-id to properly support kitty and other terminals. This aligns with the rest of the codebase and ensures floating window rules work correctly across different terminals.

Otherwise TUIs weren't floating windows ever when using with kitty or similar terminal apps