### PR TITLE
Fix: Restore former window fullscreen state after screensaver exit

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -24,32 +24,44 @@ hypr_focus_monitor() {
   hyprctl dispatch "hl.dsp.focus({ monitor = \"$1\" })" >/dev/null 2>&1 || hyprctl dispatch focusmonitor "$1" >/dev/null
 }
 
-hypr_exec() {
-  local command="$1"
+hypr_exec_ws() {
+  local workspace="$1"
+  local command="$2"
 
-  hyprctl dispatch "hl.dsp.exec_cmd([[$command]])" >/dev/null 2>&1 || hyprctl dispatch exec -- bash -lc "$command" >/dev/null
+  hyprctl dispatch "hl.dsp.exec_cmd([[[workspace special:$workspace] $command]])" >/dev/null 2>&1 ||
+    hyprctl dispatch exec "[workspace special:$workspace] $command" >/dev/null
 }
 
+# Launch Screensaver on each monitor in a unique special workspace
 for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
   hypr_focus_monitor "$m"
 
   case $terminal in
   *Alacritty*)
-    hypr_exec "alacritty --class=org.omarchy.screensaver --config-file ~/.local/share/omarchy/default/alacritty/screensaver.toml -e omarchy-screensaver"
+    hypr_exec_ws "screensaver-$m" "alacritty --class=org.omarchy.screensaver --config-file ~/.local/share/omarchy/default/alacritty/screensaver.toml -e omarchy-screensaver"
     ;;
   *ghostty*)
-    hypr_exec "ghostty --class=org.omarchy.screensaver --config-file=~/.local/share/omarchy/default/ghostty/screensaver --font-size=18 -e omarchy-screensaver"
+    hypr_exec_ws "screensaver-$m" "ghostty --class=org.omarchy.screensaver --config-file=~/.local/share/omarchy/default/ghostty/screensaver --font-size=18 -e omarchy-screensaver"
     ;;
   *foot*)
-    hypr_exec "foot --app-id=org.omarchy.screensaver --config=\"$OMARCHY_PATH/default/foot/screensaver.ini\" -e omarchy-screensaver"
+    hypr_exec_ws "screensaver-$m" "foot --app-id=org.omarchy.screensaver --config=\"$OMARCHY_PATH/default/foot/screensaver.ini\" -e omarchy-screensaver"
     ;;
   *kitty*)
-    hypr_exec "kitty --class=org.omarchy.screensaver --override font_size=18 --override window_padding_width=0 -e omarchy-screensaver"
+    hypr_exec_ws "screensaver-$m" "kitty --class=org.omarchy.screensaver --override font_size=18 --override window_padding_width=0 -e omarchy-screensaver"
     ;;
   *)
     notify-send -u low "✋  Screensaver only runs in Alacritty, Foot, Ghostty, or Kitty"
     ;;
   esac
+
+  # Switch to monitor-specific special workspace to display screensaver
+  hyprctl dispatch togglespecialworkspace "screensaver-$m"
 done
 
+# Close special workspaces
+for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
+  hyprctl dispatch togglespecialworkspace "screensaver-$m"
+done
+
+# Return focus to original monitor
 hypr_focus_monitor "$focused"


### PR DESCRIPTION
# Summary

Addresses #3218 by @rmusaev99.

Currently the fullscreen launch of the screensaver will override any former full-screen windows and will not return them to their state upon closing.

## Changes:

* Capture the former window and full-screen status
* Upon shutdown, revert focus to the prior window and restore full-screen status (1 and 2)
* Added null-safe jq defaults (`//`) to try and prevent any errors from launching screensaver from blank workspaces.

## Testing

I was able to test the individual commands using my custom instance of Hyprland on a laptop, but I was not able to get an instance of Omarchy running in a VM. Would be very appreciative if someone could test the changes on their own instance. Happy to make whatever tweaks are required to confirm this works on single-monitor and multi-monitor systems as well as small taste-related code changes.

## Other Approach
I have also experimented with the idea of forcing the screensaver to run on uniquely-named special workspaces, such as iterating over all monitors and running:
```bash
hyprctl dispatch togglespecialworkspace "screensaver-${MONITOR-NAME}"
```
This way, there is no conflict or need for reverting the state of any former windows on teardown. If this is something that would like to be looked into, I would be happy to make additional changes or open another PR.

