### PR TITLE
Add github-copilot-cli to the AI install menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -276,7 +276,7 @@ show_install_ai_menu() {
       echo ollama
   )
 
-  case $(menu "Install" "󱚤  Claude Code\n󱚤  Copilot CLI\n󱚤  Cursor CLI\n󱚤  Gemini\n󱚤  OpenAI Codex\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
+  case $(menu "Install" "󱚤  Claude Code\n󱚤  Copilot CLI [AUR]\n󱚤  Cursor CLI\n󱚤  Gemini\n󱚤  OpenAI Codex\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  opencode") in
   *Claude*) install "Claude Code" "claude-code" ;;
   *Copilot*) aur_install "Copilot CLI" "github-copilot-cli" ;;
   *Cursor*) install "Cursor CLI" "cursor-cli" ;;


### PR DESCRIPTION
GitHub Copilot CLI works like other AI tools, but it has some advantages.

- Fully integrated with GitHub, with MCP configured by default.
- [Fully integrated with GitHub Copilot coding agent](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent).
- 10$ per month pays access to different models.
- Open Source contributors have free access to the PRO plan.
- The subscription already includes the traditional auto-complete.