### PR TITLE
Fix window matching for PWAs

### DIFF
--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -7,7 +7,7 @@ fi
 
 WINDOW_PATTERN="$1"
 LAUNCH_COMMAND="${2:-"uwsm-app -- $WINDOW_PATTERN"}"
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("(^|[\\.-])" + $p + "($|[\\.-])";"i")) or (.title|test("(^|[\\.-])" + $p + "($|[\\.-])";"i")))|.address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"


### PR DESCRIPTION
The `\b` word boundaries in regex weren't matching browser PWA classes like `brave-web.whatsapp.com__-Default` Dots broke the boundaries, so the script skipped the real web app and grabbed whatever came first—like a terminal editing Whatsapp.desktop.
The fix: Swap `\b` for `(^|[\\.-])` before the pattern and `($|[\\.-])` after. Now it matches when the app name is at the start/end or next to dots/hyphens.
This keeps things precise (no false positives) while fixing PWAs. 
One line changed, focusing back to WhatsApp now works correctly.

Fixes: https://github.com/basecamp/omarchy/issues/3669
