### PR TITLE
Use the scaling for the current monitor when opening Omarchy-Windows

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -327,7 +327,7 @@ To stop: omarchy-windows-vm stop"
     "$LIFECYCLE"
 
   # Detect display scale from Hyprland
-  HYPR_SCALE=$(hyprctl monitors -j | jq '.[] | select(.focused == true) | .scale')
+  HYPR_SCALE=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .scale')
   SCALE_PERCENT=$(echo "$HYPR_SCALE" | awk '{print int($1 * 100)}')
 
   RDP_SCALE=""


### PR DESCRIPTION
Added a jq filter to select the scaling factor for the currently active monitor. 

For multi-monitor users where screens can have different scales this will open the RDP client in a scale suitable for that screen. Tested while running monitors displays as well as with one. 