### PR TITLE
Adds Omarchy Skill to OpenAI Codex CLI

### DIFF
--- a/install/config/omarchy-ai-skill.sh
+++ b/install/config/omarchy-ai-skill.sh
@@ -1,3 +1,7 @@
 # Place in ~/.claude/skills since all tools populate from there as well as their own sources
 mkdir -p ~/.claude/skills
-ln -s $OMARCHY_PATH/default/omarchy-skill ~/.claude/skills/omarchy
+ln -sfn $OMARCHY_PATH/default/omarchy-skill ~/.claude/skills/omarchy
+
+# Also place in ~/.codex/skills for OpenAI Codex CLI
+mkdir -p ~/.codex/skills
+ln -sfn $OMARCHY_PATH/default/omarchy-skill ~/.codex/skills/omarchy

--- a/migrations/1771688970.sh
+++ b/migrations/1771688970.sh
@@ -1,0 +1,3 @@
+echo "Install Omarchy skill for Codex CLI"
+
+source $OMARCHY_PATH/install/config/omarchy-ai-skill.sh


### PR DESCRIPTION
The current SKILL.md is placed in the `.claude/` folder, which is fine for using with opencode; the codex CLI has its own directory and does not read skills from there.

This change symlinks the SKILL.md file to `.codex` folder and adds a migration for current systems.