### PR TITLE
Fix keybinding description for makoctl restore

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -19,7 +19,7 @@ bindd = SUPER, COMMA, Dismiss last notification, exec, makoctl dismiss
 bindd = SUPER SHIFT, COMMA, Dismiss all notifications, exec, makoctl dismiss --all
 bindd = SUPER CTRL, COMMA, Toggle silencing notifications, exec, makoctl mode -t do-not-disturb && makoctl mode | grep -q 'do-not-disturb' && notify-send "Silenced notifications" || notify-send "Enabled notifications"
 bindd = SUPER ALT, COMMA, Invoke last notification, exec, makoctl invoke
-bindd = SUPER SHIFT ALT, COMMA, Invoke last notification, exec, makoctl restore
+bindd = SUPER SHIFT ALT, COMMA, Restore last notification, exec, makoctl restore
 
 # Toggle idling
 bindd = SUPER CTRL, I, Toggle locking on idle, exec, omarchy-toggle-idle


### PR DESCRIPTION
The description for the `makoctl restore` binding is the same as the one used for `makoctl invoke`. This causes a duplicate in the show key bindings menu.

**Before:**
<img width="806" height="583" alt="image" src="https://github.com/user-attachments/assets/71da55b1-8431-4048-8b96-55d7c80cc339" />

**After:**
<img width="808" height="586" alt="image" src="https://github.com/user-attachments/assets/9e4b18c5-ba58-46f8-bd5a-221030c11b8a" />
