### PR TITLE
Override zoom webapp browser to chromium if default browser is brave

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,4 +7,8 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*)
 *) browser="chromium.desktop" ;;
 esac
 
+if [[ "$1" == *zoom* && "$browser" == brave-browser* ]]; then
+  browser="chromium.desktop"
+fi
+
 exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"


### PR DESCRIPTION
Something changed with one of latest brave changes in the last couple of days. The share screen button does not show up in meetings. When wrapping zoom webapp in chromium, it works as expected.