### PR TITLE
Delete snapshot if update fails 

### DIFF
--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -31,4 +31,6 @@ create)
 restore)
   sudo limine-snapper-restore
   ;;
+delete)
+  sudo snapper -c "$config" delete 0
 esac

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -2,7 +2,7 @@
 
 set -e
 
-trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR
+trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m";omarchy-snapshot delete' ERR
 
 if [[ $1 == "-y" ]] || omarchy-update-confirm; then
   omarchy-snapshot create || [ $? -eq 127 ]


### PR DESCRIPTION
 It takes up unneeded space (some of my snapshots are over a gigabyte so its quite a bit of disk space), especially when redoing the update as it makes another snapshot. So, this change removes the snapshot that was just created after exiting the update.