### PR TITLE
eDP Auto Refresh Rate Switching

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -171,8 +171,12 @@ show_toggle_menu() {
 }
 
 show_hardware_menu() {
-  case $(menu "Toggle" "  Hybrid GPU") in
+  local options="  Hybrid GPU"
+  omarchy-battery-present && options="$options\n󰍹  Auto Refresh Rate"
+
+  case $(menu "Toggle" "$options") in
   *"Hybrid GPU"*) present_terminal omarchy-toggle-hybrid-gpu ;;
+  *Refresh*) omarchy-toggle-monitor-refresh-rate ;;
   *) show_trigger_menu ;;
   esac
 }

--- a/bin/omarchy-monitor-refresh-rate-watch
+++ b/bin/omarchy-monitor-refresh-rate-watch
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -o pipefail
+
+# Watch for power profile changes via D-Bus and adjust laptop monitor refresh rate.
+# power-saver → lowest refresh rate, balanced/performance → highest refresh rate.
+# Only affects the built-in laptop display (eDP-*).
+
+apply_profile() {
+  local profile=$1
+  local info
+  info=$(hyprctl monitors -j | jq '.[] | select(.name | startswith("eDP"))')
+
+  [[ -z "$info" ]] && return
+
+  local monitor resolution scale current_rate rates max_rate min_rate target_rate
+  monitor=$(echo "$info" | jq -r '.name')
+  resolution=$(echo "$info" | jq -r '"\(.width)x\(.height)"')
+  scale=$(echo "$info" | jq -r '.scale')
+  current_rate=$(echo "$info" | jq -r '.refreshRate | floor')
+
+  rates=$(echo "$info" | jq -r --arg res "$resolution" '
+    .availableModes[] | select(startswith($res + "@")) |
+    capture("@(?<hz>[0-9]+)\\.") | .hz' | sort -n | uniq)
+  max_rate=$(echo "$rates" | tail -1)
+  min_rate=$(echo "$rates" | head -1)
+
+  if [[ "$profile" == "power-saver" ]]; then
+    target_rate=$min_rate
+  else
+    target_rate=$max_rate
+  fi
+
+  if [[ "$current_rate" != "$target_rate" ]]; then
+    hyprctl keyword monitor "$monitor,${resolution}@${target_rate},auto,${scale}"
+    notify-send "󰍹  Display refresh rate set to ${target_rate}Hz"
+  fi
+}
+
+# --restore: set max rate and exit (used by toggle script)
+if [[ "$1" == "--restore" ]]; then
+  apply_profile performance
+  exit 0
+fi
+
+# Apply once on startup
+apply_profile "$(powerprofilesctl get)"
+
+# Watch for changes via D-Bus
+gdbus monitor --system --dest net.hadess.PowerProfiles \
+  --object-path /net/hadess/PowerProfiles 2>/dev/null |
+  while read -r line; do
+    if [[ "$line" == *"ActiveProfile"* ]]; then
+      profile=$(echo "$line" | grep -oP "'ActiveProfile': <'\\K[^']+")
+      [[ -n "$profile" ]] && apply_profile "$profile"
+    fi
+  done

--- a/bin/omarchy-toggle-monitor-refresh-rate
+++ b/bin/omarchy-toggle-monitor-refresh-rate
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Toggle automatic monitor refresh rate switching based on power profile.
+# When enabled, power-saver → lowest Hz, balanced/performance → highest Hz.
+# Only affects the built-in laptop display (eDP-*).
+
+SERVICE="omarchy-monitor-refresh-rate-watch.service"
+
+# Ensure the service file is installed
+if [[ ! -f ~/.config/systemd/user/$SERVICE ]]; then
+  omarchy-refresh-config systemd/user/$SERVICE
+  systemctl --user daemon-reload
+fi
+
+if systemctl --user is-active --quiet "$SERVICE"; then
+  systemctl --user disable --now "$SERVICE"
+  omarchy-monitor-refresh-rate-watch --restore
+  notify-send "󰍹  Refresh rate switching disabled"
+else
+  systemctl --user enable --now "$SERVICE"
+  notify-send "󰍹  Refresh rate switching enabled"
+fi

--- a/config/systemd/user/omarchy-monitor-refresh-rate-watch.service
+++ b/config/systemd/user/omarchy-monitor-refresh-rate-watch.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Omarchy Monitor Refresh Rate Watcher
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/share/omarchy/bin/omarchy-monitor-refresh-rate-watch
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
to sum this up i would love to get as much battery juice as possible from my laptop. 

so i made this trigger (opt-in) to automatically switch between low refresh rate & high refresh rate of laptop's preferred resolution based on active power profile.

only tested on my Asus G14:
- Performance / Balanced: 120hz
- Power Saver: 60hz

not sure if we should modify in the user `monitors.conf` directly for this or not, but for now its made to infer it for the most part & change only refresh rate using `hyprctl keyword`.

NOTE: only runs on eDP & option shows up only if you have a battery..