### PR TITLE
Create chromium-flags.conf when enabling Google account login

### DIFF
--- a/bin/omarchy-install-chromium-google-account
+++ b/bin/omarchy-install-chromium-google-account
@@ -3,14 +3,14 @@
 # Allow Chromium to sign in to Google accounts by adding the correct
 # oauth client id and secret to ~/.config/chromium-flags.conf.
 
-if [[ -f ~/.config/chromium-flags.conf ]]; then
-  CONF=~/.config/chromium-flags.conf
+CONF="$HOME/.config/chromium-flags.conf"
+mkdir -p "$(dirname "$CONF")"
+touch "$CONF"
 
-  grep -qxF -- "--oauth2-client-id=77185425430.apps.googleusercontent.com" "$CONF" ||
-    echo "--oauth2-client-id=77185425430.apps.googleusercontent.com" >>"$CONF"
+grep -qxF -- "--oauth2-client-id=77185425430.apps.googleusercontent.com" "$CONF" ||
+  echo "--oauth2-client-id=77185425430.apps.googleusercontent.com" >>"$CONF"
 
-  grep -qxF -- "--oauth2-client-secret=OTJgUOQcT7lO7GsGZq2G4IlT" "$CONF" ||
-    echo "--oauth2-client-secret=OTJgUOQcT7lO7GsGZq2G4IlT" >>"$CONF"
+grep -qxF -- "--oauth2-client-secret=OTJgUOQcT7lO7GsGZq2G4IlT" "$CONF" ||
+  echo "--oauth2-client-secret=OTJgUOQcT7lO7GsGZq2G4IlT" >>"$CONF"
 
-  echo "Now you can login to your Google Account in Chromium."
-fi
+echo "Now you can login to your Google Account in Chromium."


### PR DESCRIPTION
This script currently only runs when `~/.config/chromium-flags.conf` already exists, making it a no-op on fresh installs.

This change creates the parent directory (if needed) and touches the file before appending the OAuth flags. The operation remains idempotent (no duplicate lines on re-run).

Testing:

- `rm -f ~/.config/chromium-flags.conf`
- run `omarchy-install-chromium-google-account`
- confirm file is created and contains both `--oauth2-*` lines
- re-run and confirm no duplicates