### PR TITLE
Remove example alias for claude command

### DIFF
--- a/default/bashrc
+++ b/default/bashrc
@@ -9,4 +9,3 @@ source ~/.local/share/omarchy/default/bash/rc
 #
 # Make an alias for invoking commands you use constantly
 # alias p='python'
-# alias cx="claude --permission-mode=plan --allow-dangerously-skip-permissions"


### PR DESCRIPTION
Since it was added to the actual [`aliases`](https://github.com/basecamp/omarchy/blob/c3f7575474ccaf2e2eefdf39506cc74d3ab917a6/default/bash/aliases#L36), it no longer serves as an example.