### PR TITLE
feat: set Apple keyboard backlight to 100% on boot

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -32,4 +32,5 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-t2.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-keyboard-backlight.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh

--- a/install/config/hardware/fix-apple-keyboard-backlight.sh
+++ b/install/config/hardware/fix-apple-keyboard-backlight.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Set Apple keyboard backlight to 100% on supported MacBooks
+# This runs during installation (via all.sh) to ensure the keyboard backlight
+# is visible, since touchbar/physical backlight keys may not work without
+# additional drivers
+
+find_kbd_backlight() {
+    local device
+    for pattern in ":white:kbd_backlight" "sms::kbd_backlight" ".*::kbd_backlight"; do
+        device=$(brightnessctl -l 2>/dev/null | grep -oP "Device '\\K[^']*$pattern[^']*" | head -1)
+        if [[ -n "$device" ]]; then
+            echo "$device"
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [[ -f /sys/class/dmi/id/sys_vendor ]] && grep -qi "Apple" /sys/class/dmi/id/sys_vendor; then
+    device=$(find_kbd_backlight)
+    if [[ -n "$device" ]]; then
+        echo "Detected Apple hardware, setting keyboard backlight to 100% (device: $device)"
+        brightnessctl -d "$device" set 100% &>/dev/null
+    fi
+fi


### PR DESCRIPTION
## Summary
Automatically set keyboard backlight to maximum on Apple MacBooks during installation.

Closes #1804

## Changes
- Add `install/config/hardware/fix-apple-keyboard-backlight.sh`
- Add script to `install/config/all.sh` run order

## Why
On MacBooks, the touchbar or physical keyboard backlight keys often don't work without additional drivers (tiny-dfr, etc.). This ensures users have visible keyboard illumination out of the box.

## Implementation
- Detects Apple hardware via `/sys/class/dmi/id/sys_vendor`
- Uses `brightnessctl` to find and set keyboard backlight device
- Supports common device patterns: `:white:kbd_backlight`, `sms::kbd_backlight`
- Only runs on Apple hardware, no-op on other systems

## Testing
Tested device patterns from issue comments:
- MacBook Pro 16,1: `:white:kbd_backlight`
- MacBook Pro Retina 13: `sms::kbd_backlight`