### PR TITLE
Update browser launching to include Exec args

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 default_browser=$(xdg-settings get default-web-browser)
-browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
+browser_exec=$(sed -n 's/^Exec=//p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1 | sed 's/ *%U//g')
 
 if [[ $browser_exec =~ (firefox|zen|librewolf|mullvad) ]]; then
   private_flag="--private-window"
@@ -11,4 +11,4 @@ else
   private_flag="--incognito"
 fi
 
-exec setsid uwsm-app -- "$browser_exec" "${@/--private/$private_flag}"
+exec setsid uwsm-app -- $browser_exec "${@/--private/$private_flag}"

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,4 +7,4 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*)
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+exec setsid uwsm-app -- $(sed -n 's/^Exec=//p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1 | sed 's/ *%U//g') --app="$1" "${@:2}"


### PR DESCRIPTION
When launching the default browser, there is a sed that pulls out the binary's exec path. This drops all arguments, presumably to remove the %U present. This Change updates these scripts to include any args in the Exec line, while still ignoring the %U if present.