### PR TITLE
Update sed and yq commands for color substitutions

### DIFF
--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -18,7 +18,7 @@ if [[ -f $COLORS_FILE ]]; then
   sed_script=$(mktemp)
 
   # Generate standard and _strip substitutions
-  sed 's/=/:/' "$COLORS_FILE" | yq -r 'to_entries[] | "s|{{ \(.key) }}|\(.value)|g", "s|{{ \(.key)_strip }}|\(.value | sub("^#";""))|g"' > "$sed_script"
+  sed 's/=/:/' "$COLORS_FILE" | yq -r 'to_entries[] | ["s|{{ \(.key) }}|\(.value)|g", "s|{{ \(.key)_strip }}|\(.value | sub(\"^#\"; \"\"))|g"] | .[]' > "$sed_script"
 
   # Generate _rgb substitutions for hex colors
   while IFS='=' read -r key value; do


### PR DESCRIPTION
for some reason, the template rendering was not working properly on my installation until I:

1. Wrap strings in array and pipe to .[]: [..., ...] | .[]
2. Escape double quotes in sub(): sub(\"^#\"; \"\")

here is my version of yq

```
$ which yq
/usr/local/bin/yq

$ /usr/local/bin/yq --version
yq (https://github.com/mikefarah/yq/) version v4.48.2

$ /usr/bin/yq --version
yq 3.4.3

$ pacman -Si yq
Repository      : extra
Name            : yq
Version         : 3.4.3-2
Description     : Command-line YAML, XML, TOML processor - jq wrapper for YAML/XML/TOML documents
Architecture    : any
URL             : https://github.com/kislyuk/yq
Licenses        : Apache-2.0
Groups          : None
Provides        : None
Depends On      : jq  python-argcomplete  python-tomlkit  python-xmltodict  python-yaml
Optional Deps   : None
Conflicts With  : go-yq
Replaces        : None
Download Size   : 35.13 KiB
Installed Size  : 130.64 KiB
Packager        : Jelle van der Waa <jelle@archlinux.org>
Build Date      : Thu 21 Nov 2024 01:08:57 PM EST
Validated By    : SHA-256 Sum  Signature
```