### PR TITLE
feat: Add confirmation dialog for closing protected windows

### DIFF
--- a/bin/omarchy-hyprland-window-close
+++ b/bin/omarchy-hyprland-window-close
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Close the active window, with optional confirmation for protected apps.
+# Protected app classes are listed in ~/.config/omarchy/protected-windows (one per line).
+
+set -euo pipefail
+
+PROTECTED_FILE="$HOME/.config/omarchy/protected-windows"
+
+# Get active window info
+win_json="$(hyprctl activewindow -j 2>/dev/null || true)"
+[[ -z "$win_json" || "$win_json" == "null" ]] && exit 0
+
+cls="$(jq -r '.class // ""' <<<"$win_json")"
+icls="$(jq -r '.initialClass // ""' <<<"$win_json")"
+addr="$(jq -r '.address // ""' <<<"$win_json")"
+title="$(jq -r '.title // ""' <<<"$win_json")"
+
+# Check if window is protected
+is_protected=false
+if [[ -f "$PROTECTED_FILE" ]]; then
+  while IFS= read -r pattern || [[ -n "$pattern" ]]; do
+    # Skip empty lines and comments
+    [[ -z "$pattern" || "$pattern" =~ ^[[:space:]]*# ]] && continue
+    
+    if [[ "$cls" == "$pattern" || "$icls" == "$pattern" ]]; then
+      is_protected=true
+      break
+    fi
+  done < "$PROTECTED_FILE"
+fi
+
+# Not protected, close immediately
+if [[ "$is_protected" == false ]]; then
+  hyprctl dispatch killactive
+  exit 0
+fi
+
+# Protected: confirm in a floating terminal
+TITLE="$title" ADDR="$addr"
+
+if command -v alacritty >/dev/null 2>&1; then
+  TITLE="$TITLE" ADDR="$ADDR" alacritty --class "TUI.float" -e bash -lc '
+    gum confirm "Close $TITLE?" \
+      && hyprctl dispatch closewindow address:$ADDR
+  '
+else
+  TITLE="$TITLE" ADDR="$ADDR" xdg-terminal-exec bash -lc '
+    gum confirm "Close $TITLE?" \
+      && hyprctl dispatch closewindow address:$ADDR
+  '
+fi

--- a/config/omarchy/protected-windows
+++ b/config/omarchy/protected-windows
@@ -1,0 +1,7 @@
+# Protected windows configuration
+# List window classes (one per line) that require confirmation before closing.
+# Use `hyprctl clients -j | jq '.[] | {class, initialClass, title}'` to see all open windows.
+#
+# Examples:
+# steam_app_XXXXXX
+# vesktop

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -1,5 +1,5 @@
 # Close windows
-bindd = SUPER, W, Close window, killactive,
+bindd = SUPER, W, Close window, exec, omarchy-hyprland-window-close
 bindd = CTRL ALT, DELETE, Close all windows, exec, omarchy-hyprland-window-close-all
 
 # Control tiling


### PR DESCRIPTION
## Summary
Adds optional confirmation dialog when closing windows for user-defined "protected" applications.

## IMPORTANT
The "Close all windows" command (CTRL+ALT+DELETE) is not covered by this change. That binding is intentionally uncomfortable to press, making accidental triggers unlikely. However could be added too if wanted

## What does this "solve"
Some applications don't have built-in "unsaved changes" prompts, or users may simply want extra protection against accidentally closing critical windows. In a keyboard-driven OS like Omarchy, it's easy to hit SUPER+W by mistake (specially if you are learning it) and close something you didn't intend to a game mid-session, a chat app, a long-running process, etc.

With this PR, users can list window classes in protected-windows, and those windows will show a confirmation prompt before closing:

<img width="1232" height="328" alt="image" src="https://github.com/user-attachments/assets/6dfe07da-d776-412c-88ef-9a23715c3f6b" /> <img width="2558" height="1434" alt="image" src="https://github.com/user-attachments/assets/79f1b085-9b8a-477f-9753-79c1406edb99" />

Unprotected windows close immediately as before (killactive).

## Functionality
New script omarchy-hyprland-window-close checks if the active window's class matches any entry in protected-windows
If not protected → closes immediately
If protected → opens a floating terminal with gum confirm
SUPER+W binding updated to use this script

## Good things
No behavior change unless user configures protected windows
One window class per line
Empty config = same behavior as before
## Not too good
Tiny overhead checking the config file on every SUPER+W