### PR TITLE
Self-heal missing Elephant menu providers for theme picker

### DIFF
--- a/bin/omarchy-ensure-elephant-menus
+++ b/bin/omarchy-ensure-elephant-menus
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Ensure Elephant menu providers required by Omarchy are present.
+
+OMARCHY_ROOT="${OMARCHY_PATH:-$HOME/.local/share/omarchy}"
+ELEPHANT_DEFAULTS="$OMARCHY_ROOT/default/elephant"
+ELEPHANT_MENUS="$HOME/.config/elephant/menus"
+
+mkdir -p "$ELEPHANT_MENUS"
+ln -snf "$ELEPHANT_DEFAULTS/omarchy_themes.lua" "$ELEPHANT_MENUS/omarchy_themes.lua"
+ln -snf "$ELEPHANT_DEFAULTS/omarchy_background_selector.lua" "$ELEPHANT_MENUS/omarchy_background_selector.lua"

--- a/bin/omarchy-refresh-walker
+++ b/bin/omarchy-refresh-walker
@@ -16,6 +16,7 @@ systemctl --user daemon-reload
 omarchy-refresh-config walker/config.toml
 omarchy-refresh-config elephant/calc.toml
 omarchy-refresh-config elephant/desktopapplications.toml
+omarchy-ensure-elephant-menus
 
 # Restart service
 omarchy-restart-walker

--- a/bin/omarchy-reinstall-configs
+++ b/bin/omarchy-reinstall-configs
@@ -12,6 +12,7 @@ echo "Resetting all Omarchy configs"
 cp -R ~/.local/share/omarchy/config/* ~/.config/
 cp ~/.local/share/omarchy/default/bashrc ~/.bashrc
 echo '[[ -f ~/.bashrc ]] && . ~/.bashrc' | tee ~/.bash_profile >/dev/null
+omarchy-ensure-elephant-menus
 
 $(bash $OMARCHY_PATH/install/config/theme.sh)
 

--- a/install/config/walker-elephant.sh
+++ b/install/config/walker-elephant.sh
@@ -24,7 +24,5 @@ When = PostTransaction
 Exec = $OMARCHY_PATH/bin/omarchy-restart-walker
 EOF
 
-# Link the visual theme menu config
-mkdir -p ~/.config/elephant/menus
-ln -snf $OMARCHY_PATH/default/elephant/omarchy_themes.lua ~/.config/elephant/menus/omarchy_themes.lua
-ln -snf $OMARCHY_PATH/default/elephant/omarchy_background_selector.lua ~/.config/elephant/menus/omarchy_background_selector.lua
+# Link the visual menu providers used by Omarchy menus
+omarchy-ensure-elephant-menus


### PR DESCRIPTION
This change fixes a case where the Theme picker appears empty even though built-in themes are installed. The break happens when `~/.config/elephant/menus/omarchy_themes.lua` is missing. In that state, Walker cannot load the `menus:omarchythemes` provider, so `Style -> Theme` has no entries.

The patch adds `bin/omarchy-ensure-elephant-menus` and uses it wherever this wiring should be guaranteed. The helper recreates both required provider links with `ln -snf`: `omarchy_themes.lua` and `omarchy_background_selector.lua`. I call it from `bin/omarchy-refresh-walker` and `bin/omarchy-reinstall-configs`, and I also switch `install/config/walker-elephant.sh` to use the same helper so the link logic lives in one place.

I verified this by reproducing a broken state in an isolated HOME where only `omarchy_background_selector.lua` existed, then running `omarchy-refresh-walker` and confirming `omarchy_themes.lua` was recreated. I also confirmed both providers are present in `elephant listproviders` (`menus:omarchythemes` and `menus:omarchyBackgroundSelector`).
