### PR TITLE
fix(aur): add -a flag to yay command to assume AUR packages

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -20,7 +20,7 @@ pkg_names=$(yay -Slqa | fzf "${fzf_args[@]}")
 
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay
-  echo "$pkg_names" | tr '\n' ' ' | xargs yay -S --noconfirm
+  echo "$pkg_names" | tr '\n' ' ' | xargs yay -S -a --noconfirm
   sudo updatedb
   omarchy-show-done
 fi


### PR DESCRIPTION
Hey,

this should (!!!) fix https://github.com/basecamp/omarchy/issues/4577, but requires testing/confirmation.

Just added this flag: `-a --aur              Assume targets are from the AUR`

Regards