### PR TITLE
feat: added power profile indicator and change notification

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -194,7 +194,7 @@ show_setup_power_menu() {
   if [[ "$profile" == "CNCLD" || -z "$profile" ]]; then
     back_to show_setup_menu
   else
-    powerprofilesctl set "$profile"
+    powerprofilesctl set "$profile" && notify-send "Power Profile" "$(powerprofilesctl get)"
   fi
 }
 

--- a/bin/omarchy-powerprofiles-list
+++ b/bin/omarchy-powerprofiles-list
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 powerprofilesctl list |
-  awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }' |
+  awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[[:space:]]+|:$/,""); print }' |
   tac


### PR DESCRIPTION
I tweaked the scripts a little to indicate which power profile is currently active and to provide a notification when the power profile is switched via the menu.

The goal was to change as little as possible, so I just removed the part where the power profile indicator is removed.