### PR TITLE
Ghostty Starship Python virtual env detection on terminal UI

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -1,6 +1,6 @@
 add_newline = true
 command_timeout = 200
-format = "[$directory$git_branch$git_status]($style)$character"
+format = "[$directory$git_branch$git_status]($style)$python$character"
 
 [character]
 error_symbol = "[✗](bold cyan)"
@@ -30,3 +30,7 @@ stashed    = ""
 staged     = ""
 renamed    = ""
 deleted    = ""
+
+[python]
+detect_extensions = []
+detect_files = []


### PR DESCRIPTION
## PR Details And Description
1. Proposal: To add python virtual env detection in the terminal PS1 path.

## Proposal High-Level Steps
1. Edit the starship.toml file that configures the PS1 for ghostty

## How To Test
Changes will reflect after saving the starship.toml file in the .config dir

## Does It Run On Omarchy
Tested on personal Omarchy install

## Screenshots
Before:
<img width="604" height="129" alt="screenshot-2026-02-04_14-24-05" src="https://github.com/user-attachments/assets/6910944e-4143-4e43-abe9-c35d4c131fc0" />

After:
<img width="466" height="99" alt="screenshot-2026-02-04_15-03-36" src="https://github.com/user-attachments/assets/79ec2b4a-6dd2-4e6a-87d3-6578b97a05b7" />

<img width="565" height="99" alt="screenshot-2026-02-04_14-36-55" src="https://github.com/user-attachments/assets/bae45ea7-9611-4e4d-a97b-439eecc7540e" />

#### Notes
1. Personal preference on how it works. If this PR change  is non essential we can close it.
2. Would love feedback if any, Thank you