### PR TITLE
Add kb_variant to input.conf

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -3,6 +3,8 @@
 input {
   # Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
   # kb_layout = us,dk,eu
+
+  # Use a specific keyboard variant if needed (e.g. intl for international keyboards)
   # kb_variant = intl
 
   kb_options = compose:caps # ,grp:alts_toggle


### PR DESCRIPTION
(Very) small Quality of Life Update. I happened to look up this parameter more than once and think that it might be useful for others as well:

Personally, I use the "kb_variant = intl" to be able to type letters like ä, ö, ü also on the us layout. There are other use cases where you want to specify a variant of a layout. This is just a hint that its quickly available to users.