### PR TITLE
FIX: Missing sudo in nvidia.sh

### DIFF
--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -17,7 +17,7 @@ if [ -n "$NVIDIA" ]; then
     exit 0
   fi
 
-  pacman -S --needed --noconfirm "$KERNEL_HEADERS" "${PACKAGES[@]}"
+  sudo pacman -S --needed --noconfirm "$KERNEL_HEADERS" "${PACKAGES[@]}"
 
   # Configure modprobe for early KMS
   sudo tee /etc/modprobe.d/nvidia.conf <<EOF >/dev/null


### PR DESCRIPTION
Since omarchy v3.3.0, installation fails for host with Nvidia graphics: `nvidia.sh` cannot install nvidia drivers leading to a missing omarchy.efi file that breaks limine splash screen (showing onliy "EFI Fallback" entry).