### PR TITLE
Fix hypridle timout comment

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -11,7 +11,7 @@ listener {
 }
 
 listener {
-    timeout = 151                      # 5min
+    timeout = 151                      # ~2.5min (right after screensaver starts)
     on-timeout = loginctl lock-session # lock screen when timeout has passed
 }
 


### PR DESCRIPTION
**Changes:**

- What: fix misleading comment (151s ≠ 5min)
- Why: prevents confusion when users tweak idle/lock timings
- Scope: comment-only, no behavior change