### PR TITLE
Fix firefox detection command in omarchy-launch-browser

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -6,7 +6,7 @@
 default_browser=$(xdg-settings get default-web-browser)
 browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
 
-if [[ $browser_exec --help | grep MOZ_LOG ]]; then
+if $browser_exec --help | grep -q MOZ_LOG; then
   private_flag="--private-window"
 elif [[ $browser_exec =~ edge ]]; then
   private_flag="--inprivate"


### PR DESCRIPTION
Firefox detection was using [[ ]] which didn't interpret the pipe correctly