### PR TITLE
fix(fingerprint): Refactor fingerprint hardware detection to use fprintd-list

### DIFF
--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -20,7 +20,11 @@ print_info() {
 }
 
 check_fingerprint_hardware() {
-  if ! lsusb | grep -Eiq 'fingerprint|synaptics|goodix|elan|validity|FPC'; then
+  # Get fingerprint devices for the user
+  devices=$(fprintd-list "$USER" 2>/dev/null)
+
+  # Exit if no devices found
+  if [[ -z "$devices" ]]; then
     print_error "\nNo fingerprint sensor detected."
     return 1
   fi


### PR DESCRIPTION
This PR is related to issue #3947

It updates the fingerprint hardware check to use `fprintd-list` for more reliable detection of available fingerprint sensors.  
This improves the accuracy of identifying devices across different fprintd versions and vendors.

Alternative solution: the existing detection using `lsusb | grep -Eiq 'fingerprint|synaptics|goodix|elan|validity|FPC'` 
could be improved by adding the vendor name of the device (e.g., "LighTuning" / "Egis") to the regex.