### PR TITLE
Fix screensaver TTE import on Python updates

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -52,8 +52,8 @@ exit_screensaver() {
   if tte_is_alive; then
     kill "$TTE_PID" 2>/dev/null || true
   else
-    pkill -x tte 2>/dev/null || true
-    pkill -f terminaltexteffects 2>/dev/null || true
+    pkill -t "${tty#/dev/}" -x tte 2>/dev/null || true
+    pkill -t "${tty#/dev/}" -f terminaltexteffects 2>/dev/null || true
   fi
   pkill -f org.omarchy.screensaver 2>/dev/null
   exit 0


### PR DESCRIPTION
Description:
  This PR makes the Omarchy screensaver resilient to Python updates that break the tte entrypoint. We now:

  - verify tte actually runs before using it
  - fall back to python -m terminaltexteffects (including older Python site‑packages when needed)
  - track the spawned effect by PID and validate the command line to avoid PID reuse issues
  - always restore the cursor, even if the effect exits early

  This prevents immediate exits, stuck invisible cursors, and crashes when the module is present but the tte binary is out of sync
  with the system Python.