### PR TITLE
Add keyboard backlight toggle script and bindings

### DIFF
--- a/bin/omarchy-cmd-keyboard-backlight
+++ b/bin/omarchy-cmd-keyboard-backlight
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to control keyboard backlight brightness
-# Usage: omarchy-cmd-keyboard-backlight-toggle [cycle|toggle]
+# Usage: omarchy-cmd-keyboard-backlight [cycle|up|down|toggle]
 # Default action (no arguments): cycle
 
 DEVICE="*::kbd_backlight"
@@ -52,9 +52,41 @@ case "$ACTION" in
     fi
     ;;
 
+  up)
+    # Increase by 1, wrapping to 0 if at max
+    if [[ "$CURRENT" -ge "$MAX" ]]; then
+      NEW_VALUE=0
+      brightnessctl --device="$DEVICE" set "$NEW_VALUE"
+      notify-send "⌨  Keyboard Backlight" "Off (0/$MAX) - Wrapped from max"
+    else
+      NEW_VALUE=$((CURRENT + 1))
+      brightnessctl --device="$DEVICE" set "$NEW_VALUE"
+      PERCENT=$(awk -v c="$NEW_VALUE" -v m="$MAX" 'BEGIN{printf "%.0f", (c/m)*100}')
+      notify-send "⌨  Keyboard Backlight" "Level $NEW_VALUE/$MAX ($PERCENT%)"
+    fi
+    ;;
+
+  down)
+    # Decrease by 1
+    if [[ "$CURRENT" -le 0 ]]; then
+      notify-send "⌨  Keyboard Backlight" "Already at minimum (0/$MAX)"
+    else
+      NEW_VALUE=$((CURRENT - 1))
+      brightnessctl --device="$DEVICE" set "$NEW_VALUE"
+      if [[ "$NEW_VALUE" -eq 0 ]]; then
+        notify-send "⌨  Keyboard Backlight" "Off (0/$MAX)"
+      else
+        PERCENT=$(awk -v c="$NEW_VALUE" -v m="$MAX" 'BEGIN{printf "%.0f", (c/m)*100}')
+        notify-send "⌨  Keyboard Backlight" "Level $NEW_VALUE/$MAX ($PERCENT%)"
+      fi
+    fi
+    ;;
+
   *)
-    echo "Usage: omarchy-cmd-keyboard-backlight-toggle [cycle|toggle]"
+    echo "Usage: omarchy-cmd-keyboard-backlight-toggle [cycle|up|down|toggle]"
     echo "  cycle  - Cycle through all brightness levels (wraps to 0 at max) [DEFAULT]"
+    echo "  up     - Increase by 1 level (wraps to 0 at max)"
+    echo "  down   - Decrease by 1 level"
     echo "  toggle - Switch between off and max brightness"
     exit 1
     ;;

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -10,9 +10,9 @@ bindeld = ,XF86MonBrightnessUp, Brightness up, exec, $osdclient --brightness rai
 bindeld = ,XF86MonBrightnessDown, Brightness down, exec, $osdclient --brightness lower
 
 # Keyboard backlight controls
-bindeld = ,XF86KbdBrightnessUp, Keyboard backlight up, exec, omarchy-cmd-keyboard-backlight-toggle up
-bindeld = ,XF86KbdBrightnessDown, Keyboard backlight down, exec, omarchy-cmd-keyboard-backlight-toggle down
-bindeld = ,XF86KbdLightOnOff, Keyboard backlight cycle, exec, omarchy-cmd-keyboard-backlight-toggle cycle
+bindeld = ,XF86KbdBrightnessUp, Keyboard backlight up, exec, omarchy-cmd-keyboard-backlight up
+bindeld = ,XF86KbdBrightnessDown, Keyboard backlight down, exec, omarchy-cmd-keyboard-backlight down
+bindeld = ,XF86KbdLightOnOff, Keyboard backlight cycle, exec, omarchy-cmd-keyboard-backlight cycle
 
 # Precise 1% multimedia adjustments with Alt modifier
 bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1


### PR DESCRIPTION
Add functionality for keyboard brightness up and down keys, as well as when a computer only has a toggle key it cycles through the brightness levels. 

I don't use bash often so this is AI-enabled, however I believe this uses the principles set forth by DHH when this was built. 