### PR TITLE
Don't apply power profile source switching if only one profile is available

### DIFF
--- a/install/config/powerprofilesctl-rules.sh
+++ b/install/config/powerprofilesctl-rules.sh
@@ -1,19 +1,15 @@
 if omarchy-battery-present; then
   mapfile -t profiles < <(omarchy-powerprofiles-list)
 
-  if [[ ${#profiles[@]} -gt 0 ]]; then
+  if [[ ${#profiles[@]} -gt 1 ]]; then
 
     # Default AC profile:
     # 3 profiles → performance
     # 2 profiles → balanced
-    # 1 profile  → profiles[0]
-    ac_profile="${profiles[2]:-${profiles[1]:-${profiles[0]}}}"
+    ac_profile="${profiles[2]:-${profiles[1]}}"
 
-    # Default Battery profile:
-    # 3 profiles → balanced
-    # 2 profiles → balanced
-    # 1 profile  → profiles[0]
-    battery_profile="${profiles[1]:-${profiles[0]}}"
+    # Default Battery profile (balanced)
+    battery_profile="${profiles[1]}"
 
     cat <<EOF | sudo tee "/etc/udev/rules.d/99-power-profile.rules"
 SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/powerprofilesctl set $battery_profile"


### PR DESCRIPTION
Just realized power profile source switching does not make sense if only one profile is available. I don't  know if that's a common use case but it simplifies the code a bit.