### PR TITLE
Add cd command argument to zoxide init

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -9,19 +9,6 @@ fi
 alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
 alias eff='$EDITOR $(ff)'
 
-if command -v zoxide &> /dev/null; then
-  alias cd="zd"
-  zd() {
-    if [ $# -eq 0 ]; then
-      builtin cd ~ && return
-    elif [ -d "$1" ]; then
-      builtin cd "$1"
-    else
-      z "$@" && printf "\U000F17A9 " && pwd || echo "Error: Directory not found"
-    fi
-  }
-fi
-
 open() (
   xdg-open "$@" >/dev/null 2>&1 &
 )

--- a/default/bash/init
+++ b/default/bash/init
@@ -10,7 +10,7 @@ if command -v starship &> /dev/null; then
 fi
 
 if command -v zoxide &> /dev/null; then
-  eval "$(zoxide init bash)"
+  eval "$(zoxide init --cmd cd bash)"
 fi
 
 if command -v try &> /dev/null; then


### PR DESCRIPTION
## Pros:
### Better fzf integration:
1. 1. type `cd folder` plus space
    2. press Tab
    3. you'll get fzf window with all zoxide tokens of the same name (right now it won't work)
2. `cdi` will work without an alias (right now you need to use `zi` or manually add an alias) 
## Cons:
1. `z` and `zi` won't be available, only `cd` and `cdi`
2. since we can't use a custom `zd` function: 
   1. jumps with zoxide won't print the whole path
   2. if you `cd` into invalid folder, you'll get `zoxide: no match found` message without `Error: Directory not found`

Overall, I think this method is cleaner and better integrated. I doubt anyone uses `z` or `zi` anyways. Error message is still clear in my opinion.