### PR TITLE
fix invalid skill name

### DIFF
--- a/default/omarchy-skill/SKILL.md
+++ b/default/omarchy-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Omarchy
+name: omarchy
 description: >
   REQUIRED for ANY changes to Linux desktop, window manager, or system config.
   Use when editing ~/.config/hypr/, ~/.config/waybar/, ~/.config/walker/,


### PR DESCRIPTION
The `name` field contains invalid characters (must be lowercase a-z, 0-9, hyphens only)

ref: https://agentskills.io/specification#name-field