### PR TITLE
Improve multi-monitor behaviour for screensaver effects

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -20,13 +20,15 @@ printf '\033]11;rgb:00/00/00\007'  # Set background color to black
 
 hyprctl keyword cursor:invisible true &>/dev/null
 
+tty=$(tty 2>/dev/null)
+
 while true; do
   tte -i ~/.config/omarchy/branding/screensaver.txt \
     --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
     --random-effect --exclude-effects dev_worm \
     --no-eol --no-restore-cursor &
 
-  while pgrep -x tte >/dev/null; do
+  while pgrep -t "${tty#/dev/}" -x tte >/dev/null; do
     if read -rsn1 -t 1 || ! screensaver_in_focus; then
       exit_screensaver
     fi


### PR DESCRIPTION
This pull request updates `omarchy-cmd-screensaver` so that screensaver effects run independently on each monitor.

### What’s improved
- No more waiting for all displays to complete before continuing.
- Noticeably smoother behaviour on multi-monitor configurations.

### Why it matters
Users with multiple displays benefit from a more responsive and visually consistent screensaver experience.