### PR TITLE
Set the aether dependency using v2 directly

### DIFF
--- a/themes/vantablack/neovim.lua
+++ b/themes/vantablack/neovim.lua
@@ -2,7 +2,10 @@ return {
   {
     "bjarneo/vantablack.nvim",
     priority = 1000,
-    dependencies = { "bjarneo/aether.nvim", branch = "v2" },
+    dependencies = {
+      "bjarneo/aether.nvim",
+      branch = "v2"
+    },
   },
   {
     "LazyVim/LazyVim",


### PR DESCRIPTION
Should fix https://github.com/basecamp/omarchy/pull/4533#issuecomment-3864110104

If not, I will create an entirely new nvim theme instead of using aether.nvim with color injection.