### PR TITLE
add fresh to omarchy-launch-editor

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -3,7 +3,7 @@
 omarchy-cmd-present "$EDITOR" || EDITOR=nvim
 
 case "$EDITOR" in
-nvim | vim | nano | micro | hx | helix)
+nvim | vim | nano | micro | hx | helix | fresh)
   exec omarchy-launch-tui "$EDITOR" "$@"
   ;;
 *)


### PR DESCRIPTION
[fresh](https://github.com/fresh-editor/fresh) is a terminal text editor with multi-cursor support. Setting `EDITOR=fresh` in `~/.config/uwsm/default` doesn't work because `omarchy-launch-editor` doesn't recognize it as a TUI editor.

This is the same issue that occurred with Helix (see #1739, #1740).

fixes #4014