### PR TITLE
Add paste queue for sequential copy/paste

### DIFF
--- a/bin/omarchy-paste-queue
+++ b/bin/omarchy-paste-queue
@@ -1,0 +1,129 @@
+#!/bin/bash
+# omarchy-paste-queue: Sequential copy/paste (FIFO) like macOS Pastebot
+# Usage: omarchy-paste-queue push|paste|clear|panel
+
+QUEUE_DIR="${XDG_RUNTIME_DIR:-/tmp}/paste-queue-${UID}"
+COUNTERFILE="${XDG_RUNTIME_DIR:-/tmp}/paste-queue-counter"
+PIDFILE="${XDG_RUNTIME_DIR:-/tmp}/paste-queue-panel.pid"
+PANEL_TITLE="paste-queue-panel"
+
+next_id() {
+  local n=0
+  [[ -f "$COUNTERFILE" ]] && n=$(cat "$COUNTERFILE")
+  n=$((n + 1))
+  echo "$n" > "$COUNTERFILE"
+  printf "%06d" "$n"
+}
+
+is_panel_open() {
+  [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null
+}
+
+open_panel() {
+  if ! is_panel_open; then
+    setsid uwsm-app -- xdg-terminal-exec --title="$PANEL_TITLE" -e "$0" panel &
+    echo $! > "$PIDFILE"
+    disown
+  fi
+}
+
+close_panel() {
+  if [[ -f "$PIDFILE" ]]; then
+    local pid
+    pid=$(cat "$PIDFILE")
+    kill "$pid" 2>/dev/null
+    rm -f "$PIDFILE"
+  fi
+  hyprctl dispatch closewindow "title:$PANEL_TITLE" > /dev/null 2>&1
+}
+
+push() {
+  hyprctl dispatch sendshortcut "CTRL, Insert," > /dev/null
+  sleep 0.15
+
+  local content
+  content=$(wl-paste 2>/dev/null)
+
+  if [[ -z "$content" ]]; then
+    notify-send -t 2000 "Paste Queue" "Clipboard is empty"
+    return 1
+  fi
+
+  mkdir -p "$QUEUE_DIR"
+  echo -n "$content" > "$QUEUE_DIR/$(next_id)"
+  open_panel
+}
+
+paste() {
+  local oldest
+  oldest=$(ls -1 "$QUEUE_DIR" 2>/dev/null | sort -n | head -1)
+
+  if [[ -z "$oldest" ]]; then
+    notify-send -t 2000 "Paste Queue" "Queue is empty"
+    return 1
+  fi
+
+  wl-copy < "$QUEUE_DIR/$oldest"
+  rm "$QUEUE_DIR/$oldest"
+
+  hyprctl dispatch sendshortcut "SHIFT, Insert," > /dev/null
+
+  local remaining
+  remaining=$(ls -1 "$QUEUE_DIR" 2>/dev/null | wc -l)
+  if [[ "$remaining" -eq 0 ]]; then
+    sleep 0.5
+    close_panel
+  fi
+}
+
+clear_queue() {
+  rm -rf "$QUEUE_DIR"
+  rm -f "$COUNTERFILE"
+  close_panel
+}
+
+panel() {
+  mkdir -p "$QUEUE_DIR"
+  trap 'rm -f "$PIDFILE"; exit' EXIT INT TERM
+
+  while true; do
+    clear
+    printf "\033[1m  PASTE QUEUE\033[0m\n"
+    echo "  ───────────"
+
+    local files
+    files=$(ls -1 "$QUEUE_DIR" 2>/dev/null | sort -n)
+
+    if [[ -z "$files" ]]; then
+      echo ""
+      printf "  \033[2m(empty)\033[0m\n"
+    else
+      local i=1
+      while IFS= read -r f; do
+        local content
+        content=$(tr '\n' ' ' < "$QUEUE_DIR/$f" | cut -c1-50)
+        if [[ $(wc -c < "$QUEUE_DIR/$f") -gt 50 ]]; then
+          content="${content}…"
+        fi
+        printf "  \033[36m%d.\033[0m %s\n" "$i" "$content"
+        ((i++))
+      done <<< "$files"
+    fi
+
+    echo ""
+    printf "  \033[2mC queue · V paste · X clear\033[0m\n"
+
+    inotifywait -qq -t 10 -e create,delete,moved_to "$QUEUE_DIR" 2>/dev/null
+  done
+}
+
+case "${1:-}" in
+  push)  push ;;
+  paste) paste ;;
+  clear) clear_queue ;;
+  panel) panel ;;
+  *)
+    echo "Usage: omarchy-paste-queue {push|paste|clear|panel}"
+    exit 1
+    ;;
+esac

--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -13,3 +13,4 @@ source = ~/.local/share/omarchy/default/hypr/apps/system.conf
 source = ~/.local/share/omarchy/default/hypr/apps/terminals.conf
 source = ~/.local/share/omarchy/default/hypr/apps/walker.conf
 source = ~/.local/share/omarchy/default/hypr/apps/webcam-overlay.conf
+source = ~/.local/share/omarchy/default/hypr/apps/paste-queue.conf

--- a/default/hypr/apps/paste-queue.conf
+++ b/default/hypr/apps/paste-queue.conf
@@ -1,0 +1,6 @@
+# Paste queue floating panel
+windowrule = float on, match:title paste-queue-panel
+windowrule = size 350 200, match:title paste-queue-panel
+windowrule = move 100%-370 60, match:title paste-queue-panel
+windowrule = pin on, match:title paste-queue-panel
+windowrule = no_initial_focus on, match:title paste-queue-panel

--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -3,3 +3,8 @@ bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert,
 bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert,
 bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X,
 bindd = SUPER CTRL, V, Clipboard manager, exec, omarchy-launch-walker -m clipboard
+
+# Paste queue (sequential copy/paste like macOS Pastebot)
+bindd = SUPER ALT, C, Queue copy, exec, omarchy-paste-queue push
+bindd = SUPER ALT, V, Queue paste, exec, omarchy-paste-queue paste
+bindd = SUPER ALT, X, Clear paste queue, exec, omarchy-paste-queue clear

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -58,6 +58,7 @@ imagemagick
 impala
 imv
 inetutils
+inotify-tools
 inxi
 iwd
 jq


### PR DESCRIPTION
## Summary

- Adds `omarchy-paste-queue`, a FIFO paste queue inspired by macOS Pastebot
- Copy multiple items sequentially, then paste them back one at a time in order
- A floating panel (ghostty window) shows queued items with live updates
- Bindings: **Super+Alt+C** (queue copy), **Super+Alt+V** (queue paste), **Super+Alt+X** (clear queue)

## Changes

- `bin/omarchy-paste-queue` — the paste queue script
- `default/hypr/bindings/clipboard.conf` — keybindings added
- `default/hypr/apps/paste-queue.conf` — window rules for the floating panel
- `default/hypr/apps.conf` — sources the new window rules
- `install/omarchy-base.packages` — adds `inotify-tools` dependency (for live panel updates)

## How it works

1. **Super+Alt+C** copies the current selection and pushes it onto the queue. A floating panel appears showing all queued items.
2. **Super+Alt+V** pastes the oldest item from the queue (FIFO) and removes it. When the queue is empty, the panel closes automatically.
3. **Super+Alt+X** clears the entire queue and closes the panel.

The queue is stored in `$XDG_RUNTIME_DIR` (tmpfs, cleared on reboot). The panel uses `inotifywait` to refresh in real time when items are added or removed.

## Test plan

- [ ] Copy several items with Super+Alt+C — panel should appear and list them
- [ ] Paste with Super+Alt+V — items should paste in FIFO order
- [ ] Panel should auto-close when last item is pasted
- [ ] Super+Alt+X should clear the queue and close the panel
- [ ] Verify no conflicts with existing Super+C/V/X clipboard bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)