### PR TITLE
Make `gitk` and `git gui` commands work

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -114,6 +114,7 @@ sushi
 swaybg
 swayosd
 system-config-printer
+tk
 tldr
 tree-sitter-cli
 tobi-try


### PR DESCRIPTION
The `gitk` & `git gui` commands fail on a fresh install due to `tk` not being installed.

<img width="541" height="55" alt="gitgui" src="https://github.com/user-attachments/assets/eb0c8dbc-7500-44ca-9892-d3e6b404513e" />

The `tk` package is flagged as an optional dependency of `git` in Arch's package manager, but without it the `gitk` command falls over.

I suspect it's optional by default as `gitk` makes no sense in a headless install, but it's really handy in headmore system.

This adds 26MB to the installation.

Fixes #3927