### PR TITLE
Allowing the About menu item to be overloaded via the menu.sh file

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -567,6 +567,10 @@ show_main_menu() {
   go_to_menu "$(menu "Go" "󰀻  Apps\n󰧑  Learn\n󱓞  Trigger\n  Style\n  Setup\n󰉉  Install\n󰭌  Remove\n  Update\n  About\n  System")"
 }
 
+show_about() {
+  omarchy-launch-about
+}
+
 go_to_menu() {
   case "${1,,}" in
   *apps*) walker -p "Launch…" ;;
@@ -582,7 +586,7 @@ go_to_menu() {
   *install*) show_install_menu ;;
   *remove*) show_remove_menu ;;
   *update*) show_update_menu ;;
-  *about*) omarchy-launch-about ;;
+  *about*) show_about ;;
   *system*) show_system_menu ;;
   esac
 }

--- a/config/omarchy/extensions/menu.sh
+++ b/config/omarchy/extensions/menu.sh
@@ -12,3 +12,9 @@
 #   *) back_to show_main_menu ;;
 #   esac
 # }
+# 
+# Example of overriding just the about menu action: (Using zsh instead of bash (default))
+# 
+# show_about() {
+#   exec omarchy-launch-or-focus-tui "zsh -c 'fastfetch; read -k 1'"
+# }


### PR DESCRIPTION
## Summary 

This change allows overloading for the about menu action via the ~/.config/omarchy/extensions/menu.sh file.

The current menu.sh file basically allows you to overload functions that are defined in the `omarchy-menu` binary that is shipped with OS. Users are discouraged to edit these binary files as updates may potentially overwrite their customizations. 

The about menu action directly calls the binary to execute the fastfetch command, and to overload it, one has to overload the whole `go_to_menu` function - which is not ideal. By creating a specific function for the about, the user is able to overload just that function in the menu.sh file.
