### PR TITLE
Add icons for additional audio profiles in Waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -115,11 +115,6 @@
     "format-muted": "",
     "format-icons": {
       "headphone": "",
-      "hands-free": "",
-      "headset": "",
-      "phone": "",
-      "portable": "",
-      "car": "",
       "default": ["", "", ""]
     }
   },

--- a/migrations/1767716691.sh
+++ b/migrations/1767716691.sh
@@ -5,12 +5,7 @@ if ! grep -q '"headphone": ""' "$HOME/.config/waybar/config.jsonc"; then
     /"pulseaudio": {/,/^[ ]*}/{
       /"format-icons": {/,/^[ ]*}/{
         /"default":/i\
-\      "headphone": "",\
-\      "hands-free": "",\
-\      "headset": "",\
-\      "phone": "",\
-\      "portable": "",\
-\      "car": "",
+\      "headphone": "",
       }
     }
   ' "$HOME/.config/waybar/config.jsonc"


### PR DESCRIPTION
So first of all I know that similar PR have been rejected in the past but this does not add any moving parts to the waybar.

It is a builtin feature of the pulseaudio waybar module that replaces the default icon with a headset icon when a bluetooth headset is connected. If find it super useful to know if my headset actually connected to my computer or if it auto-connected to my phone instead.

<img width="291" height="51" alt="screenshot-2026-01-06_11-26-55" src="https://github.com/user-attachments/assets/c1e4f964-85d5-47f2-9aeb-06a97ea3db22" />

