### PR TITLE
Add OCR text capture from screen region

### DIFF
--- a/bin/omarchy-cmd-ocr
+++ b/bin/omarchy-cmd-ocr
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Select a screen region and copy recognized text to clipboard (like CleanShot X OCR).
+# Uses the same selection logic as omarchy-cmd-screenshot.
+#
+# Usage: omarchy-cmd-ocr [compact]
+#   (default)  Keep original formatting
+#   compact    Join lines into a single line, collapse whitespace
+
+if ! command -v tesseract &>/dev/null; then
+  notify-send -t 3000 "OCR" "tesseract is not installed"
+  exit 1
+fi
+
+MODE="${1:-formatted}"
+
+pkill slurp && exit 0
+
+get_rectangles() {
+  local active_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id')
+  hyprctl monitors -j | jq -r --arg ws "$active_workspace" '.[] | select(.activeWorkspace.id == ($ws | tonumber)) | "\(.x),\(.y) \((.width / .scale) | floor)x\((.height / .scale) | floor)"'
+  hyprctl clients -j | jq -r --arg ws "$active_workspace" '.[] | select(.workspace.id == ($ws | tonumber)) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
+}
+
+RECTS=$(get_rectangles)
+wayfreeze & PID=$!
+sleep .1
+SELECTION=$(echo "$RECTS" | slurp 2>/dev/null)
+kill $PID 2>/dev/null
+
+[ -z "$SELECTION" ] && exit 0
+
+TEXT=$(grim -g "$SELECTION" -t png - | tesseract -l eng stdin stdout 2>/dev/null)
+
+if [[ -z "$TEXT" || "$TEXT" =~ ^[[:space:]]*$ ]]; then
+  notify-send -t 2000 "OCR" "No text recognized"
+  exit 0
+fi
+
+# Trim leading/trailing whitespace
+TEXT=$(echo "$TEXT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+if [[ "$MODE" == "compact" ]]; then
+  TEXT=$(echo "$TEXT" | tr '\n' ' ' | sed 's/  */ /g')
+fi
+
+echo -n "$TEXT" | wl-copy
+notify-send -t 2000 "OCR" "$(echo "$TEXT" | head -c 200)"

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -36,6 +36,8 @@ bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-d
 bindd = , PRINT, Screenshot with editing, exec, omarchy-cmd-screenshot
 bindd = SHIFT, PRINT, Screenshot to clipboard, exec, omarchy-cmd-screenshot smart clipboard
 bindd = ALT, PRINT, Screenrecording, exec, omarchy-menu screenrecord
+bindd = CTRL, PRINT, OCR text capture, exec, omarchy-cmd-ocr
+bindd = SHIFT CTRL, PRINT, OCR text capture (compact), exec, omarchy-cmd-ocr compact
 bindd = SUPER, PRINT, Color picker, exec, pkill hyprpicker || hyprpicker -a
 
 # File sharing

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -116,6 +116,8 @@ sushi
 swaybg
 swayosd
 system-config-printer
+tesseract
+tesseract-data-eng
 tldr
 tree-sitter-cli
 tobi-try


### PR DESCRIPTION
## Summary

- Adds `omarchy-cmd-ocr`, a CleanShot X-style OCR tool that lets you select a screen region and copies recognized text to clipboard
- Two modes: **formatted** (preserves layout) and **compact** (single line, collapsed whitespace)
- Uses tesseract for recognition with the same smart selection (windows + regions) as the regular screenshot tool

## Changes

- `bin/omarchy-cmd-ocr` — the OCR capture script
- `default/hypr/bindings/utilities.conf` — keybindings added
- `install/omarchy-base.packages` — adds `tesseract` + `tesseract-data-eng`

## Bindings

| Key | Action |
|---|---|
| **Ctrl+Print** | OCR text capture (keeps formatting) |
| **Shift+Ctrl+Print** | OCR text capture (compact, single line) |

## How it works

1. Screen freezes via `wayfreeze`
2. Select a region or window with `slurp` (same smart selection as screenshots)
3. `grim` captures the region, pipes to `tesseract` for OCR
4. Recognized text is copied to clipboard via `wl-copy`
5. A notification shows a preview of the captured text

## Test plan

- [ ] Ctrl+Print → select region with text → text appears in clipboard with original formatting
- [ ] Shift+Ctrl+Print → same but line breaks removed, whitespace collapsed
- [ ] Selecting a region with no text shows "No text recognized" notification
- [ ] Pressing Escape during selection cancels cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)