### PR TITLE
fix: close walker menu when already open with keybind

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -468,6 +468,12 @@ go_to_menu() {
   esac
 }
 
+# Close walker if it's already open
+if hyprctl layers | grep -q walker; then
+  walker -q
+  exit 0
+fi
+
 if [[ -n "$1" ]]; then
   BACK_TO_EXIT=true
   go_to_menu "$1"

--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -212,6 +212,12 @@ prioritize_entries() {
   cut -f2-
 }
 
+# Close walker if it's already open
+if hyprctl layers | grep -q walker; then
+  walker -q
+  exit 0
+fi
+
 monitor_height=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .height')
 menu_height=$((monitor_height * 40 / 100))
 


### PR DESCRIPTION
When you open omarchy menu, system menu or keybinds list menu with the specified keybind, pressing the keybind again does not close it rather shows "No Results" in the same menu.

**Example:**
1. Open omarchy menu with `SUPER + ALT + SPACE`
2. Press same keybind again while it is open. It will show "No Results".

The intended behavior should be to close the already open menu.