### PR TITLE
Quit Walker before screensaver launch

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -13,6 +13,9 @@ if [[ -f ~/.local/state/omarchy/toggles/screensaver-off ]] && [[ $1 != "force" ]
   exit 1
 fi
 
+# Silently quit Walker on overlay
+walker -q
+
 focused=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')
 terminal=$(xdg-terminal-exec --print-id)
 


### PR DESCRIPTION
Screensaver launch is broken when Walker is open: It will fail to go fullscreen and exits right after input read's first iteration, due to the screensaver_in_focus() check. See https://github.com/basecamp/omarchy/issues/2992 for an example report.

This addition will silently quit an opened Walker menu before launching the screensaver terminal. It is mildly intrusive, alas, as a return from screensaver will not present the pre-screensaver state exactly.