### PR TITLE
Shift+Space won't type 'space' anymore

### DIFF
--- a/config/fcitx5/config
+++ b/config/fcitx5/config
@@ -1,0 +1,4 @@
+[Hotkey]
+# Prevents Shift+Space from typing "space" - fcitx5 default binds Shift+Space
+# to cycle through input methods, which breaks normal typing
+EnumerateWithTriggerKeys=False

--- a/migrations/1767965678.sh
+++ b/migrations/1767965678.sh
@@ -1,0 +1,3 @@
+echo "Fix Shift+Space typing 'space' instead of space character"
+
+omarchy-refresh-config fcitx5/config


### PR DESCRIPTION
Fixes #4202 

I'm not certain if the refresh config is needed, or if this has consequences for most use cases from folks. Just wanted to share what helped me. If you hit Shift and Space at the same time this was happening for me.

```

   fcitx5 (input method framework) intercepts Shift+Space by default for cycling through input methods
   (`EnumerateWithTriggerKeys`). When there's only one input method configured, this causes unexpected
   behavior.
   ```
   
   AI says this is why this works, I honestly don't know I just know it works now for me