### PR TITLE
fix(aur): add --cleanafter to prevent omarchy-update failures on corrupted cache, and make AUR pkg updates idempotent

### DIFF
--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -3,7 +3,7 @@
 set -e
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
-sudo pacman -Syyu --noconfirm
+sudo pacman -Syyu --noconfirm --cleanafter
 
 # Update AUR packages if any are installed
 if pacman -Qem >/dev/null; then

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -3,13 +3,13 @@
 set -e
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
-sudo pacman -Syyu --noconfirm --cleanafter
+sudo pacman -Syyu --noconfirm 
 
 # Update AUR packages if any are installed
 if pacman -Qem >/dev/null; then
   if omarchy-pkg-aur-accessible; then
     echo -e "\e[32m\nUpdate AUR packages\e[0m"
-    yay -Sua --noconfirm
+    yay -Sua --noconfirm --cleanafter
     echo
   else
     echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"


### PR DESCRIPTION
### WHY
This PR addresses a recurring failure during the `omarchy-update` process where `yay` crashes the system update.
Fixes #3917
### The Problem
When updating AUR packages, `yay` attempts to reuse existing git repositories in `~/.cache/yay/`. If a previous download was interrupted or the directory is corrupted, `git` fails because the "destination path already exists and is not an empty directory." 

Because the script uses the `--noconfirm` flag, `yay` cannot prompt the user to clean the directory and instead exits with a fatal error, having the user to manually remove the path.

### The Fix
Added the `--cleanafter` flag to the yay command. This ensures that:
1. Build directories are removed immediately after a successful system update.
2. The system state remains clean for future update cycles.
3. The update process becomes **idempotent**, preventing stale state conflicts.

