### PR TITLE
Remove bluetooth from omarchy-menu for PCs w/o the hardware

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -171,7 +171,7 @@ show_font_menu() {
 }
 
 show_setup_menu() {
-  local options="  Audio\n  Wifi"
+  local options="  Audio\n󱚾  Wi-Fi"
   has_bluetooth && options="$options\n󰂯  Bluetooth"
   options="$options\n󱐋  Power Profile\n󰍹  Monitors"
   [ -f ~/.config/hypr/bindings.conf ] && options="$options\n  Keybindings"
@@ -180,7 +180,7 @@ show_setup_menu() {
 
   case $(menu "Setup" "$options") in
   *Audio*) omarchy-launch-or-focus-tui wiremix ;;
-  *Wifi*) omarchy-launch-wifi ;;
+  *Wi-Fi*) omarchy-launch-wifi ;;
   *Bluetooth*) omarchy-launch-bluetooth ;;
   *Power*) show_setup_power_menu ;;
   *Monitors*) open_in_editor ~/.config/hypr/monitors.conf ;;


### PR DESCRIPTION
Also standardize on Wi-Fi (the registered trademark) that the update hardware menu already had correct

This also helps VMs not have the option in the menu since they don't support bluetooth without additional steps like adding a hardware USB module that can pass through the capabilities.