### PR TITLE
Keep the mouse cursor in sync with the last focused window when switching workspaces.

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -129,6 +129,7 @@ misc {
 # https://wiki.hypr.land/Configuring/Variables/#cursor
 cursor {
     hide_on_key_press = true
+    warp_on_change_workspace = 1
 }
 
 # Auto toggle scratchpad on switching workspace from scratchpad


### PR DESCRIPTION
Here's a common issue I've been noticing:

I have two terminal panes open side by side, I switch to another workspace with a browser, when I come back to the original workspace and start typing a few characters I'll suddenly lose cursor focus and end up typing in the wrong window.  This is because my mouse cursor was moved during my browsing and it is now dangling over the wrong window when I come back, susceptible to suddenly stealing focus from the last focused window I want to be on.

This fixes that problem by enabling hyprland's setting that automatically warps the mouse cursor back to the last focused window, making it behave similar to the `SUPER+arrow keys` shortcuts which always center the mouse cursor within the focused window.
