### PR TITLE
Replace removed qt5-remoteobjects with qt6-remoteobjects

### DIFF
--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -35,7 +35,7 @@ pipewire
 pipewire-alsa
 pipewire-jack
 pipewire-pulse
-qt5-remoteobjects
+qt6-remoteobjects
 qt6-wayland
 sassc
 snapper


### PR DESCRIPTION
Use `qt6-remoteobjects` since `qt5-remoteobjects` has been removed from the official repositories.