### PR TITLE
Support Mullvad Browser private window launch

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -3,7 +3,7 @@
 default_browser=$(xdg-settings get default-web-browser)
 browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
 
-if [[ $browser_exec =~ (firefox|zen|librewolf) ]]; then
+if [[ $browser_exec =~ (firefox|zen|librewolf|mullvad) ]]; then
   private_flag="--private-window"
 else
   private_flag="--incognito"


### PR DESCRIPTION
[Mullvad Browser](https://mullvad.net/en/browser) is a browser based on Firefox ESR, developed by the creators of Mullvad VPN. This PR detects it as a Firefox-based browser when launching a private window, and appends the `--private-window` flag.