### PR TITLE
Fix XWayland Window Positioning Issues

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -7,5 +7,17 @@ windowrule = opacity 0.97 0.9, class:.*
 # Fix some dragging issues with XWayland
 windowrule = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0
 
+# Fix XWayland dialogs/splash/utility windows appearing in awkward positions by floating and centering them (except menus/tooltips)
+xwayland {
+    force_zero_scaling = false # careful with mixing scaling wayland and x11
+}
+
+# dialogs/splash/utility ONLY
+windowrulev2 = float,  xwayland:1, windowtype:^(dialog|splash|utility)$
+windowrulev2 = center, xwayland:1, windowtype:^(dialog|splash|utility)$
+
+# never center menus/tooltips
+windowrulev2 = tile,   xwayland:1, windowtype:^(popup_menu|dropdown_menu|tooltip)$
+
 # App-specific tweaks
 source = ~/.local/share/omarchy/default/hypr/apps.conf


### PR DESCRIPTION
# Fix XWayland Window Positioning Issues

## Problem
Legacy X11 applications running on Wayland via XWayland often spawn dialog boxes, splash screens, and utility windows in awkward or off-screen positions, creating a frustrating user experience.

## Solution
This PR adds window rules to automatically handle XWayland window positioning:

- Float and center dialog boxes, splash screens, and utility windows for easy access
- Preserve normal behavior for menus and tooltips, allowing them to appear at cursor position
- Configure XWayland scaling behavior to prevent conflicts between Wayland and X11 scaling

## Changes Made

### XWayland Configuration
- Added `xwayland` configuration block with `force_zero_scaling = false`

### Window Rules
- Added `windowrulev2` rules to float and center specific XWayland window types
- Added exception rules to prevent menus and tooltips from being affected

## Testing
- [x] Test with legacy X11 applications that use dialog boxes (e.g., older Qt/GTK apps, Java applications)
- [x] Verify dialogs appear centered and accessible
- [x] Ensure menus and tooltips still appear at cursor position
- [x] Check that scaling behavior works correctly across different DPI settings