### PR TITLE
QOL: Adds bash tab completion cycling

### DIFF
--- a/default/bash/inputrc
+++ b/default/bash/inputrc
@@ -37,3 +37,11 @@ set skip-completed-text on
 
 # Coloring for Bash 4 tab completions.
 set colored-stats on
+
+# Cycle forward and backward through completion candidates (tab/shift+tab)
+# (completion listing and display behavior configured above)
+TAB: menu-complete
+"\e[Z": menu-complete-backward
+
+# On first Tab, complete the common prefix before cycling candidates
+set menu-complete-display-prefix on


### PR DESCRIPTION
#### Summary 
Updates the bash config (inputrc) to enable menu-style tab completion for completion candidates. Preserves the existing “common prefix” completion behaviour while allowing candidates to be cycled using repeated Tab presses.

1st Tab: Functionally remains the same, showing a list of completions and filling in common when ambiguous.
2nd+ Tab: Cycles through each candidate (with Shift-Tab cycling backwards)
 
This behaviour mimics what I got used to liking when using ZSH previously.

#### Drawbacks
You do lose the nice annotations on some completions by replacing `complete` with `menu-complete`. Maybe binding to a different key combo could get around this.

e.g: 
Before:
```bash
> docker # 1st Tab
attach      (Attach local standard input, output, and error streams to a running container) 
images      (List images)                                                                  
rmi         (Remove one or more images)
...
```
After:
```bash
> docker # 1st Tab
attach      builder     commit 
...
```