### PR TITLE
Fix screenrecord not saving

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -62,7 +62,10 @@ start_screenrecording() {
   # Merge audio tracks into one - separate tracks only play one at a time in most players
   [[ "$AUDIO" == "true" ]] && audio_args="-a default_output|default_input"
 
-  gpu-screen-recorder -w "$@" -f 60 -c mp4 -o "$filename" $audio_args &
+  if ! gpu-screen-recorder -w "$@" -f 60 -c mp4 -o "$filename" $audio_args 2>&1 & then
+      echo "Primary GPU encoding failed. Falling back to CPU encoder..."
+      gpu-screen-recorder -encoder cpu -w "$@" -f 60 -c mp4 -o "$filename" $audio_args 2>&1 &
+  fi
   toggle_screenrecording_indicator
 }
 


### PR DESCRIPTION
I had problem with screenrecord.
It seems like it worked, even when i stopped i get notification that recording is stopped and saved, but it was empty.
<img width="1824" height="1499" alt="Pasted image" src="https://github.com/user-attachments/assets/c6a047fe-ef6a-4b3d-9a28-52ba258c3dae" />
<img width="1442" height="1544" alt="image" src="https://github.com/user-attachments/assets/1c45d2c5-2f3d-45f2-ad8a-aff29b1e8337" />

I debug it, and this is log:
<img width="2197" height="1171" alt="image" src="https://github.com/user-attachments/assets/028165e1-d6e4-4e82-932d-b8f497f72582" />

After my changes:
<img width="2188" height="1941" alt="image" src="https://github.com/user-attachments/assets/6a9f169c-4926-41c1-9358-6f7c715233a2" />



So it uses default command bat if that fails it goes to next which fixed my problem.
If I get it right this problem is connected to NVIDIA gpu.
