### PR TITLE
Fix Bluetooth device showing bluez ID instead of friendly name

### DIFF
--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -28,8 +28,16 @@ next_sink_name=$(echo "$next_sink" | jq -r '.name')
 
 next_sink_description=$(echo "$next_sink" | jq -r '.description')
 if [ "$next_sink_description" = "(null)" ] || [ "$next_sink_description" = "null" ] || [ -z "$next_sink_description" ]; then
-  sink_id=$(echo "$next_sink" | jq -r '.properties."object.id"')
-  next_sink_description=$(wpctl status | grep -E "\s+\*?\s+${sink_id}\." | sed -E 's/^.*[0-9]+\.\s+//' | sed -E 's/\s+\[.*$//')
+  # For Bluetooth devices, the friendly name is on the Device entry (device.id), not the Sink entry (object.id)
+  device_id=$(echo "$next_sink" | jq -r '.properties."device.id"')
+  if [ "$device_id" != "null" ] && [ -n "$device_id" ]; then
+    next_sink_description=$(wpctl status | grep -E "^\s*│?\s+${device_id}\." | sed -E 's/^.*[0-9]+\.\s+//' | sed -E 's/\s+\[.*$//')
+  fi
+  # Fall back to object.id lookup if device.id didn't yield a result
+  if [ -z "$next_sink_description" ]; then
+    sink_id=$(echo "$next_sink" | jq -r '.properties."object.id"')
+    next_sink_description=$(wpctl status | grep -E "\s+\*?\s+${sink_id}\." | sed -E 's/^.*[0-9]+\.\s+//' | sed -E 's/\s+\[.*$//')
+  fi
 fi
 
 next_sink_volume=$(echo "$next_sink" | jq -r \


### PR DESCRIPTION
## Summary

- Fixes regression where Bluetooth devices (e.g., AirPods Max) show raw bluez ID like `bluez_output.90:9C:4A:EE:01:1C` instead of friendly name when switching audio sources with `Super+Mute`

## Root Cause

For Bluetooth audio devices, the friendly name is stored on the **Device** entry in wpctl (accessible via `device.id`), not the **Sink** entry (accessible via `object.id`). The previous fix looked up `object.id`, which returns the sink line showing the raw bluez ID.

## Fix

Look up `device.id` first to get the friendly name from the Device entry, falling back to `object.id` for non-Bluetooth devices.

## Test plan

- [ ] Connect Bluetooth headphones (AirPods, etc.)
- [ ] Press `Super+Mute` to cycle audio outputs
- [ ] Verify the friendly device name appears instead of `bluez_output.XX:XX:XX...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)