### PR TITLE
#3431: Fix Ristretto cursor visibility in Ghostty/neovim

### DIFF
--- a/themes/ristretto/ghostty.conf
+++ b/themes/ristretto/ghostty.conf
@@ -1,1 +1,2 @@
 theme = Monokai Pro Ristretto
+cursor-text = #000000


### PR DESCRIPTION
Fixes issue referenced in [https://github.com/basecamp/omarchy/issues/3431](https://github.com/basecamp/omarchy/issues/3431). 

To test locally:

1. Update ~/.local/share/omarchy/themes/ristretto/ghostty.conf:

```
# add this line
cursor-text = #000000
```

2. Close out all neovim terminals.

3. Reload the theme: Style -> Theme -> Ristretto

4. Open neovim and move cursor to any character

<img width="857" height="700" alt="ristretto-nvim" src="https://github.com/user-attachments/assets/1bff5e50-4083-4a90-994e-59d335c42d17" />
