### PR TITLE
Fix low contrast for muted/faint text in Obsidian theme template

### DIFF
--- a/default/themed/obsidian.css.tpl
+++ b/default/themed/obsidian.css.tpl
@@ -30,8 +30,8 @@
   --interactive-accent-hover: {{ accent }};
 
   /* Muted text */
-  --text-muted: {{ color8 }};
-  --text-faint: {{ color8 }};
+  --text-muted: color-mix(in srgb, {{ foreground }} 70%, transparent);
+  --text-faint: color-mix(in srgb, {{ foreground }} 55%, transparent);
 
   /* Code */
   --code-normal: {{ color6 }};


### PR DESCRIPTION
#### Problem

The Obsidian theme template (`default/themed/obsidian.css.tpl`) uses `{{ color8 }}` for muted/faint text. On most dark themes, this color is **too similar to the background**, making text nearly invisible.

**Example - Gruvbox theme:**

<img width="2536" height="1390" alt="screenshot" src="https://github.com/user-attachments/assets/80d3d499-1362-4d78-b13e-b7b03d853c35" />

As you can see, both sidebars (folder tree on the left, tags list on the right) are nearly unreadable. The text blends into the background because \`color8\` (\`#3c3836\`) is too close to the background (\`#282828\`).

**Affected areas in Obsidian:**
- Sidebar folders and files
- Tag counts in right sidebar  
- Tab labels
- Metadata and timestamps
- Property labels ("aliases", "tags", "date", "+ Add property")

This issue affects most dark themes: gruvbox, everforest, nord, tokyo-night, catppuccin, and others.

#### Solution

Use the foreground color at reduced opacity instead in `default/themed/obsidian.css.tpl`:

```css
--text-muted: color-mix(in srgb, {{ foreground }} 70%, transparent);
--text-faint: color-mix(in srgb, {{ foreground }} 55%, transparent);
```


#### Why this works

The foreground color is **always designed to be readable** on the background. By using it at 70% opacity, we get a color that is:
- Visibly lighter/muted than normal text
- But still **clearly readable** on the background

This approach works automatically with all themes (dark and light) without any per-theme adjustments.

#### Parameters

- **70%** for muted text: visible but subdued
- **55%** for faint text: more subtle, for decorative/secondary elements

#### Disclaimer

I'm not a UX expert, but this solution seems to work well in my testing.

#### Tested

Manually verified on all 16 bundled themes (dark and light).