### PR TITLE
Fix hyprctl crash when screensaver is terminated

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -5,7 +5,7 @@ screensaver_in_focus() {
 }
 
 exit_screensaver() {
-  hyprctl keyword cursor:invisible false
+  hyprctl keyword cursor:invisible false &>/dev/null || true
   pkill -x tte 2>/dev/null
   pkill -f org.omarchy.screensaver 2>/dev/null
   exit 0


### PR DESCRIPTION
## Summary
Fixes hyprctl SIGABRT crash that occurs when the screensaver window is closed (via lock screen, keyboard shortcut, or any other method).

## Problem
When the screensaver is terminated externally, hyprctl crashes with SIGABRT. The crash occurs in the `exit_screensaver` trap handler when it calls `hyprctl keyword cursor:invisible false`.

Note: Dismissing via mouse movement or keyboard input does NOT crash - the script exits naturally with valid stdout.

### Root Cause
1. External close (close window keybind, lock screen pkill, hyprctl closewindow) kills the terminal window
2. Terminal death triggers bash trap handler, but stdout is now invalid
3. hyprctl executes the cursor command successfully
4. hyprctl tries to print "ok" response to stdout via `std::println()`
5. Write to dead PTY returns EIO → `std::println()` throws `std::system_error`
6. Uncaught exception → `std::terminate` → SIGABRT

The fix discards hyprctl's output so it writes to /dev/null instead of the dead terminal.

## Changes
Redirect hyprctl output in the cleanup handler to prevent crash on broken stdout:

```diff
- hyprctl keyword cursor:invisible false
+ hyprctl keyword cursor:invisible false &>/dev/null || true
```

## Reproduction Steps

**Scenario A: Close with keybind**
1. Start screensaver: `omarchy-launch-screensaver force`
2. Close with close window keybind
3. Check for crash: `coredumpctl list | grep hyprctl`

**Scenario B: Wait for lock screen**
1. Wait for idle timeout to trigger screensaver
2. Wait for lock screen to appear
3. Unlock and check for crash: `coredumpctl list | grep hyprctl`

Expected (before fix): New hyprctl crash entry with signal 6 (SIGABRT)
Expected (after fix): No new crash

## Test Plan
- [x] Start screensaver, close with keybind - no crash
- [x] Real idle flow (screensaver → lock → unlock) - no crash
- [x] Reverted fix, confirmed crash returns