### PR TITLE
fix typo

### DIFF
--- a/changes/v3-4-0.md
+++ b/changes/v3-4-0.md
@@ -6,7 +6,7 @@
 - Add Tmux with tailored config for improved aesthetics and ergonomics accessible via `t` alias in any terminal by @dhh
 - Add hibernation by default on new installs by @dhh
 - Add hybrid GPU mode toggle via supergfxctl for compatible laptops through _Trigger > Hardware_ by @dhh
-- Add full compatibility (volume/brightness/hybrid GPU switching) with Asus Zephyrous G14/16 laptops by @dhh
+- Add full compatibility (volume/brightness/hybrid GPU switching) with Asus Zephyrus G14/16 laptops by @dhh
 - Add Motorcomm YT6801 ethernet driver for Slimbook + Tuxedo laptops by @dhh
 - Add automatic power profile switching when plugged/unplugged by @pomartel
 - Add SSH port forwarding functions fip/dip/lip for web development by @dhh


### PR DESCRIPTION
`Asus Zephyrous G14/16` --> `Asus Zephyrus G14/16` (Zephyrus is the correct model line).