### PR TITLE
Enhanced Waybar config with mpris module and adjustments

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -4,7 +4,7 @@
   "position": "top",
   "spacing": 0,
   "height": 26,
-  "modules-left": ["custom/omarchy", "hyprland/workspaces"],
+  "modules-left": ["custom/omarchy", "hyprland/workspaces", "mpris"],
   "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator"],
   "modules-right": [
     "group/tray-expander",
@@ -50,7 +50,7 @@
     "on-click": "omarchy-launch-floating-terminal-with-presentation omarchy-update",
     "tooltip-format": "Omarchy update available",
     "signal": 7,
-    "interval": 21600
+    "interval": 3600
   },
 
   "cpu": {
@@ -122,8 +122,24 @@
     },
     "modules": ["custom/expand-icon", "tray"]
   },
+  "mpris": {
+    "format": "   {player_icon} {status_icon} <i>{artist} - {title}</i>",
+    "player": "playerctld",
+    "max-length": 50,
+    "on-click": "playerctl play-pause",
+    "format-paused": "   {player_icon} {status_icon} {artist} - {title}",
+    "player-icons": {
+      "default": "",
+      "spotify": " ",
+      "mpv": " "
+    },
+    "status-icons": {
+      "paused": "⏸",
+      "playing": "▶"
+    }
+  },
   "custom/expand-icon": {
-    "format": "",
+    "format": " ",
     "tooltip": false
   },
   "custom/screenrecording-indicator": {
@@ -134,6 +150,6 @@
   },
   "tray": {
     "icon-size": 12,
-    "spacing": 17
+    "spacing": 12
   }
 }


### PR DESCRIPTION
## What

- Add a media (MPRIS) module to the Waybar configuration.
- Show current track status (playing/paused) and artist/title in the bar.
- Bind left-click to play/pause using `playerctl`.

## Why

- Makes it easy to see and control currently playing media directly from the bar.
- Improves usability for setups using Hyprland + Omarchy with media players (Spotify, mpv, etc.).

## How

- Extend `modules-left` (or `modules-center`, as agreed) to include the `mpris` module.
- Configure `player`, `status_icons`, and formatting to match existing icon/style conventions.

## Testing

- Verified Waybar reloads without errors.
- Tested with:
  - `playerctld` running
  - Media playing/paused in <your player, e.g. Spotify/mpv>
- Confirmed:
  - Status icon updates between playing/paused
  - Track info (artist – title) truncates correctly
  - Click toggles play/pause as expected
<img width="1920" height="96" alt="screenshot-2025-11-18_21-48-53" src="https://github.com/user-attachments/assets/bd3d66f3-e673-4b89-b34b-67584dfd8ad0" />
