### PR TITLE
Fix Hyprland Chromium flags migration newline handling

### DIFF
--- a/migrations/1760401344.sh
+++ b/migrations/1760401344.sh
@@ -3,13 +3,13 @@ echo "Add Chromium crash workaround flag for Hyprland to existing configs"
 # Add flag to chromium-flags.conf if it exists and doesn't already have it
 if [[ -f ~/.config/chromium-flags.conf ]]; then
   if ! grep -qF -- "--disable-features=WaylandWpColorManagerV1" ~/.config/chromium-flags.conf; then
-    sed -i '$a # Chromium crash workaround for Wayland color management on Hyprland - see https://github.com/hyprwm/Hyprland/issues/11957\n--disable-features=WaylandWpColorManagerV1' ~/.config/chromium-flags.conf
+    sed -i -e '$a # Chromium crash workaround for Wayland color management on Hyprland - see https://github.com/hyprwm/Hyprland/issues/11957' -e '$a --disable-features=WaylandWpColorManagerV1' ~/.config/chromium-flags.conf
   fi
 fi
 
 # Add flag to brave-flags.conf if it exists and doesn't already have it
 if [[ -f ~/.config/brave-flags.conf ]]; then
   if ! grep -qF -- "--disable-features=WaylandWpColorManagerV1" ~/.config/brave-flags.conf; then
-    sed -i '$a # Chromium crash workaround for Wayland color management on Hyprland - see https://github.com/hyprwm/Hyprland/issues/11957\n--disable-features=WaylandWpColorManagerV1' ~/.config/brave-flags.conf
+    sed -i -e '$a # Chromium crash workaround for Wayland color management on Hyprland - see https://github.com/hyprwm/Hyprland/issues/11957' -e '$a --disable-features=WaylandWpColorManagerV1' ~/.config/brave-flags.conf
   fi
 fi


### PR DESCRIPTION
The migration appends a comment and flag using a `sed '$a ...\n--flag'` string, which results in a literal `\n` and keeps the flag on the same line as the comment.
This change appends the comment and flag as two separate lines so the flag is applied correctly and the URL remains readable.