### PR TITLE
first-run: Use balanced profile for desktop as well

### DIFF
--- a/install/first-run/battery-monitor.sh
+++ b/install/first-run/battery-monitor.sh
@@ -1,10 +1,8 @@
+# Set balanced profile to allow power savings when idle
+powerprofilesctl set balanced || true
+
 if ls /sys/class/power_supply/BAT* &>/dev/null; then
   # This computer runs on a battery
-  powerprofilesctl set balanced || true
-
   # Enable battery monitoring timer for low battery notifications
   systemctl --user enable --now omarchy-battery-monitor.timer
-else
-  # This computer runs on power outlet
-  powerprofilesctl set performance || true
 fi

--- a/migrations/1763556534.sh
+++ b/migrations/1763556534.sh
@@ -1,0 +1,6 @@
+echo "Set power profile to balanced if set to performance"
+
+profile=$(powerprofilesctl get 2>/dev/null || echo -n balanced)
+if [[ "$profile" -eq "performance" ]]; then
+  powerprofilesctl set balanced
+fi


### PR DESCRIPTION
My cpu (9550x3d) idles at 30w with the balanced governor, but 45w when in performance.

This patch changes the default to balanced for both because desktop cpus also benefit from scaling in the form of power savings (i.e. in my case this could be $15/year assuming a 80% idle scenario), lower part degradation, lower heat generation and fan noise.

The CPU will still reach higher clocks when under load, but we still reap the benefits when on idle.