### PR TITLE
Fix: Toggle gaps uses configured values in hyprland instead of static values

### DIFF
--- a/bin/omarchy-hyprland-workspace-toggle-gaps
+++ b/bin/omarchy-hyprland-workspace-toggle-gaps
@@ -3,8 +3,14 @@
 workspace_id=$(hyprctl activeworkspace -j | jq -r .id)
 gaps=$(hyprctl workspacerules -j | jq -r ".[] | select(.workspaceString==\"$workspace_id\") | .gapsOut[0] // 0")
 
+configured_gap_out_array=($(hyprctl -j getoption general:gaps_out | jq -r '.custom'))
+configured_gap_out=${configured_gap_out_array[*]:0:1}
+configured_gap_in_array=($(hyprctl -j getoption general:gaps_in | jq -r '.custom'))
+configured_gap_in=${configured_gap_in_array[*]:0:1}
+configured_border=$(hyprctl -j getoption general:border_size | jq -r '.int')
+
 if [[ $gaps == "0" ]]; then
-  hyprctl keyword "workspace $workspace_id, gapsout:10, gapsin:5, bordersize:2"
+  hyprctl keyword "workspace $workspace_id, gapsout:$configured_gap_out, gapsin:$configured_gap_in, bordersize:$configured_border"
 else \
   hyprctl keyword "workspace $workspace_id, gapsout:0, gapsin:0, bordersize:0"
 fi

--- a/bin/omarchy-hyprland-workspace-toggle-gaps
+++ b/bin/omarchy-hyprland-workspace-toggle-gaps
@@ -1,16 +1,17 @@
 #!/bin/bash
 
 workspace_id=$(hyprctl activeworkspace -j | jq -r .id)
-gaps=$(hyprctl workspacerules -j | jq -r ".[] | select(.workspaceString==\"$workspace_id\") | .gapsOut[0] // 0")
 
-configured_gap_out_array=($(hyprctl -j getoption general:gaps_out | jq -r '.custom'))
-configured_gap_out=${configured_gap_out_array[*]:0:1}
-configured_gap_in_array=($(hyprctl -j getoption general:gaps_in | jq -r '.custom'))
-configured_gap_in=${configured_gap_in_array[*]:0:1}
-configured_border=$(hyprctl -j getoption general:border_size | jq -r '.int')
+gapsOut=$(hyprctl workspacerules -j | jq -r ".[] | select(.workspaceString==\"$workspace_id\") | .gapsOut[0]")
+gapsIn=$(hyprctl workspacerules -j | jq -r ".[] | select(.workspaceString==\"$workspace_id\") | .gapsIn[0]")
+borderSize=$(hyprctl workspacerules -j | jq -r ".[] | select(.workspaceString==\"$workspace_id\") | .borderSize")
 
-if [[ $gaps == "0" ]]; then
-  hyprctl keyword "workspace $workspace_id, gapsout:$configured_gap_out, gapsin:$configured_gap_in, bordersize:$configured_border"
+if [[ $gapsOut == "0" && $gapsIn == "0" && $borderSize ==  0 ]]; then
+  hyprctl keyword "workspace $workspace_id, \
+    gapsout:$(hyprctl getoption general:gaps_out -j | jq .custom -r), \
+    gapsin:$(hyprctl getoption general:gaps_in -j | jq .custom -r), \
+    bordersize:$(hyprctl getoption general:border_size -j | jq .int -r) \
+    "
 else \
   hyprctl keyword "workspace $workspace_id, gapsout:0, gapsin:0, bordersize:0"
 fi


### PR DESCRIPTION
Instead of using static values fetch configured gaps and bordersize from hyprland config with hyprctl.

Fixes this #2977

Bash array magic required to support bash and zsh is from here:
https://stackoverflow.com/questions/50427449/behavior-of-arrays-in-bash-scripting-and-zsh-shell-start-index-0-or-1