### PR TITLE
Exit screensaver when mouse moves or clicks

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -11,7 +11,10 @@ exit_screensaver() {
   exit 0
 }
 
+# Exit the screensaver on signals and input from keyboard and mouse
 trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
+printf '\e[?1000h\e[?1003h' # Enable mouse tracking (clicks: 1000, movement: 1003)
+while read -rsn1 -t 0.1; do :; done # Flush any pending input
 
 printf '\033]11;rgb:00/00/00\007'  # Set background color to black
 
@@ -24,7 +27,7 @@ while true; do
     --no-eol --no-restore-cursor &
 
   while pgrep -x tte >/dev/null; do
-    if read -n 1 -t 1 || ! screensaver_in_focus; then
+    if read -rsn1 -t 1 || ! screensaver_in_focus; then
       exit_screensaver
     fi
   done


### PR DESCRIPTION
Turns out there are control codes for tracking mouse actions in xterm-compatible terminal emulators (mind blown).

This patch adds mouse action awareness to our beloved screensaver setup:

- on setup it sends the respective control codes for movement and click detection
- in the main loop it opens up the input reader to read raw bytes and, thus, enables to detect even so much as a mouse's squeak

Personally, I love swiping my trackpad to exit screensaver. But the explicit pressing-a-key to exit is nice, also.

And I don't know if many people have jitter issues with their mouses or trackpads. Reckon though, if they had they wouldn't get to ever see the glory that TTE is, anyway :)

This is tested and working in Ghostty/Alacritty/Kitty.