### PR TITLE
Allow user themes to override individual files from official themes

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -12,11 +12,7 @@ OMARCHY_THEMES_PATH="$OMARCHY_PATH/themes"
 
 THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 
-if [[ -d "$USER_THEMES_PATH/$THEME_NAME" ]]; then
-  THEME_PATH="$USER_THEMES_PATH/$THEME_NAME"
-elif [[ -d "$OMARCHY_THEMES_PATH/$THEME_NAME" ]]; then
-  THEME_PATH="$OMARCHY_THEMES_PATH/$THEME_NAME"
-else
+if [[ ! -d "$OMARCHY_THEMES_PATH/$THEME_NAME" ]] && [[ ! -d "$USER_THEMES_PATH/$THEME_NAME" ]]; then
   echo "Theme '$THEME_NAME' does not exist"
   exit 1
 fi
@@ -25,8 +21,9 @@ fi
 rm -rf "$NEXT_THEME_PATH"
 mkdir -p "$NEXT_THEME_PATH"
 
-# Copy static configs
-cp -r "$THEME_PATH/"* "$NEXT_THEME_PATH/" 2>/dev/null
+# Copy official theme first, then overlay user customizations on top
+cp -r "$OMARCHY_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
+cp -r "$USER_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 
 # Generate dynamic configs
 omarchy-theme-set-templates


### PR DESCRIPTION
## Summary
- Instead of choosing exclusively between the official or user theme directory, copy the official theme first, then overlay any user customizations on top
- This allows users to override specific theme files (e.g. backgrounds, keyboard backlight, colors) without having to duplicate the entire theme
- Fully custom user themes (not based on an official theme) continue to work as before

## Example

To override just the keyboard backlight color for Catppuccin:

```
~/.config/omarchy/themes/catppuccin/asusctl.rgb
```

The rest of the theme (colors, backgrounds, neovim, btop, etc.) stays in sync with official updates.