### PR TITLE
Fix AUR package list corruption in omarchy-pkg-aur-install

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -14,7 +14,8 @@ fzf_args=(
   --color 'pointer:green,marker:green'
 )
 
-pkg_names=$(yay -Slqa | fzf "${fzf_args[@]}")
+# Usar curl directamente porque yay -Slqa tiene un bug que genera datos corruptos
+pkg_names=$(curl -s "https://aur.archlinux.org/packages.gz" | gunzip | fzf "${fzf_args[@]}")
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay


### PR DESCRIPTION
## Problem

The command `yay -Slqa` generates corrupted binary data instead of package names on some systems. This causes the AUR installation interface (`omarchy-pkg-aur-install`) to:

- Display garbage/unreadable characters instead of package names
- Fail with errors like: `can't use target with option --a`

### Screenshot of the issue
The AUR package list shows binary data like:
```
�Td��U��ӷ���Z�7����櫞/��|��iV...
```

### Investigation findings
- `yay -Ss` (search) works correctly
- `yay -Sl core` (list official repos) works correctly  
- `yay -Sl --aur` generates corrupted binary output
- Reinstalling yay does not fix the issue
- The AUR API works correctly when accessed directly

## Solution

Fetch the package list directly from the AUR server using `curl` instead of relying on `yay -Slqa`:

```bash
curl -s "https://aur.archlinux.org/packages.gz" | gunzip
```

This is more reliable and produces the same result (list of all AUR package names).

## Testing

Verified that:
1. The curl command returns valid package names
2. The fzf interface displays packages correctly
3. Package installation with yay still works normally