### PR TITLE
Add locale-aware date to waybar clock format

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -61,7 +61,7 @@
     "on-click-right": "alacritty"
   },
   "clock": {
-    "format": "{:L%A %H:%M}",
+    "format": "{:L%A %H:%M %x}",
     "format-alt": "{:L%d %B W%V %Y}",
     "tooltip": false,
     "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"


### PR DESCRIPTION
## Summary

- Adds the locale-aware date (`%x`) to the default waybar clock format
- New format: `{:L%A %H:%M %x}` displays as "Tuesday 17:47 01/20/2026"
- Uses the `:L` prefix with `%x` to respect system locale (MM/DD/YYYY for US, DD/MM/YYYY for others)