### PR TITLE
Feature: OAuth picker for walker

### DIFF
--- a/bin/omarchy-oauth-menu
+++ b/bin/omarchy-oauth-menu
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+SECRETS_FILE="$HOME/.totp"
+
+if [[ ! -f "$SECRETS_FILE" ]]; then
+    notify-send "Error" "$SECRETS_FILE not found"
+    exit 1
+fi
+
+CHOICE=$(awk '{print $1}' "$SECRETS_FILE" | walker --dmenu -p "OAuth account:")
+
+if [[ -n "$CHOICE" ]]; then
+    SECRET=$(awk -v acc="$CHOICE" '$1 == acc {print $2}' "$SECRETS_FILE")
+
+    if [[ -n "$SECRET" ]]; then
+        CODE=$(oathtool --totp -b "$SECRET" 2>/dev/null)
+
+        if [[ -n "$CODE" ]]; then
+            echo -n "$CODE" | wl-copy
+            notify-send "TOTP Code Copied" "$CHOICE: $CODE"
+        else
+            notify-send "Error" "Failed to generate TOTP for $CHOICE"
+        fi
+    else
+        notify-send "Error" "No secret found for $CHOICE"
+    fi
+else
+    notify-send "Cancelled" "No account selected"
+fi


### PR DESCRIPTION
OAuth is necessary but annoying to work with most of the time.

This PR adds a small script that lets you pick an OAuth/TOTP account from a .totp  file using walker --dmenu. Once you select an account, it generates the current TOTP code and copies it to your clipboard.


**Depends on**
oathtool (oath-toolkit)

**How it works:**
Type in your OAuth code into the .totp file in your home directory like so:

```
github SKDFHWOEFKH
microsoft KSAJDFHSDSDFKJ
google KJSGHKSDJFHHJDS
```

Shows all account names from your secrets file in walker's dmenu
Generates a 6-digit TOTP code with oathtool from your selection
Copies the code to the clipboard
Sends a confirmation notification with the name and code or an error message

My personal keybinding is SUPER CONTROL, O (OAuth)

**Why this is useful:**
It makes accessing TOTP codes super easy without having to open a seperate app, pull out your phone, etc.



<img width="1920" height="1080" alt="screenshot-2025-11-09_21-42-01" src="https://github.com/user-attachments/assets/2780c3e2-a071-492a-90f9-d63ec2967eef" />

If this is of interest I can integrate with the menu under Setup > Security > OAuth