### PR TITLE
fix: skill name must match case of skill directory exactly

### DIFF
--- a/default/omarchy-skill/SKILL.md
+++ b/default/omarchy-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Omarchy
+name: omarchy
 description: >
   REQUIRED for ANY changes to Linux desktop, window manager, or system config.
   Use when editing ~/.config/hypr/, ~/.config/waybar/, ~/.config/walker/,


### PR DESCRIPTION
the spec of skills requires skill directories and skill names to match case exactly. This skill that seems to have been bundled with the new update had 'Omarchy' in the skill name in the frontmatter but 'omarchy' in the directory name. This fails silently on some agents but is a problem on agents that are more strict about following the spec. 

https://agentskills.io/specification

