### PR TITLE
omarchy-open

### DIFF
--- a/bin/omarchy-open
+++ b/bin/omarchy-open
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -eEo pipefail
+
+# Omarchy cli launcher: open applications, files, or URLs
+#  Launches $1 with $2+ as arguments
+#
+#  $1 can be:
+#    - A url (dispatched to xdg-open)
+#    - A file (dispatched to xdg-open)
+#    - A directory (dispatched to xdg-open, should open file manager)
+#    - A command (executed directly)
+#    - A .desktop file (launched with uwsm-app)
+#
+#  If $1 is not found, we will search through $XDG_DATA_DIRS for .desktop files or $PATH for executables
+#
+#  Uses uwsm-app for proper wayland session management.
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <app|url|file> [args...]"
+  exit 1
+fi
+
+target=$1
+shift
+
+launch_app() {
+  echo -e "\e[32mLaunching app:\e[0m $*" >&2
+  exec setsid uwsm-app -- "$@"
+}
+
+launch_cli() {
+  echo -e "\e[32mLaunching cli:\e[0m $*" >&2
+  exec "$@"
+}
+
+# Check if it's a URL (http://, https://, file://, etc.)
+if [[ "$target" =~ ^[a-z][a-z0-9+.-]*:// ]]; then
+  launch_app xdg-open "$target" "$@"
+fi
+
+# If open was called on an existing file or directory..
+if [ -e "$target" ]; then
+  target=$(realpath "$target")
+
+  # ... if its not executable (e.g. mp4, mp3, etc.) delegate to xdg-open
+  if [ ! -x "$target" ]; then
+    launch_app xdg-open "$target" "$@"
+  fi
+
+  # ... if it's a directory, delegate to xdg-open
+  if [ -d "$target" ]; then
+    launch_app xdg-open "$target" "$@"
+  fi
+
+  # ... if it's a .desktop file, launch it
+  if [[ "$target" == *.desktop && -f "$target" ]]; then
+    launch_app "$target" "$@"
+  fi
+
+  # ... if we get here, and its executable, just launch it in shell
+  if [[ -x "$target" ]]; then
+    launch_cli "$target" "$@"
+  fi
+fi
+
+# Search $XDG_DATA_HOME + all $XDG_DATA_DIRS for applications to launch
+xdg_data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+IFS=: read -ra search_dirs <<< "$xdg_data_home:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+
+# Search for .desktop file in XDG directories
+for dir in "${search_dirs[@]}"; do
+  if [ -d "$dir/applications" ]; then
+    desktop_file=$(find $dir/applications -maxdepth 1 -iname "${target}*.desktop" 2>/dev/null | head -1)
+    if [ -n "$desktop_file" ]; then
+      launch_app "$desktop_file" "$@"
+    fi
+  fi
+done
+
+# If still not found, try as command name in PATH
+if command -v "$target" &>/dev/null; then
+  launch_cli "$target" "$@"
+fi
+
+# Give up if nothing found
+echo -e "\e[31mError:\e[0m Application not found: $target"
+exit 1
+


### PR DESCRIPTION
Omarchy could use something like apple's open, a generic way that cli
users can use to start desktop apps, urls, directories, or files using
their XDG default players.

Currently supports as parameters:
  - url (dispatched to xdg-open)
  - files (.wav, .mp4, *) (dispatched to xdg-open)
  - directory (dispatched to xdg-open, opens file-manager)
  - terminal commands (executed directly)
  - .desktop files (launched with uwsm-app)

```bash
tobi ~ ❯❯❯ omarchy-open .
Launching app: xdg-open /home/tobi

tobi ~ ❯❯❯ omarchy-open Videos/screenrecording-2025-11-10_12-02-17.mp4
Launching app: xdg-open /home/tobi/Videos/screenrecording-2025-11-10_12-02-17.mp4

tobi ~ ❯❯❯ omarchy-open hey
Launching app: /home/tobi/.local/share/applications/HEY.desktop
```

It also searches through XDG directories for applications to launch. Examples: `omarchy-launch hey" will find the .desktop in /home/user/.local/share/applications/HEY.desktop and execute that. 

I personally find this script useful, merge if you like it. I `alias open=omarchy-open` on my system.
