### PR TITLE
Add headset icon to pulseaudio module in waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -116,6 +116,7 @@
     "format-muted": "",
     "format-icons": {
       "headphone": "",
+      "headset": "",
       "default": ["", "", ""]
     }
   },

--- a/migrations/1768270644.sh
+++ b/migrations/1768270644.sh
@@ -1,0 +1,14 @@
+echo "Add icon for headset audio profile in Waybar"
+
+if ! grep -q '"headset": ""' "$HOME/.config/waybar/config.jsonc"; then
+  sed -i '
+    /"pulseaudio": {/,/^[ ]*}/{
+      /"format-icons": {/,/^[ ]*}/{
+        /"default":/i\
+\      "headset": "",
+      }
+    }
+  ' "$HOME/.config/waybar/config.jsonc"
+
+  omarchy-restart-waybar
+fi


### PR DESCRIPTION
Regarding #4100, it turns out that the headset icon is also necessary for real headset like the Sony wh-1000xm5. Just the headphone icon does not work.