### PR TITLE
Support opening web apps with a specified browser

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -1,10 +1,18 @@
 #!/bin/bash
 
-browser=$(xdg-settings get default-web-browser)
+# use browser passed as arg or the user default one
+browser="${2:-$(xdg-settings get default-web-browser)}"
 
 case $browser in
 google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium-browser*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+# if second arg was used as browser, use remaining args for flags
+if [[ $# -ge 2 && "$2" == "$browser" ]]; then
+  flags=("${@:3}")
+else
+  flags=("${@:2}")
+fi
+
+exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${flags[@]}"


### PR DESCRIPTION
## Overview
This PR adds support for opening web apps with a specified browser.

This is useful in scenarios where instead of using different browser profiles for work and personal browsing (the most common approach), users use different browsers (in my case Brave for personal browsing, with strict privacy settings, and Chromium for work).

## Example
I want to open the Youtube web app with Brave instead of my default (work) browser.

With this change I can edit the desktop file at `~/.local/share/omarchy/applications/Youtube.desktop` and change the `Exec` param to specify a different browser:

```shell
[Desktop Entry]
Version=1.0
Name=YouTube
Comment=YouTube
Exec=omarchy-launch-webapp https://youtube.com/ brave-browser.desktop
Terminal=false
Type=Application
Icon=/home/rogeriopvl/.local/share/applications/icons/YouTube.png
StartupNotify=true
```

I understand this may be considered "edge-case enough" to be included in Omarchy and that's ok. I just wanted to share it in case more people are interested in this feature.