### PR TITLE
Reset keyboard layout to default first one on the lock screen

### DIFF
--- a/bin/omarchy-lock-screen
+++ b/bin/omarchy-lock-screen
@@ -3,6 +3,9 @@
 # Lock the screen
 pidof hyprlock || hyprlock &
 
+# Set keyboard layout to default (first layout)
+hyprctl switchxkblayout all 0 > /dev/null 2>&1
+
 # Ensure 1password is locked
 if pgrep -x "1password" >/dev/null; then
   1password --lock &


### PR DESCRIPTION
### Problem
Whenever hyprlock is triggered with non-Latin keyboard layout being active in the system, user ends up trapped on the lockscreen without any possibility to change layout.
 
### Proposed Solution
Add simple line to switch to default first keyboard layout, that is usually English, and usually used when creating passwords.

### Additional thoughts
I personally also added a button to lock screen, because I found out about buttons on the screen before I realized I can customize what script is called to trigger lock screen. Maybe adding some general purpose buttons like omarchy system menu to the lockscreen would be beneficial. What do you think?