### PR TITLE
Expanded Legacy NVIDIA GPU support with correct backend selection

### DIFF
--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -34,7 +34,7 @@ EOF
   # Add NVIDIA environment variables based on GPU architecture
   if [ "$GPU_ARCH" = "turing_plus" ]; then
     # Turing+ (RTX 20xx, GTX 16xx, and newer) with GSP firmware support
-    cat >>$HOME/.config/hypr/envs.conf <<'EOF'
+    cat >>"$HOME/.config/hypr/envs.conf" <<'EOF'
 
 # NVIDIA (Turing+ with GSP firmware)
 env = NVD_BACKEND,direct
@@ -43,7 +43,7 @@ env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
   elif [ "$GPU_ARCH" = "maxwell_pascal_volta" ]; then
     # Maxwell/Pascal/Volta (GTX 9xx/10xx, GT 10xx, Quadro P/M/GV, MX series, Titan X/Xp/V) lack GSP firmware
-    cat >>$HOME/.config/hypr/envs.conf <<'EOF'
+    cat >>"$HOME/.config/hypr/envs.conf" <<'EOF'
 
 # NVIDIA (Maxwell/Pascal/Volta without GSP firmware)
 env = NVD_BACKEND,egl

--- a/migrations/1770159912.sh
+++ b/migrations/1770159912.sh
@@ -14,13 +14,11 @@ if echo "$NVIDIA" | grep -qE "GTX (9[0-9]{2}|10[0-9]{2})|GT 10[0-9]{2}|Quadro [P
       # Create backup
       cp "$ENVS_CONF" "$ENVS_CONF.bak.$(date +%s)"
 
-      # Remove problematic lines and old NVIDIA section header
-      sed -i '/^env = NVD_BACKEND,direct$/d' "$ENVS_CONF"
-      sed -i '/^env = LIBVA_DRIVER_NAME,nvidia$/d' "$ENVS_CONF"
-      sed -i '/^# NVIDIA$/d' "$ENVS_CONF"
+      # Remove all NVIDIA env lines and section headers (we re-add the correct ones below)
+      sed -i '/^env = \(NVD_BACKEND\|LIBVA_DRIVER_NAME\|__GLX_VENDOR_LIBRARY_NAME\),/d; /^# NVIDIA/d' "$ENVS_CONF"
 
       # Add correct environment variables for legacy GPUs
-      cat >>$ENVS_CONF <<'EOF'
+      cat >>"$ENVS_CONF" <<'EOF'
 
 # NVIDIA (Maxwell/Pascal/Volta without GSP firmware)
 env = NVD_BACKEND,egl


### PR DESCRIPTION
## Problem

Omarchy v3.3.0 fixed legacy NVIDIA driver installation (nvidia-580xx for Maxwell/Pascal/Volta) but still sets `NVD_BACKEND=direct` universally, breaking GPUs without GSP firmware support.

**Impact:** Maxwell/Pascal/Volta users see "Unknown-1" displays and blank screens in Hyprland.

**Root cause:** The `direct` backend requires GSP firmware (Turing+ only). Aquamarine validates backends strictly and rejects invalid configurations.

**Affected hardware:** GTX 9xx/10xx, Quadro M/P, MX series, Titan X/Xp/V, Tesla V100

## Solution

This PR completes the legacy GPU fix with generation-aware environment configuration:

**Detection improvements:**
- Expanded regex to catch GT 1030, MX series, Titan variants, Quadro M/P/GV
- Correctly excludes unsupported Kepler GPUs (GTX 7xx, Quadro K-series)

**Backend configuration:**
- **Turing+** (RTX 20xx+, GTX 16xx, datacenter A/H/T/L): `NVD_BACKEND=direct`, `LIBVA_DRIVER_NAME=nvidia`, nvidia-open-dkms
- **Maxwell/Pascal/Volta**: `NVD_BACKEND=egl`, nvidia-580xx-dkms (no LIBVA_DRIVER_NAME)
- **Both**: `__GLX_VENDOR_LIBRARY_NAME=nvidia`

Migration script (`1770159912.sh`) automatically fixes existing installations.

## Testing

Validated against 40+ GPU models including GT 1030, GTX 960/1080 Ti, Quadro P2000/M6000, MX450, Titan V, RTX 4090, H100. Kepler exclusion verified.

## References

- [nvidia-vaapi-driver](https://github.com/elFarto/nvidia-vaapi-driver/blob/master/src/vabackend.c): Direct backend GSP requirement
- [NVIDIA open-gpu-kernel-modules](https://github.com/NVIDIA/open-gpu-kernel-modules): Turing+ GSP support
- [NVIDIA legacy drivers](https://www.nvidia.com/en-us/drivers/unix/legacy-gpu/): 580.xx series documentation
- Related: Hyprland [#7001](https://github.com/hyprwm/Hyprland/issues/7001), [#8519](https://github.com/hyprwm/Hyprland/issues/8519), [#6343](https://github.com/hyprwm/Hyprland/issues/6343)

## Compatibility

Preserves Turing+ behavior. Migration creates backups. No impact on non-NVIDIA systems.

---

**Supplementary:** 
[details.md](https://github.com/user-attachments/files/25059824/details.md)
[security-review.md](https://github.com/user-attachments/files/25059718/security-review.md) 
[anecdotal-verification.md](https://github.com/user-attachments/files/25059721/anecdotal-verification.md)