### PR TITLE
Fix Windows VM timezone and add a confirmation prompt before removing the VM

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -185,6 +185,8 @@ services:
       DISK_SIZE: "$SELECTED_DISK"
       USERNAME: "$USERNAME"
       PASSWORD: "$PASSWORD"
+      TZ: "$(timedatectl show -p Timezone --value 2>/dev/null || echo UTC)"
+      ARGUMENTS: "-rtc base=localtime,clock=host,driftfix=slew"
     devices:
       - /dev/kvm
       - /dev/net/tun


### PR DESCRIPTION
Fix for Windows VM timezone that defaults to UTC. The container timezone must match host for QEMU RTC to work correctly. Without this, container runs in UTC and Windows shows wrong time.

All credits goes to @visch for finding the bug and implementing the fix : https://github.com/basecamp/omarchy/discussions/4411#discussioncomment-15685704

While I was working on this, I realized there's no confirmation prompt when deleting the Windows VM. I thought it would be safe to add one.