### PR TITLE
Update omarchy-cmd-screenshot

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -73,11 +73,14 @@ esac
 
 [ -z "$SELECTION" ] && exit 0
 
+EARLY_EXIT=()
+[[ "$PROCESSING" == "clipboard" ]] && EARLY_EXIT=(--early-exit)
+
 if [[ $PROCESSING == "slurp" ]]; then
 grim -g "$SELECTION" - |
   satty --filename - \
     --output-filename "$OUTPUT_DIR/screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png" \
-    --early-exit \
+    "${EARLY_EXIT[@]}" \
     --actions-on-enter save-to-clipboard \
     --save-after-copy \
     --copy-command 'wl-copy'


### PR DESCRIPTION
As it stands you can copy a screenshot to clipboard as well as edit a screenshot. Users cannot currently "save as". This is due to a missing control surface in the Satty CLI. Some users comment out `--early-exit` in order to get this behavior but it comes with the drawback of having to then manually exit for a simple throwaway screenshot. This workaround enables users to "save as" if they execute `omarchy-cmd-screenshot` without messing with `omarchy-cmd-screenshot smart clipboard` by using conditional logic to apply/omit that flag.