### PR TITLE
Fix omarchy-update failing outside Hyprland session

### DIFF
--- a/bin/omarchy-update-without-idle
+++ b/bin/omarchy-update-without-idle
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Ensure screensaver/sleep doesn't set in during updates
-hyprctl dispatch tagwindow +noidle &> /dev/null
+hyprctl dispatch tagwindow +noidle &> /dev/null || true


### PR DESCRIPTION
Discovered this when trying to update my machine via ssh.

The omarchy-update-without-idle script fails when HYPRLAND_INSTANCE_SIGNATURE is not set (e.g., when running updates via SSH, TTY, or a non-Hyprland session).

Even though the hyprctl output is suppressed, set -e in the parent script
catches the non-zero exit code and triggers the error trap, causing the
update to fail with no visible error message.

Adding || true allows the update to proceed gracefully when the idle
inhibitor can't be set.