### PR TITLE
Add example to enable three-finger drag in input configuration

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -25,7 +25,7 @@ input {
     # Control the speed of your scrolling
     scroll_factor = 0.4
 
-    # Enable three finger drag (0 -> disabled, 1 -> 3 fingers, 2 -> 4 fingers)
+    # Move windows with three-finger drag
     # drag_3fg = 1
   }
 }


### PR DESCRIPTION
Not sure if this needs a migration?

Commented out by default, similar to other examples in the input configuration.