### PR TITLE
Support single-key keyboard backlight cycling (like Asus F4)

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Adjust keyboard backlight brightness using available steps.
+# Usage: omarchy-brightness-keyboard <up|down|cycle|toggle>
+
+direction="${1:-up}"
+
+# Find keyboard backlight device (look for *kbd_backlight* pattern in leds class).
+device=""
+for candidate in /sys/class/leds/*kbd_backlight*; do
+  if [[ -e "$candidate" ]]; then
+    device="$(basename "$candidate")"
+    break
+  fi
+done
+
+if [[ -z "$device" ]]; then
+  echo "No keyboard backlight device found" >&2
+  exit 1
+fi
+
+# Get current and max brightness to determine step size.
+max_brightness="$(brightnessctl -d "$device" max)"
+current_brightness="$(brightnessctl -d "$device" get)"
+
+# Calculate step as one unit (keyboards typically have discrete levels like 0-3).
+if [[ "$direction" == "cycle" || "$direction" == "toggle" ]]; then
+  new_brightness=$(( (current_brightness + 1) % (max_brightness + 1) ))
+elif [[ "$direction" == "up" ]]; then
+  new_brightness=$((current_brightness + 1))
+  [[ $new_brightness -gt $max_brightness ]] && new_brightness=$max_brightness
+else
+  new_brightness=$((current_brightness - 1))
+  [[ $new_brightness -lt 0 ]] && new_brightness=0
+fi
+
+# Set the new brightness.
+brightnessctl -d "$device" set "$new_brightness" >/dev/null
+
+# Use SwayOSD to display the new brightness setting.
+percent=$((new_brightness * 100 / max_brightness))
+omarchy-swayosd-kbd-brightness "$percent"

--- a/bin/omarchy-swayosd-kbd-brightness
+++ b/bin/omarchy-swayosd-kbd-brightness
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Display keyboard brightness level using SwayOSD on the current monitor.
+# Usage: omarchy-swayosd-kbd-brightness <percent>
+
+percent="$1"
+
+progress="$(awk -v p="$percent" 'BEGIN{printf "%.2f", p/100}')"
+[[ "$progress" == "0.00" ]] && progress="0.01"
+
+swayosd-client \
+  --monitor "$(hyprctl monitors -j | jq -r '.[]|select(.focused==true).name')" \
+  --custom-icon keyboard-brightness \
+  --custom-progress "$progress" \
+  --custom-progress-text "${percent}%"

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -9,6 +9,11 @@ bindeld = ,XF86AudioMicMute, Mute microphone, exec, $osdclient --input-volume mu
 bindeld = ,XF86MonBrightnessUp, Brightness up, exec, $osdclient --brightness raise
 bindeld = ,XF86MonBrightnessDown, Brightness down, exec, $osdclient --brightness lower
 
+# Keyboard Backlight keys
+bindeld = ,XF86KbdBrightnessUp, Keyboard brightness up, exec, omarchy-brightness-keyboard up
+bindeld = ,XF86KbdBrightnessDown, Keyboard brightness down, exec, omarchy-brightness-keyboard down
+bindld = ,XF86KbdLightOnOff, Keyboard backlight cycle, exec, omarchy-brightness-keyboard cycle
+
 # Precise 1% multimedia adjustments with Alt modifier
 bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1
 bindeld = ALT, XF86AudioLowerVolume, Volume down precise, exec, $osdclient --output-volume -1


### PR DESCRIPTION
## Summary
- Adds `cycle` argument support to `omarchy-brightness-keyboard` for hardware that uses a single key to loop through backlight levels (like Asus laptops pressing F4).
- Adds a dedicated `omarchy-swayosd-kbd-brightness` wrapper so the SwayOSD pop-up uses a `keyboard-brightness` icon instead of the generic screen brightness icon.
- Adds `XF86KbdLightOnOff` to default `media.conf` so these keys work out-of-the-box.