### PR TITLE
enhancement : Enhanced the `os age` feature in fastfetch config

### DIFF
--- a/config/fastfetch/config.jsonc
+++ b/config/fastfetch/config.jsonc
@@ -134,7 +134,7 @@
       "type": "command",
       "key": "󱦟 OS Age",
       "keyColor": "magenta",
-      "text": "birth_install=$(stat -c %W /); current=$(date +%s); time_progression=$((current - birth_install)); days_difference=$((time_progression / 86400)); echo $days_difference days"
+      "text": "echo $(( ($(date +%s) - $(stat -c %W /)) / 86400 )) days"
     },
     {
       "type": "uptime",


### PR DESCRIPTION
The command to print `os age` is good but we can write this more clearly. I hope this helps to make Omarchy good!


Have a nice day!


**One suggestion for core devlopers:**

Please add a `contributing.md`