### PR TITLE
Add patch to /etc/updatedb.conf to include /home directory

### DIFF
--- a/install/config/localdb.sh
+++ b/install/config/localdb.sh
@@ -1,2 +1,17 @@
 # Update localdb so that locate will find everything installed
+
+UPDATEDB_CONF="/etc/updatedb.conf"
+
+if [[ -f "$UPDATEDB_CONF" ]]; then
+  # Ensure /home (and other non-pruned mounts) are included in the locate database by default.
+  # Be tolerant of whitespace: PRUNE_BIND_MOUNTS = "yes" / PRUNE_BIND_MOUNTS="yes" / etc.
+  if grep -qE '^[[:space:]]*PRUNE_BIND_MOUNTS[[:space:]]*=' "$UPDATEDB_CONF"; then
+    sudo sed -i -E 's|^[[:space:]]*PRUNE_BIND_MOUNTS[[:space:]]*=.*$|PRUNE_BIND_MOUNTS = "no"|' "$UPDATEDB_CONF"
+  else
+    echo 'PRUNE_BIND_MOUNTS = "no"' | sudo tee -a "$UPDATEDB_CONF" >/dev/null
+  fi
+else
+  echo "Warning: $UPDATEDB_CONF not found; skipping PRUNE_BIND_MOUNTS configuration" >&2
+fi
+
 sudo updatedb


### PR DESCRIPTION
## Problem description
New Omarchy Linux installations currently ship with the following value in in `/etc/updatedb.conf`:

```bash
PRUNE_BIND_MOUNTS = "yes"
```

With this value, the `updatedb` run used by `locate`/`plocate` prunes bind mounts, which results in paths under `/home` being omitted from the locate database. As a consequence, searches via `locate`/`plocate` do not return matches for files located in users’ home directories.

This PR updates the default configuration to:

```bash
PRUNE_BIND_MOUNTS = "no"
```

so that /home contents are indexed and searchable by default after installation.

### Steps to reproduce the issue

1. Confirm current config: `grep -n 'PRUNE_BIND_MOUNTS' /etc/updatedb.conf`. Expected to show: `PRUNE_BIND_MOUNTS = "yes"`.
2. Create a test file under `/home`: `touch /home/$USER/locate-test-file`.
3. Rebuild the `locate`/`plocate` database: `sudo updatedb`.
5. Search for the file: `locate locate-test-file` (or `plocate locate-test-file`). Notice the file is missing from results.

### Summary of changes
During installation, before running `updatedb` in `install/config/localdb.sh`, the script now enforces `PRUNE_BIND_MOUNTS = "no"` in `/etc/updatedb.conf` (whitespace-tolerant: updates the existing setting if present, otherwise appends it), then rebuilds the locate database as usual.

### Testing
1. Verified the updated `localdb.sh` script on an existing Omarchy 3.3.3 installation: the script executed successfully with no errors and `updatedb` completed as expected.
2. Built and installed a new Omarchy ISO from the `omarchy-iso` repository using:

   ```bash
   OMARCHY_INSTALLER_REPO="jorge-campo/omarchy" OMARCHY_INSTALLER_REF="fix-localdb-prune-bind-mounts" ./bin/omarchy-iso-make
   ```
   Installation completed without issues using this ISO image, and after the install, `/etc/updatedb.conf` contained the updated `PRUNE_BIND_MOUNTS = "no"` value.

Screenshot from the installation test on a virtual machine:

<img width="2160" height="1035" alt="image" src="https://github.com/user-attachments/assets/94c6f144-b8cc-4523-b7a8-17d044ba558d" />

> [!NOTE]
>
> This PR was prepared with support from GitHub Copilot.

closes #3744 
