### PR TITLE
fix update not cancelling

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+omarchy-update-confirm
+if [ $? -ne 0 ]; then
+  exit 0
+fi
+
 set -e
 
 trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR
 
-omarchy-update-confirm
 omarchy-snapshot create || [ $? -eq 127 ]
 omarchy-update-git
 omarchy-update-perform

--- a/bin/omarchy-update-confirm
+++ b/bin/omarchy-update-confirm
@@ -10,5 +10,5 @@ gum style --border normal --border-foreground 6 --padding "1 2" \
 
 if ! gum confirm "Continue with update?"; then
   echo "Update cancelled"
-  exit 0
+  exit 1
 fi


### PR DESCRIPTION
This should take care of #3301 as the update script wasn´t cancelling when declined. We move the confirmation up so it doens´t fall in the trap and also change the return code from the `omarchy-update-confirm` script