### PR TITLE
Walker: Add runner provider prefix for quick command execution

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -43,3 +43,7 @@ provider = "websearch"
 [[providers.prefixes]]
 prefix = "$"
 provider = "clipboard"
+
+[[providers.prefixes]]
+prefix = "!"
+provider = "runner"


### PR DESCRIPTION
This PR adds a `!` prefix for the runner provider in Walker, enabling quick command execution through the launcher interface. For example: `!omarblue` shows bluetooth-related commands

<img width="830" height="544" alt="image" src="https://github.com/user-attachments/assets/2f53606f-edf0-4a6a-80c5-d91a53faaab3" />