### PR TITLE
Update omarchy-update-system-pkgs

### DIFF
--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -10,18 +10,28 @@ echo -e "\e[32m\nUpdate system packages\e[0m"
 [[ -n $ignored_packages ]] && echo "sudo pacman -Syu --noconfirm --ignore \"$ignored_packages\""
 sudo pacman -Syu --noconfirm --ignore "$ignored_packages"
 
-# Update AUR packages if any are installed
-if pacman -Qem >/dev/null; then
-  if omarchy-pkg-aur-accessible; then
-    echo -e "\e[32m\nUpdate AUR packages\e[0m"
-    [[ -n $ignored_packages ]] && echo "yay -Sua --noconfirm  --ignore \"$ignored_packages\""
-    yay -Sua --noconfirm --ignore "$ignored_packages"
-    echo
-  else
-    echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"
-    echo
+gum style --border normal --border-foreground 6 --padding "1 2" \
+  "Do you want to skip the AUR packages update ?" \
+  "" \
+  "• This wont update any of the AUR packages!" \
+  "• You can update them manually after the update."
+
+if ! gum confirm "Skip AUR update?"; then
+  echo "Skipping AUR update."
+else
+  if pacman -Qem >/dev/null; then
+    if omarchy-pkg-aur-accessible; then
+      echo -e "\e[32m\nUpdate AUR packages\e[0m"
+      [[ -n $ignored_packages ]] && echo "yay -Sua --noconfirm  --ignore \"$ignored_packages\""
+      yay -Sua --noconfirm --ignore "$ignored_packages"
+      echo
+    else
+      echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"
+      echo
+    fi
   fi
 fi
+
 
 orphans=$(pacman -Qtdq || true)
 if [[ -n $orphans ]]; then


### PR DESCRIPTION
Add option to skip AUR packages update.

My last Omarchy update broke because of one AUR package that could not be downloaded "qt5-webengine", even manually i could not update it, issue on code.qt.io server.