### PR TITLE
Add `usage` to base packages

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -119,6 +119,7 @@ tzupdate
 ufw
 ufw-docker
 unzip
+usage
 uwsm
 waybar
 wayfreeze


### PR DESCRIPTION
# Add `usage` CLI

## What

Add [`usage`](https://github.com/jdx/usage) to the base package list.

## Why

The `usage` CLI is required for `mise` tab completions to work.

## Comment

I've tested this on my side, and `usage` does not appear to conflict with the distribution's completion setup.
