### PR TITLE
Make style path absolute in swayosd config

### DIFF
--- a/config/swayosd/config.toml
+++ b/config/swayosd/config.toml
@@ -1,4 +1,4 @@
 [server]
 show_percentage = true
 max_volume = 100
-style = "./style.css"
+style = "~/.config/swayosd/style.css"


### PR DESCRIPTION
If you have a `style.css` file in your home directory (I.E. `~/style.css`) swayosd will use it instead of the intended `~/.config/swayosd/style.css` resulting in broken styling. This PR makes the CSS file path absolute and resolves the problem. 

I can create an accompanying issue if needed.