### PR TITLE
fix: remove SDL_VIDEODRIVER=wayland to fix Proton games

### DIFF
--- a/default/hypr/envs.conf
+++ b/default/hypr/envs.conf
@@ -6,7 +6,6 @@ env = HYPRCURSOR_SIZE,24
 env = GDK_BACKEND,wayland,x11,*
 env = QT_QPA_PLATFORM,wayland;xcb
 env = QT_STYLE_OVERRIDE,kvantum
-env = SDL_VIDEODRIVER,wayland
 env = MOZ_ENABLE_WAYLAND,1
 env = ELECTRON_OZONE_PLATFORM_HINT,wayland
 env = OZONE_PLATFORM,wayland


### PR DESCRIPTION
## Summary
Remove the `SDL_VIDEODRIVER=wayland` environment variable that causes compatibility issues with Proton/Steam games.

Closes #2564

## Changes
- Remove `env = SDL_VIDEODRIVER,wayland` from `default/hypr/envs.conf`

## Why
Setting `SDL_VIDEODRIVER=wayland` forcibly overrides SDL's auto-detection, causing many Proton games to fail to launch:
- Deadlock
- The Finals
- ARC Raiders
- And many others

Per [SDL3 documentation](https://wiki.libsdl.org/SDL3/SDL_HINT_VIDEO_DRIVER):
> By default, SDL will try all available video backends in a reasonable order until it finds one that can work

SDL properly auto-detects Wayland when running under Hyprland, so this override is unnecessary and causes more problems than it solves.

## Testing
Verified that affected games launch correctly after removing this override.