### PR TITLE
omarchy-remove-tui not recognizing custom TUIs fix

### DIFF
--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -6,7 +6,7 @@ DESKTOP_DIR="$HOME/.local/share/applications/"
 if [ "$#" -eq 0 ]; then
   # Find all TUIs
   while IFS= read -r -d '' file; do
-    if grep -q '^Exec=.*$TERMINAL.*-e' "$file"; then
+    if grep -qE '^Exec=.*(\$TERMINAL|xdg-terminal-exec).*-e' "$file"; then
       TUIS+=("$(basename "${file%.desktop}")")
     fi
   done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0)


### PR DESCRIPTION
### Problem Description
Because TUI Apps are now saved with `Exec=xdg-terminal-exec` and not `Exec=$TERMINAL`, omarchy-tui-remove wont find newly created TUI-Apps. 

### Related Issure
Fixes #3550