### PR TITLE
openai-codex-bin -> openai-codex in menus

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -279,7 +279,7 @@ show_install_ai_menu() {
   case $(menu "Install" "󱚤  Claude Code\n󱚤  Cursor CLI\n󱚤  Gemini\n󱚤  OpenAI Codex\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
   *Claude*) install "Claude Code" "claude-code" ;;
   *Cursor*) install "Cursor CLI" "cursor-cli" ;;
-  *OpenAI*) install "OpenAI Codex" "openai-codex-bin" ;;
+  *OpenAI*) install "OpenAI Codex" "openai-codex" ;;
   *Gemini*) install "Gemini" "gemini-cli" ;;
   *Studio*) install "LM Studio" "lmstudio" ;;
   *Ollama*) install "Ollama" $ollama_pkg ;;

--- a/migrations/1765884267.sh
+++ b/migrations/1765884267.sh
@@ -1,0 +1,6 @@
+echo "Change to openai-codex instead of openai-codex-bin"
+
+if omarchy-pkg-present openai-codex-bin; then
+    omarchy-pkg-drop openai-codex-bin
+    omarchy-pkg-add openai-codex
+fi


### PR DESCRIPTION
This was done in a migration in 0588cc8e5b76c8ff4cdf1c08e8657983dac9e307 but the menu entry was never updated. Installs after the migration will still get the outdated version.

Added a new migration as well for those that installed meanwhile.