### PR TITLE
Fail early when mise is missing in install-dev-env

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -7,6 +7,11 @@ if [[ -z "$1" ]]; then
   exit 1
 fi
 
+if ! command -v mise >/dev/null 2>&1; then
+  echo "Error: mise is required but not installed (or not in PATH)." >&2
+  exit 1
+fi
+
 install_php() {
   sudo pacman -S php composer php-sqlite xdebug --noconfirm
 


### PR DESCRIPTION
`omarchy-install-dev-env` relies on `mise` for most install targets, but currently fails later with `mise: command not found` when it isn’t installed.

This adds a small preflight check to print a clear error and exit early. No behavior change when `mise` is present.

Testing:

- Run `omarchy-install-dev-env deno` without `mise` installed → shows clear error and exits 1.
- With `mise` installed → behavior unchanged.