### PR TITLE
Unbind ctrl+shift+left/right in Ghostty so it doesn't interfere with tmux keybindings

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -23,14 +23,14 @@ cursor-style-blink = false
 shell-integration-features = no-cursor,ssh-env
 
 # Keyboard bindings
+keybind = ctrl+shift+left=unbind
+keybind = ctrl+shift+right=unbind
 keybind = shift+insert=paste_from_clipboard
 keybind = control+insert=copy_to_clipboard
 keybind = super+control+shift+alt+arrow_down=resize_split:down,100
 keybind = super+control+shift+alt+arrow_up=resize_split:up,100
 keybind = super+control+shift+alt+arrow_left=resize_split:left,100
 keybind = super+control+shift+alt+arrow_right=resize_split:right,100
-keybind = ctrl+shift+left=unbind
-keybind = ctrl+shift+right=unbind
 
 # Slowdown mouse scrolling
 mouse-scroll-multiplier = 0.95

--- a/migrations/1770728860.sh
+++ b/migrations/1770728860.sh
@@ -1,6 +1,5 @@
 echo "Unbind ctrl+shift+left/right in Ghostty so it doesn't interfere with tmux keybindings"
 
 if ! grep -q "keybind = ctrl+shift+left=" ~/.config/ghostty/config; then
-  sed -i '/keybind = super+control+shift+alt+arrow_right=resize_split:right,100/a\keybind = ctrl+shift+left=unbind\nkeybind = ctrl+shift+right=unbind' ~/.config/ghostty/config
+  sed -i '/# Keyboard bindings/a\keybind = ctrl+shift+left=unbind\nkeybind = ctrl+shift+right=unbind' ~/.config/ghostty/config
 fi
-


### PR DESCRIPTION
When there is more than one tab opened in Ghostty, CTRL+SHIFT+LEFT/RIGHT is not sent to tmux.