### PR TITLE
Fix OpenCode control sequence leaking in the editor pane with the nic function

### DIFF
--- a/default/bash/functions
+++ b/default/bash/functions
@@ -151,6 +151,11 @@ tml() {
   # Run nvim in the left pane
   tmux send-keys -t "$editor_pane" "$EDITOR ." C-m
 
+  # Short pause to avoid OpenCode terminal control sequence from leaking into the editor pane
+  if [[ "$ai" == "c" ]]; then
+    sleep 2
+  fi
+
   # Select the nvim pane for focus
   tmux select-pane -t "$editor_pane"
 }

--- a/default/bash/functions
+++ b/default/bash/functions
@@ -151,11 +151,6 @@ tml() {
   # Run nvim in the left pane
   tmux send-keys -t "$editor_pane" "$EDITOR ." C-m
 
-  # Short pause to avoid OpenCode terminal control sequence from leaking into the editor pane
-  if [[ "$ai" == "c" ]]; then
-    sleep 2
-  fi
-
   # Select the nvim pane for focus
   tmux select-pane -t "$editor_pane"
 }

--- a/default/bash/functions
+++ b/default/bash/functions
@@ -151,6 +151,11 @@ tml() {
   # Run nvim in the left pane
   tmux send-keys -t "$editor_pane" "$EDITOR ." C-m
 
+  # Temporarily disable passthrough for the ai pane to prevent
+  # OpenCode control sequences from leaking into the editor pane
+  tmux set-option -pt "$ai_pane" allow-passthrough off
+  sleep 3 && tmux set-option -pt "$ai_pane" allow-passthrough on &
+
   # Select the nvim pane for focus
   tmux select-pane -t "$editor_pane"
 }


### PR DESCRIPTION
When using the `nic` command in tmux, an OpenCode control sequence leaks in the editor pane (see video).

This PR adds a 2 seconds pause before switching the focus to the editor pane to give sufficient time for OpenCode to initialize.

Two other ways to fix this :

- Keep the focus in the AI pane
- Disable tmux passthrough for the AI pane. This also works but I don't know if it could have unwanted side effects.

I scoped the fix to OpenCode only. I don't have a Claude Code subscription to test if it's also causing the issue.

https://github.com/user-attachments/assets/d2bae8ff-3a16-4775-9592-a643c0c5d18b

