### PR TITLE
Fix: High IO pressure caused by ghostty

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -32,3 +32,6 @@ keybind = super+control+shift+alt+arrow_right=resize_split:right,100
 
 # Slowdown mouse scrolling
 mouse-scroll-multiplier = 0.95
+
+# Fix general slowness on hyprland (https://github.com/ghostty-org/ghostty/discussions/3224)
+async-backend = epoll


### PR DESCRIPTION
## Replicate the issue

Start ghostty and then see that the IO pressure is going to 90%+.

```bash
cat /proc/pressure/io

some avg10=91.01 avg60=95.83 avg300=96.44 total=1724090155
full avg10=91.01 avg60=95.66 avg300=95.56 total=1694927483
```

Close ghostty, and notice it has gone down back to 0.

### Solution

This problem has been reported to ghostty on https://github.com/ghostty-org/ghostty/discussions/3224

Not only the IO is high, but I experienced the same symptom as the following user.

> I will note that for anyone using hyprland, leaving this settings on auto (resulting in uring) eventually caused all of my ghostty windows to trigger ANR and it was forced to terminate them all or have them entirely freeze permanently if I chose 'wait' instead.

With this fix, the IO is back to near 0. Don't ask me why, it's above my pay grade. 

---

PS: I have read [this article](https://lwn.net/Articles/989272/), which seems to say that it is more of a display issue on user space than really CPU being idle. However, I doubt this is the same issue. Because the problem should have been fixed in kernel 6.12 but  I am running 6.18.3.

On top of this, my laptop seemed sluggish, and I got ghostty crashes before, so didn't seem a display issue to me. (This is what prompted me to track this issue)