### PR TITLE
auto toggle scratchpad on switching workspace

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -131,6 +131,11 @@ cursor {
     hide_on_key_press = true
 }
 
+# Auto toggle scratchpad on switching workspace from scratchpad
+binds {
+    hide_special_on_workspace_change = true
+}
+
 # Style Gum confirm to match terminal theme
 env = GUM_CONFIRM_PROMPT_FOREGROUND,6       # Cyan
 env = GUM_CONFIRM_SELECTED_FOREGROUND,0     # Black


### PR DESCRIPTION
The **default behaviour** when switching workspace from scratchpad should be to

- **auto toggle scratchpad and show the main workspace**

Reason

**why would anyone want to switch workspace if he still want to see the scratchpad after switching workspace, if the user switches the workspace the scratchpad should toggle and the main workspace should be visible.**

This PR uses an already defined variable in hyprland to acheive this.