### PR TITLE
Fix WiFi not working on boot

### DIFF
--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -1,6 +1,15 @@
 # Ensure iwd service will be started
 sudo systemctl enable iwd.service
 
+# Enable systemd-networkd to handle DHCP for iwd connections
+sudo systemctl enable systemd-networkd.service
+
 # Prevent systemd-networkd-wait-online timeout on boot
 sudo systemctl disable systemd-networkd-wait-online.service
 sudo systemctl mask systemd-networkd-wait-online.service
+
+# Fix rfkill race condition on boot (WiFi soft-blocked before systemd-rfkill restores state)
+# This ensures WiFi is unblocked when the interface appears, fixing issues with MediaTek MT7925 and similar
+if [[ ! -f /etc/udev/rules.d/81-wifi-unblock.rules ]]; then
+  echo 'ACTION=="add", SUBSYSTEM=="net", KERNEL=="wlan*", RUN+="/usr/bin/rfkill unblock wifi"' | sudo tee /etc/udev/rules.d/81-wifi-unblock.rules
+fi


### PR DESCRIPTION
## Summary

Fixes #4190 (my issue) - WiFi broken after 3.2 update.

After updating to omarchy 3.2, WiFi stopped working on boot. Two issues were identified:

1. **systemd-networkd not enabled** - iwd connects to WiFi but no DHCP/IP address
2. **rfkill race condition** - WiFi soft-blocked before systemd-rfkill can restore state

## Changes

- Enable `systemd-networkd.service` alongside iwd
- Add udev rule `/etc/udev/rules.d/81-wifi-unblock.rules` to unblock WiFi when interface appears

## Testing

Both fixes have been tested on my machine and confirmed working:
- **Hardware:** Desktop (AMD Ryzen AI Max 300 Series) with MediaTek MT7925 WiFi 7
- **Kernel:** 6.18.3-arch1-1
- WiFi now works automatically on boot without manual intervention

## Open to Alternatives

This is my proposed fix based on debugging the issue. If there are better or alternative solutions, I'm open to feedback and suggestions.