### PR TITLE
Rename hyprland-qtutils to hyprland-guiutils

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -45,7 +45,7 @@ gvfs-nfs
 gvfs-smb
 hypridle
 hyprland
-hyprland-qtutils
+hyprland-guiutils
 hyprlock
 hyprpicker
 hyprsunset


### PR DESCRIPTION
The package has been renamed upstream.

Fixes #3257.