### PR TITLE
Add turn off keyboard backlight

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -20,3 +20,9 @@ listener {
     on-timeout = hyprctl dispatch dpms off                   # screen off when timeout has passed
     on-resume = hyprctl dispatch dpms on && brightnessctl -r # screen on when activity is detected
 }
+
+listener {
+  timeout = 330                                            # 5.5min
+    on-timeout = brightnessctl -d '*::kbd_backlight' set 0 # turn off keyboard backlight
+    on-resume = brightnessctl -d '*::kbd_backlight' set 2  # turn on keyboard backlight
+}


### PR DESCRIPTION
Laptop keyboard have backlight turned on all the time, even Omarchy is locked and screen is off.

It is set that keyboard backlight turn off when screen is off (after 5.5 minutes).
It turns back on when some key or touchpad is pressed.