### PR TITLE
fix: avoid layout shift on screensaver close

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -9,6 +9,7 @@ windowrule = float, class:org.gnome.Calculator
 
 # Fullscreen screensaver
 windowrule = fullscreen, class:org.omarchy.screensaver
+windowrule = float, class:org.omarchy.screensaver
 
 # No transparency on media windows
 windowrule = opacity 1 1, class:^(zoom|vlc|mpv|org.kde.kdenlive|com.obsproject.Studio|com.github.PintaProject.Pinta|imv|org.gnome.NautilusPreviewer)$


### PR DESCRIPTION
Hello!

when screensaver is closed workspace layout shifts to fill space used by screensaver window.

which looks a little unexpected imo.

this pr makes screensaver float to avoid that.