### PR TITLE
Add CTRL ALT SHIFT DEL to close all windows except current workspace

### DIFF
--- a/bin/omarchy-hyprland-window-close-all-except-workspace
+++ b/bin/omarchy-hyprland-window-close-all-except-workspace
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Close all windows except current workspace, move remaining to workspace 1
+WS=$(hyprctl activeworkspace -j | jq '.id')
+
+hyprctl clients -j | jq -r ".[] | select(.workspace.id != $WS) | .address" | \
+  xargs -I{} hyprctl dispatch closewindow address:{}
+
+# Move remaining windows to workspace 1 (if not already there)
+if [ "$WS" != "1" ]; then
+  hyprctl clients -j | jq -r '.[].address' | \
+    xargs -I{} hyprctl dispatch movetoworkspacesilent 1,address:{}
+fi
+
+hyprctl dispatch workspace 1

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -1,6 +1,7 @@
 # Close windows
 bindd = SUPER, W, Close window, killactive,
 bindd = CTRL ALT, DELETE, Close all windows, exec, omarchy-hyprland-window-close-all
+bindd = CTRL ALT SHIFT, DELETE, Close all windows except current workspace, exec, omarchy-hyprland-window-close-all-except-workspace
 
 # Control tiling
 bindd = SUPER, J, Toggle window split, togglesplit, # dwindle


### PR DESCRIPTION
As addition to existing CTRL ALT DEL, i like to clean up everything except the current workspace / what im looking at currently. 

CTRL ALT DEL SHIFT closes everything except current workspace and moves it to workspace 1. 