### PR TITLE
Clean up icon spacing in Update menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -481,7 +481,7 @@ show_remove_elixir_menu() {
 }
 
 show_update_menu() {
-  case $(menu "Update" " Omarchy\n󰔫  Channel\n  Config\n󰸌  Extra Themes\n  Process\n󰇅  Hardware\n  Firmware\n  Password\n  Timezone\n  Time") in
+  case $(menu "Update" "  Omarchy\n󰔫  Channel\n  Config\n󰸌  Extra Themes\n  Process\n󰇅  Hardware\n  Firmware\n  Password\n  Timezone\n  Time") in
   *Omarchy*) present_terminal omarchy-update ;;
   *Channel*) show_update_channel_menu ;;
   *Config*) show_update_config_menu ;;


### PR DESCRIPTION
Before:
<img width="250" alt="screenshot-2026-02-12_10-26-21" src="https://github.com/user-attachments/assets/3efdf7c2-a206-4007-9d77-d14d8bcd2e24" />

After:
<img width="250" alt="screenshot-2026-02-12_10-28-46" src="https://github.com/user-attachments/assets/be2ec6e8-859b-48ad-82c5-1ccc58dc1265" />

This change makes use of the ["thin space" Unicode character](https://unicode-explorer.com/c/2009) to handle the spacing. A regular (full) space is too large, i.e.

<img width="250" alt="screenshot-2026-02-12_10-37-22" src="https://github.com/user-attachments/assets/f2cf82b4-8f8b-447d-be89-71a36e982803" />
