### PR TITLE
fix(waybar/config.jsonc): remove extra character in clock's format-alt

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -62,7 +62,7 @@
   },
   "clock": {
     "format": "{:L%A %H:%M}",
-    "format-alt": "{:L%d %B W%V %Y}",
+    "format-alt": "{:L%d %B %V %Y}",
     "tooltip": false,
     "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
   },


### PR DESCRIPTION
"format-alt": "{:L%d %B W%V %Y}" -> "format-alt": "{:L%d %B %V %Y}"