### PR TITLE
Added Iosevka to font menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -309,11 +309,12 @@ show_install_style_menu() {
 }
 
 show_install_font_menu() {
-  case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono" "--width 350") in
+  case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono\n  Iosevka" "--width 350") in
   *Meslo*) install_font "Meslo LG Mono" "ttf-meslo-nerd" "MesloLGL Nerd Font" ;;
   *Fira*) install_font "Fira Code" "ttf-firacode-nerd" "FiraCode Nerd Font" ;;
   *Victor*) install_font "Victor Code" "ttf-victor-mono-nerd" "VictorMono Nerd Font" ;;
   *Bistream*) install_font "Bistream Vera Code" "ttf-bitstream-vera-mono-nerd" "BitstromWera Nerd Font" ;;
+  *Iosevka*) install_font "Iosevka" "ttf-iosevka-nerd" "Iosevka Nerd Font Mono" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
Added Iosevka support to the font installation menu.

This change expands the Install Font menu by including Iosevka as a selectable option alongside the existing fonts (Meslo, Fira Code, Victor Mono, Bitstream Vera). Selecting it correctly routes to install_font with the appropriate Nerd Font package:

`install_font "Iosevka" "ttf-iosevka-nerd" "Iosevka Nerd Font Mono"`

Nice and simple -- finally gives Iosevka fans a first-class option.