### PR TITLE
Add nautilus-python package for 'Open in Ghostty' shortcut in Nautilus

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -78,6 +78,7 @@ mariadb-libs
 mise
 mpv
 nautilus
+nautilus-python
 gnome-disk-utility
 noto-fonts
 noto-fonts-cjk

--- a/migrations/1769183359.sh
+++ b/migrations/1769183359.sh
@@ -1,0 +1,3 @@
+echo "Add nautilus-python package for 'Open in Ghostty' shortcut in Nautilus"
+
+omarchy-pkg-add nautilus-python


### PR DESCRIPTION
If Ghostty is installed, this will add an Open in Ghostty shortcut for Nautilus on right click.

<img width="1492" height="939" alt="screenshot-2026-01-23_09-24-40" src="https://github.com/user-attachments/assets/e380f8c0-ede5-4240-8b7d-346aeb723d08" />
