### PR TITLE
Add user envs.conf override for environment variables

### DIFF
--- a/config/hypr/envs.conf
+++ b/config/hypr/envs.conf
@@ -1,0 +1,2 @@
+# Override default Omarchy environment variables
+# env = XCURSOR_SIZE,32

--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -17,6 +17,7 @@ source = ~/.config/hypr/monitors.conf
 source = ~/.config/hypr/input.conf
 source = ~/.config/hypr/bindings.conf
 source = ~/.config/hypr/looknfeel.conf
+source = ~/.config/hypr/envs.conf
 source = ~/.config/hypr/autostart.conf
 
 # Add any other personal Hyprland configuration below


### PR DESCRIPTION
Users had no way to override environment variables set in the default `envs.conf` (like `QT_STYLE_OVERRIDE`) without manually editing `hyprland.conf` to add a source line.

This adds `envs.conf` to the user config pattern, matching how other configs (monitors, input, bindings, looknfeel, autostart) already work.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)