### PR TITLE
feat: Add China region connectivity support

### DIFF
--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -1,0 +1,109 @@
+# Omarchy 中国地区安装指南
+
+本文档提供了针对中国大陆地区用户优化的安装方法，以解决网络连接问题。
+
+## 快速安装（使用中国镜像）
+
+如果您在中国大陆，可以使用以下命令进行安装，这将自动使用中国友好的镜像源：
+
+```bash
+curl -o- https://omarchy.org/install | OMARCHY_USE_CHINA_MIRRORS=1 bash
+```
+
+## 环境变量选项
+
+### OMARCHY_USE_CHINA_MIRRORS
+
+设置为 `1` 启用中国镜像源（清华、中科大、阿里云等）：
+
+```bash
+export OMARCHY_USE_CHINA_MIRRORS=1
+```
+
+### OMARCHY_GIT_MIRROR
+
+指定 Git 仓库镜像站点（如果 GitHub 访问困难）：
+
+```bash
+# 使用 Gitee 镜像（需要先在 Gitee 上创建镜像）
+export OMARCHY_GIT_MIRROR=gitee.com
+
+# 使用 GitCode 镜像（需要先在 GitCode 上创建镜像）
+export OMARCHY_GIT_MIRROR=gitcode.com
+```
+
+## 手动切换到中国镜像
+
+如果您已经安装了 Omarchy，可以随时切换到中国镜像：
+
+```bash
+omarchy-refresh-pacman china
+```
+
+切换回默认镜像：
+
+```bash
+omarchy-refresh-pacman stable
+```
+
+## 支持的中国镜像源
+
+系统会自动使用以下中国大陆镜像源（按优先级排序）：
+
+1. **清华大学开源镜像站** - https://mirrors.tuna.tsinghua.edu.cn
+2. **中国科学技术大学镜像站** - https://mirrors.ustc.edu.cn  
+3. **阿里云镜像站** - https://mirrors.aliyun.com
+4. **腾讯云镜像站** - https://mirrors.cloud.tencent.com
+5. **网易镜像站** - https://mirrors.163.com
+6. **华为云镜像站** - https://repo.huaweicloud.com
+
+## GPG 密钥服务器
+
+系统已配置多个 GPG 密钥服务器以提高连接成功率：
+
+- keyserver.ubuntu.com
+- pgp.mit.edu
+- pgp.surfnet.nl
+- keys.mailvelope.com
+- keyring.debian.org
+- keys.openpgp.org
+
+安装脚本会自动尝试多个密钥服务器，直到成功为止。
+
+## 完整安装示例
+
+```bash
+# 设置环境变量
+export OMARCHY_USE_CHINA_MIRRORS=1
+export OMARCHY_GIT_MIRROR=gitee.com  # 可选，如果 GitHub 访问困难
+
+# 开始安装
+curl -o- https://omarchy.org/install | bash
+```
+
+## 故障排除
+
+### 如果 GitHub 克隆失败
+
+1. 尝试使用 Gitee 或 GitCode 镜像（需要先在这些平台创建仓库镜像）
+2. 或使用代理：`export https_proxy=http://your-proxy:port`
+
+### 如果 GPG 密钥导入失败
+
+脚本会自动尝试多个密钥服务器。如果全部失败，您可以：
+
+1. 检查网络连接
+2. 尝试使用代理
+3. 手动导入密钥
+
+### 如果包下载速度慢
+
+使用中国镜像命令：
+
+```bash
+omarchy-refresh-pacman china
+```
+
+## 支持
+
+如有问题，请访问：https://discord.gg/tXFUdasqhY

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Omarchy is a beautiful, modern & opinionated Linux distribution by DHH.
 
 Read more at [omarchy.org](https://omarchy.org).
 
+## Installation for China Region / 中国地区安装
+
+For users in mainland China, we provide optimized mirrors for better connectivity. See [INSTALL_CN.md](INSTALL_CN.md) for detailed instructions.
+
+中国大陆用户可以使用优化的镜像源以获得更好的连接速度。详情请查看 [INSTALL_CN.md](INSTALL_CN.md)。
+
 ## License
 
 Omarchy is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -6,7 +6,12 @@ sudo cp -f /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
 
 sudo cp -f ~/.local/share/omarchy/default/pacman/pacman.conf /etc/pacman.conf
 
-if [[ $1 == "edge" ]]; then
+# Check if user wants to use China mirrors
+if [[ $1 == "china" ]]; then
+  sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-china /etc/pacman.d/mirrorlist
+  sudo sed -i 's|https://pkgs.omarchy.org/.*$arch|https://pkgs.omarchy.org/stable/$arch|' /etc/pacman.conf
+  echo "Setting mirrors to China region for better connectivity"
+elif [[ $1 == "edge" ]]; then
   sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-edge /etc/pacman.d/mirrorlist
   sudo sed -i 's|https://pkgs.omarchy.org/.*$arch|https://pkgs.omarchy.org/edge/$arch|' /etc/pacman.conf
   echo "Setting channel to edge"

--- a/default/gpg/dirmngr.conf
+++ b/default/gpg/dirmngr.conf
@@ -1,7 +1,10 @@
 keyserver hkps://keyserver.ubuntu.com
+keyserver hkps://pgp.mit.edu
 keyserver hkps://pgp.surfnet.nl
 keyserver hkps://keys.mailvelope.com
 keyserver hkps://keyring.debian.org
-keyserver hkps://pgp.mit.edu
+keyserver hkps://keys.openpgp.org
+keyserver hkp://keyserver.ubuntu.com:80
+keyserver hkp://pgp.mit.edu:80
 
 connect-quick-timeout 4

--- a/default/pacman/mirrorlist-china
+++ b/default/pacman/mirrorlist-china
@@ -1,0 +1,20 @@
+# China mirrors for Arch Linux
+# These mirrors are known to work well in mainland China
+
+# Tsinghua University (清华大学)
+Server = https://mirrors.tuna.tsinghua.edu.cn/archlinux/$repo/os/$arch
+
+# USTC (中国科学技术大学)
+Server = https://mirrors.ustc.edu.cn/archlinux/$repo/os/$arch
+
+# Aliyun (阿里云)
+Server = https://mirrors.aliyun.com/archlinux/$repo/os/$arch
+
+# Tencent Cloud (腾讯云)
+Server = https://mirrors.cloud.tencent.com/archlinux/$repo/os/$arch
+
+# Netease (网易)
+Server = https://mirrors.163.com/archlinux/$repo/os/$arch
+
+# Huawei Cloud (华为云)
+Server = https://repo.huaweicloud.com/archlinux/$repo/os/$arch

--- a/install/post-install/pacman.sh
+++ b/install/post-install/pacman.sh
@@ -1,6 +1,13 @@
 # Configure pacman
 sudo cp -f ~/.local/share/omarchy/default/pacman/pacman.conf /etc/pacman.conf
-sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-stable /etc/pacman.d/mirrorlist
+
+# Support for China mirrors - users can set OMARCHY_USE_CHINA_MIRRORS=1
+if [[ "${OMARCHY_USE_CHINA_MIRRORS:-0}" == "1" ]]; then
+  echo "Using China mirrors for better connectivity in mainland China..."
+  sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-china /etc/pacman.d/mirrorlist
+else
+  sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-stable /etc/pacman.d/mirrorlist
+fi
 
 if lspci -nn | grep -q "106b:180[12]"; then
   cat <<EOF | sudo tee -a /etc/pacman.conf >/dev/null

--- a/install/preflight/pacman.sh
+++ b/install/preflight/pacman.sh
@@ -4,10 +4,40 @@ if [[ -n ${OMARCHY_ONLINE_INSTALL:-} ]]; then
 
   # Configure pacman
   sudo cp -f ~/.local/share/omarchy/default/pacman/pacman.conf /etc/pacman.conf
-  sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist /etc/pacman.d/mirrorlist
+  
+  # Support for China mirrors - users can set OMARCHY_USE_CHINA_MIRRORS=1
+  if [[ "${OMARCHY_USE_CHINA_MIRRORS:-0}" == "1" ]]; then
+    echo "Using China mirrors for better connectivity in mainland China..."
+    sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-china /etc/pacman.d/mirrorlist
+  else
+    sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-stable /etc/pacman.d/mirrorlist
+  fi
 
-  sudo pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver keys.openpgp.org
-  sudo pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571
+  # Try multiple keyservers for better reliability, especially in China
+  KEYSERVERS=(
+    "keys.openpgp.org"
+    "keyserver.ubuntu.com"
+    "pgp.mit.edu"
+    "keyserver.pgp.com"
+  )
+  
+  KEY_RECEIVED=false
+  for keyserver in "${KEYSERVERS[@]}"; do
+    echo "Attempting to receive key from $keyserver..."
+    if sudo pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver "$keyserver" 2>/dev/null; then
+      KEY_RECEIVED=true
+      echo "Successfully received key from $keyserver"
+      break
+    fi
+  done
+  
+  if [ "$KEY_RECEIVED" = false ]; then
+    echo "Warning: Failed to receive key from all keyservers. Installation may fail."
+    echo "You may need to manually import the key or check your network connection."
+  else
+    # Only sign the key if it was successfully received
+    sudo pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571
+  fi
 
   sudo pacman -Sy
   sudo pacman -S --noconfirm --needed omarchy-keyring


### PR DESCRIPTION
- Add GitHub repository cloning mirror support in boot.sh
- Add China-friendly keyserver fallbacks in install/preflight/pacman.sh
- Add China-friendly keyserver configuration in default/gpg/dirmngr.conf
- Add Arch Linux package mirror list for China (mirrorlist-china)
- Create INSTALL_CN.md installation documentation for Chinese users
- Update README.md with reference to China installation guide
- Update omarchy-refresh-pacman to support china option