### PR TITLE
fix: reorder mise activation to prevent PROMPT_COMMAND hook overwrite

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -1,6 +1,3 @@
-if command -v mise &> /dev/null; then
-  eval "$(mise activate bash)"
-fi
 
 if command -v starship &> /dev/null; then
   eval "$(starship init bash)"
@@ -21,4 +18,9 @@ if command -v fzf &> /dev/null; then
   if [[ -f /usr/share/fzf/key-bindings.bash ]]; then
     source /usr/share/fzf/key-bindings.bash
   fi
+fi
+
+# Activate mise LAST so its PROMPT_COMMAND hook isn't overwritten
+if command -v mise &> /dev/null; then
+  eval "$(mise activate bash)"
 fi


### PR DESCRIPTION
- Moves `mise activate` to the end of `bash/init` so its `PROMPT_COMMAND` hook isn't overwritten by starship and zoxide
- Ensures mise-managed tools (Python, Node, etc.) are correctly available in new terminal sessions