### PR TITLE
fix: add walker action hints

### DIFF
--- a/default/walker/themes/omarchy-default/layout.xml
+++ b/default/walker/themes/omarchy-default/layout.xml
@@ -113,6 +113,35 @@
               </object>
             </child>
             <child>
+              <object class="GtkBox" id="KeybindsWrapper">
+                <property name="hexpand">true</property>
+                <style>
+                  <class name="keybinds-wrapper"></class>
+                </style>
+                <child>
+                  <object class="GtkBox" id="GlobalKeybinds">
+                    <property name="hexpand">true</property>
+                    <property name="spacing">10</property>
+                    <property name="margin-top">10</property>
+                    <style>
+                      <class name="global-keybinds"></class>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="Keybinds">
+                    <property name="hexpand">true</property>
+                    <property name="halign">end</property>
+                    <property name="spacing">10</property>
+                    <property name="margin-top">10</property>
+                    <style>
+                      <class name="keybinds"></class>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkLabel" id="Error">
                 <style>
                   <class name="error"></class>


### PR DESCRIPTION
I think Omarchy should expose the possible keybind actions available to users, as default Walker already does.

Hiding this information from users doesn't really serve any purpose and in fact: people don't even know what their Walker can do.

I just added the according xml section... of course styling can be adjusted. I think @ryanrhughes worked on this at some point.

I think you should really get this in.

For reference: i'm talking about these

<img width="927" height="857" alt="image" src="https://github.com/user-attachments/assets/a213d21d-ae5a-4eb6-9b66-60e70089c0b1" />
