### PR TITLE
Update terminal binding to use --dir option

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -2,7 +2,7 @@
 $terminal = uwsm-app -- xdg-terminal-exec
 $browser = omarchy-launch-browser
 
-bindd = SUPER, RETURN, Terminal, exec, $terminal --working-directory="$(omarchy-cmd-terminal-cwd)"
+bindd = SUPER, RETURN, Terminal, exec, $terminal --dir="$(omarchy-cmd-terminal-cwd)"
 bindd = SUPER SHIFT, F, File manager, exec, uwsm-app -- nautilus --new-window
 bindd = SUPER SHIFT, B, Browser, exec, $browser
 bindd = SUPER SHIFT ALT, B, Browser (private), exec, $browser --private


### PR DESCRIPTION
In basecamp@4c97a31, a migration was added to fix this option on existing installs, but I think the default config was never updated with the new option.