### PR TITLE
fix: dynamic Windows VM boot synchronization for RDP

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -309,6 +309,32 @@ launch_windows() {
       notify-send -u critical "Windows VM" "Failed to start Windows VM"
       exit 1
     fi
+
+    echo "Waiting for RDP to be ready..."
+    WAIT_COUNT=0
+    while ! nc -z 127.0.0.1 3389 2>/dev/null; do
+      sleep 2
+      WAIT_COUNT=$((WAIT_COUNT + 1))
+      if [ $WAIT_COUNT -gt 60 ]; then  # 2 minutes timeout
+        echo "❌ Timeout waiting for RDP!"
+        echo "   The VM might still be installing Windows."
+        echo "   Check progress at: http://127.0.0.1:8006"
+        exit 1
+      fi
+    done
+
+    echo "Waiting for Windows VM to start..."
+    WAIT_COUNT=0
+    until docker logs omarchy-windows 2>&1 | grep -qi "windows started successfully"; do
+      sleep 2
+      WAIT_COUNT=$((WAIT_COUNT + 1))
+      if [ $WAIT_COUNT -gt 60 ]; then  # 2 minutes timeout
+        echo ""
+        echo "❌ Timeout: Windows VM failed to start within 2 minutes"
+        echo "   Check logs: docker logs omarchy-windows"
+        exit 1
+      fi
+    done
   fi
 
   if ! wait_for_rdp_ready "$WIN_USER" "$WIN_PASS"; then


### PR DESCRIPTION
The current 5-second sleep is not enough for all hardware. On my PC (and likely many others), Windows takes longer to initialize. If the script tries to connect via RDP before Windows is fully ready, the connection fails or hangs.

I replaced the hard-coded sleep with a dynamic loop that checks the Docker logs for the "Windows started successfully" message. This ensures the RDP client only starts once Windows has confirmed it's ready, making the launch process much more reliable across different hardware specs.

Fixes #2599 