### PR TITLE
Allow overriding webapp launch browser via environment variable

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Launch the passed in URL as a web app in the default browser (or chromium if the default doesn't support --app).
+# Allow setting the browser via environment variable if you don't want to change the default browser
 
-browser=$(xdg-settings get default-web-browser)
+browser="${OMARCHY_WEBAPP_BROWSER:-$(xdg-settings get default-web-browser)}"
 
 case $browser in
 google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*) ;;


### PR DESCRIPTION
Allow the user to set an environment variable to override the browser temporarily (or semi-permanently) without changing the default browser.

I find this useful because I mainly use Zoom for work which I only use a specific browser for so I can either update the Zoom .desktop file or create a new one that will tell the webapp launcher which browser to use without changing by default browser.