### PR TITLE
Reduce keyboard fatigue for move window focus

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -18,10 +18,10 @@ bindd = SUPER, UP, Move window focus up, movefocus, u
 bindd = SUPER, DOWN, Move window focus down, movefocus, d
 
 # Move focus with SUPER + VIM direction keys
-bindd = SUPER, H, Move window focus left, movefocus, l
-bindd = SUPER, L, Move window focus right, movefocus, r
-bindd = SUPER, K, Move window focus up, movefocus, u
-bindd = SUPER, J, Move window focus down, movefocus, d
+bindd = SUPER SHIFT, H, Move window focus left, movefocus, l
+bindd = SUPER SHIFT, L, Move window focus right, movefocus, r
+bindd = SUPER SHIFT, K, Move window focus up, movefocus, u
+bindd = SUPER SHIFT, J, Move window focus down, movefocus, d
 
 # Switch workspaces with SUPER + [1-9; 0]
 bindd = SUPER, code:10, Switch to workspace 1, workspace, 1


### PR DESCRIPTION
By adding VIM direction keys as another way to move window focus.

Moving focus windows is a common action. I believe some devs (myself included) will find it more comfortable to navigate with the VIM keys since their hands are already at that position rather than having to constantly shift their hands down and to the right to reach the arrow keys.