### PR TITLE
fix: prevent word splitting in omarchy-launch-about

### DIFF
--- a/bin/omarchy-launch-or-focus-tui
+++ b/bin/omarchy-launch-or-focus-tui
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-APP_ID="org.omarchy.$(basename $1)"
+APP_ID="org.omarchy.$(basename "$1")"
 LAUNCH_COMMAND="omarchy-launch-tui $@"
 
 exec omarchy-launch-or-focus "$APP_ID" "$LAUNCH_COMMAND"


### PR DESCRIPTION
Unquoted variable expansion in omarchy-launch-or-focus-tui APP_ID was breaking omarchy-launch-about when passing "bash -c 'fastfetch; read -n 1 -s'"
