### PR TITLE
feat: add cliphist-based clipboard manager with image preview

### DIFF
--- a/bin/omarchy-clipboard-manager
+++ b/bin/omarchy-clipboard-manager
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Alternative clipboard manager using cliphist + fzf
+# Fixes Walker clipboard crash with non-UTF-8 multibyte characters
+# See: https://github.com/basecamp/omarchy/issues/4316
+
+set -euo pipefail
+
+HISTORY_SIZE=500
+
+show_clipboard_history() {
+    local selection
+
+    # Preview command with image support via kitty's icat
+    local preview_cmd='
+entry={}
+if [[ "$entry" == *"[[ binary data"* ]]; then
+    if command -v kitten &>/dev/null; then
+        echo "$entry" | cliphist decode 2>/dev/null | kitten icat --clear --transfer-mode=memory --unicode-placeholder --stdin=yes --place="${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES}@0x0"
+    else
+        echo "[Binary data - install kitty for image preview]"
+    fi
+else
+    echo "$entry" | cliphist decode 2>/dev/null
+fi
+'
+
+    selection=$(cliphist list | head -n "$HISTORY_SIZE" | \
+        fzf --height=100% \
+            --layout=reverse \
+            --border=rounded \
+            --prompt="📋 Clipboard: " \
+            --header="Enter: paste | Ctrl-D: delete" \
+            --preview="$preview_cmd" \
+            --preview-window=right:50%:wrap \
+            --bind="ctrl-d:execute-silent(echo {} | cliphist delete)+reload(cliphist list | head -n $HISTORY_SIZE)")
+
+    if [[ -n "$selection" ]]; then
+        echo "$selection" | cliphist decode | wl-copy
+    fi
+}
+
+clear_history() {
+    cliphist wipe
+    notify-send "Clipboard" "History cleared" -i edit-clear
+}
+
+case "${1:-show}" in
+    show)
+        show_clipboard_history
+        ;;
+    clear)
+        clear_history
+        ;;
+    *)
+        echo "Usage: omarchy-clipboard-manager [show|clear]"
+        exit 1
+        ;;
+esac

--- a/config/systemd/user/cliphist.service
+++ b/config/systemd/user/cliphist.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cliphist Clipboard History Daemon
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/wl-paste --watch cliphist store
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -3,7 +3,7 @@ windowrule = float on, match:tag floating-window
 windowrule = center on, match:tag floating-window
 windowrule = size 875 600, match:tag floating-window
 
-windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
+windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.omarchy.clipboard|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
 windowrule = tag +floating-window, match:class (xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), match:title ^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)
 windowrule = float on, match:class org.gnome.Calculator
 

--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -2,4 +2,4 @@
 bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert,
 bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert,
 bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X,
-bindd = SUPER CTRL, V, Clipboard manager, exec, omarchy-launch-walker -m clipboard
+bindd = SUPER CTRL, V, Clipboard manager, exec, xdg-terminal-exec --class=org.omarchy.clipboard -e omarchy-clipboard-manager

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -14,6 +14,7 @@ bolt
 brightnessctl
 btop
 clang
+cliphist
 cups
 cups-browsed
 cups-filters

--- a/migrations/1768936150.sh
+++ b/migrations/1768936150.sh
@@ -1,0 +1,2 @@
+systemctl --user enable cliphist.service
+systemctl --user start cliphist.service


### PR DESCRIPTION
## Summary

Fixes #4316 - Walker clipboard crashes on non-UTF-8 multibyte characters (emoji, CJK, binary data).

This PR replaces Walker clipboard with cliphist + fzf, which handles all character encodings correctly.

## Features

- **Crash-proof**: Handles emoji, CJK, and binary data without crashes
- **Image preview**: Shows image thumbnails via kitty's icat (graceful fallback for other terminals)
- **Delete entries**: Ctrl-D removes individual items
- **Clear history**: `omarchy-clipboard-manager clear` wipes all

## Files Changed

| File | Purpose |
|------|---------|
| `bin/omarchy-clipboard-manager` | Main script with fzf interface |
| `config/systemd/user/cliphist.service` | Daemon to capture clipboard |
| `default/hypr/apps/system.conf` | Window rule for floating popup |
| `default/hypr/bindings/clipboard.conf` | SUPER+CTRL+V keybind |
| `install/omarchy-base.packages` | Adds cliphist dependency |
| `migrations/1768936150.sh` | Enables systemd service |

## Credits

- Image preview implementation suggested by @Yiin in #4316

## Testing

1. Install: `sudo pacman -S cliphist`
2. Run migration or `systemctl --user enable --now cliphist.service`
3. Copy some text/images
4. Press SUPER+CTRL+V to open clipboard manager