### PR TITLE
Fix config error for hyprland 0.53 windowrule in kanagawa theme

### DIFF
--- a/themes/kanagawa/hyprland.conf
+++ b/themes/kanagawa/hyprland.conf
@@ -9,4 +9,4 @@ group {
 }
 
 # Kanagawa backdrop is too strong for detault opacity
-windowrule = opacity 0.98 0.95, tag:terminal
+windowrule = opacity 0.98 0.95, match:tag terminal


### PR DESCRIPTION
### Summary
Minor fix to the kanagawa theme for the new windowrule syntax for hyprland 0.53
Current version throws config error now that the current sytax is no longer valid. 

### Related
- https://github.com/basecamp/omarchy/pull/4025
- https://github.com/basecamp/omarchy/issues/4023

-----

###### Before:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/f2a58e9b-9e34-4b2d-b20a-d911de7fe789" />

-----

###### After
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a9a1e703-a6e3-49d4-98ef-f66f25ba24d3" />


