### PR TITLE
Fix: adjust windowrule regex for pip to avoid Hyprland parsing error

### DIFF
--- a/default/hypr/apps/pip.conf
+++ b/default/hypr/apps/pip.conf
@@ -1,5 +1,5 @@
 # Picture-in-picture overlays
-windowrule = tag +pip, title:(Picture.{0,1}in.{0,1}[Pp]icture)
+windowrule = tag +pip, title:(Picture.?in.?[Pp]icture)
 windowrule = float, tag:pip
 windowrule = pin, tag:pip
 windowrule = size 600 338, tag:pip


### PR DESCRIPTION
## Fix windowrule regex parsing in Hyprland
**Problem:**
The previous regex line in `pip.conf`:

`windowrule = tag +pip, title:(Picture.{0,1}in.{0,1}[Pp]icture)`

caused a parsing error in recent versions of Hyprland:

<img width="1390" height="77" alt="image" src="https://github.com/user-attachments/assets/c9ebd816-2954-458d-988e-7409ad498a5b" />


**Solution:**
Replaced `{0,1}` with `?`, which is equivalent in regex and compatible with Hyprland's parser:
