### PR TITLE
actually querying yay instead of searching through cache

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -12,9 +12,10 @@ fzf_args=(
   --bind 'alt-b:change-preview:yay -Gpa {1} | tail -n +5'
   --bind 'alt-B:change-preview:yay -Siia {1}'
   --color 'pointer:green,marker:green'
+  --bind "change:reload(yay -qSs {q})"
 )
 
-pkg_names=$(yay -Slqa | fzf "${fzf_args[@]}")
+pkg_names=$(yay -qSs | fzf "${fzf_args[@]}")
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay


### PR DESCRIPTION
I was trying to install joplin, but i couldn't find it in yay install option (mod+alt+space > install > AUR)

so I looked into why, and it turned out we are actually simple searching through cache, and not actually querying the aur repository

I updated the script to make it work

please let me know if any changes or explanation is needed