### PR TITLE
Correct omarchy-debug journalctl section label

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -47,7 +47,7 @@ DMESG
 $DMESG_OUTPUT
 
 =========================================
-JOURNALCTL (CURRENT BOOT, ERRORS ONLY)
+JOURNALCTL (CURRENT BOOT, WARNINGS+ERRORS)
 =========================================
 $(journalctl -b -p 4..1)
 


### PR DESCRIPTION
The journalctl command uses `-p 4..1`, which includes warnings as well as errors.
This PR updates the label to match the actual output. No behavior change.