### PR TITLE
Make open alias behave more like open in macOS, remove the job control noise

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -21,9 +21,9 @@ if command -v zoxide &> /dev/null; then
   }
 fi
 
-open() {
+open() (
   xdg-open "$@" >/dev/null 2>&1 &
-}
+)
 
 # Directories
 alias ..='cd ..'


### PR DESCRIPTION
Replacing {} with () on function closure means a sub-shell is used, preventing job control noise from showing up in the current shell.

If it is not run as a sub-shell, using open and then subsequently closing the app will pollute the existing terminal with messages like:
  [1] 287915
  [1]+  Done  xdg-open "$@" > /dev/null 2>&1

Making it a subshell removes this noise and keeps it more like the open command in macOS. 