### PR TITLE
Voxtype: suppress generic post-install instructions during install / setup

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -11,7 +11,7 @@ if gum confirm "Install Voxtype + AI model (~400MB) to enable dictation?"; then
   mkdir -p ~/.config/voxtype
   cp $OMARCHY_PATH/default/voxtype/config.toml ~/.config/voxtype/
 
-  voxtype setup --download
+  voxtype setup --download --no-post-install
   voxtype setup systemd
 
   omarchy-restart-waybar


### PR DESCRIPTION
Voxtype v0.4.9 adds a `--no-post-install` flag that suppresses the "Next steps" instructions after downloading the model. Since Omarchy handles systemd setup, hotkey configuration, and displays its own success notification, these generic instructions are redundant and potentially confusing to users.

The flag still shows download progress, just suppresses the post-download instructions.

If the maintainers prefer 100% silent operation, this can be changed to `--quiet` instead.