### PR TITLE
Fix: missing mako notifications icons

### DIFF
--- a/default/mako/core.ini
+++ b/default/mako/core.ini
@@ -6,6 +6,7 @@ padding=10,15
 border-size=2
 max-icon-size=32
 font=sans-serif 14px
+icon-path=icon-path=/usr/share/icons/Yaru-dark:/usr/share/icons/Yaru:/usr/share/icons/breeze-dark:/usr/share/icons/breeze:/usr/share/icons/Adwaita:/usr/share/icons/hicolor:/usr/share/pixmaps
 
 [app-name=Spotify]
 invisible=1


### PR DESCRIPTION
### What this change does
Adds icon-path field to mako config file

### Why
Notifications that are called with notify-send or any other api that include icons such as battey-caution, dialog-information etc. were missing from notification, this was because mako config was missing path to icon libraries.

### Verification
Triggered a notification using notify-send
Verified icons are showing up properly
### Screenshots

**Before**
<img width="2880" height="1800" alt="no-icon" src="https://github.com/user-attachments/assets/0ce58e12-cfc6-4551-ad4c-25f268488ce4" />
**After**
<img width="2880" height="1800" alt="with-icon" src="https://github.com/user-attachments/assets/8a12c7db-1f19-4112-afe9-34e41be2577e" />
