### PR TITLE
Fix driver for older NVIDIA MXxxx mobile GPUs

### DIFF
--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -7,8 +7,8 @@ if [ -n "$NVIDIA" ]; then
   if echo "$NVIDIA" | grep -qE "RTX [2-9][0-9]|GTX 16"; then
     # Turing (16xx, 20xx), Ampere (30xx), Ada (40xx), and newer recommend the open-source kernel modules
     PACKAGES=(nvidia-open-dkms nvidia-utils lib32-nvidia-utils libva-nvidia-driver)
-  elif echo "$NVIDIA" | grep -qE "GTX 9|GTX 10|Quadro P"; then
-    # Pascal (10xx or Quadro Pxxx) and Maxwell (9xx) use legacy branch that can only be installed from AUR
+  elif echo "$NVIDIA" | grep -qE "GTX 9|GTX 10|Quadro P|MX1|MX2|MX3"; then
+    # Pascal (10xx, Quadro Pxxx, MX150, MX2xx, and MX3xx) and Maxwell (9xx, MX110, and MX130) use legacy branch that can only be installed from AUR
     PACKAGES=(nvidia-580xx-dkms nvidia-580xx-utils lib32-nvidia-580xx-utils)
   fi
   # Bail if no supported GPU

--- a/migrations/1768906440.sh
+++ b/migrations/1768906440.sh
@@ -1,0 +1,19 @@
+echo "Migrate legacy mobile NVIDIA GPUs to nvidia-580xx driver (if needed)"
+
+# Only migrate MX1xx, 2xx or 3xx (Pascal/Maxwell)
+NVIDIA="$(lspci | grep -i 'nvidia')"
+if echo "$NVIDIA" | grep -qE "MX1|MX2|MX3"; then
+  if ! pacman -Qq | grep -qE '^linux(-[a-z0-9]+)?-headers$'; then
+    echo "Error: no linux headers package installed (required for DKMS drivers). Please install the appropriate headers and re-run this migration."
+    exit 1
+  fi
+
+  # Piping yes to override existing packages
+  yes | sudo pacman -S nvidia-580xx-dkms nvidia-580xx-utils lib32-nvidia-580xx-utils
+
+  # Verify packages were installed
+  if ! pacman -Qq nvidia-580xx-dkms nvidia-580xx-utils lib32-nvidia-580xx-utils &>/dev/null; then
+    echo "Error: NVIDIA 580xx driver packages failed to install"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
Restores support for for older mobile Pascal and Maxwell GPUs (MXxx, MX2xx, MX3xx) by using the legacy drivers.
This fixes nvidia-smi failing with: `NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver`

See also #4138 