### PR TITLE
Add webcam source selection for screen recording

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -14,6 +14,7 @@ fi
 DESKTOP_AUDIO="false"
 MICROPHONE_AUDIO="false"
 WEBCAM="false"
+WEBCAM_DEVICE=""
 STOP_RECORDING="false"
 
 for arg in "$@"; do
@@ -21,6 +22,7 @@ for arg in "$@"; do
     --with-desktop-audio) DESKTOP_AUDIO="true" ;;
     --with-microphone-audio) MICROPHONE_AUDIO="true" ;;
     --with-webcam) WEBCAM="true" ;;
+    --webcam-device=*) WEBCAM_DEVICE="${arg#*=}" ;;
     --stop-recording) STOP_RECORDING="true"
   esac
 done
@@ -32,6 +34,15 @@ cleanup_webcam() {
 start_webcam_overlay() {
   cleanup_webcam
 
+  # Auto-detect first available webcam if none specified
+  if [[ -z "$WEBCAM_DEVICE" ]]; then
+    WEBCAM_DEVICE=$(v4l2-ctl --list-devices 2>/dev/null | grep -m1 "^\s*/dev/video" | tr -d '\t')
+    if [[ -z "$WEBCAM_DEVICE" ]]; then
+      notify-send "No webcam devices found" -u critical -t 3000
+      return 1
+    fi
+  fi
+
   # Get monitor scale
   local scale=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .scale')
 
@@ -41,7 +52,7 @@ start_webcam_overlay() {
   # Try preferred 16:9 resolutions in order, use first available
   local preferred_resolutions=("640x360" "1280x720" "1920x1080")
   local video_size_arg=""
-  local available_formats=$(v4l2-ctl --list-formats-ext -d /dev/video0 2>/dev/null)
+  local available_formats=$(v4l2-ctl --list-formats-ext -d "$WEBCAM_DEVICE" 2>/dev/null)
 
   for resolution in "${preferred_resolutions[@]}"; do
     if echo "$available_formats" | grep -q "$resolution"; then
@@ -50,7 +61,7 @@ start_webcam_overlay() {
     fi
   done
 
-  ffplay -f v4l2 $video_size_arg -framerate 30 /dev/video0 \
+  ffplay -f v4l2 $video_size_arg -framerate 30 "$WEBCAM_DEVICE" \
     -vf "scale=${target_width}:-1" \
     -window_title "WebcamOverlay" \
     -noborder \

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -113,13 +113,43 @@ show_screenshot_menu() {
   esac
 }
 
+get_webcam_list() {
+  v4l2-ctl --list-devices 2>/dev/null | while IFS= read -r line; do
+    if [[ "$line" != $'\t'* && -n "$line" ]]; then
+      local name="$line"
+      IFS= read -r device || break
+      device=$(echo "$device" | tr -d '\t' | head -1)
+      [[ -n "$device" ]] && echo "$device  $name"
+    fi
+  done
+}
+
+show_webcam_select_menu() {
+  local devices=$(get_webcam_list)
+  local count=$(echo "$devices" | grep -c . 2>/dev/null || echo 0)
+
+  if [[ -z "$devices" || "$count" -eq 0 ]]; then
+    notify-send "No webcam devices found" -u critical -t 3000
+    return 1
+  fi
+
+  if [[ "$count" -eq 1 ]]; then
+    echo "$devices" | awk '{print $1}'
+  else
+    menu "Select Webcam" "$devices" | awk '{print $1}'
+  fi
+}
+
 show_screenrecord_menu() {
   omarchy-cmd-screenrecord --stop-recording && exit 0
 
   case $(menu "Screenrecord" "  With desktop audio\n  With desktop + microphone audio\n  With desktop + microphone audio + webcam") in
   *"With desktop audio") omarchy-cmd-screenrecord --with-desktop-audio ;;
   *"With desktop + microphone audio") omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio ;;
-  *"With desktop + microphone audio + webcam") omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam ;;
+  *"With desktop + microphone audio + webcam")
+    local device=$(show_webcam_select_menu) || { back_to show_capture_menu; return; }
+    omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam --webcam-device="$device"
+    ;;
   *) back_to show_capture_menu ;;
   esac
 }


### PR DESCRIPTION
I had trouble selecting my second webcam when I tried to start a screen recording. To fix it, I edited the code a bit and added a camera selection menu when more than one camera device is connected

- Add --webcam-device argument to omarchy-cmd-screenrecord
- Auto-detect first available webcam if none specified
- Add webcam selection UI in omarchy-menu when multiple cameras available
- Skip selection UI when only one webcam is detected

I don’t want to deal with how to record the screen without a capture card, because obs doesn’t show the window menu. So this is just a demo recorded on an iphone

https://github.com/user-attachments/assets/ad7a7b83-1e57-4d13-941d-009495357f02


