### PR TITLE
Enable scanner support

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -106,9 +106,11 @@ qt5-wayland
 ripgrep
 ruby
 rust
+sane-airscan
 satty
 sddm
 signal-desktop
+simple-scan
 slurp
 spotify
 starship

--- a/migrations/1765836578.sh
+++ b/migrations/1765836578.sh
@@ -1,0 +1,4 @@
+echo "Enable scanner support"
+# https://wiki.archlinux.org/title/SANE
+
+omarchy-pkg-add simple-scan sane-airscan


### PR DESCRIPTION
Install the Gnome Document Scanner frontend (simple-scan), which automatically includes the required dependencies for scanner support.

Enable support for modern 'driverless' scanners with sane-airscan.

Note: This adds 47.23 MiB to the base install size.

See: https://wiki.archlinux.org/title/SANE

Fixes #4102.