### PR TITLE
Add Google DNS option

### DIFF
--- a/bin/omarchy-setup-dns
+++ b/bin/omarchy-setup-dns
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z $1 ]]; then
-  dns=$(gum choose --height 5 --header "Select DNS provider" Cloudflare DHCP Custom)
+  dns=$(gum choose --height 5 --header "Select DNS provider" Cloudflare Google DHCP Custom)
 else
   dns=$1
 fi
@@ -14,23 +14,50 @@ DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com
 FallbackDNS=9.9.9.9 149.112.112.112
 DNSOverTLS=opportunistic
 EOF
-  
+
   # Ensure network interfaces don't override our DNS settings
   for file in /etc/systemd/network/*.network; do
     [[ -f "$file" ]] || continue
     if ! grep -q "^\[DHCPv4\]" "$file"; then continue; fi
-    
+
     # Add UseDNS=no to DHCPv4 section if not present
     if ! sed -n '/^\[DHCPv4\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
       sudo sed -i '/^\[DHCPv4\]/a UseDNS=no' "$file"
     fi
-    
+
     # Add UseDNS=no to IPv6AcceptRA section if present
     if grep -q "^\[IPv6AcceptRA\]" "$file" && ! sed -n '/^\[IPv6AcceptRA\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
       sudo sed -i '/^\[IPv6AcceptRA\]/a UseDNS=no' "$file"
     fi
   done
-  
+
+  sudo systemctl restart systemd-networkd systemd-resolved
+  ;;
+
+Google)
+  sudo tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
+[Resolve]
+DNS=8.8.8.8 8.8.4.4
+FallbackDNS=9.9.9.9 149.112.112.112
+DNSOverTLS=opportunistic
+EOF
+
+  # Ensure network interfaces don't override our DNS settings
+  for file in /etc/systemd/network/*.network; do
+    [[ -f "$file" ]] || continue
+    if ! grep -q "^\[DHCPv4\]" "$file"; then continue; fi
+
+    # Add UseDNS=no to DHCPv4 section if not present
+    if ! sed -n '/^\[DHCPv4\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
+      sudo sed -i '/^\[DHCPv4\]/a UseDNS=no' "$file"
+    fi
+
+    # Add UseDNS=no to IPv6AcceptRA section if present
+    if grep -q "^\[IPv6AcceptRA\]" "$file" && ! sed -n '/^\[IPv6AcceptRA\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
+      sudo sed -i '/^\[IPv6AcceptRA\]/a UseDNS=no' "$file"
+    fi
+  done
+
   sudo systemctl restart systemd-networkd systemd-resolved
   ;;
 
@@ -39,13 +66,13 @@ DHCP)
 [Resolve]
 DNSOverTLS=no
 EOF
-  
+
   # Allow network interfaces to use DHCP DNS
   for file in /etc/systemd/network/*.network; do
     [[ -f "$file" ]] || continue
     sudo sed -i '/^UseDNS=no/d' "$file"
   done
-  
+
   sudo systemctl restart systemd-networkd systemd-resolved
   ;;
 
@@ -63,23 +90,23 @@ Custom)
 DNS=$dns_servers
 FallbackDNS=9.9.9.9 149.112.112.112
 EOF
-  
+
   # Ensure network interfaces don't override our DNS settings
   for file in /etc/systemd/network/*.network; do
     [[ -f "$file" ]] || continue
     if ! grep -q "^\[DHCPv4\]" "$file"; then continue; fi
-    
+
     # Add UseDNS=no to DHCPv4 section if not present
     if ! sed -n '/^\[DHCPv4\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
       sudo sed -i '/^\[DHCPv4\]/a UseDNS=no' "$file"
     fi
-    
+
     # Add UseDNS=no to IPv6AcceptRA section if present
     if grep -q "^\[IPv6AcceptRA\]" "$file" && ! sed -n '/^\[IPv6AcceptRA\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
       sudo sed -i '/^\[IPv6AcceptRA\]/a UseDNS=no' "$file"
     fi
   done
-  
+
   sudo systemctl restart systemd-networkd systemd-resolved
 
   ;;


### PR DESCRIPTION
Inspired by Cloudflare's latest major downtime incident, it would be nice if we had an option to quickly switch to using Google's Public DNS servers.

This PR adds Google as a DNS option to the Setup > DNS so that if Cloudflare goes down again, Omarchy users can quickly switch to Google's Public DNS (which does not use any of Cloudflare's infrastructure).