### PR TITLE
Add delta theme template for automatic diff color theming

### DIFF
--- a/default/themed/delta.gitconfig.tpl
+++ b/default/themed/delta.gitconfig.tpl
@@ -1,0 +1,19 @@
+[delta]
+    syntax-theme = base16
+    minus-style = bold "{{ color1 }}"
+    minus-emph-style = bold underline "{{ color9 }}"
+    minus-non-emph-style = "{{ color1 }}"
+    plus-style = bold "{{ color2 }}"
+    plus-emph-style = bold underline "{{ color10 }}"
+    plus-non-emph-style = "{{ color2 }}"
+    file-style = "{{ accent }}" bold
+    file-decoration-style = "{{ accent }}" underline
+    hunk-header-style = omit
+    line-numbers = true
+    line-numbers-minus-style = "{{ color1 }}"
+    line-numbers-plus-style = "{{ color2 }}"
+    line-numbers-left-style = "{{ color8 }}"
+    line-numbers-right-style = "{{ color8 }}"
+    line-numbers-zero-style = "{{ color8 }}"
+    commit-style = "{{ foreground }}" bold
+    commit-decoration-style = "{{ accent }}" box


### PR DESCRIPTION
## Summary

[Delta](https://github.com/dandavison/delta) is a widely-used syntax-highlighting pager for `git diff`, `git log`, and `git blame`. This PR adds a template that automatically generates a delta config from each Omarchy theme's `colors.toml`, so diff colors follow the active theme just like terminals, waybar, and other apps already do.

- Adds `default/themed/delta.gitconfig.tpl` — generates `~/.config/omarchy/current/theme/delta.gitconfig` on every theme switch
- Uses `syntax-theme = base16` so syntax highlighting piggybacks on the terminal color palette (already themed by Omarchy), giving full theme coverage with no extra work
- Structural diff colors (added/removed lines, file headers, line numbers, commit boxes) are mapped from `color1`, `color2`, `color9`, `color10`, `accent`, `color8`, and `foreground`

## Activation

Users who have delta installed add one `[include]` to their `~/.gitconfig` **after** any existing `[delta]` block:

```gitconfig
[include]
    path = ~/.config/omarchy/current/theme/delta.gitconfig
```

From then on, every `omarchy-theme-set` automatically regenerates the delta config alongside all other themed configs. No restart needed — delta reads gitconfig fresh on each invocation.

## Color mapping

| Delta setting | `colors.toml` key | Purpose |
|---|---|---|
| `minus-style` / `minus-non-emph-style` | `color1` | Removed lines (terminal red) |
| `minus-emph-style` | `color9` | Emphasized removals (bright red) |
| `plus-style` / `plus-non-emph-style` | `color2` | Added lines (terminal green) |
| `plus-emph-style` | `color10` | Emphasized additions (bright green) |
| `file-style`, `file-decoration-style` | `accent` | File name header |
| `commit-decoration-style` | `accent` | Commit hash box border |
| `line-numbers-*-style` (gutter) | `color8` | Muted line number column |
| `commit-style` | `foreground` | Commit hash text |