### PR TITLE
Improve update check to verify latest tag is newer

### DIFF
--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -14,7 +14,7 @@ if [[ -z "$current_tag" ]]; then
   exit 1
 fi
 
-if [[ "$current_tag" != "$latest_tag" ]]; then
+if [[ "$current_tag" != "$latest_tag" && "$(printf '%s\n' "$current_tag" "$latest_tag" | sort -V | tail -n 1)" == "$latest_tag" ]]; then
   echo "Omarchy update available ($latest_tag)"
   exit 0
 else


### PR DESCRIPTION
Running on the dev branch, which is currently set at v3.3.3, I see the update icon in the waybar.

The `omarchy-update-script` condition should also check if the latest tag is greater than the current tag. Currently, it just checks if it's equal.