### PR TITLE
Replace gum spinning globe with nerdfont checkmark

### DIFF
--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 echo
-gum spin --spinner "globe" --title "Done! Press any key to close..." -- bash -c 'read -n 1 -s'
+echo "󰄬 Done! Press any key to close..."
+read -n 1 -s


### PR DESCRIPTION
The animated globe icon in omarchy-show-done (seen after actions like installing or removing packages from the Omarchy menu) looks out of place with the rest of the clean aesthetic across Omarchy. This replaces the animation with a nerdfont checkmark. Before and after below:

![gum spin --spinner "globe"](https://github.com/user-attachments/assets/c1876d24-2c97-4676-b234-325ed106f41d)

<img width="1186" height="820" alt="show-done-with-nerdfont" src="https://github.com/user-attachments/assets/4e33fc7c-ccc4-434c-b603-90d4015857af" />

