### PR TITLE
Set macOS-style screenshot keybindings

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -36,6 +36,11 @@ bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-d
 bindd = , PRINT, Screenshot with editing, exec, omarchy-cmd-screenshot
 bindd = SHIFT, PRINT, Screenshot to clipboard, exec, omarchy-cmd-screenshot smart clipboard
 bindd = ALT, PRINT, Screenrecording, exec, omarchy-menu screenrecord
+# macOS-style screenshots
+bindd = SUPER CTRL, 3, Screenshot fullscreen to clipboard, exec, omarchy-cmd-screenshot fullscreen clipboard
+bindd = SUPER CTRL, 4, Screenshot area with editing, exec, omarchy-cmd-screenshot region
+bindd = SUPER CTRL, 5, Screenshot fullscreen to file, exec, omarchy-cmd-screenshot fullscreen
+# Color picker
 bindd = SUPER, PRINT, Color picker, exec, pkill hyprpicker || hyprpicker -a
 
 # File sharing


### PR DESCRIPTION
Not every keyboard have the printscreen keys, so having macOS-screenshot keybindings is helpful and in overall omarchy style.