### PR TITLE
Improve error detection in `omarchy-update-analyze-logs`

### DIFF
--- a/bin/omarchy-update-analyze-logs
+++ b/bin/omarchy-update-analyze-logs
@@ -2,10 +2,50 @@
 
 update_log="/tmp/omarchy-update.log"
 
-# Check for errors
-if grep -qi "error" "$update_log"; then
+
+# Case-Insensitive Excludes.
+EXCLUDES=(
+    "Compiling thiserror"
+    "-Werror="
+)
+
+
+FOUND_ERROR_START_ANSI=$'\e[31m'
+FOUND_ERROR_END_ANSI=$'\e[0m'
+
+check_logs() {
+    # 1. Pre-filter: Only grab lines that contain "error"
+    grep -i "error" "$update_log" | while read -r line; do
+        
+        # 2. Create a "scratchpad" copy and convert to LOWERCASE
+        # ${var,,} converts the whole string to lowercase
+        clean_line="${line,,}"
+        
+        # 3. Loop through excludes
+        # While probably a little confusing, this covers the `error compiling thiserror` edge case,
+        # where an exclude string is on the same line as a real error
+        for ignore in "${EXCLUDES[@]}"; do
+            # Convert the exclude pattern to lowercase match the scratchpad
+            ignore_lower="${ignore,,}"
+            
+            # Remove the pattern from the scratchpad
+            clean_line="${clean_line//$ignore_lower/}" 
+        done
+        
+        # 4. Check if "error" still exists in the cleaned (lowercase) line
+        # We use standard bash matching [[ ]] which is faster than grep here
+        if [[ "$clean_line" == *"error"* ]]; then
+             # 5. It's a real error. Print the ORIGINAL line.
+             echo "$line" | sed "s/error/${FOUND_ERROR_START_ANSI}&${FOUND_ERROR_END_ANSI}/Ig"
+        fi
+    done
+}
+
+errors=$(check_logs)
+
+if [ -n "$errors" ]; then
   echo -e "\e[31mNon-stopping errors detected during update:\e[0m"
-  grep -i "error" "$update_log"
+  echo "$errors"
   echo
 fi
 


### PR DESCRIPTION
I was getting really unhelpful error messages after omarchy update that always took like 45 seconds to find and figure out. Not the end of the world but with 100k users (guess) this is like cumulative days for a problem I can fix in an hour.

# The problem

Before:
```
~ ❯ omarchy-update-analyze-logs
Non-stopping errors detected during update:
gcc -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/home/pfornage/.cache/yay/pycharm/src=/usr/src/debug/pycharm -flto=auto -fPIC -I/usr/include/python3.13 -c _pydevd_bundle/pydevd_cython.c -o build/temp.linux-x86_64-cpython-313/_pydevd_bundle/pydevd_cython.o
gcc -shared -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/home/pfornage/.cache/yay/pycharm/src=/usr/src/debug/pycharm -flto=auto build/temp.linux-x86_64-cpython-313/_pydevd_bundle/pydevd_cython.o -L/usr/lib -o build/lib.linux-x86_64-cpython-313/_pydevd_bundle/pydevd_cython.cpython-313-x86_64-linux-gnu.so
gcc -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/home/pfornage/.cache/yay/pycharm/src=/usr/src/debug/pycharm -flto=auto -fPIC -I/usr/include/python3.13 -c _pydevd_bundle/pydevd_pep_669_tracing_cython.c -o build/temp.linux-x86_64-cpython-313/_pydevd_bundle/pydevd_pep_669_tracing_cython.o
gcc -shared -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/home/pfornage/.cache/yay/pycharm/src=/usr/src/debug/pycharm -flto=auto build/temp.linux-x86_64-cpython-313/_pydevd_bundle/pydevd_pep_669_tracing_cython.o -L/usr/lib -o build/lib.linux-x86_64-cpython-313/_pydevd_bundle/pydevd_pep_669_tracing_cython.cpython-313-x86_64-linux-gnu.so
Real fake error: balls balls # Should show up
Error compiling thiserror # Should show up
compiling thiserror # not a real error
some gcc call -Werror=format-deez-nuts # not a real error
actual error hidden in a large paragraph Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus elit sit amet semper suscipit. Suspendisse varius congue arcu ultrices tristique. Nullam augue nibh, molestie lacinia molestie a, faucibus vitae libero. Nulla cursus blandit risus sed iaculis. In hac habitasse platea dictumst. Nunc condimentum vulputate quam sed molestie. Nam egestas, dui et interdum rhoncus, lectus erat efficitur nulla, sit amet vulputate ipsum tellus sit amet arcu. Mauris in odio dapibus metus ultrices convallis consectetur non turpis. Nulla tristique pharetra ullamcorper. In at hendrerit dui, vel volutpat lacus. Nunc volutpat sollicitudin libero bibendum imperdiet. Ut volutpat justo mauris, ac congue enim lobortis vitae. Nam diam lorem, feugiat quis nunc eu, fermentum molestie mauris
```

I manually added some test cases to the update logs, but the gcc `-Werror=...` is real and I get like 8 of those. With line wrapping thats like half a screen of arbitrary args to sort for why the error shows up.

# The solution?

Now, there is an 'exclude list' for times the string 'error' appears, but is obviously not part of an error. These are ignored.
Also, when the real errors are printed, the capture that triggered the line to be included the 'error' is in red, so this cues the user that we are just doing a string search and it might not be an error, as well as letting them easily scan that essay to find out it's not real.

```
~ ❯ ./new-om-update-log-anal
**Non-stopping errors detected during update:**
Real fake **error**: balls balls # Should show up
**Error** compiling this**error** # Should show up
actual **error** hidden in a large paragraph Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus elit sit amet semper suscipit. Suspendisse varius congue arcu ultrices tristique. Nullam augue nibh, molestie lacinia molestie a, faucibus vitae libero. Nulla cursus blandit risus sed iaculis. In hac habitasse platea dictumst. Nunc condimentum vulputate quam sed molestie. Nam egestas, dui et interdum rhoncus, lectus erat efficitur nulla, sit amet vulputate ipsum tellus sit amet arcu. Mauris in odio dapibus metus ultrices convallis consectetur non turpis. Nulla tristique pharetra ullamcorper. In at hendrerit dui, vel volutpat lacus. Nunc volutpat sollicitudin libero bibendum imperdiet. Ut volutpat justo mauris, ac congue enim lobortis vitae. Nam diam lorem, feugiat quis nunc eu, fermentum molestie mauris
```
<img width="827" height="185" alt="image" src="https://github.com/user-attachments/assets/f8828b93-4ea7-44ed-b6fa-45ffa081dd0d" />

