### PR TITLE
Add migration to rebuild python-terminaltexteffects for Python 3.14

### DIFF
--- a/migrations/1768585821.sh
+++ b/migrations/1768585821.sh
@@ -1,0 +1,6 @@
+echo "Rebuild python-terminaltexteffects for Python 3.14 compatibility"
+
+if omarchy-pkg-present python-terminaltexteffects; then
+  omarchy-pkg-drop python-terminaltexteffects
+  omarchy-pkg-aur-add python-terminaltexteffects
+fi


### PR DESCRIPTION
Fixes issue where python-terminaltexteffects fails with ModuleNotFoundError after system upgrade to Python 3.14. The package was built for Python 3.13 and installed to /usr/lib/python3.13/site-packages, but Python 3.14 only searches /usr/lib/python3.14/site-packages.

The migration removes the outdated OPR package and reinstalls from AUR, forcing a rebuild with the current Python version.

Fixes #4263