### PR TITLE
Change qt5-remoteobjects to qt6-remoteobjects

### DIFF
--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -35,7 +35,7 @@ pipewire
 pipewire-alsa
 pipewire-jack
 pipewire-pulse
-qt5-remoteobjects
+qt6-remoteobjects
 qt6-wayland
 sassc
 snapper


### PR DESCRIPTION
I was trying to use omarchy-iso to build a custom image and was failing due to q5-remoteobjects not found, searching found that qt5-remoteobjects was removed so I upgraded to qt6, not sure if needs more editing but the ISO was built successfully.

https://archlinux.org/packages/extra/x86_64/qt5-remoteobjects/