### PR TITLE
Fix Realtek RTL8111/8168 ethernet adapter support for ASUS TUF Gaming laptops

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -37,3 +37,4 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-apple-t2.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-asus-rog-audio-mixer.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-asus-rog-mic.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-realtek-r8168.sh

--- a/install/config/hardware/fix-realtek-r8168.sh
+++ b/install/config/hardware/fix-realtek-r8168.sh
@@ -1,0 +1,11 @@
+# Install r8168 driver for Realtek RTL8111/8168/8211/8411 ethernet adapters
+# Common in ASUS TUF Gaming laptops and other modern systems
+if lspci | grep -i "RTL8111\|RTL8168\|RTL8211\|RTL8411"; then
+  omarchy-pkg-add linux-headers r8168-lts
+  
+  # Blacklist problematic r8169 driver
+  echo "blacklist r8169" | sudo tee /etc/modprobe.d/blacklist-r8169.conf
+  
+  # Regenerate initramfs to ensure r8168 loads on boot
+  sudo mkinitcpio -P
+fi

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -147,3 +147,4 @@ xournalpp
 yaru-icon-theme
 yay
 zoxide
+r8168-lts

--- a/migrations/1770186458.sh
+++ b/migrations/1770186458.sh
@@ -1,0 +1,6 @@
+echo "Fix Realtek RTL8111/8168/8211/8411 ethernet adapter support for ASUS TUF and other laptops"
+
+# Run the hardware detection script for existing installations
+if [ -f "$OMARCHY_INSTALL/config/hardware/fix-realtek-r8168.sh" ]; then
+  run_logged $OMARCHY_INSTALL/config/hardware/fix-realtek-r8168.sh
+fi


### PR DESCRIPTION
## Summary
- Add hardware detection and driver installation for Realtek RTL8111/8168/8211/8411 ethernet adapters
- Install r8168-lts driver and blacklist problematic r8169 driver  
- Regenerate initramfs to ensure proper driver loading on boot
- Add migration script for existing installations

## Background
Many modern laptops (especially ASUS TUF Gaming A15 and similar) have Realtek RTL8111/8168 ethernet adapters that fail with the default r8169 driver, showing NO-CARRIER and no network connectivity. The r8168-lts driver provides proper support for these chipsets.

## Changes
- **Added**: `/install/config/hardware/fix-realtek-r8168.sh` - Hardware detection script
- **Added**: `/migrations/1770186458.sh` - Migration for existing installations  
- **Modified**: `/install/config/all.sh` - Added hardware script to install pipeline
- **Modified**: `/install/omarchy-base.packages` - Added r8168-lts to core packages

## Testing
Tested on ASUS TUF Gaming A15 (FA507NV) with Realtek RTL8111/8168/8211/8411 adapter. Ethernet interface now comes online properly after installation.

## Technical Details
The script detects RTL8111/8168/8211/8411 chipsets via `lspci`, installs the `r8168-lts` package from Arch repos, blacklists the conflicting `r8169` driver in `/etc/modprobe.d/blacklist-r8169.conf`, and regenerates the initramfs to ensure the proper driver loads on boot.