### PR TITLE
Avoid error in omarchy-restart-opencode if opencode isn't running.

### DIFF
--- a/bin/omarchy-restart-opencode
+++ b/bin/omarchy-restart-opencode
@@ -2,4 +2,6 @@
 
 # Reload opencode configuration (used by the Omarchy theme switching).
 
-killall -SIGUSR2 opencode
+if pgrep -x opencode >/dev/null; then
+  killall -SIGUSR2 opencode
+fi


### PR DESCRIPTION
`killall` was giving me an error in `omarchy-restart-opencode` if opencode was not running. This pull request adds a check consistent with the implementation in `omarchy-restart-terminal` to avoid such an error.