### PR TITLE
feat(touchscreen): add opt-in touchscreen support with gestures

### DIFF
--- a/bin/omarchy-install-touchscreen
+++ b/bin/omarchy-install-touchscreen
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -e
+
+# Install touchscreen support with gestures for Hyprland
+
+# Helper function for safe sed replacement with fallback
+safe_sed_replace() {
+  local file="$1"
+  local pattern="$2"
+  local replacement="$3"
+  local description="$4"
+
+  if grep -q "$pattern" "$file" 2>/dev/null; then
+    sed -i "s/$pattern/$replacement/" "$file"
+    return 0
+  else
+    notify-send "  Manual config needed" "$description\nPattern not found in $file" -t 8000
+    return 1
+  fi
+}
+
+# Detect touchscreen hardware
+detect_touchscreen() {
+  # Check for touch devices via libinput
+  if command -v libinput &>/dev/null; then
+    libinput list-devices 2>/dev/null | grep -qi "touch" && return 0
+  fi
+  # Fallback: check /dev/input for touch devices
+  if grep -l "touch" /sys/class/input/*/name 2>/dev/null | grep -q .; then
+    return 0
+  fi
+  return 1
+}
+
+# Main installation
+echo "Checking for touchscreen hardware..."
+
+if ! detect_touchscreen; then
+  echo ""
+  echo "⚠️  No touchscreen hardware detected."
+  echo ""
+  echo "This could mean:"
+  echo "  • Your device doesn't have a touchscreen"
+  echo "  • The touchscreen driver isn't loaded"
+  echo "  • You're installing for future hardware (external touchscreen, etc.)"
+  echo ""
+  echo "You can still install touch support - it will activate when touch hardware is available."
+  echo ""
+  if ! gum confirm "Continue with touchscreen support installation?"; then
+    echo "Installation cancelled."
+    exit 0
+  fi
+else
+  echo "✓ Touchscreen hardware detected"
+  echo ""
+  if ! gum confirm "Install touchscreen support with multi-touch gestures?"; then
+    exit 0
+  fi
+fi
+
+echo ""
+echo "Installing touchscreen support..."
+
+# Ensure base-devel is installed (required for hyprgrass compilation)
+echo "Ensuring build dependencies..."
+omarchy-pkg-add base-devel
+
+# Install hyprgrass plugin for touchscreen gestures
+echo "Installing hyprgrass plugin..."
+if ! hyprpm update; then
+  echo "Error: hyprpm update failed"
+  exit 1
+fi
+
+if ! hyprpm add https://github.com/horriblename/hyprgrass; then
+  echo "Error: Failed to install hyprgrass plugin"
+  echo "This may be due to compilation errors or network issues."
+  exit 1
+fi
+
+hyprpm enable hyprgrass
+
+# Copy touch-specific configs
+echo "Configuring touch gestures..."
+mkdir -p ~/.config/hypr
+cp "$OMARCHY_PATH/default/hypr/touch.conf" ~/.config/hypr/
+
+# Append source line to hyprland.conf if not present
+if ! grep -q "touch.conf" ~/.config/hypr/hyprland.conf; then
+  echo "" >> ~/.config/hypr/hyprland.conf
+  echo "# Touchscreen support (installed via omarchy-install-touchscreen)" >> ~/.config/hypr/hyprland.conf
+  echo "source = ~/.config/hypr/touch.conf" >> ~/.config/hypr/hyprland.conf
+fi
+
+# Apply touch-friendly waybar sizing
+echo "Applying touch-friendly UI..."
+mkdir -p ~/.config/waybar
+cp "$OMARCHY_PATH/default/waybar/touch.css" ~/.config/waybar/
+
+# Add touch CSS import to user's style.css if not present
+if ! grep -q "touch.css" ~/.config/waybar/style.css 2>/dev/null; then
+  # Prepend import to style.css (after theme import)
+  sed -i '1a @import "touch.css";' ~/.config/waybar/style.css
+fi
+
+# Update waybar height in config.jsonc (with fallback)
+safe_sed_replace ~/.config/waybar/config.jsonc \
+  '"height": 26' \
+  '"height": 44' \
+  "Waybar height adjustment" || true
+
+# Reload (ignore errors if Hyprland not running)
+echo "Reloading configuration..."
+hyprctl reload 2>/dev/null || true
+omarchy-restart-waybar 2>/dev/null || true
+
+echo ""
+echo "✓ Touchscreen support installed!"
+notify-send "  Touchscreen Ready" "3-finger swipe left/right for workspaces.\nLong-press to drag windows.\n\nRun omarchy-remove-touchscreen to revert." -t 10000

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -239,7 +239,7 @@ show_setup_power_menu() {
 }
 
 show_setup_security_menu() {
-  case $(menu "Setup" "󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Setup" "󰈷  Fingerprint\n  Fido2\n  Touchscreen") in
   *Fingerprint*) present_terminal omarchy-setup-fingerprint ;;
   *Fido2*) present_terminal omarchy-setup-fido2 ;;
   *) show_setup_menu ;;
@@ -285,7 +285,7 @@ show_setup_system_menu() {
 }
 
 show_install_menu() {
-  case $(menu "Install" "󰣇  Package\n󰣇  AUR\n  Web App\n  TUI\n  Service\n  Style\n󰵮  Development\n  Editor\n  Terminal\n󱚤  AI\n󰍲  Windows\n  Gaming") in
+  case $(menu "Install" "󰣇  Package\n󰣇  AUR\n  Web App\n  TUI\n  Service\n  Style\n󰵮  Development\n  Editor\n  Terminal\n󱚤  AI\n󰍲  Windows\n  Gaming\n󰍹  Hardware") in
   *Package*) terminal omarchy-pkg-install ;;
   *AUR*) terminal omarchy-pkg-aur-install ;;
   *Web*) present_terminal omarchy-webapp-install ;;
@@ -298,7 +298,16 @@ show_install_menu() {
   *AI*) show_install_ai_menu ;;
   *Windows*) present_terminal "omarchy-windows-vm install" ;;
   *Gaming*) show_install_gaming_menu ;;
+  *Hardware*) show_install_hardware_menu ;;
   *) show_main_menu ;;
+  esac
+}
+
+show_install_hardware_menu() {
+  case $(menu "Install" "  Touchscreen\n󰖺  Xbox Controller [AUR]") in
+  *Touchscreen*) present_terminal omarchy-install-touchscreen ;;
+  *Xbox*) present_terminal omarchy-install-xbox-controllers ;;
+  *) show_install_menu ;;
   esac
 }
 
@@ -434,7 +443,7 @@ show_install_elixir_menu() {
 }
 
 show_remove_menu() {
-  case $(menu "Remove" "󰣇  Package\n  Web App\n  TUI\n󰵮  Development\n󰏓  Preinstalls\n  Dictation\n󰸌  Theme\n󰍲  Windows\n󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Remove" "󰣇  Package\n  Web App\n  TUI\n󰵮  Development\n󰏓  Preinstalls\n  Dictation\n󰸌  Theme\n󰍲  Windows\n󰈷  Fingerprint\n  Fido2\n  Touchscreen") in
   *Package*) terminal omarchy-pkg-remove ;;
   *Web*) present_terminal omarchy-webapp-remove ;;
   *TUI*) present_terminal omarchy-tui-remove ;;
@@ -445,6 +454,7 @@ show_remove_menu() {
   *Windows*) present_terminal "omarchy-windows-vm remove" ;;
   *Fingerprint*) present_terminal "omarchy-setup-fingerprint --remove" ;;
   *Fido2*) present_terminal "omarchy-setup-fido2 --remove" ;;
+  *Touchscreen*) present_terminal omarchy-remove-touchscreen ;;
   *) show_main_menu ;;
   esac
 }

--- a/bin/omarchy-remove-touchscreen
+++ b/bin/omarchy-remove-touchscreen
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# Remove touchscreen support
+
+if ! gum confirm "Remove touchscreen support (gestures and UI sizing)?"; then
+  exit 0
+fi
+
+echo "Removing touchscreen support..."
+
+# Remove hyprgrass plugin
+echo "Removing hyprgrass plugin..."
+hyprpm remove hyprgrass 2>/dev/null || true
+
+# Remove touch config
+rm -f ~/.config/hypr/touch.conf
+
+# Remove source line from hyprland.conf
+if [[ -f ~/.config/hypr/hyprland.conf ]]; then
+  sed -i '/touch\.conf/d' ~/.config/hypr/hyprland.conf
+  sed -i '/Touchscreen support/d' ~/.config/hypr/hyprland.conf
+fi
+
+# Revert waybar sizing
+rm -f ~/.config/waybar/touch.css
+
+if [[ -f ~/.config/waybar/style.css ]]; then
+  sed -i '/touch\.css/d' ~/.config/waybar/style.css
+fi
+
+# Revert waybar height (if pattern found)
+if [[ -f ~/.config/waybar/config.jsonc ]]; then
+  if grep -q '"height": 44' ~/.config/waybar/config.jsonc; then
+    sed -i 's/"height": 44/"height": 26/' ~/.config/waybar/config.jsonc
+  fi
+fi
+
+# Reload (ignore errors if Hyprland not running)
+echo "Reloading configuration..."
+hyprctl reload 2>/dev/null || true
+omarchy-restart-waybar 2>/dev/null || true
+
+echo ""
+echo "✓ Touchscreen support removed"
+notify-send "Touchscreen support removed" -t 5000

--- a/default/hypr/touch.conf
+++ b/default/hypr/touch.conf
@@ -1,0 +1,37 @@
+# Touchscreen gesture configuration (via hyprgrass plugin)
+# https://github.com/horriblename/hyprgrass
+
+plugin {
+  touch_gestures {
+    sensitivity = 4.0                    # Higher for touchscreen vs trackpad
+    workspace_swipe_fingers = 3          # 3-finger horizontal swipe
+    long_press_delay = 400               # ms before long-press triggers
+    resize_on_border_long_press = true   # Long-press window border to resize
+    edge_margin = 20                     # Pixels from edge for edge gestures
+  }
+}
+
+# Enable workspace swipe gestures
+gestures {
+  workspace_swipe = true
+  workspace_swipe_cancel_ratio = 0.15
+}
+
+# Gesture bindings
+hyprgrass-bind = , swipe:3:r, workspace, e+1      # 3-finger swipe right → next workspace
+hyprgrass-bind = , swipe:3:l, workspace, e-1      # 3-finger swipe left → prev workspace
+hyprgrass-bind = , swipe:3:u, togglespecialworkspace, scratchpad  # Swipe up → scratchpad
+hyprgrass-bind = , swipe:3:d, exec, omarchy-launch-walker         # Swipe down → launcher
+
+# Edge swipes (from screen edge)
+hyprgrass-bind = , edge:l:r, workspace, e-1       # Left edge swipe right → prev workspace
+hyprgrass-bind = , edge:r:l, workspace, e+1       # Right edge swipe left → next workspace
+
+# Long press to move/resize (alternative to SUPER+drag)
+hyprgrass-bindm = , longpress:2, movewindow       # 2-finger long press → move window
+
+# Ensure touch wakes display
+misc {
+  key_press_enables_dpms = true
+  mouse_move_enables_dpms = true
+}

--- a/default/waybar/touch.css
+++ b/default/waybar/touch.css
@@ -1,0 +1,40 @@
+/* Touch-friendly sizing overrides
+ * To revert: remove @import "touch.css" from ~/.config/waybar/style.css
+ * and set "height": 26 in config.jsonc
+ */
+
+/* Larger workspace buttons for touch */
+#workspaces button {
+  padding: 0 14px;
+  min-width: 32px;
+  margin: 0 3px;
+}
+
+/* Larger icons and spacing */
+#cpu,
+#battery,
+#pulseaudio,
+#custom-omarchy,
+#custom-update {
+  min-width: 24px;
+  margin: 0 12px;
+}
+
+/* Larger tray icons */
+#tray {
+  margin-right: 20px;
+}
+
+/* More padding on indicators */
+#custom-screenrecording-indicator,
+#custom-idle-indicator,
+#custom-notification-silencing-indicator {
+  min-width: 24px;
+  margin: 0 8px;
+  font-size: 14px;
+}
+
+/* Larger font for better readability */
+* {
+  font-size: 14px;
+}


### PR DESCRIPTION
# NOTE

This is not finalized, but an working experiement to make it work well on my Windows Surface

## Summary

Add opt-in touchscreen support for devices like Microsoft Surface, Framework 16, and convertible laptops using the hyprgrass plugin for Hyprland.

## Changes

- **New installer:** `omarchy-install-touchscreen` with hardware detection and error handling
- **New removal script:** `omarchy-remove-touchscreen` for clean uninstallation
- **Gesture configuration:** 3-finger swipes for workspaces, edge swipes, long-press to move windows
- **Touch-friendly UI:** Larger waybar (44px), bigger workspace buttons, increased icon spacing
- **Menu integration:** Install → Hardware → Touchscreen, Remove → Touchscreen

## Implementation Details

| File | Purpose |
|------|---------|
| `bin/omarchy-install-touchscreen` | Main installer with hardware detection, hyprgrass plugin installation |
| `bin/omarchy-remove-touchscreen` | Clean removal of all touchscreen components |
| `default/hypr/touch.conf` | Hyprgrass gesture bindings and touch settings |
| `default/waybar/touch.css` | Touch-friendly waybar sizing overrides |
| `bin/omarchy-menu` | Added Hardware submenu under Install |

## Gestures Configured

- **3-finger swipe left/right:** Navigate workspaces
- **3-finger swipe up:** Toggle scratchpad
- **3-finger swipe down:** Open launcher (walker)
- **Edge swipes:** Alternative workspace navigation
- **2-finger long-press:** Move window (replaces SUPER+drag)

## Testing

- [ ] Install on touchscreen device
- [ ] Verify gesture recognition
- [ ] Test waybar touch targets
- [ ] Verify clean removal

## Screenshots

Will come :) 
