### PR TITLE
feat: add numpad keybinds for workspace switching

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -29,6 +29,18 @@ bindd = SUPER, code:17, Switch to workspace 8, workspace, 8
 bindd = SUPER, code:18, Switch to workspace 9, workspace, 9
 bindd = SUPER, code:19, Switch to workspace 10, workspace, 10
 
+# Switch workspaces with SUPER + NumPad [1-9; 0]
+bindd = SUPER, code:87, Switch to workspace 1 (NumPad), workspace, 1
+bindd = SUPER, code:88, Switch to workspace 2 (NumPad), workspace, 2
+bindd = SUPER, code:89, Switch to workspace 3 (NumPad), workspace, 3
+bindd = SUPER, code:83, Switch to workspace 4 (NumPad), workspace, 4
+bindd = SUPER, code:84, Switch to workspace 5 (NumPad), workspace, 5
+bindd = SUPER, code:85, Switch to workspace 6 (NumPad), workspace, 6
+bindd = SUPER, code:79, Switch to workspace 7 (NumPad), workspace, 7
+bindd = SUPER, code:80, Switch to workspace 8 (NumPad), workspace, 8
+bindd = SUPER, code:81, Switch to workspace 9 (NumPad), workspace, 9
+bindd = SUPER, code:90, Switch to workspace 10 (NumPad), workspace, 10
+
 # Move active window to a workspace with SUPER + SHIFT + [1-9; 0]
 bindd = SUPER SHIFT, code:10, Move window to workspace 1, movetoworkspace, 1
 bindd = SUPER SHIFT, code:11, Move window to workspace 2, movetoworkspace, 2
@@ -41,6 +53,18 @@ bindd = SUPER SHIFT, code:17, Move window to workspace 8, movetoworkspace, 8
 bindd = SUPER SHIFT, code:18, Move window to workspace 9, movetoworkspace, 9
 bindd = SUPER SHIFT, code:19, Move window to workspace 10, movetoworkspace, 10
 
+# Move active window to a workspace with SUPER + SHIFT + NumPad [1-9; 0]
+bindd = SUPER SHIFT, code:87, Move window to workspace 1 (NumPad), movetoworkspace, 1
+bindd = SUPER SHIFT, code:88, Move window to workspace 2 (NumPad), movetoworkspace, 2
+bindd = SUPER SHIFT, code:89, Move window to workspace 3 (NumPad), movetoworkspace, 3
+bindd = SUPER SHIFT, code:83, Move window to workspace 4 (NumPad), movetoworkspace, 4
+bindd = SUPER SHIFT, code:84, Move window to workspace 5 (NumPad), movetoworkspace, 5
+bindd = SUPER SHIFT, code:85, Move window to workspace 6 (NumPad), movetoworkspace, 6
+bindd = SUPER SHIFT, code:79, Move window to workspace 7 (NumPad), movetoworkspace, 7
+bindd = SUPER SHIFT, code:80, Move window to workspace 8 (NumPad), movetoworkspace, 8
+bindd = SUPER SHIFT, code:81, Move window to workspace 9 (NumPad), movetoworkspace, 9
+bindd = SUPER SHIFT, code:90, Move window to workspace 10 (NumPad), movetoworkspace, 10
+
 # Move active window silently to a workspace with SUPER + SHIFT + ALT + [1-9; 0]
 bindd = SUPER SHIFT ALT, code:10, Move window silently to workspace 1, movetoworkspacesilent, 1
 bindd = SUPER SHIFT ALT, code:11, Move window silently to workspace 2, movetoworkspacesilent, 2
@@ -52,6 +76,18 @@ bindd = SUPER SHIFT ALT, code:16, Move window silently to workspace 7, movetowor
 bindd = SUPER SHIFT ALT, code:17, Move window silently to workspace 8, movetoworkspacesilent, 8
 bindd = SUPER SHIFT ALT, code:18, Move window silently to workspace 9, movetoworkspacesilent, 9
 bindd = SUPER SHIFT ALT, code:19, Move window silently to workspace 10, movetoworkspacesilent, 10
+
+# Move active window silently to a workspace with SUPER + SHIFT + ALT + NumPad [1-9; 0]
+bindd = SUPER SHIFT ALT, code:87, Move window silently to workspace 1 (NumPad), movetoworkspacesilent, 1
+bindd = SUPER SHIFT ALT, code:88, Move window silently to workspace 2 (NumPad), movetoworkspacesilent, 2
+bindd = SUPER SHIFT ALT, code:89, Move window silently to workspace 3 (NumPad), movetoworkspacesilent, 3
+bindd = SUPER SHIFT ALT, code:83, Move window silently to workspace 4 (NumPad), movetoworkspacesilent, 4
+bindd = SUPER SHIFT ALT, code:84, Move window silently to workspace 5 (NumPad), movetoworkspacesilent, 5
+bindd = SUPER SHIFT ALT, code:85, Move window silently to workspace 6 (NumPad), movetoworkspacesilent, 6
+bindd = SUPER SHIFT ALT, code:79, Move window silently to workspace 7 (NumPad), movetoworkspacesilent, 7
+bindd = SUPER SHIFT ALT, code:80, Move window silently to workspace 8 (NumPad), movetoworkspacesilent, 8
+bindd = SUPER SHIFT ALT, code:81, Move window silently to workspace 9 (NumPad), movetoworkspacesilent, 9
+bindd = SUPER SHIFT ALT, code:90, Move window silently to workspace 10 (NumPad), movetoworkspacesilent, 10
 
 # Control scratchpad
 bindd = SUPER, S, Toggle scratchpad, togglespecialworkspace, scratchpad


### PR DESCRIPTION
## Summary
Add NumPad keybinds for workspace switching, mirroring the existing number row keybinds.

Closes #4033

## Changes
- Add `SUPER + NumPad [0-9]` to switch workspaces
- Add `SUPER + SHIFT + NumPad [0-9]` to move windows to workspaces

## Why
Users with external keyboards or laptops with numpad can now use the numpad for workspace navigation, providing a more natural workflow for users accustomed to numpad usage.

## Testing
- Tested keycodes on standard US keyboard layout
- NumPad 1 = code:87, NumPad 2 = code:88, etc.