### PR TITLE
Custom screenshot filename

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -3,7 +3,11 @@
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}}"
 DATE_FORMAT="${OMARCHY_SCREENSHOT_DATE_FORMAT:-%Y-%m-%d_%H-%M-%S}"
-FILENAME="${OMARCHY_SCREENSHOT_PREFIX:-screenshot}-$(date +"$DATE_FORMAT")${OMARCHY_SCREENSHOT_SUFFIX:-.png}"
+if [[ $OMARCHY_SCREENSHOT_PREFIX == false ]]; then
+  FILENAME="$(date +"$DATE_FORMAT")${OMARCHY_SCREENSHOT_SUFFIX:-.png}"
+else
+  FILENAME="${OMARCHY_SCREENSHOT_PREFIX:-screenshot_}$(date +"$DATE_FORMAT")${OMARCHY_SCREENSHOT_SUFFIX:-.png}"
+fi
 
 if [[ ! -d "$OUTPUT_DIR" ]]; then
   notify-send "Screenshot directory does not exist: $OUTPUT_DIR" -u critical -t 3000


### PR DESCRIPTION
Small tweak to allow for the customization of the screenshot filename through 3 additional environment variables. 
Lot's of other ways to do it of course.
This one doesn't change the defaults, and overrides can be put in the `.config/hypr/env.conf`, much like `OMARCHY_SCREENSHOT_DIR`

e.g.
```
env = OMARCHY_SCREENSHOT_DATE_FORMAT,%Y.%m.%dT%H.%M.%S
env = OMARCHY_SCREENSHOT_PREFIX,false
env = OMARCHY_SCREENSHOT_SUFFIX,_screenshot.png
```
