### PR TITLE
Update opacity rule for Steam window class

### DIFF
--- a/default/hypr/apps/steam.conf
+++ b/default/hypr/apps/steam.conf
@@ -1,7 +1,7 @@
 # Float Steam
 windowrule = float on, match:class steam
 windowrule = center on, match:class steam, match:title Steam
-windowrule = opacity 1 1, match:class steam
+windowrule = opacity 1 1, match:class steam.*
 windowrule = size 1100 700, match:class steam, match:title Steam
 windowrule = size 460 800, match:class steam, match:title Friends List
 windowrule = idle_inhibit fullscreen, match:class steam


### PR DESCRIPTION
The steam class for opacity is missing the `.*` regular expression. Just `steam` does not match launched steam apps. Therefore, currently, steam apps have the default opacity of `0.97` of omarchy. This is usually not noticable, but very distracting on an OLED Screen and Games with dark/black scenes / menues and a brighter / any app opend 'behind' the game.


# Example Screenshot

This is "No Rest for the Wicked" with the Steam Library shining through (with omarchy blur). Open the image "fullscreen" and you are able to see the "blurry lines" on the left hand side of the screenshot.

<img width="457" height="713" alt="image" src="https://github.com/user-attachments/assets/6139c75a-18e1-4b8c-8571-f2f95663b9fa" />
