### PR TITLE
update: Update archlinux-keyring before updating packages

### DIFF
--- a/bin/omarchy-update-keyring
+++ b/bin/omarchy-update-keyring
@@ -12,3 +12,6 @@ if omarchy-pkg-missing omarchy-keyring || ! sudo pacman-key --list-keys 40DFB630
 
   sudo pacman-key --list-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571
 fi
+
+# Ensure we have the latest archlinux-keyring, maintainer keys might have changed
+sudo pacman -Sy archlinux-keyring


### PR DESCRIPTION
Maintainer keys might have been added/revoked, let's ensure that we have the latest before updating the packages, otherwise users might have to do this manually.

Fixes https://github.com/basecamp/omarchy/issues/4608