### PR TITLE
Dynamically set hyprlock font and placeholder text

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -18,6 +18,7 @@ if [[ -n "$font_name" && "$font_name" != "CNCLD" ]]; then
       pkill -SIGUSR2 ghostty
     fi
 
+    sed -i "s/font_family = .*/font_family = $font_name/g" ~/.config/hypr/hyprlock.conf
     sed -i "s/font-family: .*/font-family: '$font_name';/g" ~/.config/waybar/style.css
     sed -i "s/font-family: .*/font-family: '$font_name';/g" ~/.config/swayosd/style.css
     xmlstarlet ed -L \

--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -51,6 +51,16 @@ EOF
   fi
 }
 
+add_hyprlock_fingerprint_icon() {
+  print_info "Adding fingerprint icon to hyprlock placeholder text..."
+  sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰈷 <\/span>/' ~/.config/hypr/hyprlock.conf
+}
+
+remove_hyprlock_fingerprint_icon() {
+  print_info "Removing fingerprint icon from hyprlock placeholder text..."
+  sed -i 's/placeholder_text = .*/placeholder_text = Enter Password/' ~/.config/hypr/hyprlock.conf
+}
+
 remove_pam_config() {
   # Remove from sudo
   if grep -q pam_fprintd.so /etc/pam.d/sudo; then
@@ -71,6 +81,9 @@ if [[ "--remove" == "$1" ]]; then
   # Remove PAM configuration
   remove_pam_config
 
+  # Remove fingerprint icon from hyprlock placeholder text
+  remove_hyprlock_fingerprint_icon
+
   # Uninstall packages
   print_info "Removing fingerprint packages..."
   sudo pacman -Rns --noconfirm fprintd
@@ -89,6 +102,9 @@ else
 
   # Configure PAM
   setup_pam_config
+
+  # Add fingerprint icon to hyprlock placeholder text
+  add_hyprlock_fingerprint_icon
 
   # Enroll first fingerprint
   print_success "\nLet's setup your right index finger as the first fingerprint."

--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -22,10 +22,10 @@ input-field {
     outer_color = $outer_color
     outline_thickness = 4
 
-    font_family = CaskaydiaMono Nerd Font Propo
+    font_family = CaskaydiaMono Nerd Font
     font_color = $font_color
 
-    placeholder_text = Enter Password 󰈷
+    placeholder_text = Enter Password
     check_color = $check_color
     fail_text = <i>$FAIL ($ATTEMPTS)</i>
 

--- a/migrations/1762684663.sh
+++ b/migrations/1762684663.sh
@@ -1,0 +1,12 @@
+echo "Update hyprlock font to match current system font"
+
+font_name=$(omarchy-font-current)
+
+if [[ -n "$font_name" ]]; then
+  cp ~/.config/hypr/hyprlock.conf ~/.config/hypr/hyprlock.conf.bak.$(date +%s)
+
+  echo "Found font '$font_name', updating hyprlock"
+  sed -i "s/font_family = .*/font_family = $font_name/g" ~/.config/hypr/hyprlock.conf
+else
+  echo "No font found, skipping migration"
+fi

--- a/migrations/1762685081.sh
+++ b/migrations/1762685081.sh
@@ -1,0 +1,12 @@
+echo "Update hyprlock placeholder text based on fingerprint setup status"
+
+cp ~/.config/hypr/hyprlock.conf ~/.config/hypr/hyprlock.conf.bak.$(date +%s)
+
+# Check if fprintd is installed and has enrolled fingerprints
+if command -v fprintd-list &>/dev/null && fprintd-list "$USER" 2>/dev/null | grep -q "Fingerprints for user"; then
+  echo "Fingerprint detected, updating placeholder text with fingerprint icon"
+  sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰈷 <\/span>/' ~/.config/hypr/hyprlock.conf
+else
+  echo "No fingerprint enrolled, updating placeholder text without fingerprint icon"
+  sed -i 's/placeholder_text = .*/placeholder_text = Enter Password/' ~/.config/hypr/hyprlock.conf
+fi


### PR DESCRIPTION
Currently, hyprlock has a fixed font, and its placeholder text always includes the fingerprint icon even if fingerprint auth isn't setup.

This PR fixes this by:
1. Updating `omarchy-font-set` to change the hyprlock font
2. Updating `omarchy-setup-fingerprint` to add/remove the fingerprint icon from the hyprlock placeholder text

Dynamic font demo:

https://github.com/user-attachments/assets/c9254852-d7b0-449d-aba9-8ced00ab097d

Dynamic fingerprint icon demo:

https://github.com/user-attachments/assets/c4eb70a3-eb83-4df5-8332-c47ad84c7b41
