### PR TITLE
Add SUPER+M keybinding for maximize window

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -9,6 +9,7 @@ bindd = SUPER, T, Toggle window floating/tiling, togglefloating,
 bindd = SUPER, F, Full screen, fullscreen, 0
 bindd = SUPER CTRL, F, Tiled full screen, fullscreenstate, 0 2
 bindd = SUPER ALT, F, Full width, fullscreen, 1
+bindd = SUPER, M, Maximize window, fullscreenstate, 1 0
 bindd = SUPER, O, Pop window out (float & pin), exec, omarchy-hyprland-window-pop
 
 # Move focus with SUPER + arrow keys


### PR DESCRIPTION
## Summary

- Adds `SUPER+M` as a maximize keybinding using `fullscreenstate, 1 0`
- Unlike `SUPER+F` (true fullscreen), this keeps waybar visible and apps keep their own UI (e.g. Chromium tabs/address bar remain visible)

## How it works

`fullscreenstate, 1 0` tells Hyprland to maximize the window at the compositor level (fills the screen, keeps waybar) while reporting "normal" to the client app — so browsers don't hide their toolbar.

## Test plan

- [ ] Press `SUPER+M` on a tiled window — should maximize while keeping waybar
- [ ] Press `SUPER+M` on Chromium — tabs and address bar should remain visible
- [ ] Press `SUPER+M` again — should toggle back to tiled
- [ ] Verify no conflict with existing keybindings (`SUPER+M` is currently unbound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)