### PR TITLE
feat(walker): set window_integration true

### DIFF
--- a/config/elephant/desktopapplications.toml
+++ b/config/elephant/desktopapplications.toml
@@ -1,3 +1,5 @@
 show_actions = false
 only_search_title = true
 history = false
+window_integration = true
+window_integration_ignore_actions = true


### PR DESCRIPTION
`window_integration` makes the `desktopapplications` provider behave like this:

- if an application is already opened => focus window instead of opening a new instance

`window_integration_ignore_actions` will cause elephant to ignore this behaviour for desktop actions, f.e. `new private window` => actions always open a new instance.

I think this behaviour is more in line with "vanilla" omarchy, because it uses `launch-or-focus` everywhere in the keybinds to start/focus apps.