### PR TITLE
feat: add support for SSH git URLs when installing themes

### DIFF
--- a/bin/omarchy-theme-install
+++ b/bin/omarchy-theme-install
@@ -5,7 +5,7 @@
 
 if [ -z "$1" ]; then
   echo -e "\e[32mSee https://manuals.omamix.org/2/the-omarchy-manual/90/extra-themes\n\e[0m"
-  REPO_URL=$(gum input --placeholder="Git repo URL for theme" --header="")
+  REPO_URL=$(gum input --placeholder="Git repo URL (https or git@host:org/repo.git)" --header="")
 else
   REPO_URL="$1"
 fi
@@ -15,7 +15,20 @@ if [ -z "$REPO_URL" ]; then
 fi
 
 THEMES_DIR="$HOME/.config/omarchy/themes"
-THEME_NAME=$(basename "$REPO_URL" .git | sed -E 's/^omarchy-//; s/-theme$//')
+
+# Handle scp-style SSH URLs (git@host:org/repo.git) when deriving the theme name.
+REPO_PATH="$REPO_URL"
+if [[ "$REPO_PATH" != *"://"* && "$REPO_PATH" == *:*/* ]]; then
+  REPO_PATH="${REPO_PATH#*:}"
+fi
+REPO_PATH="${REPO_PATH%/}"
+
+REPO_BASENAME=$(basename "$REPO_PATH")
+REPO_BASENAME="${REPO_BASENAME%.git}"
+
+THEME_NAME=$(
+  echo "$REPO_BASENAME" | sed -E 's/^omarchy-//; s/-theme$//'
+)
 THEME_PATH="$THEMES_DIR/$THEME_NAME"
 
 # Remove existing theme if present


### PR DESCRIPTION
### What this does

Adds support for installing Omarchy themes from SSH (scp-style) Git repository URLs and clarifies the accepted URL formats in the prompt.

### Why

Previously, the theme installer only worked correctly with HTTPS Git URLs. Providing an SSH URL such as `git@github.com:org/omarchy-foo-theme.git` resulted in an incorrect theme name and install path.

Supporting SSH URLs makes it easier for contributors and users who rely on SSH-based Git workflows.

### Changes

- Adds support for scp-style SSH Git URLs (`git@host:org/repo.git`) when deriving the theme name.
- Normalizes SSH URLs before calling `basename` to ensure correct theme directory naming.
- Updates the `gum input` placeholder to explicitly document supported Git URL formats.
- Keeps existing theme naming rules intact (`omarchy-` prefix and `-theme` suffix removal).

### Examples

- `https://github.com/org/omarchy-foo-theme.git` → `~/.config/omarchy/themes/foo`
- `git@github.com:org/omarchy-foo-theme.git` → `~/.config/omarchy/themes/foo`

### Notes

- No behavior changes for existing HTTPS-based installs.
- This change only affects how the repository name is parsed and does not modify cloning behavior.
