### PR TITLE
Prevent notifications from being seen when screensharing

### DIFF
--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -5,6 +5,7 @@ source = ~/.local/share/omarchy/default/hypr/apps/browser.conf
 source = ~/.local/share/omarchy/default/hypr/apps/hyprshot.conf
 source = ~/.local/share/omarchy/default/hypr/apps/jetbrains.conf
 source = ~/.local/share/omarchy/default/hypr/apps/localsend.conf
+source = ~/.local/share/omarchy/default/hypr/apps/mako.conf
 source = ~/.local/share/omarchy/default/hypr/apps/pip.conf
 source = ~/.local/share/omarchy/default/hypr/apps/qemu.conf
 source = ~/.local/share/omarchy/default/hypr/apps/retroarch.conf

--- a/default/hypr/apps/mako.conf
+++ b/default/hypr/apps/mako.conf
@@ -1,0 +1,2 @@
+# Black out notifications when screen sharing
+layerrule = noscreenshare, notifications


### PR DESCRIPTION
Hello,

This PR add a `noscreenshare`rule for notifications

Can be tested by:

1. Sharing your screen. You can use this [website](https://www.webrtc-experiment.com/Pluginfree-Screen-Sharing/) 
2. Open a terminal and enter `notify-send "Hello, world"`

You should see a black rectangle where the notification is.