### PR TITLE
feat: optional re-run scripts instead of force close

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,4 +1,11 @@
 #!/bin/bash
 
 cmd="$*"
-exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "omarchy-show-logo; $cmd; omarchy-show-done"
+
+exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "
+while true; do
+  omarchy-show-logo
+  $cmd
+  omarchy-show-done || break
+done
+"

--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -20,5 +20,5 @@ if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay
   echo "$pkg_names" | tr '\n' ' ' | xargs yay -S --noconfirm
   sudo updatedb
-  omarchy-show-done
+  omarchy-show-done "$0"
 fi

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -17,5 +17,5 @@ pkg_names=$(pacman -Slq | fzf "${fzf_args[@]}")
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay
   echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm
-  omarchy-show-done
-fi
+  omarchy-show-done "$0"
+ fi

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -17,5 +17,5 @@ pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay
   echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
-  omarchy-show-done
+  omarchy-show-done "$0"
 fi

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,4 +1,23 @@
 #!/bin/bash
 
+title="Done! Press 'r' to run again or any other key to close..."
+
+# Exit gum spin command with exit code 10 if pressed 'r', otherwise exit like normal
 echo
-gum spin --spinner "globe" --title "Done! Press any key to close..." -- bash -c 'read -n 1 -s'
+gum spin --spinner "globe" --title "$title" -- bash -c 'read -rsn1 key; [[ "${key,,}" == "r" ]] && exit 10'
+code=$?
+
+# If user pressed 'r' (code 10) - run command again
+if [[ $code -eq 10 ]]; then
+  # If caller provided restart command, run exec
+  if [[ -n "$1" ]]; then
+    exec "$@"
+  fi
+
+  # Fallback, restart logic handled by caller
+  # Exit 0 means "Run script again"
+  exit 0
+fi
+
+# Exit 1 means "Exit script" (Error code on clean exit to avoid looping on real script errors)
+exit 1


### PR DESCRIPTION
### What

Add option for `omarchy-show-done` to run the script again. Hope it's usecase is clear enough. Especially when starting out and configuring omarchy, one can be forced to open up the menu quite a few times, and this should reduce friction a bit.

Hopefully someone finds it useful, at least.

### Why

It is tedious to open up the menu and find the right entry every time one:
- want to install multiple programs/themes (yes, one can tab/multi-select in some scripts, but not others)
- do a typo e.g. when creating a webapp, and want to restart

### Screenshots

<img width="549" height="372" alt="image" src="https://github.com/user-attachments/assets/65b8a301-5082-4344-95c8-d713226c1013" />


https://github.com/user-attachments/assets/489dcbe9-4367-49e3-8356-303444bbf8f3


https://github.com/user-attachments/assets/c230991d-73ea-4419-8392-1128ce4334ad

### Considerations
- Is it worth it/useful enough for everyone?
- `r` could be swapped out with some other key/key-combo
- The messages are clear enough IMO, but UX is not my expertise
- Unclear for developers how it should be used (additional complexity)?
- Unclear for users what "run again" means?
- Confusing for existing users?

_Thanks for Omarchy_