### PR TITLE
Prevent premature exit of omarchy-update-firmware

### DIFF
--- a/bin/omarchy-update-firmware
+++ b/bin/omarchy-update-firmware
@@ -7,5 +7,5 @@ if omarchy-cmd-missing fwupdmgr; then
   omarchy-pkg-add fwupd
 fi
 
-fwupdmgr refresh
+fwupdmgr refresh --force
 sudo fwupdmgr update


### PR DESCRIPTION
This adds the `--force` option to `fwupdmgr refresh` so that this script will not exit, due to `set -e`, when `fwupdmgr refresh` exits non-zero due to the metadata being up-to-date, i.e.,

```
Metadata is up to date; use --force to refresh again.
```

Another option would be to use `|| true` but that might hide a legitimate error.

This was motivated when I cancelled a run of this script and then later invoked it again, via Update > Firmware, and it would not run `sudo fwupdmgr update` because `fwupdmgr refresh` was exiting non-zero with the above metadata up-to-date "error".