### PR TITLE
Redesign screen capture option

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -11,12 +11,14 @@ fi
 DESKTOP_AUDIO="false"
 MICROPHONE_AUDIO="false"
 WEBCAM="false"
+STOP_RECORDING="false"
 
 for arg in "$@"; do
   case "$arg" in
     --with-desktop-audio) DESKTOP_AUDIO="true" ;;
     --with-microphone-audio) MICROPHONE_AUDIO="true" ;;
     --with-webcam) WEBCAM="true" ;;
+    --stop-recording) STOP_RECORDING="true"
   esac
 done
 
@@ -109,8 +111,10 @@ if screenrecording_active; then
   else
     stop_screenrecording
   fi
-else
+elif [[ "$STOP_RECORDING" == "false" ]]; then
   [[ "$WEBCAM" == "true" ]] && start_webcam_overlay
 
   start_screenrecording || cleanup_webcam
+else
+  exit 1
 fi

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -112,10 +112,12 @@ show_screenshot_menu() {
 }
 
 show_screenrecord_menu() {
+  omarchy-cmd-screenrecord --stop-recording && exit 0
+
   case $(menu "Screenrecord" "  With desktop audio\n  With desktop + microphone audio\n  With desktop + microphone audio + webcam") in
-  *"With desktop audio"*) omarchy-cmd-screenrecord --with-desktop-audio ;;
-  *"With desktop + microphone audio"*) omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio ;;
-  *"With desktop + microphone audio + webcam"*) omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam ;;
+  *"With desktop audio") omarchy-cmd-screenrecord --with-desktop-audio ;;
+  *"With desktop + microphone audio") omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio ;;
+  *"With desktop + microphone audio + webcam") omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam ;;
   *) back_to show_capture_menu ;;
   esac
 }


### PR DESCRIPTION
Use desktop portal capture option which allows capturing monitors connected to external gpus (common on laptops with dedicated gpus) and supports capturing properly when hdr is enabled.

Desktop portal capture allows selecting capture of a window, monitor or screen region.

Add -fallback-cpu-encoding yes to use cpu encoding if the system doesn't support gpu encoding. Ideally omarchy should install vaapi drivers which would fix this issue for most users, but some users have a gpu that dont support gpu encoding at all so this option is still needed.

Use pgrep with ^ as is done in waybar indicator screen-recording.sh to only grep for gpu-screen-recorder program.

Update omarchy-menu to reflect not selecting region/display capture and instead allow capturing only desktop audio or desktop + microphone audio.

Stop recording when pressing the record hotkey or navigating to the record menu instead of having to select
a recording option and then stopping the recording.

Fixes #3367, #3303 and #3118