### PR TITLE
fix: starship git status

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -17,7 +17,7 @@ format = "[$branch]($style) "
 style = "italic cyan"
 
 [git_status]
-format     = '[$all_status]($style)'
+format     = '[$all_status$ahead_behind]($style)'
 style      = "cyan"
 ahead      = "⇡${count} "
 diverged   = "⇕⇡${ahead_count}⇣${behind_count} "
@@ -27,6 +27,6 @@ up_to_date = " "
 untracked  = "? "
 modified   = " "
 stashed    = ""
-staged     = ""
+staged     = "+ "
 renamed    = ""
 deleted    = ""

--- a/migrations/1768300084.sh
+++ b/migrations/1768300084.sh
@@ -1,0 +1,3 @@
+echo "Update starship config with latest defaults"
+
+omarchy-refresh-config starship.toml


### PR DESCRIPTION
Starship prompt was missing "up-to-dateness" statuses of the repository: ahead, behind, up to date.
Starship doc states that `$ahead_behind` should be included for that in addition to `$all_status`

Because formatting for `ahead`, `behind`, and `diverged` was included in config, I assumed that they were meant to be shown. 

_If I'm mistaken, and current behavior is intended, please close this PR._

Also, added "+" status when all changes are staged, because currently clean working tree and one with staged changes look the same in a prompt, IMO it is confusing. More so because just moment before staging them, unstaged changes had indicator in the prompt.

<img width="202" height="737" alt="screenshot-2026-01-15_00-26-19" src="https://github.com/user-attachments/assets/c9164d96-66dd-4d89-a268-a860e4a02644" />
