### PR TITLE
Convert r alias into a function that uses bin/rails if available (1 line change)

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -32,7 +32,7 @@ alias ....='cd ../../..'
 
 # Tools
 alias d='docker'
-alias r='rails'
+r() {if [ -x "bin/rails" ]; then bin/rails "$@"; else rails "$@"; fi}
 n() { if [ "$#" -eq 0 ]; then nvim .; else nvim "$@"; fi; }
 
 # Git


### PR DESCRIPTION
Turns the `r` alias into a function that checks for `bin/rails` first and use it if available, otherwise falls back to `rails`

## How to test
- Run `r` in a Rails project (where `bin/rails` present) - should use `bin/rails`
- Run `r` from another path where `bin/rails` is not available - should fall back to `rails`

## Why?
I recently start learning Rails and if I understood correctly it is a better practice to use `bin/rails` over `rails`. This change makes it effortless to follow the better practice.