### PR TITLE
feat: increase memlock limits for emulators and audio apps

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -6,6 +6,7 @@ run_logged $OMARCHY_INSTALL/config/gpg.sh
 run_logged $OMARCHY_INSTALL/config/timezones.sh
 run_logged $OMARCHY_INSTALL/config/increase-sudo-tries.sh
 run_logged $OMARCHY_INSTALL/config/increase-lockout-limit.sh
+run_logged $OMARCHY_INSTALL/config/increase-memlock-limits.sh
 run_logged $OMARCHY_INSTALL/config/ssh-flakiness.sh
 run_logged $OMARCHY_INSTALL/config/detect-keyboard-layout.sh
 run_logged $OMARCHY_INSTALL/config/xcompose.sh

--- a/install/config/increase-memlock-limits.sh
+++ b/install/config/increase-memlock-limits.sh
@@ -1,0 +1,9 @@
+TARGET_USER="${SUDO_USER:-$USER}"
+sudo mkdir -p /etc/security/limits.d
+sudo tee /etc/security/limits.d/99-memlock.conf >/dev/null <<EOF
+# Increase memlock limits for the primary user
+# Required for: RPCS3, PCSX2, audio production (JACK), and other applications
+# that need to lock large amounts of memory
+${TARGET_USER} soft memlock unlimited
+${TARGET_USER} hard memlock unlimited
+EOF


### PR DESCRIPTION
## Summary
Add system-wide memlock limits configuration to support applications that require large locked memory regions.

Closes #3059

## Changes
- Add `install/config/increase-memlock-limits.sh` to create `/etc/security/limits.d/99-memlock.conf`
- Add script to `install/config/all.sh` run order

## Why
Applications like RPCS3, PCSX2, and audio production software (JACK, Ardour) require unlimited memlock to function properly. Without this, these applications may fail or exhibit poor performance.

## Configuration
Sets both soft and hard memlock limits to unlimited for all users:
```
* soft memlock unlimited
* hard memlock unlimited
```