### PR TITLE
Feature: added config options for nightlight

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -210,11 +210,12 @@ show_setup_power_menu() {
 }
 
 show_setup_config_menu() {
-  case $(menu "Setup" "  Hyprland\n  Hypridle\n  Hyprlock\n  Hyprsunset\n  Swayosd\n󰌧  Walker\n󰍜  Waybar\n󰞅  XCompose") in
+  case $(menu "Setup" "  Hyprland\n  Hypridle\n  Hyprlock\n  Hyprsunset\n󰔎  Nightlight\n  Swayosd\n󰌧  Walker\n󰍜  Waybar\n󰞅  XCompose") in
   *Hyprland*) open_in_editor ~/.config/hypr/hyprland.conf ;;
   *Hypridle*) open_in_editor ~/.config/hypr/hypridle.conf && omarchy-restart-hypridle ;;
   *Hyprlock*) open_in_editor ~/.config/hypr/hyprlock.conf ;;
   *Hyprsunset*) open_in_editor ~/.config/hypr/hyprsunset.conf && omarchy-restart-hyprsunset ;;
+  *Nightlight*) open_in_editor ~/.config/omarchy/nightlight.conf ;;
   *Swayosd*) open_in_editor ~/.config/swayosd/config.toml && omarchy-restart-swayosd ;;
   *Walker*) open_in_editor ~/.config/walker/config.toml && omarchy-restart-walker ;;
   *Waybar*) open_in_editor ~/.config/waybar/config.jsonc && omarchy-restart-waybar ;;

--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -1,30 +1,175 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
-# Default temperature values
-ON_TEMP=4000
-OFF_TEMP=6000
+# defaults (used if no valid user config)
+DEFAULT_LIST=(6000 4000)
 
-# Ensure hyprsunset is running
-if ! pgrep -x hyprsunset; then
-  setsid uwsm-app -- hyprsunset &
-  sleep 1 # Give it time to register
-fi
+VALID_MIN=1000
+VALID_MAX=20000
 
-# Query the current temperature
-CURRENT_TEMP=$(hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+')
+USER_CFG="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/nightlight.conf"
 
-restart_nightlighted_waybar() {
-  if grep -q "custom/nightlight" ~/.config/waybar/config.jsonc; then
-    omarchy-restart-waybar # restart waybar in case user has waybar module for hyprsunset
+# State dir for intermittent invalid-config notifications
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+INVALID_NOTE_FILE="$STATE_DIR/nightlight_invalid_notice"
+NOTIFY_TTL_SECS=1800  # notify at most once every 30 minutes unless config changes
+
+ensure_hyprsunset() {
+  if ! pgrep -x hyprsunset >/dev/null 2>&1; then
+    setsid uwsm-app -- hyprsunset >/dev/null 2>&1 &
+    sleep 0.5
   fi
 }
 
-if [[ "$CURRENT_TEMP" == "$OFF_TEMP" ]]; then
-  hyprctl hyprsunset temperature $ON_TEMP
-  notify-send "  Nightlight screen temperature"
+read_current_temp() {
+  local t
+  t="$(hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+' || true)"
+  if [[ -z "$t" ]]; then
+    echo "${DEFAULT_LIST[0]}"
+  else
+    echo "$t"
+  fi
+}
+
+# Global flags & arrays populated by loader
+FLAG_INVALID=0
+CFG_TEMPS=()
+
+# Compute a stable checksum for the user config if it exists; empty if not
+cfg_checksum() {
+  if [[ -f "$USER_CFG" ]]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$USER_CFG" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+      shasum -a 256 "$USER_CFG" | awk '{print $1}'
+    else
+      # Fallback: bytes+mtime combo (not cryptographic, but stable enough for change detection)
+      stat --printf='%s-%Y' "$USER_CFG" 2>/dev/null || echo "$(wc -c <"$USER_CFG" 2>/dev/null)-0"
+    fi
+  else
+    echo "NOFILE"
+  fi
+}
+
+# Decide whether to show the invalid-config notification now
+should_notify_invalid() {
+  mkdir -p "$STATE_DIR"
+  local epoch last_epoch=0 last_sum=""
+  epoch="$(date +%s)"
+  local sum
+  sum="$(cfg_checksum)"
+
+  if [[ -f "$INVALID_NOTE_FILE" ]]; then
+    # file format: "<epoch> <checksum>"
+    read -r last_epoch < "$INVALID_NOTE_FILE" || true
+    read -r last_sum < <(tail -n +2 "$INVALID_NOTE_FILE") || true
+  fi
+
+  # Re-notify if checksum changed (user edited config), or TTL expired, or no record
+  if [[ "$sum" != "$last_sum" ]] || (( epoch - last_epoch >= NOTIFY_TTL_SECS )); then
+    printf '%s\n%s\n' "$epoch" "$sum" > "$INVALID_NOTE_FILE"
+    return 0
+  fi
+  return 1
+}
+
+# Load/validate config into CFG_TEMPS; set FLAG_INVALID if missing/invalid
+load_config_temps() {
+  FLAG_INVALID=0
+  CFG_TEMPS=()
+
+  if [[ -f "$USER_CFG" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      # Trim
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      # Skip comments/blank
+      [[ -z "$line" || "$line" =~ ^# ]] && continue
+
+      if ! [[ "$line" =~ ^[0-9]+$ ]]; then
+        FLAG_INVALID=1
+        continue
+      fi
+      if (( line < VALID_MIN || line > VALID_MAX )); then
+        FLAG_INVALID=1
+        continue
+      fi
+
+      CFG_TEMPS+=("$line")
+    done < "$USER_CFG"
+  else
+    # No user config present
+    FLAG_INVALID=1
+  fi
+
+  # If nothing valid collected, mark invalid
+  if [[ ${#CFG_TEMPS[@]} -eq 0 ]]; then
+    FLAG_INVALID=1
+  fi
+}
+
+restart_nightlighted_waybar() {
+  if grep -q "custom/nightlight" "${HOME}/.config/waybar/config.jsonc" 2>/dev/null; then
+    omarchy-restart-waybar || true
+  fi
+}
+
+notify_for_temp() {
+  local k=$1
+  if (( k >= 7500)); then
+    notify-send "  Screen temperature - Cool (${k}K)"
+  elif (( k >= 5500 )); then
+    notify-send "  Screen temperature - Neutral (${k}K)"
+  elif (( k >= 3500 )); then
+    notify-send "󰖚  Screen temperature - Warm (${k}K)"
+  elif (( k >= 1000 )); then
+    notify-send "  Screen temperature - Hot (${k}K)"
+  else
+    notify-send "Error in setting temperature"
+  fi
+}
+
+main() {
+  ensure_hyprsunset
+
+  # Load config or fallback to defaults
+  load_config_temps
+  local -a CYCLE=()
+  if [[ $FLAG_INVALID -eq 1 ]]; then
+    CYCLE=("${DEFAULT_LIST[@]}")
+    if should_notify_invalid; then
+      notify-send "󰂚 Nightlight config not found/invalid" "Using defaults:\n${CYCLE[*]}"
+    fi
+  else
+    CYCLE=("${CFG_TEMPS[@]}")
+  fi
+
+  # Determine next temp
+  local current next_idx=0
+  current="$(read_current_temp)"
+
+  local found_idx=-1
+  for i in "${!CYCLE[@]}"; do
+    if [[ "${CYCLE[$i]}" == "${current}" ]]; then
+      found_idx=$i
+      break
+    fi
+  done
+
+  if [[ $found_idx -ge 0 ]]; then
+    next_idx=$(( (found_idx + 1) % ${#CYCLE[@]} ))
+  else
+    next_idx=0
+  fi
+
+  local next="${CYCLE[$next_idx]}"
+
+  # Apply and refresh UI
+  hyprctl hyprsunset temperature "$next" >/dev/null 2>&1 || true
+  notify_for_temp "$next"
   restart_nightlighted_waybar
-else
-  hyprctl hyprsunset temperature $OFF_TEMP
-  notify-send "   Daylight screen temperature"
-  restart_nightlighted_waybar
-fi
+}
+
+main "$@"
+

--- a/config/omarchy/nightlight.conf
+++ b/config/omarchy/nightlight.conf
@@ -1,0 +1,6 @@
+# One Kelvin value per line, in the order you want to cycle.
+# Valid: integers only, no units/words. Valid range: 1000-20000.
+# 6000 is neutral, lower is warmer, higher is colder.
+6000
+4000
+


### PR DESCRIPTION
User can edit nightlight.conf to add or change temperature of hyprsunset to cycle through their own preferences.
- Default toggle options still set to @dhh 's preferences, but easily adjustable.
- Edited `omarchy-toggle-nightlight` to access values from `.config/omarchy/nightlight.conf`.
Updated `omarchy-menu` to include access to config file.

<img width="780" height="1082" alt="image" src="https://github.com/user-attachments/assets/1b9b4fdd-d363-4cc8-a622-40ca086807ca" />

<img width="916" height="352" alt="image" src="https://github.com/user-attachments/assets/33234c52-dcd2-48d3-b2e8-23358a4df695" />


I felt like this aligned with @dhh 's views on defaults being easily accessed to change. The current nightlight felt lacking for anyone that likes to use night mode with any sort of customization. Seems like it'd be a good addition for future versions.

AI Disclosure: I did use AI to help me through the BASH scripting, as I don't work with it much. The code in this PR has been thoroughly massaged and nitpicked by yours truly, let me know if I missed anything and need to make adjustments.

Complete honesty, this is my first time contributing to open source, so anyone with the time to, please let me know if I need to go about any of this differently. Hope this can help someone :+1: 