### PR TITLE
Remove Fcitx5 autostart desktop entry

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -14,6 +14,7 @@ run_logged $OMARCHY_INSTALL/config/mise-work.sh
 run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
+run_logged $OMARCHY_INSTALL/config/remove-fcitx5-autostart.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/walker-elephant.sh
 run_logged $OMARCHY_INSTALL/config/fast-shutdown.sh

--- a/install/config/remove-fcitx5-autostart.sh
+++ b/install/config/remove-fcitx5-autostart.sh
@@ -1,0 +1,1 @@
+sudo rm -f /etc/xdg/autostart/org.fcitx.Fcitx5.desktop

--- a/migrations/1772120972.sh
+++ b/migrations/1772120972.sh
@@ -1,0 +1,3 @@
+echo "Remove Fcitx5 XDG autostart desktop entry"
+
+source $OMARCHY_PATH/install/config/remove-fcitx5-autostart.sh


### PR DESCRIPTION
Turns out we are starting fcitx5 twice. This PR removes the autostart desktop entry.