### PR TITLE
fix: use --no-restore-cursor on tte screensaver

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -18,7 +18,7 @@ hyprctl keyword cursor:invisible true &>/dev/null
 while true; do
   effect=$(tte 2>&1 | grep -oP '{\K[^}]+' | tr ',' ' ' | tr ' ' '\n' | sed -n '/^beams$/,$p' | sort -u | shuf -n1)
   tte -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 240 --canvas-width 0 --canvas-height 0 --anchor-canvas c --anchor-text c --no-eol \
+    --frame-rate 240 --canvas-width 0 --canvas-height 0 --anchor-canvas c --anchor-text c --no-eol --no-restore-cursor \
     "$effect" &
 
   while pgrep -x tte >/dev/null; do


### PR DESCRIPTION
with this flag, the cursor will never be visible during the screensaver, thus, fixing errors where the cursor appears at the end of some effects, where such cases were introduced by --no-eol flag.

the --no-restore-cursor flag comes with tte version 0.13 (https://github.com/ChrisBuilds/terminaltexteffects/releases/tag/release-0.13.0), which has just been released.

this closes: #3418 