### PR TITLE
Fix: Allows Ctrl+C to cancel TUI and Web App install/remove

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cmd="$*"
-exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"
+exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; if [ \$? -ne 130 ]; then omarchy-show-done; fi"

--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$#" -ne 4 ]; then
   echo -e "\e[32mLet's create a TUI shortcut you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My TUI")

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
 

--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$#" -lt 3 ]; then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
 


### PR DESCRIPTION
Allows Ctrl+C to close installers/removers for TUI's and Web Apps via the Omarchy Menu. Previous functionality did not let you use Ctrl+C, and, trying to abort via blank entries still showed "Done! Press any key to close..." 

This fix matches the UX of installing and removing Packages and AURs and cleanly exits.

https://github.com/user-attachments/assets/5d33bcab-330d-4d1d-a4f4-f2490bf902d9

