### PR TITLE
Update pip.conf, fix Invalid rule/parameter errors after hyprland update

### DIFF
--- a/default/hypr/apps/pip.conf
+++ b/default/hypr/apps/pip.conf
@@ -1,5 +1,5 @@
 # Picture-in-picture overlays
-windowrule = tag +pip, title:(Picture.{0,1}in.{0,1}[Pp]icture)
+windowrule = tag +pip, title:(Picture.?in.?[Pp]icture)
 windowrule = float, tag:pip
 windowrule = pin, tag:pip
 windowrule = size 600 338, tag:pip


### PR DESCRIPTION
Updated hyprland throws Invalid rule / Invalid parameter on the pip windowrule; reported in  #3254 