### PR TITLE
Sanitize prompt before starship init

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -3,6 +3,9 @@ if command -v mise &> /dev/null; then
 fi
 
 if command -v starship &> /dev/null; then
+  # clear stale readline state before rendering prompt (prevents artifacts in prompt after abnormal exits like SIGQUIT)
+  __sanitize_prompt() { printf '\r\033[K'; }
+  PROMPT_COMMAND="__sanitize_prompt${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
   eval "$(starship init bash)"
 fi
 


### PR DESCRIPTION
### Summary

Adds prompt sanitization to clear stale terminal line state after abnormal exits, preventing prompt artifacts.

In some cases, exiting a program abruptly can leave residual output on the current terminal line, causing the next prompt to render incorrectly. This change ensures the prompt is always drawn on a clean line.

---

### Example

```sh
iex
# press Ctrl-\
```

Exiting `iex` with `Ctrl-\` sends `SIGQUIT`, which terminates the process without restoring terminal display state. When control returns to the shell, leftover output may remain on the line.

This behavior is not specific to IEx; any program that exits without cleaning up the terminal line can trigger it.

---

### Fix

Starship assumes a clean terminal line when rendering the prompt and does not perform line hygiene itself. Before rendering the prompt, the shell now resets the cursor position and clears the current line, preventing prompt corruption regardless of how the previous process exited.