### PR TITLE
Add keybinds to move current workspace between monitors

### DIFF
--- a/default/hypr/bindings/tiling.conf
+++ b/default/hypr/bindings/tiling.conf
@@ -57,6 +57,10 @@ bindd = SUPER SHIFT, equal, Expand window down, resizeactive, 0 100
 bindd = SUPER, mouse_down, Scroll active workspace forward, workspace, e+1
 bindd = SUPER, mouse_up, Scroll active workspace backward, workspace, e-1
 
+# Move current workspace to another monitor
+bindd = SUPER CTRL, left, Move workspace to left monitor, movecurrentworkspacetomonitor, l
+bindd = SUPER CTRL, right, Move workspace to right monitor, movecurrentworkspacetomonitor, r
+
 # Move/resize windows with mainMod + LMB/RMB and dragging
 bindmd = SUPER, mouse:272, Move window, movewindow
 bindmd = SUPER, mouse:273, Resize window, resizewindow


### PR DESCRIPTION
Adds keyboard shortcuts to move the current workspace to another monitor:

- `SUPER + CTRL + LEFT` - Move workspace to left monitor
- `SUPER + CTRL + RIGHT` - Move workspace to right monitor