### PR TITLE
Remove duplication in omarchy-setup-dns

### DIFF
--- a/bin/omarchy-setup-dns
+++ b/bin/omarchy-setup-dns
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+# Ensure network interfaces don't override our DNS settings
+ensureNetworkInterfacesDontOverrideDns() {
+  for file in /etc/systemd/network/*.network; do
+    [[ -f "$file" ]] || continue
+    if ! grep -q "^\[DHCPv4\]" "$file"; then continue; fi
+
+    # Add UseDNS=no to DHCPv4 section if not present
+    if ! sed -n '/^\[DHCPv4\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
+      sudo sed -i '/^\[DHCPv4\]/a UseDNS=no' "$file"
+    fi
+
+    # Add UseDNS=no to IPv6AcceptRA section if present
+    if grep -q "^\[IPv6AcceptRA\]" "$file" && ! sed -n '/^\[IPv6AcceptRA\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
+      sudo sed -i '/^\[IPv6AcceptRA\]/a UseDNS=no' "$file"
+    fi
+  done
+}
+
 if [[ -z $1 ]]; then
   dns=$(gum choose --height 5 --header "Select DNS provider" Cloudflare DHCP Custom)
 else
@@ -14,23 +32,8 @@ DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com
 FallbackDNS=9.9.9.9 149.112.112.112
 DNSOverTLS=opportunistic
 EOF
-  
-  # Ensure network interfaces don't override our DNS settings
-  for file in /etc/systemd/network/*.network; do
-    [[ -f "$file" ]] || continue
-    if ! grep -q "^\[DHCPv4\]" "$file"; then continue; fi
-    
-    # Add UseDNS=no to DHCPv4 section if not present
-    if ! sed -n '/^\[DHCPv4\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
-      sudo sed -i '/^\[DHCPv4\]/a UseDNS=no' "$file"
-    fi
-    
-    # Add UseDNS=no to IPv6AcceptRA section if present
-    if grep -q "^\[IPv6AcceptRA\]" "$file" && ! sed -n '/^\[IPv6AcceptRA\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
-      sudo sed -i '/^\[IPv6AcceptRA\]/a UseDNS=no' "$file"
-    fi
-  done
-  
+
+  ensureNetworkInterfacesDontOverrideDns
   sudo systemctl restart systemd-networkd systemd-resolved
   ;;
 
@@ -39,13 +42,13 @@ DHCP)
 [Resolve]
 DNSOverTLS=no
 EOF
-  
+
   # Allow network interfaces to use DHCP DNS
   for file in /etc/systemd/network/*.network; do
     [[ -f "$file" ]] || continue
     sudo sed -i '/^UseDNS=no/d' "$file"
   done
-  
+
   sudo systemctl restart systemd-networkd systemd-resolved
   ;;
 
@@ -63,23 +66,8 @@ Custom)
 DNS=$dns_servers
 FallbackDNS=9.9.9.9 149.112.112.112
 EOF
-  
-  # Ensure network interfaces don't override our DNS settings
-  for file in /etc/systemd/network/*.network; do
-    [[ -f "$file" ]] || continue
-    if ! grep -q "^\[DHCPv4\]" "$file"; then continue; fi
-    
-    # Add UseDNS=no to DHCPv4 section if not present
-    if ! sed -n '/^\[DHCPv4\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
-      sudo sed -i '/^\[DHCPv4\]/a UseDNS=no' "$file"
-    fi
-    
-    # Add UseDNS=no to IPv6AcceptRA section if present
-    if grep -q "^\[IPv6AcceptRA\]" "$file" && ! sed -n '/^\[IPv6AcceptRA\]/,/^\[/p' "$file" | grep -q "^UseDNS="; then
-      sudo sed -i '/^\[IPv6AcceptRA\]/a UseDNS=no' "$file"
-    fi
-  done
-  
+
+  ensureNetworkInterfacesDontOverrideDns
   sudo systemctl restart systemd-networkd systemd-resolved
 
   ;;


### PR DESCRIPTION
https://github.com/basecamp/omarchy/pull/3462#issuecomment-3557744362

This PR removes the duplicated logic in `bin/omarchy-setup-dns` by moving the duplicated logic into a function.