### PR TITLE
Add migration to fix Claude Code installMethod config

### DIFF
--- a/migrations/1765054976.sh
+++ b/migrations/1765054976.sh
@@ -1,0 +1,7 @@
+echo "Configure Claude Code install method for pacman-based installation"
+
+if command -v claude &>/dev/null && [ -f ~/.claude.json ]; then
+  if grep -q '"installMethod": "unknown"' ~/.claude.json; then
+    sed -i 's/"installMethod": "unknown"/"installMethod": "native"/' ~/.claude.json
+  fi
+fi


### PR DESCRIPTION
## Summary

- Adds a migration to fix Claude Code `/doctor` warnings on Omarchy installations

## Problem

When Claude Code is installed via the `claude-code` AUR package (Menu → Install → AI → Claude Code), the `/doctor` command shows these warnings:

```
Warning: Running native installation but config install method is 'unknown'
Warning: Native installation exists but ~/.local/bin is not in your PATH
```

These warnings are cosmetic but confusing for users. The AUR package installs a native binary but doesn't register itself with Claude's config.

## Solution

This migration sets `installMethod` to `"native"` in `~/.claude.json` for users who have Claude Code installed. This is the correct value for pacman-based native binary installations.

The migration:
- Only runs if `claude` command exists and `~/.claude.json` exists
- Only modifies if `installMethod` is currently `"unknown"` (safe/idempotent)
- Uses `sed` for direct JSON editing (consistent with other Omarchy migrations)

## Test plan

- [x] Tested `sed` command on local `~/.claude.json` - correctly changes value
- [x] Verified output JSON remains valid
- [x] Verified condition checks work correctly

Related: Discussion #3433 mentions Claude Code throwing warnings when installed via Omarchy