### PR TITLE
fix(mako): show battery notifications over fullscreen apps

### DIFF
--- a/default/mako/core.ini
+++ b/default/mako/core.ini
@@ -18,6 +18,7 @@ invisible=false
 
 [urgency=critical]
 default-timeout=0
+layer=overlay
 
 [summary~="Setup Wi-Fi"]
 on-button-left=exec sh -c 'omarchy-notification-dismiss "Setup Wi-Fi"; omarchy-launch-wifi'


### PR DESCRIPTION
 ### What this change does
Adds `layer=overlay` to the mako configuration.

### Why
Fixes #3066
Previously, critical notifications (like low battery alerts) were rendered behind fullscreen windows (e.g., video players, games), causing users to miss them and allowing the laptop to completely discharge. This change forces critical notifications to render on the top layer, ensuring they are always visible.

### Verification
Tested locally:
- Opened a fullscreen video.
- Triggered a notification.
- Verified it appears on top of the content.


