### PR TITLE
Fix try init in bash when launched from fish shell

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -14,7 +14,7 @@ if command -v zoxide &> /dev/null; then
 fi
 
 if command -v try &> /dev/null; then
-  eval "$(try init ~/Work/tries)"
+  eval "$(SHELL=/bin/bash try init ~/Work/tries)"
 fi
 
 if command -v fzf &> /dev/null; then


### PR DESCRIPTION
## Summary

Fixes a bug where launching bash from fish causes a syntax error due to the `try init` command generating Fish syntax instead of Bash syntax.

## Problem

When bash is launched from a fish shell, the `$SHELL` environment variable remains set to `/usr/bin/fish`. The `try` command uses `$SHELL` to detect which shell syntax to generate, causing it to output Fish syntax in a Bash context:

```
bash: eval: line 15: syntax error near unexpected token `set'
bash: eval: line 15: `  set -l script_path "/usr/bin/try"'
```

## Solution

Explicitly set `SHELL=/bin/bash` when calling `try init` in the Bash initialization file, ensuring the correct shell syntax is generated regardless of the parent shell.

## Changes

- Modified `default/bash/init` to use `SHELL=/bin/bash try init` instead of just `try init`