### PR TITLE
Fix: Add missing fullscreen keybind to tiling.conf

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -10,6 +10,7 @@ bindd = SUPER, J, Toggle window split, togglesplit, # dwindle
 bindd = SUPER, P, Pseudo window, pseudo, # dwindle
 bindd = SUPER SHIFT, V, Toggle window floating/tiling, togglefloating,
 bindd = SHIFT, F11, Force full screen, fullscreen, 0
+bindd = SUPER, F, Full screen, fullscreen, 1
 bindd = ALT, F11, Full width, fullscreen, 1
 
 # Move focus with SUPER + arrow keys


### PR DESCRIPTION
This PR adds the keybind for toggling fullscreen (SUPER + F), which was missing from the tiling.conf file.

I understand there is tiling-v2.conf which i believe is the version 2 but the bindd = SUPER, F, Full screen, fullscreen, 0  was non-functional or maybe it was not being loaded well