### PR TITLE
Change pacman command to not cause possible dependency issues

### DIFF
--- a/bin/omarchy-update-keyring
+++ b/bin/omarchy-update-keyring
@@ -5,7 +5,7 @@ if omarchy-pkg-missing omarchy-keyring || ! sudo pacman-key --list-keys 40DFB630
   sudo pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver keys.openpgp.org
   sudo pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571
 
-  sudo pacman -Sy
+  sudo pacman -Syu
   omarchy-pkg-add omarchy-keyring
 
   sudo pacman-key --list-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571


### PR DESCRIPTION
## TLDR
omarchy-update-keyring runs `sudo pacman -Sy` which can create partial updates and break dependencies.
Unless specifically needed then it should be changed to `sudo pacman -Syu`

## Long version

Call stack
```
omarchy-update
   omarchy-update-perform
      omarchy-update-keyring
```
When you update Omarchy it ends up calling *omarchy/bin/omarchy-update-keyring* which contains the following line `sudo pacman -Sy`. The pacman man pages advice against using this combination which can lead to dependency issues.

This may be mitigated by *omarchy-update-perform* later calling *omarchy-update-system-pkgs* which runs the full pacman command.
```bash
sudo pacman -Syu --noconfirm --ignore "$ignored_packages"
```
However given how modular Omarchy is, another module might call *omarchy-update-keyring* which can lead to dependency issues. So unless there is a good reason to keep this as is, where it could break dependencies, then adding the `-u` argument might be in order.