### PR TITLE
Add voxtype modifier suppression during transcription

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -13,24 +13,6 @@ if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
   voxtype setup --download --no-post-install
   voxtype setup systemd
 
-  # Add voxtype bindings to hyprland config if not present
-  if [[ -f ~/.config/hypr/bindings.conf ]] && ! grep -q "voxtype_recording" ~/.config/hypr/bindings.conf; then
-    cat >> ~/.config/hypr/bindings.conf << 'EOF'
-
-# Voxtype dictation bindings
-# Press SUPER+CTRL+X to record, release X first to stop (keep modifiers held), ESCAPE to cancel
-# Or release a modifier first to keep dictation going, then press SUPER+CTRL+X again to stop
-bindd = SUPER CTRL, X, Start dictation, exec, voxtype record start
-
-# Voxtype recording submap - active during recording/transcription
-submap = voxtype_recording
-binddr = SUPER CTRL, X, Stop dictation, exec, voxtype record stop
-binddi = , ESCAPE, Cancel dictation, exec, voxtype record cancel; hyprctl dispatch submap reset
-submap = reset
-EOF
-    hyprctl reload
-  fi
-
   omarchy-restart-waybar
   notify-send "    Voxtype Dictation Ready" "Hold Super + Ctrl + X to dictate.\nEdit ~/.config/voxtype/config.toml for options." -t 10000
 fi

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -51,8 +51,17 @@ bindd = SUPER CTRL, B, Bluetooth controls, exec, omarchy-launch-bluetooth
 bindd = SUPER CTRL, W, Wifi controls, exec, omarchy-launch-wifi
 bindd = SUPER CTRL, T, Activity, exec, omarchy-launch-tui btop
 
-# Voxtype modifier suppression - blocks modifier keys during text output
-# NOTE: Do not bind Escape here - it causes wtype to drop the first character
+# Dictation
+bindd  = SUPER CTRL, X, Start dictation, exec, voxtype record start
+binddr = SUPER CTRL, X, Stop dictation, exec, voxtype record stop
+
+# Voxtype modifier suppression - blocks modifier keys during transcription output
+# Voxtype triggers this via pre_output_command/post_output_command hooks
+#
+# NOTE: Escape must NOT be bound here. Binding Escape causes wtype's first
+# character to be dropped. Escape appears to clear compositor state during
+# submap transitions; binding it to a no-op prevents this.
+# See: https://github.com/hyprwm/Hyprland/issues/3165
 submap = voxtype_suppress
 bind = , SUPER_L, exec, true
 bind = , SUPER_R, exec, true
@@ -60,7 +69,7 @@ bind = , Control_L, exec, true
 bind = , Control_R, exec, true
 bind = , Alt_L, exec, true
 bind = , Alt_R, exec, true
-bind = , F12, submap, reset  # Emergency escape if voxtype crashes
+bind = , F12, submap, reset  # Emergency escape if voxtype fails to call post_output_command
 submap = reset
 
 # Lock system

--- a/default/voxtype/config.toml
+++ b/default/voxtype/config.toml
@@ -67,8 +67,8 @@ fallback_to_clipboard = true
 # 0 = fastest possible, increase if characters are dropped
 type_delay_ms = 1
 
-# Compositor integration hooks for Hyprland
-pre_recording_command = "hyprctl dispatch submap voxtype_recording"
+# Modifier key suppression for Hyprland
+# Prevents held modifier keys from interfering with transcription output
 pre_output_command = "hyprctl dispatch submap voxtype_suppress"
 post_output_command = "hyprctl dispatch submap reset"
 

--- a/migrations/1767939322.sh
+++ b/migrations/1767939322.sh
@@ -1,34 +1,14 @@
-echo "Add voxtype compositor integration"
+echo "Add voxtype modifier suppression hooks"
 
-VOXTYPE_CONFIG=~/.config/voxtype/config.toml
-HYPR_BINDINGS=~/.config/hypr/bindings.conf
+CONFIG_FILE=~/.config/voxtype/config.toml
+[[ ! -f "$CONFIG_FILE" ]] && exit 0
 
-# Skip if voxtype is not installed
-[[ ! -f "$VOXTYPE_CONFIG" ]] && exit 0
-
-# Add hooks to voxtype config if not present
-if ! grep -q "pre_recording_command" "$VOXTYPE_CONFIG"; then
+# Add pre_output_command and post_output_command if not present
+if ! grep -q "pre_output_command" "$CONFIG_FILE"; then
   sed -i '/^type_delay_ms = /a\
 \
-# Compositor integration hooks for Hyprland\
-pre_recording_command = "hyprctl dispatch submap voxtype_recording"\
+# Modifier key suppression for Hyprland\
+# Prevents held modifier keys from interfering with transcription output\
 pre_output_command = "hyprctl dispatch submap voxtype_suppress"\
-post_output_command = "hyprctl dispatch submap reset"' "$VOXTYPE_CONFIG"
-fi
-
-# Add voxtype bindings to hypr bindings.conf if not present
-if [[ -f "$HYPR_BINDINGS" ]] && ! grep -q "voxtype_recording" "$HYPR_BINDINGS"; then
-  cat >> "$HYPR_BINDINGS" << 'EOF'
-
-# Voxtype dictation bindings
-# Press SUPER+CTRL+X to record, release X to stop (keep modifiers held), ESCAPE to cancel
-# Or release a modifier first for toggle mode, then press SUPER+CTRL+X again to stop
-bindd = SUPER CTRL, X, Start dictation, exec, voxtype record start
-
-# Voxtype recording submap - active during recording/transcription
-submap = voxtype_recording
-binddr = SUPER CTRL, X, Stop dictation, exec, voxtype record stop
-binddi = , ESCAPE, Cancel dictation, exec, voxtype record cancel; hyprctl dispatch submap reset
-submap = reset
-EOF
+post_output_command = "hyprctl dispatch submap reset"' "$CONFIG_FILE"
 fi


### PR DESCRIPTION
## Summary

Adds a Hyprland submap that blocks modifier keys (SUPER, CTRL, ALT) while voxtype is typing transcribed text. This prevents held modifier keys from triggering window manager shortcuts during output.

## Problem

When using voxtype with push-to-talk (SUPER+CTRL+X), if the user releases keys slowly or in the wrong order, modifiers may still be held while voxtype types the transcription. This causes typed characters to trigger shortcuts instead of inserting text.

## Solution

- Add a `voxtype_suppress` submap to Hyprland bindings that blocks modifier keys
- Configure voxtype to activate/deactivate the submap via `pre_output_command`/`post_output_command` hooks
- Include F12 as emergency escape if voxtype fails to reset the submap
- Migration for existing voxtype installations

## Dependencies

⚠️ **This PR depends on voxtype 0.4.10+** which includes the `pre_output_command`/`post_output_command` hooks.

- Voxtype issue: https://github.com/peteonrails/voxtype/issues/53
- Voxtype PR: https://github.com/peteonrails/voxtype/pull/54

## Changes

- `default/hypr/bindings/utilities.conf` - Add `voxtype_suppress` submap
- `default/voxtype/config.toml` - Add hook configuration
- `migrations/1767939322.sh` - Add hooks to existing voxtype configs

## Test plan

- [x] Voxtype 0.4.10 released with hooks feature
- [x] Test with SUPER+CTRL+X hold, release in various orders
- [x] Verify modifiers don't trigger shortcuts during transcription
- [x] Verify F12 escapes the submap if stuck

Related: #4159