### PR TITLE
Remove deprecated and unsupported Kitty settings

### DIFF
--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -7,9 +7,7 @@ font_size        9.0
 
 # Window
 window_padding_width 14
-window_padding_height 14
 hide_window_decorations yes
-show_window_resize_notification no
 confirm_os_window_close 0
 
 # Keybindings
@@ -17,7 +15,6 @@ map ctrl+insert copy_to_clipboard
 map shift+insert paste_from_clipboard
 
 # Allow remote access
-single_instance yes
 allow_remote_control yes
 
 # Aesthetics


### PR DESCRIPTION
The following options are no longer recognized by Kitty and caused warnings during startup:

window_padding_height

show_window_resize_notification

single_instance

They have been removed to keep the configuration compatible with current Kitty versions.