### PR TITLE
Fix: Jetbrains popup dialog would not get focus automatically

### DIFF
--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -1,18 +1,18 @@
 # Fix splash screen showing in weird places and prevent annoying focus takeovers
-windowrule = tag +jb-splash, class:^(jetbrains-.*)$, title:^(splash)$, floating:1
-windowrule = center, tag:jb-splash
-windowrule = nofocus, tag:jb-splash
-windowrule = noborder, tag:jb-splash
+windowrule = tag +jetbrains-splash, class:^(jetbrains-.*)$, title:^(splash)$, floating:1
+windowrule = center, tag:jetbrains-splash
+windowrule = nofocus, tag:jetbrains-splash
+windowrule = noborder, tag:jetbrains-splash
 
 # Center popups/find windows
-windowrule = tag +jb, class:^(jetbrains-.*), title:^()$, floating:1
-windowrule = center, tag:jb
+windowrule = tag +jetbrains, class:^(jetbrains-.*), title:^()$, floating:1
+windowrule = center, tag:jetbrains
 
-# Enabling this makes it impossible to provide input to any popup dialogue (search window, new file, etc.)
-windowrule = stayfocused, tag:jb
-windowrule = noborder, tag:jb
+# Enabling this makes it possible to provide input in popup dialogs (search window, new file, etc.)
+windowrule = stayfocused, tag:jetbrains
+windowrule = noborder, tag:jetbrains
 
-# For some reason tag:jb does not work for size rule
+# For some reason tag:jetbrains does not work for size rule
 windowrule = size >50% >50%, class:^(jetbrains-.*), title:^()$, floating:1
 
 # Disable window flicker when autocomplete or tooltips appear


### PR DESCRIPTION
This PR fix regression caused by https://github.com/basecamp/omarchy/pull/2899.
It also fix a scaling issues on `Find in Files` popups.

The config shipped with omarchy misbehaves with popups. Opening a popup
would not shift the focus automatically to it, requiring manual click on
it to start typing into it.

You can reproduce with by trying to open any popup dialog (for example
CTRL+T on Rider, or CTRL+SHIFT+F)

This config with `-Dawt.toolkit.name=WLToolkit` in the custom VM options
fixes all the issues I have with jetbrains. 

Second, I changed the size rule from `50% 50%` to `>50% >50%` to fix a scaling
issue that you will see on the third popup of this video (Find in Files).

https://github.com/user-attachments/assets/45958d8a-1e81-40f3-915d-ef2fd7927e6f

@AdamMusa could you try this on your setup to make sure I didn't break anything on Android Studio?