### PR TITLE
background selector v2

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -148,7 +148,10 @@ show_screenrecord_menu() {
   *"With desktop audio") omarchy-cmd-screenrecord --with-desktop-audio ;;
   *"With desktop + microphone audio") omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio ;;
   *"With desktop + microphone audio + webcam")
-    local device=$(show_webcam_select_menu) || { back_to show_capture_menu; return; }
+    local device=$(show_webcam_select_menu) || {
+      back_to show_capture_menu
+      return
+    }
     omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam --webcam-device="$device"
     ;;
   *) back_to show_capture_menu ;;
@@ -185,7 +188,7 @@ show_style_menu() {
   case $(menu "Style" "󰸌  Theme\n  Font\n  Background\n  Hyprland\n󱄄  Screensaver\n  About") in
   *Theme*) show_theme_menu ;;
   *Font*) show_font_menu ;;
-  *Background*) omarchy-theme-bg-next ;;
+  *Background*) terminal omarchy-theme-bg-select ;;
   *Hyprland*) open_in_editor ~/.config/hypr/looknfeel.conf ;;
   *Screensaver*) open_in_editor ~/.config/omarchy/branding/screensaver.txt ;;
   *About*) open_in_editor ~/.config/omarchy/branding/about.txt ;;
@@ -585,6 +588,7 @@ show_main_menu() {
 go_to_menu() {
   case "${1,,}" in
   *apps*) walker -p "Launch…" ;;
+  *background*) terminal omarchy-theme-bg-select ;;
   *learn*) show_learn_menu ;;
   *trigger*) show_trigger_menu ;;
   *share*) show_share_menu ;;

--- a/bin/omarchy-theme-bg-select
+++ b/bin/omarchy-theme-bg-select
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Paths
+WALLPAPER_DIR="$HOME/.config/omarchy/current/theme/backgrounds"
+TARGET_LINK="$HOME/.config/omarchy/current/background"
+CACHE_DIR="$HOME/.cache/bg_selector_thumbs"
+FINAL_PREVIEW="/tmp/bg_grid_fast.png"
+
+mkdir -p "$CACHE_DIR"
+
+# 1. Load images
+mapfile -t images < <(find "$WALLPAPER_DIR" -maxdepth 1 -type f \( -name "*.jpg" -o -name "*.jpeg" -o -name "*.png" -o -name "*.gif" -o -name "*.bmp" -o -name "*.webp" \) 2>/dev/null)
+count=${#images[@]}
+[[ $count -eq 0 ]] && echo "No wallpapers found." && exit 1
+
+# 2. Pre-generate thumbnails (only if they don't exist)
+echo "Syncing thumbnails..."
+for img in "${images[@]}"; do
+  thumb_name=$(echo -n "$img" | md5sum | cut -d' ' -f1)
+  thumb_path="$CACHE_DIR/${thumb_name}.png"
+  if [[ ! -f "$thumb_path" ]]; then
+    magick "$img" -resize 300x200^ -gravity center -extent 300x200 "$thumb_path"
+  fi
+done
+
+index=0
+
+render_grid() {
+  local start_idx=$(((index / 4) * 4))
+  local cmd=(magick)
+
+  for i in {0..3}; do
+    local current=$((start_idx + i))
+    if [ $current -lt $count ]; then
+      local thumb_name=$(echo -n "${images[$current]}" | md5sum | cut -d' ' -f1)
+      local thumb_path="$CACHE_DIR/${thumb_name}.png"
+
+      # Add image with conditional border in a single process
+      if [ $current -eq $index ]; then
+        cmd+=(\( "$thumb_path" -bordercolor "#ffcc66" -border 6 \))
+      else
+        cmd+=(\( "$thumb_path" -bordercolor "none" -border 6 \))
+      fi
+    else
+      # Fill empty space with a transparent tile
+      cmd+=(\( -size 312x212 xc:none \))
+    fi
+  done
+
+  # Stitch 4x1 and output
+  "${cmd[@]}" +append "$FINAL_PREVIEW"
+
+  clear
+  echo -e "\n  --- [ Background Selector ] ---\n"
+  chafa --size=130x20 "$FINAL_PREVIEW"
+  echo -e "\n  (h/l) Navigate  |  (Enter) Set  |  (q) Quit"
+}
+
+# Main Loop
+while true; do
+  render_grid
+  read -rsn1 key
+  case "$key" in
+  l) index=$(((index + 1) % count)) ;;
+  h) index=$(((index - 1 + count) % count)) ;;
+  "")
+    selected="${images[$index]}"
+    ln -sf "$selected" "$TARGET_LINK"
+    pkill -x swaybg
+    setsid uwsm-app -- swaybg -i "$selected" -m fill >/dev/null 2>&1 &
+    # break
+    ;;
+  q)
+    rm -rf $CACHE_DIR &&
+      exit 0
+    ;;
+  esac
+done

--- a/migrations/1770846792.sh
+++ b/migrations/1770846792.sh
@@ -1,0 +1,3 @@
+# Install dependencies
+
+omarchy-pkg-add chafa


### PR DESCRIPTION
it's the v2 of background selector in my PR of #4519 

Key of difference :
1. Using TUI
2. Add chafa as dependency => [migrations/1770846792.sh](https://github.com/dhms013/omarchy/blob/0546d18cc48c010ee0d7970dd7d28adc1afc4cfd/migrations/1770846792.sh)
3. Follow the previous method, omarchy-menu > style > background => access [omarchy-theme-bg-select](https://github.com/dhms013/omarchy/blob/0546d18cc48c010ee0d7970dd7d28adc1afc4cfd/bin/omarchy-theme-bg-select)
4. Follow DHH's request regarding [layout](https://github.com/basecamp/omarchy/pull/4519#issuecomment-3871373493) (not the same, but at least preview show multiple images)

Downside : 
1. Not as snappy as #4519 
2. Doesn't have 'search' feature 

https://github.com/user-attachments/assets/2bf7301b-0e5f-4044-a7ed-d738402edd33

