### PR TITLE
Add NVIDIA Container Toolkit for Docker GPU support

### DIFF
--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -77,4 +77,12 @@ env = LIBVA_DRIVER_NAME,nvidia
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
   fi
+  # Install NVIDIA Container Toolkit for Docker GPU support
+  sudo pacman -S --needed --noconfirm nvidia-container-toolkit
+
+  # Configure Docker to use NVIDIA runtime
+  sudo nvidia-ctk runtime configure --runtime=docker
+
+  # Restart Docker to apply changes
+  sudo systemctl restart docker
 fi


### PR DESCRIPTION
### Problem
Omarchy currently installs Docker and NVIDIA drivers automatically, but doesn't configure Docker to use the GPU. Users have to manually install and configure `nvidia-container-toolkit` after installation.

### Solution
This PR automatically installs and configures the NVIDIA Container Toolkit when an NVIDIA GPU is detected, enabling GPU-accelerated Docker containers out of the box.

### Changes
- Added `nvidia-container-toolkit` installation to `nvidia.sh`
- Configured Docker runtime to recognize NVIDIA GPU