### PR TITLE
Open directory in Image Viewer

### DIFF
--- a/applications/imv.desktop
+++ b/applications/imv.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Image Viewer
-Exec=imv %F
+Exec=bash -c 'imv -n "$1" "$(dirname "$1")"' bash %f
 Icon=imv
 Type=Application
 MimeType=image/png;image/jpeg;image/jpg;image/gif;image/bmp;image/webp;image/tiff;image/x-xcf;image/x-portable-pixmap;image/x-xbitmap;


### PR DESCRIPTION
When opening an image currently the left and right arrow keys do nothing. Any Mac or Windows user would expect the left/right keys to navigate to the previous/next images in the directory. To achieve this imv needs to be told the path to start at.