### PR TITLE
Disable plocate database updates on boot

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -14,6 +14,7 @@ run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
+run_logged $OMARCHY_INSTALL/config/plocate.sh
 run_logged $OMARCHY_INSTALL/config/walker-elephant.sh
 run_logged $OMARCHY_INSTALL/config/fast-shutdown.sh
 run_logged $OMARCHY_INSTALL/config/sudoless-asdcontrol.sh

--- a/install/config/plocate.sh
+++ b/install/config/plocate.sh
@@ -1,0 +1,4 @@
+# Disable plocate database updates on boot to avoid I/O load during startup. Updates still run on daily schedule.
+sudo mkdir -p /etc/systemd/system/plocate-updatedb.timer.d
+echo -e "[Timer]\nPersistent=false" | sudo tee /etc/systemd/system/plocate-updatedb.timer.d/override.conf > /dev/null
+sudo systemctl daemon-reload


### PR DESCRIPTION
Add plocate.sh config script to prevent database updates from running on boot by setting Persistent=false for plocate-updatedb. This prevents the timer from running catch-up updates immediately after boot if the system was off during the scheduled daily update time. Avoids I/O load during startup while still allowing daily scheduled updates to run (saved between 400-500ms on bootup in my tests).