### PR TITLE
Fix bash error when fns directory is empty

### DIFF
--- a/default/bash/functions
+++ b/default/bash/functions
@@ -1,1 +1,3 @@
-for f in $OMARCHY_PATH/default/bash/fns/*; do source "$f"; done
+for f in "$OMARCHY_PATH"/default/bash/fns/*; do
+  [ -f "$f" ] && source "$f"
+done


### PR DESCRIPTION
The current loop throws an error if the directory exists but is empty, which mine was after the 3.4 update. 