### PR TITLE
Small improvements to the 'update available' waybar module

### DIFF
--- a/migrations/1765198150.sh
+++ b/migrations/1765198150.sh
@@ -1,18 +1,25 @@
 echo "Display update version number and allow right-click to open release notes"
 
-WAYBAR_CONFIG="$HOME/.config/waybar/config_test.jsonc"
+WAYBAR_CONFIG="$HOME/.config/waybar/config.jsonc"
 
-# Check only inside custom/update for on-click-right
 if ! sed -n '/"custom\/update": {/,/},/p' "$WAYBAR_CONFIG" | grep -q '"on-click-right"'; then
   sed -i '/"custom\/update": {/,/},/ {
     /"exec":/a\    "on-click-right": "xdg-open https://github.com/basecamp/omarchy/releases",
   }' "$WAYBAR_CONFIG"
 fi
 
-# Check only inside custom/update for tooltip-format
-if ! sed -n '/"custom\/update": {/,/},/p' "$WAYBAR_CONFIG" | grep -q '"tooltip-format"'; then
+UPDATE_BLOCK=$(sed -n '/"custom\/update": {/,/},/p' "$WAYBAR_CONFIG")
+
+if ! grep -q '"tooltip-format"' <<<"$UPDATE_BLOCK"; then
+  # Add if missing
   sed -i '/"custom\/update": {/,/},/ {
     /"exec":/a\    "tooltip-format": "{text}",
+  }' "$WAYBAR_CONFIG"
+
+elif grep -q '"tooltip-format": "Omarchy update available"' <<<"$UPDATE_BLOCK"; then
+  # Replace if default
+  sed -i '/"custom\/update": {/,/},/ {
+    s/"tooltip-format": "Omarchy update available"/"tooltip-format": "{text}"/
   }' "$WAYBAR_CONFIG"
 fi
 


### PR DESCRIPTION
## Display the version number of the available update
I wanted to know ahead, which version number is available when the 'update available' module appears in the waybar.

Since the `omarchy-update-available` command already returns a string like `Omarchy update available (v3.2.2)`, might as well just use it instead of hard coding the string without the version number.

Preview:
<img width="429" height="129" alt="screenshot-2025-12-03_11-20-07" src="https://github.com/user-attachments/assets/9c15f16a-d661-4826-9a5d-e8c94a5fe859" />

## Open the GitHub releases page when right clicking the module
Also, since I always read the release notes (as you should) before updating, I wanted a quick way to do it. So I added a right-click function to the update module that opens `https://github.com/basecamp/omarchy/releases`.

Originally brought up here: https://github.com/basecamp/omarchy/discussions/3324