### PR TITLE
fix: stop paging git diff output when running omarchy-update

### DIFF
--- a/bin/omarchy-update-git
+++ b/bin/omarchy-update-git
@@ -5,4 +5,4 @@ set -e
 echo -e "\e[32mUpdate Omarchy\e[0m"
 
 git -C $OMARCHY_PATH pull --autostash
-git --no-pager -C $OMARCHY_PATH diff --check || git -C $OMARCHY_PATH reset --merge
+git -C $OMARCHY_PATH --no-pager diff --check || git -C $OMARCHY_PATH reset --merge


### PR DESCRIPTION
When running omarchy-menu, the git diff command opens a pager, causing the update to hang until the pager is closed.
This change ensures that git diff runs without opening a pager, preventing the update from hanging.

https://github.com/user-attachments/assets/40284545-d207-404d-8d25-0e094784cbd2

