### PR TITLE
Enable parallel compilation of packages

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -17,6 +17,7 @@ run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/walker-elephant.sh
 run_logged $OMARCHY_INSTALL/config/fast-shutdown.sh
 run_logged $OMARCHY_INSTALL/config/sudoless-asdcontrol.sh
+run_logged $OMARCHY_INSTALL/config/enable-parallel-compilation.sh
 run_logged $OMARCHY_INSTALL/config/hardware/network.sh
 run_logged $OMARCHY_INSTALL/config/hardware/set-wireless-regdom.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-fkeys.sh

--- a/install/config/enable-parallel-compilation.sh
+++ b/install/config/enable-parallel-compilation.sh
@@ -1,0 +1,2 @@
+# Set make to use all cpus/cores during compilation
+sudo sed -i 's/^#MAKEFLAGS="-j2"/MAKEFLAGS="--jobs=$(nproc)"/' /etc/makepkg.conf

--- a/migrations/1766512893.sh
+++ b/migrations/1766512893.sh
@@ -1,0 +1,2 @@
+echo "Set make to use all cpus/cores during compilation"
+sudo sed -i 's/^#MAKEFLAGS="-j2"/MAKEFLAGS="--jobs=$(nproc)"/' /etc/makepkg.conf


### PR DESCRIPTION
## What
Enable `make` to [parallel compiling](https://wiki.archlinux.org/title/Makepkg#Parallel_compilation) packages using all cpu cores.

## Why
I was updating an AUR package today and noticed that it was using just one core, and it was taking some time to finish. After enabling all cores it only took a few seconds. Some packages – like `qt5-webengine` – could take a very long time to compile on just 1 core.