### PR TITLE
prevent multiple impala terminal instances

### DIFF
--- a/bin/omarchy-launch-wifi
+++ b/bin/omarchy-launch-wifi
@@ -1,3 +1,18 @@
 #!/bin/bash
 
-exec setsid uwsm-app -- xdg-terminal-exec --app-id=com.omarchy.Impala -e impala "$@"
+APP_ID="com.omarchy.Impala"
+CMD="impala"
+
+# Find existing instance PID
+PID=$(pgrep -f "$CMD")
+
+if [ -n "$PID" ]; then
+  echo "Instance already running (PID: $PID). Focusing..."
+  uwsm-client focus "$APP_ID" 2>/dev/null || \
+  xdotool search --class "Impala" windowactivate 2>/dev/null || \
+  echo "Unable to focus existing window."
+else
+  echo "No instance found. Launching new one..."
+  exec setsid uwsm-app -- xdg-terminal-exec --app-id="$APP_ID" -e "$CMD" "$@"
+fi
+


### PR DESCRIPTION
Added a single-instance check to the Omarchy Wi-Fi launcher script.
The script now verifies if an impala instance with app-id com.omarchy.Impala
is already running using `uwsm-client list`. If found, it exits gracefully
without spawning a duplicate process.

**Before:**

<img width="2567" height="1401" alt="screenshot-2025-11-09_21-55-08" src="https://github.com/user-attachments/assets/0e5f67d6-0f4f-4f79-a1d4-185637d0cacf" />

[**Relate iusse:**](https://github.com/basecamp/omarchy/issues/3287#issue-3605933813)

**After:** 

https://github.com/user-attachments/assets/cf332047-fd42-4cb3-81bd-492ffda36164

