### PR TITLE
Avoid invalid terminal working directory

### DIFF
--- a/bin/omarchy-cmd-terminal-cwd
+++ b/bin/omarchy-cmd-terminal-cwd
@@ -6,8 +6,10 @@ shell_pid=$(pgrep -P "$terminal_pid" | tail -n1)
 
 if [[ -n $shell_pid ]]; then
   cwd=$(readlink -f "/proc/$shell_pid/cwd" 2>/dev/null)
+  shell=$(readlink -f "/proc/$shell_pid/exe" 2>/dev/null)
 
-  if [[ -d $cwd ]]; then
+  # Check if $shell is a valid shell and $cwd is a directory.
+  if grep -qs "$shell" /etc/shells && [[ -d $cwd ]]; then
     echo "$cwd"
   else
     echo "$HOME"


### PR DESCRIPTION
Don't use the working directory of the last child of the active window when opening a new terminal with Super+Enter.

Fixes #3427.