### PR TITLE
Fix omarchy-update failing outside Hyprland session

### DIFF
--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -3,7 +3,7 @@
 set -e
 
 # Ensure screensaver/sleep doesn't set in during updates
-hyprctl dispatch tagwindow +noidle &> /dev/null
+hyprctl dispatch tagwindow +noidle &> /dev/null || true
 
 # Perform all update steps
 omarchy-update-time
@@ -15,4 +15,4 @@ omarchy-hook post-update
 omarchy-update-restart
 
 # Re-enable screensaver/sleep after updates
-hyprctl dispatch tagwindow -- -noidle &> /dev/null
+hyprctl dispatch tagwindow -- -noidle &> /dev/null || true


### PR DESCRIPTION
Updated fix from #3992 after idle management was moved to `omarchy-update-perform` in e44e937.

When running `omarchy-update` via SSH, TTY, or any non-Hyprland session, the update fails silently because `hyprctl` exits non-zero when `HYPRLAND_INSTANCE_SIGNATURE` is not set. Even though output is suppressed, `set -e` catches the exit code and triggers the error trap.

Adding `|| true` to both `hyprctl` calls allows updates to proceed gracefully when the idle inhibitor can't be set.