### PR TITLE
feat(bidings): Add BlueTUI and Wiremix binding to bindings.conf

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -11,7 +11,8 @@ bindd = SUPER SHIFT, G, Signal, exec, omarchy-launch-or-focus ^signal$ "uwsm-app
 bindd = SUPER SHIFT, O, Obsidian, exec, omarchy-launch-or-focus ^obsidian$ "uwsm-app -- obsidian -disable-gpu --enable-wayland-ime"
 bindd = SUPER SHIFT, W, Typora, exec, uwsm-app -- typora --enable-wayland-ime
 bindd = SUPER SHIFT, SLASH, Passwords, exec, uwsm-app -- 1password
-bindd = SUPER, B, BlueTUI, exec, omarchy-launch-tui bluetui
+bindd = SUPER SHIFT, R, BlueTUI, exec, omarchy-launch-tui bluetui
+bindd = SUPER SHIFT, S, Wiremix, exec, omarchy-launch-or-focus-tui wiremix
 
 # If your web app url contains #, type it as ## to prevent hyprland treating it as a comment
 bindd = SUPER SHIFT, A, ChatGPT, exec, omarchy-launch-webapp "https://chatgpt.com"


### PR DESCRIPTION
This pull request adds a new keyboard binding to the Hyprland configuration, allowing quick access to the BlueTUI application.

New key binding:

* Added a binding for `SUPER + B` to launch `BlueTUI` using the `omarchy-launch-tui` script.