### PR TITLE
feat: add display configuration tool using wdisplays

### DIFF
--- a/bin/omarchy-displays
+++ b/bin/omarchy-displays
@@ -1,0 +1,52 @@
+#!/bin/bash
+# omarchy-displays - Display configuration tool launcher
+# Provides a unified interface for monitor configuration
+
+set -euo pipefail
+
+launch_wdisplays() {
+    if command -v wdisplays &>/dev/null; then
+        exec wdisplays
+    else
+        notify-send "Display Configuration" "wdisplays not installed. Run: yay -S wdisplays" -i display
+        exit 1
+    fi
+}
+
+show_current() {
+    hyprctl monitors -j | jq -r '.[] | "[\(.name)] \(.width)x\(.height)@\(.refreshRate)Hz scale:\(.scale) pos:\(.x),\(.y)"'
+}
+
+usage() {
+    cat <<EOF
+Usage: omarchy-displays [COMMAND]
+
+Commands:
+    gui      Launch wdisplays GUI (default)
+    show     Show current monitor configuration
+    help     Show this help message
+
+The GUI allows you to:
+- Arrange multiple displays
+- Set resolution and refresh rate
+- Configure scaling
+- Enable/disable displays
+EOF
+}
+
+case "${1:-gui}" in
+    gui|"")
+        launch_wdisplays
+        ;;
+    show|status)
+        show_current
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        echo "Unknown command: $1"
+        usage
+        exit 1
+        ;;
+esac

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -131,6 +131,7 @@ usage
 uwsm
 waybar
 wayfreeze
+wdisplays
 whois
 wireless-regdb
 wiremix


### PR DESCRIPTION
## Summary
Add wdisplays package and omarchy-displays launcher for easy multi-monitor configuration with a graphical interface.

Closes #2858

## Changes
- Add `wdisplays` package to `omarchy-base.packages`
- Add `bin/omarchy-displays` launcher script

## Usage
```bash
omarchy-displays        # Launch GUI (default)
omarchy-displays gui    # Launch GUI
omarchy-displays show   # Show current monitor configuration
```

## Features
- GUI for arranging multiple displays
- Set resolution and refresh rate
- Configure scaling per display
- Enable/disable displays
- Works with Wayland/Hyprland

## Why
Users need a user-friendly way to configure multiple displays without manually editing config files. wdisplays provides a mature, well-tested GUI that integrates well with Hyprland.

This addresses the need mentioned in #2858 for a display configuration tool that:
- Keeps things simple
- Still allows config files
- Fits Omarchy's theme