### PR TITLE
Feat: Compact partition summary for omarchy-drive-info

### DIFF
--- a/bin/omarchy-drive-info
+++ b/bin/omarchy-drive-info
@@ -25,4 +25,42 @@ display="$drive"
 [[ -n "$size" ]] && display="$display ($size)"
 [[ -n "$model" ]] && display="$display - $model"
 
+# Build compact partition summary
+part_summary=""
+
+while IFS= read -r line; do
+  NAME=""
+  TYPE=""
+  FSTYPE=""
+  MOUNTPOINT=""
+
+  eval "$line" 2>/dev/null
+
+  # Only care about actual partitions
+  [[ "$TYPE" != "part" ]] && continue
+
+  part_name="${NAME##*/}"
+
+  entry="$part_name"
+  if [[ -n "$FSTYPE" ]]; then
+    entry+=":$FSTYPE"
+  else
+    entry+=":unknown"
+  fi
+
+  if [[ -n "$MOUNTPOINT" ]]; then
+    entry+="($MOUNTPOINT)"
+  fi
+
+  if [[ -z "$part_summary" ]]; then
+    part_summary="$entry"
+  else
+    part_summary+=", $entry"
+  fi
+done < <(lsblk -P -o NAME,TYPE,FSTYPE,MOUNTPOINT "$root_drive" 2>/dev/null)
+
+if [[ -n "$part_summary" ]]; then
+  display+=" [${part_summary}]"
+fi
+
 echo "$display"


### PR DESCRIPTION
## Summary

Adds compact partition map summary to the bin/omarchy-drive-info bash script that is used by the installer.

## Changes

* Parse partition map and add compact summary of partition table to drive selection menu.

## Example output

>$ ./omarchy-drive-info /dev/nvme0n1
>/dev/nvme0n1 ( 1.8T) - Samsung SSD 990 PRO 2TB [nvme0n1p1:vfat(/boot/efi), nvme0n1p2:ext4(/boot), nvme0n1p3:crypto_LUKS]
>$ ./omarchy-drive-info /dev/nvme1n1
>/dev/nvme1n1 ( 1.8T) - Samsung SSD 990 PRO 2TB [nvme1n1p1:vfat, nvme1n1p2:unknown, nvme1n1p3:BitLocker, nvme1n1p4:ntfs]

## Pros

* For those of us who have two or more drives of the same size and model, this makes it easier to select the drive you intend overwrite with Omarchy.

## Cons

* Lower resolution screens may not look as nice in the drive selection menu.

## Disclosures

* I've tested by running the script directly, but not when it's run via the installer.
* This PR contains AI written code.