### PR TITLE
UPDATE: omarchy-aur-install add sudo -v

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -20,6 +20,7 @@ pkg_names=$(yay -Slqa | fzf "${fzf_args[@]}")
 
 if [[ -n "$pkg_names" ]]; then
   # Add aur/ prefix to each package name and convert to space-separated for yay
+  sudo -v
   echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm
   sudo updatedb
   omarchy-show-done


### PR DESCRIPTION
I installed Omarchy again recently, and now I remembered that I can't leave my computer before the download is completed.
I use to input my password right away after I choose packages, and waiting the download before input my password is a bit 'no' for me..

so I add [sudo -v](https://github.com/dhms013/omarchy/blob/12f8333dd731a54a4fb6989d3c41e7c2d2ba8650/bin/omarchy-pkg-aur-install#L23) in omarchy-pkg-aur-install that made it have the same behaviour with [Install > Package](https://github.com/basecamp/omarchy/blob/34f0a4215d974b0ef76fdcd318a484870d94cce8/bin/omarchy-pkg-install), [Remove > Package](https://github.com/basecamp/omarchy/blob/34f0a4215d974b0ef76fdcd318a484870d94cce8/bin/omarchy-pkg-remove), and [Update > Omarchy](https://github.com/basecamp/omarchy/blob/34f0a4215d974b0ef76fdcd318a484870d94cce8/bin/omarchy-update) 