### PR TITLE
Replace alacritty with xdg-terminal-exec in the waybar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -58,7 +58,7 @@
     "interval": 5,
     "format": "󰍛",
     "on-click": "omarchy-launch-or-focus-tui btop",
-    "on-click-right": "alacritty"
+    "on-click-right": "xdg-terminal-exec"
   },
   "clock": {
     "format": "{:L%A %H:%M}",

--- a/migrations/1769290972.sh
+++ b/migrations/1769290972.sh
@@ -1,0 +1,3 @@
+echo "Replace alacritty with xdg-terminal-exec in the waybar"
+
+sed -i 's/alacritty/xdg-terminal-exec/' ~/.config/waybar/config.jsonc


### PR DESCRIPTION
Right-clicking on the waybar cpu icon opens a Alacritty. I changed it to use the user's preferred terminal instead.

Since right clicking the waybar Omarchy logo already opens a terminal, we could also remove the right click action for the cpu icon.