### PR TITLE
Use web app favicon if none given in omarchy-webapp-install

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -6,7 +6,7 @@ if [ "$#" -lt 3 ]; then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
   APP_URL=$(gum input --prompt "URL> " --placeholder "https://example.com")
-  ICON_REF=$(gum input --prompt "Icon URL> " --placeholder "See https://dashboardicons.com (must use PNG!)")
+  ICON_REF=$(gum input --prompt "Icon URL> " --placeholder "See https://dashboardicons.com (must use PNG or leave blank to use the default web app icon)")
   CUSTOM_EXEC=""
   MIME_TYPES=""
   INTERACTIVE_MODE=true
@@ -17,6 +17,10 @@ else
   CUSTOM_EXEC="$4" # Optional custom exec command
   MIME_TYPES="$5"  # Optional mime types
   INTERACTIVE_MODE=false
+fi
+
+if [[ -z "$ICON_REF" ]]; then
+  ICON_REF="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
 fi
 
 # Ensure valid execution


### PR DESCRIPTION
This uses a Google API to fetch a website favicon if none was provided. At first I tried to implement the logic in a bash script but there are so many edge cases and security issues to consider.

The pros :
- Very robust, handles all edge cases. Whatever URL you throw at it, it will return an icon or use a default one if none was found.
- Always returns a PNG file so no ICO conversion needed.
- It's dead simple!

The cons:
- Could this be a privacy issue?
- Although it's widely used, it does not seem to be official or documented. There's no guarantee this will always work. But if it does stop to work, the consequences are minimal.