### PR TITLE
feat: add cliphist-based clipboard manager to fix Walker crash

### DIFF
--- a/bin/omarchy-clipboard-manager
+++ b/bin/omarchy-clipboard-manager
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Alternative clipboard manager using cliphist + fzf
+# Fixes Walker clipboard crash with non-UTF-8 multibyte characters
+# See: https://github.com/basecamp/omarchy/issues/4316
+
+set -euo pipefail
+
+HISTORY_SIZE=500
+PREVIEW_LENGTH=100
+
+show_clipboard_history() {
+    local selection
+    selection=$(cliphist list | head -n "$HISTORY_SIZE" | \
+        fzf --height=100% \
+            --layout=reverse \
+            --border=rounded \
+            --prompt="Clipboard: " \
+            --preview="echo {} | cliphist decode | head -c $PREVIEW_LENGTH" \
+            --preview-window=down:3:wrap \
+            --bind="ctrl-d:execute-silent(echo {} | cliphist delete)+reload(cliphist list | head -n $HISTORY_SIZE)")
+
+    if [[ -n "$selection" ]]; then
+        echo "$selection" | cliphist decode | wl-copy
+    fi
+}
+
+clear_history() {
+    cliphist wipe
+    notify-send "Clipboard" "History cleared" -i edit-clear
+}
+
+case "${1:-show}" in
+    show)
+        show_clipboard_history
+        ;;
+    clear)
+        clear_history
+        ;;
+    *)
+        echo "Usage: omarchy-clipboard-manager [show|clear]"
+        exit 1
+        ;;
+esac

--- a/config/systemd/user/cliphist.service
+++ b/config/systemd/user/cliphist.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cliphist Clipboard History Daemon
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/wl-paste --watch cliphist store
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -3,7 +3,7 @@ windowrule = float on, match:tag floating-window
 windowrule = center on, match:tag floating-window
 windowrule = size 875 600, match:tag floating-window
 
-windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
+windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.omarchy.clipboard|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
 windowrule = tag +floating-window, match:class (xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), match:title ^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)
 windowrule = float on, match:class org.gnome.Calculator
 

--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -2,4 +2,4 @@
 bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert,
 bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert,
 bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X,
-bindd = SUPER CTRL, V, Clipboard manager, exec, omarchy-launch-walker -m clipboard
+bindd = SUPER CTRL, V, Clipboard manager, exec, xdg-terminal-exec --class=org.omarchy.clipboard -e omarchy-clipboard-manager

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -14,6 +14,7 @@ bolt
 brightnessctl
 btop
 clang
+cliphist
 cups
 cups-browsed
 cups-filters

--- a/migrations/1768936150.sh
+++ b/migrations/1768936150.sh
@@ -1,0 +1,2 @@
+systemctl --user enable cliphist.service
+systemctl --user start cliphist.service


### PR DESCRIPTION
## Summary
Add alternative clipboard manager using cliphist + fzf to fix Walker clipboard crash with non-UTF-8 multibyte characters.

Closes #4316

## Changes
- Add `bin/omarchy-clipboard-manager` script with fzf interface
- Add `cliphist` package to `omarchy-base.packages`
- Add `cliphist.service` systemd user service for clipboard history
- Update `clipboard.conf` with `SUPER CTRL V` keybind for new manager

## Features
- Preview clipboard entries before selecting
- `Ctrl+D` to delete entries from history
- `omarchy-clipboard-manager clear` to wipe history
- Handles non-UTF-8 characters that crash Walker

## Why
Walker's clipboard module crashes when clipboard contains certain non-UTF-8 multibyte characters. This provides a robust alternative using well-tested tools (cliphist + fzf).

## Credit
Solution based on workaround provided by @evandro-macedo in #4316.