### PR TITLE
Hide fcitx5 icon from waybar

### DIFF
--- a/bin/omarchy-restart-app
+++ b/bin/omarchy-restart-app
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Restart an application by killing it and relaunching via uwsm.
-# Usage: omarchy-restart-app <application-name>
+# Usage: omarchy-restart-app <application-name> [application-args...]
 
 pkill -x $1
-setsid uwsm-app -- $1 >/dev/null 2>&1 &
+setsid uwsm-app -- "$@" >/dev/null 2>&1 &

--- a/bin/omarchy-restart-xcompose
+++ b/bin/omarchy-restart-xcompose
@@ -2,4 +2,4 @@
 
 # Restart the XCompose input method service (fcitx5) to apply new compose key settings.
 
-omarchy-restart-app fcitx5
+omarchy-restart-app fcitx5 --disable notificationitem

--- a/config/fcitx5/addon/notificationitem.conf
+++ b/config/fcitx5/addon/notificationitem.conf
@@ -1,1 +1,0 @@
-Enabled=False

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -1,7 +1,7 @@
 exec-once = uwsm-app -- hypridle
 exec-once = uwsm-app -- mako
 exec-once = uwsm-app -- waybar
-exec-once = uwsm-app -- fcitx5
+exec-once = uwsm-app -- fcitx5 --disable notificationitem
 exec-once = uwsm-app -- swaybg -i ~/.config/omarchy/current/background -m fill
 exec-once = uwsm-app -- swayosd-server
 exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1

--- a/migrations/1771666449.sh
+++ b/migrations/1771666449.sh
@@ -1,4 +1,0 @@
-echo "Hide fcitx5 tray icon from waybar"
-
-mkdir -p ~/.config/fcitx5/addon
-cp $OMARCHY_PATH/config/fcitx5/addon/notificationitem.conf ~/.config/fcitx5/addon/


### PR DESCRIPTION
The fix to hide the fcitx5 icon in this commit did not work for me: https://github.com/basecamp/omarchy/commit/b5dbb23c9ff76f5dcb80226299442e1fb23b66b3

This is the solution that works for me to hide the icon. But if that previous commit fixes it for everybody but me then you can just close the PR and I will keep  the fix local.