### PR TITLE
feat: add headphone battery indicator to waybar

### DIFF
--- a/bin/omarchy-headphone-status
+++ b/bin/omarchy-headphone-status
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Shows headphone icon with battery level if bluetooth audio device is the active sink
+
+# Get the active audio sink (marked with *)
+ACTIVE_SINK=$(wpctl status 2>/dev/null | sed -n '/Audio/,/Video/p' | grep -E "^\s*│\s+\*" | head -1)
+
+if echo "$ACTIVE_SINK" | grep -qiE "WH-|WF-|airpods|buds|headphone|headset|earbuds|bose|jabra|beats|galaxy|sony|xm[0-9]"; then
+    # Get battery percentage from upower for headset devices
+    BATTERY=""
+    for device in $(upower -e 2>/dev/null | grep headset); do
+        PERCENTAGE=$(upower -i "$device" 2>/dev/null | grep -oP 'percentage:\s+\K\d+')
+        if [ -n "$PERCENTAGE" ]; then
+            BATTERY="$PERCENTAGE%"
+            break
+        fi
+    done
+
+    if [ -n "$BATTERY" ]; then
+        echo "󰋋 <span font_size='10pt'>$BATTERY</span>"
+    else
+        echo "󰋋"
+    fi
+fi

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -8,6 +8,7 @@
   "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator"],
   "modules-right": [
     "group/tray-expander",
+    "custom/headphone",
     "bluetooth",
     "network",
     "pulseaudio",
@@ -105,6 +106,12 @@
     "format-no-controller": "",
     "tooltip-format": "Devices connected: {num_connections}",
     "on-click": "omarchy-launch-bluetooth"
+  },
+  "custom/headphone": {
+    "exec": "omarchy-headphone-status",
+    "interval": 3,
+    "format": "{}",
+    "tooltip-format": "Headphones connected"
   },
   "pulseaudio": {
     "format": "{icon}",

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -44,6 +44,10 @@
   margin-right: 16px;
 }
 
+#custom-headphone {
+  margin-right: 12px;
+}
+
 #bluetooth {
   margin-right: 17px;
 }


### PR DESCRIPTION
Shows Bluetooth headphone icon with battery percentage when headphones are the active audio sink. Uses UPower to retrieve battery level.