### PR TITLE
fix: use correct blue for Alacritty

### DIFF
--- a/migrations/1765836579.sh
+++ b/migrations/1765836579.sh
@@ -1,3 +1,0 @@
-echo "Fix blue color for Alacritty"
-
-sed -i 's/blue = "#205EA6"/blue = "#4385BE"/' $OMARCHY_PATH/themes/flexoki-light/alacritty.toml 


### PR DESCRIPTION
use blue from https://github.com/kepano/flexoki/blob/main/alacritty/flexoki-light.toml which is already used by kitty.conf