### PR TITLE
Fail with usage on unknown install-dev-env and remove-dev-env target

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -3,7 +3,7 @@
 # Install one of the supported development environments. Usually called via Install > Development > * in the Omarchy Menu.
 
 usage() {
-  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure>" >&2
+  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>" >&2
 }
 
 if [[ -z "$1" ]]; then
@@ -144,6 +144,11 @@ clojure)
   echo -e "Installing Clojure...\n"
   omarchy-pkg-add rlwrap
   mise use --global clojure@latest
+  ;;
+scala)
+  echo -e "Installing Scala...\n"
+  mise use --global scala@latest
+  mise use --global scala-cli@latest
   ;;
 *)
   echo "Unknown environment: $1" >&2

--- a/bin/omarchy-remove-dev-env
+++ b/bin/omarchy-remove-dev-env
@@ -4,7 +4,7 @@
 # Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala>
 
 usage() {
-  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure>" >&2
+  echo "Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>" >&2
 }
 
 if [[ -z "$1" ]]; then


### PR DESCRIPTION
If an unknown argument is provided, the script currently does nothing and exits successfully.
This adds a default case to print an error + usage and exit 1. No changes for valid options.