### PR TITLE
Remove Wayland color manager disabling flag from Chromium configs (#4610)

### DIFF
--- a/config/brave-flags.conf
+++ b/config/brave-flags.conf
@@ -2,5 +2,3 @@
 --ozone-platform-hint=wayland
 --enable-features=TouchpadOverscrollHistoryNavigation
 --load-extension=~/.local/share/omarchy/default/chromium/extensions/copy-url
-# Chromium crash workaround for Wayland color management on Hyprland - see https://github.com/hyprwm/Hyprland/issues/11957
---disable-features=WaylandWpColorManagerV1

--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -2,5 +2,3 @@
 --ozone-platform-hint=wayland
 --enable-features=TouchpadOverscrollHistoryNavigation
 --load-extension=~/.local/share/omarchy/default/chromium/extensions/copy-url
-# Chromium crash workaround for Wayland color management on Hyprland - see https://github.com/hyprwm/Hyprland/issues/11957
---disable-features=WaylandWpColorManagerV1

--- a/migrations/1771188969.sh
+++ b/migrations/1771188969.sh
@@ -1,0 +1,14 @@
+echo "Remove temporary Wayland color manager disabling flag from existing Chromium configs"
+
+# This reverts the workaround originally added by migration 1760401344.sh
+# Remove flag and comment from chromium-flags.conf only if found
+if [[ -f ~/.config/chromium-flags.conf ]]; then
+    sed -i '/--disable-features=WaylandWpColorManagerV1/d' ~/.config/chromium-flags.conf
+    sed -i '/# Chromium crash workaround for Wayland color management on Hyprland/d' ~/.config/chromium-flags.conf
+fi
+
+# Remove flag and comment from brave-flags.conf only if found
+if [[ -f ~/.config/brave-flags.conf ]]; then
+    sed -i '/--disable-features=WaylandWpColorManagerV1/d' ~/.config/brave-flags.conf
+    sed -i '/# Chromium crash workaround for Wayland color management on Hyprland/d' ~/.config/brave-flags.conf
+fi


### PR DESCRIPTION
Fix: This commit removes the `--disable-features=WaylandWpColorManagerV1` flag from `chromium-flags.conf` and `brave-flags.conf` config files as discussed in #4610 

The `--disable-features=WaylandWpColorManagerV1` flag was added as a temporary measure to resolve the browser window crashing on monitor change https://github.com/hyprwm/Hyprland/issues/11957

The flag was added through [this commit](https://github.com/basecamp/omarchy/commit/800962b18fe39e1bb8b4be6e7206f7ce214b519b) introducing [1760401344.sh](https://github.com/basecamp/omarchy/blob/dev/migrations/1760401344.sh) migration.

What this fixes:
- HDR in the browser
- Wider Color Gamut
- Improves color accuracy
and other stuff that [Wayland Color Manager](https://wayland.app/protocols/color-management-v1) has to offer.

Sufficient amount of time has passed after the Chromium upstream fix [Review #7003036](https://chromium-review.googlesource.com/c/chromium/src/+/7003036).