### PR TITLE
feat: new icon for connected bluetooth waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -99,7 +99,7 @@
   "bluetooth": {
     "format": "",
     "format-disabled": "󰂲",
-    "format-connected": "",
+    "format-connected": "!",
     "tooltip-format": "Devices connected: {num_connections}",
     "on-click": "blueberry"
   },


### PR DESCRIPTION
## The problem:
I didn't know if I was connected to my bluetooth buds without opening blueberry.

## Solution:
I just added "!" symbol to connected bluetooth so it's possible to easily see if you're connected or not.