### PR TITLE
fix: start elephant as systemd service, walker as xdg-autostart

### DIFF
--- a/autostart/walker.desktop
+++ b/autostart/walker.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Walker
+Comment=Walker Service
+Exec=walker --gapplication-service
+StartupNotify=false
+Terminal=false
+Type=Application

--- a/bin/omarchy-restart-walker
+++ b/bin/omarchy-restart-walker
@@ -12,11 +12,10 @@ if [[ $EUID -eq 0 ]]; then
   # Restart services as the script owner
   systemd-run --uid="$SCRIPT_OWNER" --setenv=XDG_RUNTIME_DIR="/run/user/$USER_UID" \
     bash -c "
-      setsid uwsm-app -- elephant &
-      setsid uwsm-app -- walker --gapplication-service &
+      systemctl --user restart elephant.service
+      systemctl --user restart app-walker@autostart.service
     "
 else
-  setsid uwsm-app -- elephant &
-  wait 2
-  setsid uwsm-app -- walker --gapplication-service &
+  systemctl --user restart elephant.service
+  systemctl --user restart app-walker@autostart.service
 fi

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -6,8 +6,6 @@ exec-once = uwsm-app -- swaybg -i ~/.config/omarchy/current/background -m fill
 exec-once = uwsm-app -- swayosd-server
 exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 exec-once = omarchy-cmd-first-run
-exec-once = uwsm-app -- elephant
-exec-once = uwsm-app -- walker --gapplication-service
 
 # Slow app launch fix -- set systemd vars
 exec-once = systemctl --user import-environment $(env | cut -d'=' -f 1)

--- a/migrations/1762873545.sh
+++ b/migrations/1762873545.sh
@@ -1,0 +1,6 @@
+pkill elephant
+elephant service enable
+systemctl --user start elephant.service
+
+mkdir -p ~/.config/autostart/
+cp $OMARCHY_PATH/autostart/walker.desktop ~/.config/autostart/


### PR DESCRIPTION
This makes Omarchy use a systemd service for elephant instead of relying on hyprland's exec-once, which might cause issues. Additionally systemd will restart elephant on failure.

Walker will also be started via xdg-autostart properly.