### PR TITLE
feat: Change color picker binding to work with 60% keyboards

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -36,7 +36,7 @@ bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-d
 bindd = , PRINT, Screenshot with editing, exec, omarchy-cmd-screenshot
 bindd = SHIFT, PRINT, Screenshot to clipboard, exec, omarchy-cmd-screenshot smart clipboard
 bindd = ALT, PRINT, Screenrecording, exec, omarchy-menu screenrecord
-bindd = SUPER, PRINT, Color picker, exec, pkill hyprpicker || hyprpicker -a
+bindd = SUPER CTRL, P, Color picker, exec, pkill hyprpicker || hyprpicker -a
 
 # File sharing
 bindd = SUPER CTRL, S, Share, exec, omarchy-menu share


### PR DESCRIPTION
This PR updates the color picker keybinding.

The shortcut was changed from SUPER + PRINT to SUPER + CTRL + P because most 60% keyboard layouts do not have a dedicated Print Screen key (it’s usually behind an Fn layer), making the original binding unreliable or unusable.
