### PR TITLE
Add window rules for Bitwarden Chrome Extension

### DIFF
--- a/default/hypr/apps/bitwarden.conf
+++ b/default/hypr/apps/bitwarden.conf
@@ -1,2 +1,6 @@
 windowrule = no_screen_share on, match:class ^(Bitwarden)$
 windowrule = tag +floating-window, match:class ^(Bitwarden)$
+
+# Bitwarden Chrome Extension
+windowrule = no_screen_share on, match:class chrome-nngceckbapebfimnlniiiahkandclblb-Default
+windowrule = tag +floating-window, match:class chrome-nngceckbapebfimnlniiiahkandclblb-Default


### PR DESCRIPTION
adds same windowrules for Bitwarden Chrome Extension as already defined for Bitwarden app