### PR TITLE
fix: Map Logitech MX Keys S special keys to equivalent Omarchy commands

### DIFF
--- a/bin/omarchy-cmd-audio
+++ b/bin/omarchy-cmd-audio
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+prog=$(basename "$0")
+
+usage() {
+  cat <<EOF
+Controls input and output audio volume, mute and device.
+
+Usage:
+  $prog input mute-toggle
+  $prog output mute-toggle
+  $prog output raise
+  $prog output lower
+  $prog output +1
+  $prog output -1
+  $prog output switch
+EOF
+  exit 1
+}
+
+osd() {
+  swayosd-client --monitor "$(hyprctl monitors -j | jq -r '.[] | select(.focused).name')" "$@"
+}
+
+[[ $# -eq 2 ]] || usage
+
+mode="$1"
+action="$2"
+
+case "$mode:$action" in
+  input:mute-toggle)
+    osd --input-volume mute-toggle
+    ;;
+  output:mute-toggle|output:raise|output:lower|output:+1|output:-1)
+    osd --output-volume "$action"
+    ;;
+  output:switch)
+    omarchy-cmd-audio-switch
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -2,16 +2,16 @@
 $osdclient = swayosd-client --monitor "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')"
 
 # Laptop multimedia keys for volume and LCD brightness (with OSD)
-bindeld = ,XF86AudioRaiseVolume, Volume up, exec, $osdclient --output-volume raise
-bindeld = ,XF86AudioLowerVolume, Volume down, exec, $osdclient --output-volume lower
-bindeld = ,XF86AudioMute, Mute, exec, $osdclient --output-volume mute-toggle
-bindeld = ,XF86AudioMicMute, Mute microphone, exec, $osdclient --input-volume mute-toggle
+bindeld = ,XF86AudioRaiseVolume, Volume up, exec, omarchy-cmd-audio output raise
+bindeld = ,XF86AudioLowerVolume, Volume down, exec, omarchy-cmd-audio output lower
+bindeld = ,XF86AudioMute, Mute, exec, omarchy-cmd-audio output mute-toggle
+bindeld = ,XF86AudioMicMute, Mute microphone, exec, omarchy-cmd-audio input mute-toggle
 bindeld = ,XF86MonBrightnessUp, Brightness up, exec, omarchy-cmd-brightness +5%
 bindeld = ,XF86MonBrightnessDown, Brightness down, exec, omarchy-cmd-brightness 5%-
 
 # Precise 1% multimedia adjustments with Alt modifier
-bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1
-bindeld = ALT, XF86AudioLowerVolume, Volume down precise, exec, $osdclient --output-volume -1
+bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, omarchy-cmd-audio output +1
+bindeld = ALT, XF86AudioLowerVolume, Volume down precise, exec, omarchy-cmd-audio output -1
 bindeld = ALT, XF86MonBrightnessUp, Brightness up precise, exec, omarchy-cmd-brightness +1%
 bindeld = ALT, XF86MonBrightnessDown, Brightness down precise, exec, omarchy-cmd-brightness 1%-
 

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -34,3 +34,4 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-t2.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
+run_logged $OMARCHY_INSTALL/config/hardware/logitech.sh

--- a/install/config/hardware/logitech.sh
+++ b/install/config/hardware/logitech.sh
@@ -1,0 +1,58 @@
+# This sets up the special keys on Logitech keyboards
+if grep -q 'Logitech USB Receiver' /proc/bus/input/devices; then
+  echo "Detected Logitech USB Receiver"
+
+  sudo pacman -S --needed --noconfirm solaar
+
+  mkdir -p ~/.config/solaar
+  cat <<EOF > ~/.config/solaar/rules.yaml
+%YAML 1.3
+---
+- Key: [Dictation, pressed]
+- Execute: [/usr/bin/voxtype,record,start]
+...
+---
+- Key: [Dictation, released]
+- Execute: [/usr/bin/voxtype,record,stop]
+...
+---
+- Key: [Emoji, pressed]
+- Execute: [$HOME/.local/share/omarchy/bin/omarchy-launch-walker,-m,symbols]
+...
+---
+- Key: [Mute Microphone, pressed]
+- Execute: [$HOME/.local/share/omarchy/bin/omarchy-cmd-audio,input,mute-toggle]
+...
+---
+- Key: [Screen Capture, pressed]
+- Execute: $HOME/.local/share/omarchy/bin/omarchy-cmd-screenshot
+...
+---
+- Key: [Screen Lock, pressed]
+- Execute: $HOME/.local/share/omarchy/bin/omarchy-lock-screen
+...
+EOF
+
+  sudo solaar config "MX Keys S" divert-keys "Dictation" Diverted
+  sudo solaar config "MX Keys S" divert-keys "Emoji" Diverted
+  sudo solaar config "MX Keys S" divert-keys "Mute Microphone" Diverted
+  sudo solaar config "MX Keys S" divert-keys "Screen Capture" Diverted
+  sudo solaar config "MX Keys S" divert-keys "Screen Lock" Diverted
+
+  cat <<EOF > ~/.config/systemd/user/solaar.service
+[Unit]
+Description=Solaar
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/solaar -w hide -b solaar
+Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target
+EOF
+
+  systemctl --user daemon-reload
+  systemctl --user enable solaar.service
+fi


### PR DESCRIPTION
This detects Logitech MX Keys S keyboards and maps their special keys onto the equivalent Omarchy commands.

All keys that previously weren't functional now work out of the box as expected:
- Dictation
- Emoji
- Mute Microphone
- Screen Capture
- Screen Lock