### PR TITLE
Fix argument bugs

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -43,7 +43,7 @@ case "$MODE" in
     SELECTION=$(echo "$RECTS" | slurp 2>/dev/null)
     kill $PID 2>/dev/null
 
-    # If the selction area is L * W < 20, we'll assume you were trying to select whichever
+    # If the selection area is L * W < 20, we'll assume you were trying to select whichever
     # window or output it was inside of to prevent accidental 2px snapshots
     if [[ "$SELECTION" =~ ^([0-9]+),([0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]]; then
       if (( ${BASH_REMATCH[3]} * ${BASH_REMATCH[4]} < 20 )); then

--- a/bin/omarchy-install-docker-dbs
+++ b/bin/omarchy-install-docker-dbs
@@ -3,7 +3,7 @@
 options=("MySQL" "PostgreSQL" "Redis" "MongoDB" "MariaDB" "MSSQL")
 
 if [[ "$#" -eq 0 ]]; then
-  choices=$(printf "%s\n" "${options[@]}" | gum choose --header "Select database (return to install, esc to cancel)") || main_menu
+  choices=$(printf "%s\n" "${options[@]}" | gum choose --header "Select database (return to install, esc to cancel)") || exit 0
 else
   choices="$@"
 fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z $1 && $1 != "CNCLD" ]]; then
+if [[ -z $1 || $1 == "CNCLD" ]]; then
   echo "Usage: omarchy-theme-set <theme-name>"
   exit 1
 fi

--- a/bin/omarchy-upload-log
+++ b/bin/omarchy-upload-log
@@ -100,7 +100,7 @@ installed)
   ;;
 
 *)
-  echo "Usage: $0 [install|this-boot|last-boot|system-info]"
+  echo "Usage: $0 [install|this-boot|last-boot|installed]"
   echo "  install      - Upload installation logs (default)"
   echo "  this-boot    - Upload logs from current boot"
   echo "  last-boot    - Upload logs from previous boot"


### PR DESCRIPTION
Four small fixes:

1. **omarchy-theme-set** — Logic error: `[[ -z $1 && $1 != "CNCLD" ]]` always evaluates wrong. Changed to `[[ -z $1 || $1 == "CNCLD" ]]`
2. **omarchy-install-docker-dbs** — Calls undefined `main_menu` on Escape. Changed to `exit 0`
3. **omarchy-cmd-screenshot** — Little typo: "selction" → "selection"
4. **omarchy-upload-log** — Usage says `system-info` but case uses `installed`