### PR TITLE
Remove Aether dependency for the ethereal nvim theme

### DIFF
--- a/themes/ethereal/neovim.lua
+++ b/themes/ethereal/neovim.lua
@@ -1,7 +1,6 @@
 return {
   {
     "bjarneo/ethereal.nvim",
-    dependencies = { "bjarneo/aether.nvim" }, -- Ensure aether is loaded first
     priority = 1000,
   },
   {


### PR DESCRIPTION
This nvim theme is now standalone.