### PR TITLE
Add ZSH shell support

### DIFF
--- a/bin/omarchy-install-shell
+++ b/bin/omarchy-install-shell
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if (($# == 0)); then
+  echo "Usage: omarchy-install-shell [bash|zsh]"
+  exit 1
+fi
+
+shell="$1"
+
+case "$shell" in
+  bash)
+    rc_file="bashrc"
+    ;;
+  zsh)
+    rc_file="zshrc"
+    ;;
+  *)
+    echo "Unknown shell: $shell"
+    exit 1
+    ;;
+esac
+
+# Install package (zsh needs installing, bash is always present)
+if [ "$shell" = "zsh" ]; then
+  if ! omarchy-pkg-add zsh; then
+    echo "Failed to install $shell"
+    exit 1
+  fi
+fi
+
+# Copy shell config
+echo "Setting up $shell configuration..."
+cp ~/.local/share/omarchy/default/$rc_file ~/.$rc_file
+
+echo "$shell configuration installed."

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -65,6 +65,10 @@ install_terminal() {
   present_terminal "omarchy-install-terminal $1"
 }
 
+install_shell() {
+  present_terminal "omarchy-install-shell $1"
+}
+
 aur_install() {
   present_terminal "echo 'Installing $1 from AUR...'; yay -S --noconfirm $2"
 }
@@ -175,7 +179,7 @@ show_setup_menu() {
   local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n󰍹  Monitors"
   [ -f ~/.config/hypr/bindings.conf ] && options="$options\n  Keybindings"
   [ -f ~/.config/hypr/input.conf ] && options="$options\n  Input"
-  options="$options\n  Defaults\n󰱔  DNS\n  Security\n  Config"
+  options="$options\n  Defaults\n󱆃  Shell\n󰱔  DNS\n  Security\n  Config"
 
   case $(menu "Setup" "$options") in
   *Audio*) xdg-terminal-exec --app-id=com.omarchy.Wiremix -e wiremix ;;
@@ -192,6 +196,7 @@ show_setup_menu() {
   *Keybindings*) open_in_editor ~/.config/hypr/bindings.conf ;;
   *Input*) open_in_editor ~/.config/hypr/input.conf ;;
   *Defaults*) open_in_editor ~/.config/uwsm/default ;;
+  *Shell*) show_setup_shell_menu ;;
   *DNS*) present_terminal omarchy-setup-dns ;;
   *Security*) show_setup_security_menu ;;
   *Config*) show_setup_config_menu ;;
@@ -209,6 +214,14 @@ show_setup_power_menu() {
   fi
 }
 
+
+show_setup_shell_menu() {
+  case $(menu "Shell" "bash\nzsh") in
+  *bash*) present_terminal "omarchy-shell-set bash" ;;
+  *zsh*) present_terminal "omarchy-shell-set zsh" ;;
+  *) show_setup_menu ;;
+  esac
+}
 show_setup_config_menu() {
   case $(menu "Setup" "  Hyprland\n  Hypridle\n  Hyprlock\n  Hyprsunset\n  Swayosd\n󰌧  Walker\n󰍜  Waybar\n󰞅  XCompose") in
   *Hyprland*) open_in_editor ~/.config/hypr/hyprland.conf ;;
@@ -232,7 +245,7 @@ show_setup_security_menu() {
 }
 
 show_install_menu() {
-  case $(menu "Install" "󰣇  Package\n󰣇  AUR\n  Web App\n  TUI\n  Service\n  Style\n󰵮  Development\n  Editor\n  Terminal\n󱚤  AI\n󰍲  Windows\n  Gaming") in
+  case $(menu "Install" "󰣇  Package\n󰣇  AUR\n  Web App\n  TUI\n  Service\n  Style\n󰵮  Development\n  Editor\n  Terminal\n󱆃  Shell\n󱚤  AI\n󰍲  Windows\n  Gaming") in
   *Package*) terminal omarchy-pkg-install ;;
   *AUR*) terminal omarchy-pkg-aur-install ;;
   *Web*) present_terminal omarchy-webapp-install ;;
@@ -242,6 +255,7 @@ show_install_menu() {
   *Development*) show_install_development_menu ;;
   *Editor*) show_install_editor_menu ;;
   *Terminal*) show_install_terminal_menu ;;
+  *Shell*) show_install_shell_menu ;;
   *AI*) show_install_ai_menu ;;
   *Windows*) present_terminal "omarchy-windows-vm install" ;;
   *Gaming*) show_install_gaming_menu ;;
@@ -276,6 +290,14 @@ show_install_terminal_menu() {
   *Alacritty*) install_terminal "alacritty" ;;
   *Ghostty*) install_terminal "ghostty" ;;
   *Kitty*) install_terminal "kitty" ;;
+  *) show_install_menu ;;
+  esac
+}
+
+show_install_shell_menu() {
+  case $(menu "Install" "bash\nzsh") in
+  *bash*) install_shell "bash" ;;
+  *zsh*) install_shell "zsh" ;;
   *) show_install_menu ;;
   esac
 }

--- a/bin/omarchy-shell-set
+++ b/bin/omarchy-shell-set
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if (($# == 0)); then
+  echo "Usage: omarchy-shell-set [bash|zsh]"
+  exit 1
+fi
+
+shell="$1"
+shell_path="/bin/$shell"
+
+# Validate shell exists
+if [[ ! -x "$shell_path" ]]; then
+  echo "Shell not found: $shell_path"
+  echo "Run 'omarchy-install-shell $shell' first."
+  exit 1
+fi
+
+# Check if already using this shell
+if [[ "$SHELL" == "$shell_path" ]]; then
+  echo "Already using $shell as default shell."
+  exit 0
+fi
+
+gum style --border normal --border-foreground 6 --padding "1 2" \
+  "Change default shell to $shell?" \
+  "" \
+  "• Your password will be required" \
+  "• You'll need to log out for the change to take effect"
+
+if ! gum confirm "Continue?"; then
+  echo "Cancelled"
+  exit 0
+fi
+
+# chsh prompts for password automatically
+if chsh -s "$shell_path"; then
+  echo ""
+  if gum confirm "Shell changed to $shell. Log out now to apply?"; then
+    hyprctl dispatch exit
+  fi
+else
+  echo "Failed to change shell."
+  exit 1
+fi

--- a/default/zsh/aliases
+++ b/default/zsh/aliases
@@ -1,0 +1,43 @@
+# File system
+if command -v eza &> /dev/null; then
+  alias ls='eza -lh --group-directories-first --icons=auto'
+  alias lsa='ls -a'
+  alias lt='eza --tree --level=2 --long --icons --git'
+  alias lta='lt -a'
+fi
+
+alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
+
+if command -v zoxide &> /dev/null; then
+  alias cd="zd"
+  zd() {
+    if [ $# -eq 0 ]; then
+      builtin cd ~ && return
+    elif [ -d "$1" ]; then
+      builtin cd "$1"
+    else
+      z "$@" && printf "\U000F17A9 " && pwd || echo "Error: Directory not found"
+    fi
+  }
+fi
+
+open() {
+  xdg-open "$@" >/dev/null 2>&1 &
+}
+
+# Directories
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+
+# Tools
+alias d='docker'
+alias r='rails'
+n() { if [ "$#" -eq 0 ]; then nvim .; else nvim "$@"; fi; }
+
+# Git
+alias g='git'
+alias gcm='git commit -m'
+alias gcam='git commit -a -m'
+alias gcad='git commit -a --amend'
+

--- a/default/zsh/envs
+++ b/default/zsh/envs
@@ -1,0 +1,4 @@
+# Editor used by CLI
+export SUDO_EDITOR="$EDITOR"
+export BAT_THEME=ansi
+

--- a/default/zsh/functions
+++ b/default/zsh/functions
@@ -1,0 +1,68 @@
+# Compression
+compress() { tar -czf "${1%/}.tar.gz" "${1%/}"; }
+alias decompress="tar -xzf"
+
+# Write iso file to sd card
+iso2sd() {
+  if [ $# -ne 2 ]; then
+    echo "Usage: iso2sd <input_file> <output_device>"
+    echo "Example: iso2sd ~/Downloads/ubuntu-25.04-desktop-amd64.iso /dev/sda"
+    echo -e "\nAvailable SD cards:"
+    lsblk -d -o NAME | grep -E '^sd[a-z]' | awk '{print "/dev/"$1}'
+  else
+    sudo dd bs=4M status=progress oflag=sync if="$1" of="$2"
+    sudo eject $2
+  fi
+}
+
+# Format an entire drive for a single partition using ext4
+format-drive() {
+  if [ $# -ne 2 ]; then
+    echo "Usage: format-drive <device> <name>"
+    echo "Example: format-drive /dev/sda 'My Stuff'"
+    echo -e "\nAvailable drives:"
+    lsblk -d -o NAME -n | awk '{print "/dev/"$1}'
+  else
+    echo "WARNING: This will completely erase all data on $1 and label it '$2'."
+    read -rp "Are you sure you want to continue? (y/N): " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+      sudo wipefs -a "$1"
+      sudo dd if=/dev/zero of="$1" bs=1M count=100 status=progress
+      sudo parted -s "$1" mklabel gpt
+      sudo parted -s "$1" mkpart primary ext4 1MiB 100%
+      sudo mkfs.ext4 -L "$2" "$([[ $1 == *"nvme"* ]] && echo "${1}p1" || echo "${1}1")"
+      sudo chmod -R 777 "/run/media/$USER/$2"
+      echo "Drive $1 formatted and labeled '$2'."
+    fi
+  fi
+}
+
+# Transcode a video to a good-balance 1080p that's great for sharing online
+transcode-video-1080p() {
+  ffmpeg -i $1 -vf scale=1920:1080 -c:v libx264 -preset fast -crf 23 -c:a copy ${1%.*}-1080p.mp4
+}
+
+# Transcode a video to a good-balance 4K that's great for sharing online
+transcode-video-4K() {
+  ffmpeg -i $1 -c:v libx265 -preset slow -crf 24 -c:a aac -b:a 192k ${1%.*}-optimized.mp4
+}
+
+# Transcode any image to JPG image that's great for shrinking wallpapers
+img2jpg() {
+  magick $1 -quality 95 -strip ${1%.*}.jpg
+}
+
+# Transcode any image to JPG image that's great for sharing online without being too big
+img2jpg-small() {
+  magick $1 -resize 1080x\> -quality 95 -strip ${1%.*}.jpg
+}
+
+# Transcode any image to compressed-but-lossless PNG
+img2png() {
+  magick "$1" -strip -define png:compression-filter=5 \
+    -define png:compression-level=9 \
+    -define png:compression-strategy=1 \
+    -define png:exclude-chunk=all \
+    "${1%.*}.png"
+}
+

--- a/default/zsh/init
+++ b/default/zsh/init
@@ -1,0 +1,21 @@
+if command -v mise &> /dev/null; then
+  eval "$(mise activate zsh)"
+fi
+
+if command -v starship &> /dev/null; then
+  eval "$(starship init zsh)"
+fi
+
+if command -v zoxide &> /dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
+if command -v fzf &> /dev/null; then
+  if [[ -f /usr/share/fzf/completion.zsh ]]; then
+    source /usr/share/fzf/completion.zsh
+  fi
+  if [[ -f /usr/share/fzf/key-bindings.zsh ]]; then
+    source /usr/share/fzf/key-bindings.zsh
+  fi
+fi
+

--- a/default/zsh/keybindings
+++ b/default/zsh/keybindings
@@ -1,0 +1,10 @@
+# Arrow keys match what you've typed so far against your command history
+autoload -U up-line-or-beginning-search
+autoload -U down-line-or-beginning-search
+zle -N up-line-or-beginning-search
+zle -N down-line-or-beginning-search
+bindkey "^[[A" up-line-or-beginning-search
+bindkey "^[[B" down-line-or-beginning-search
+bindkey "^[[C" forward-char
+bindkey "^[[D" backward-char
+

--- a/default/zsh/prompt
+++ b/default/zsh/prompt
@@ -1,0 +1,8 @@
+# Technicolor dreams
+force_color_prompt=yes
+color_prompt=yes
+
+# Simple prompt with path in the window/pane title and caret for typing line
+PROMPT=$'\uf0a9 '
+precmd() { print -Pn "\e]0;%~\a"; }
+

--- a/default/zsh/rc
+++ b/default/zsh/rc
@@ -1,0 +1,8 @@
+source ~/.local/share/omarchy/default/zsh/shell
+source ~/.local/share/omarchy/default/zsh/aliases
+source ~/.local/share/omarchy/default/zsh/functions
+source ~/.local/share/omarchy/default/zsh/prompt
+source ~/.local/share/omarchy/default/zsh/init
+source ~/.local/share/omarchy/default/zsh/envs
+source ~/.local/share/omarchy/default/zsh/keybindings
+

--- a/default/zsh/shell
+++ b/default/zsh/shell
@@ -1,0 +1,20 @@
+# History control
+setopt APPEND_HISTORY
+setopt HIST_IGNORE_DUPS
+setopt HIST_IGNORE_SPACE
+setopt SHARE_HISTORY
+HISTSIZE=32768
+SAVEHIST=32768
+HISTFILE=~/.zsh_history
+
+# Autocompletion
+autoload -Uz compinit
+compinit
+
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
+zstyle ':completion:*' menu select
+zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+
+# Ensure command hashing is off for mise
+setopt NO_HASH_CMDS
+

--- a/default/zshrc
+++ b/default/zshrc
@@ -1,0 +1,12 @@
+# If not running interactively, don't do anything (leave this at the top of this file)
+[[ -o interactive ]] || return
+
+# All the default Omarchy aliases and functions
+# (don't mess with these directly, just overwrite them here!)
+source ~/.local/share/omarchy/default/zsh/rc
+
+# Add your own exports, aliases, and functions here.
+#
+# Make an alias for invoking commands you use constantly
+# alias p='python'
+


### PR DESCRIPTION
## Summary
- Adds ZSH as an alternative shell option in Omarchy
- **Install → Shell**: installs shell package and copies config
- **Setup → Shell**: changes default login shell via `chsh` with gum confirmation
## Files Added
- `bin/omarchy-install-shell` - install shell + config
- `bin/omarchy-shell-set` - change default shell with confirmation
- `bin/omarchy-menu` - add Shell to Install and Setup menus
- `default/zshrc` - wrapper file (like bashrc)
- `default/zsh/*` - full ZSH config (8 files, exact counterpart to bash)
## ZSH config matches bash exactly
All ZSH files are 1:1 counterparts of their bash equivalents with only necessary ZSH syntax differences.

> **Note:** This PR was vibecoded with AI assistance, but all changes have been manually tested and verified.
