### PR TITLE
feat: battery time in Waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -88,8 +88,8 @@
       "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
     },
     "format-full": "󰂅",
-    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
-    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%\n{time}",
+    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%\n{time}",
     "interval": 5,
     "on-click": "omarchy-menu power",
     "states": {


### PR DESCRIPTION
Just a simple feature: show time the battery to be full or empty in the tooltip.