### PR TITLE
Add copy-filepath-to-clipboard mode to screenshot tool

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -81,7 +81,7 @@ grim -g "$SELECTION" - |
     --actions-on-enter save-to-clipboard \
     --save-after-copy \
     --copy-command 'wl-copy'
-elif [[ $PROCESSING == "clipboard-path" ]]; then
+elif [[ $PROCESSING == "copy-filepath-to-clipboard" ]]; then
   FILENAME="$OUTPUT_DIR/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png"
   grim -g "$SELECTION" - |
     satty --filename - \

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -35,7 +35,6 @@ bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-d
 # Captures
 bindd = , PRINT, Screenshot with editing, exec, omarchy-cmd-screenshot
 bindd = SHIFT, PRINT, Screenshot to clipboard, exec, omarchy-cmd-screenshot smart clipboard
-bindd = CTRL, PRINT, Screenshot path to clipboard, exec, omarchy-cmd-screenshot smart clipboard-path
 bindd = ALT, PRINT, Screenrecording, exec, omarchy-menu screenrecord
 bindd = SUPER, PRINT, Color picker, exec, pkill hyprpicker || hyprpicker -a
 


### PR DESCRIPTION
Adds a new processing mode that copies the screenshot's file path to clipboard instead of the image data. Useful for terminal applications like Claude Code or Open Code that can't paste images directly but accept file paths.

The keybinding `Ctrl+PrtScr` runs `omarchy-cmd-screenshot smart clipboard-path`. It still opens satty for annotation, saves to the same location with the same naming convention as other screenshots, and copies the full path to clipboard on save.