### PR TITLE
Modify clipboard copy binding for Zed application

### DIFF
--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -1,5 +1,8 @@
 # Copy / Paste
-bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert,
+bindd = SUPER, C, Universal copy, exec, \
+       sh -c 'case $(hyprctl activewindow -j | jq -r .class) in \
+              Zed) zed --uri "zed:copy" ;; \
+              *) ydotool key Ctrl+Insert ;; esac'
 bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert,
 bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X,
 bindd = SUPER CTRL, V, Clipboard manager, exec, omarchy-launch-walker -m clipboard


### PR DESCRIPTION
Updated clipboard bindings to make universal copy work on Zed editor.