### PR TITLE
Enable tiny-dfr and t2fanrd services on T2 Macs

### DIFF
--- a/install/config/hardware/fix-apple-t2.sh
+++ b/install/config/hardware/fix-apple-t2.sh
@@ -11,6 +11,13 @@ if lspci -nn | grep -q "106b:180[12]"; then
     t2fanrd \
     tiny-dfr
 
+  # Add user to video group (required for tiny-dfr to access /dev/dri devices)
+  sudo usermod -aG video ${USER}
+
+  # Enable T2 services
+  sudo systemctl enable t2fanrd.service
+  sudo systemctl enable tiny-dfr.service
+
   echo "apple-bce" | sudo tee /etc/modules-load.d/t2.conf >/dev/null
 
   echo "MODULES+=(apple-bce usbhid hid_apple hid_generic xhci_pci xhci_hcd)" | sudo tee /etc/mkinitcpio.conf.d/apple-t2.conf >/dev/null


### PR DESCRIPTION
## Summary

Partially addresses #3791

Add missing setup steps for T2 Mac Touch Bar and fan control:

1. **Add user to video group** - Required for tiny-dfr to access `/dev/dri/card*` devices
2. **Enable t2fanrd.service** - Fan control daemon
3. **Enable tiny-dfr.service** - Touch Bar daemon

Without these steps, users must manually configure the services after installation for the Touch Bar to work on boot.

## Related

**Note:** To fully resolve issue #3791, the upstream fix to the `tiny-dfr-arch` package must also be merged:
https://github.com/NoaHimesaka1873/tiny-dfr-arch/pull/2

That PR fixes the service file which has `BindsTo=` dependencies on Apple Silicon devices that don't exist on Intel T2 Macs.

## Testing

Tested on MacBook Pro 16,1 (2019) with linux-t2 6.17.7-1.