### PR TITLE
wiremix: less confusing audio default device character for input/output audio

### DIFF
--- a/config/wiremix/wiremix.toml
+++ b/config/wiremix/wiremix.toml
@@ -1,0 +1,5 @@
+# overwrites default wiremix configuration
+# defaults: https://github.com/tsowell/wiremix/blob/main/wiremix.toml
+
+[char_sets.default]
+default_device = "⮞"


### PR DESCRIPTION
Slightly less confusion default_device character "⮞" instead of "◇"
Marks the default device on the Input/Output Audio Devices tabs