### PR TITLE
fix: theme template rendering with yq v4.50+

### DIFF
--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -15,19 +15,22 @@ hex_to_rgb() {
 if [[ -f $COLORS_FILE ]]; then
   sed_script=$(mktemp)
 
-  while IFS='=' read -r key value; do
-    key="${key//[\"\' ]/}"                # strip quotes and spaces from key
-    [[ $key && $key != \#* ]] || continue # skip empty lines and comments
-    value="${value#*[\"\']}"
-    value="${value%%[\"\']*}" # extract value between quotes (ignores inline comments)
+  # Generate standard substitutions
+  # Note: Split into two yq calls to avoid nested interpolation bug in yq v4.50+
+  sed 's/=/:/' "$COLORS_FILE" | yq -r 'to_entries[] | "s|{{ \(.key) }}|\(.value)|g"' > "$sed_script"
+  
+  # Generate _strip substitutions (removes # prefix from hex colors)
+  sed 's/=/:/' "$COLORS_FILE" | yq -r 'to_entries[] | "s|{{ \(.key)_strip }}|\(.value | sub(\"#\"; \"\"))|g"' >> "$sed_script"
 
-    printf 's|{{ %s }}|%s|g\n' "$key" "$value"            # {{ key }} -> value
-    printf 's|{{ %s_strip }}|%s|g\n' "$key" "${value#\#}" # {{ key_strip }} -> value without leading #
+  # Generate _rgb substitutions for hex colors
+  while IFS='=' read -r key value; do
+    key=$(echo "$key" | xargs)
+    value=$(echo "$value" | xargs | tr -d '"')
     if [[ $value =~ ^# ]]; then
       rgb=$(hex_to_rgb "$value")
-      echo "s|{{ ${key}_rgb }}|${rgb}|g"
+      echo "s|{{ ${key}_rgb }}|${rgb}|g" >> "$sed_script"
     fi
-  done <"$COLORS_FILE" >"$sed_script"
+  done < "$COLORS_FILE"
 
   shopt -s nullglob
 
@@ -38,7 +41,7 @@ if [[ -f $COLORS_FILE ]]; then
 
     # Don't overwrite configs already exists in the output directory (copied from theme specific folder)
     if [[ ! -f $output_path ]]; then
-      sed -f "$sed_script" "$tpl" >"$output_path"
+      sed -f "$sed_script" "$tpl" > "$output_path"
     fi
   done
 


### PR DESCRIPTION
## Summary

Fixes theme templates not rendering due to yq string interpolation bug. Template variables like `{{ background }}` and `{{ accent_strip }}` were being passed through literally instead of being replaced with color values.

## Changes

Split the yq expression in `omarchy-theme-set-templates` into two separate calls:

```bash
# Before (broken with yq v4.50+)
sed 's/=/:/' "$COLORS_FILE" | yq -r 'to_entries[] | "s|{{ \(.key) }}|\(.value)|g", "s|{{ \(.key)_strip }}|\(.value | sub("^#";""))|g"' > "$sed_script"

# After (works)
sed 's/=/:/' "$COLORS_FILE" | yq -r 'to_entries[] | "s|{{ \(.key) }}|\(.value)|g"' > "$sed_script"
sed 's/=/:/' "$COLORS_FILE" | yq -r 'to_entries[] | "s|{{ \(.key)_strip }}|\(.value | sub(\"#\"; \"\"))|g"' >> "$sed_script"
```

## Root Cause

The nested string interpolation with `sub()` in a single yq expression causes:
1. A lexer error: `invalid input text "^#\";\"\"))|g\""`
2. Variable not interpolating in second output (produces `{{ _strip }}` instead of `{{ accent_strip }}`)

## Test Plan

1. Run `omarchy-theme-set "Any Theme"`
2. Verify `~/.config/omarchy/current/theme/ghostty.conf` has actual color values (e.g., `background = #FFFCF0`) not template variables
3. Verify `~/.config/omarchy/current/theme/hyprland.conf` has rendered `_strip` values (e.g., `rgb(205EA6)`)

Fixes #4470