### PR TITLE
fix: update voxtype dictation notification phrasing

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -14,5 +14,5 @@ if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
   voxtype setup systemd
 
   omarchy-restart-waybar
-  notify-send "    Voxtype Dictation Ready" "Hold Super + Ctrl + X to dictate.\nEdit ~/.config/voxtype/config.toml for options." -t 10000
+  notify-send "    Voxtype Dictation Ready" "Press Super + Ctrl + X to toggle dictation.\nEdit ~/.config/voxtype/config.toml for options." -t 10000
 fi


### PR DESCRIPTION
## Summary
* Updated the voxtype installation notification to say "Press ... to toggle dictation" instead of "Hold ... to dictate", to accurately reflect the current toggle keybinding behavior.