### PR TITLE
Theme boot screens (Limine + Plymouth) on theme change

### DIFF
--- a/bin/omarchy-limine-update-colors
+++ b/bin/omarchy-limine-update-colors
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Updates limine bootloader colors in /boot/limine.conf.
+# Reads key=value pairs from stdin and updates matching lines.
+# Intended to be run via sudo from omarchy-theme-set-limine.
+
+LIMINE_CONF="/boot/limine.conf"
+
+[[ -f $LIMINE_CONF ]] || exit 1
+
+while IFS='=' read -r key value; do
+  [[ $key && $value ]] || continue
+  sed -i "s/^${key}:.*/${key}: ${value}/" "$LIMINE_CONF"
+done

--- a/bin/omarchy-plymouth-update-theme
+++ b/bin/omarchy-plymouth-update-theme
@@ -16,8 +16,10 @@ fi
 cp "$STAGED_DIR"/* "$PLYMOUTH_THEME_DIR/"
 rm -rf "$STAGED_DIR"
 
+# Rebuild initramfs in the background so theme switching isn't blocked.
+# This already runs as root via sudo, so no further auth is needed.
 if command -v limine-mkinitcpio &>/dev/null; then
-  limine-mkinitcpio
+  nohup limine-mkinitcpio >/dev/null 2>&1 &
 else
-  mkinitcpio -P
+  nohup mkinitcpio -P >/dev/null 2>&1 &
 fi

--- a/bin/omarchy-plymouth-update-theme
+++ b/bin/omarchy-plymouth-update-theme
@@ -2,9 +2,14 @@
 
 # Copies themed plymouth files into the system theme directory and rebuilds
 # the initramfs. Intended to be run via sudo from omarchy-theme-set-plymouth.
+#
+# Uses flock to serialize concurrent invocations. When multiple theme
+# switches happen rapidly, each waits its turn. Only the final copy's
+# initramfs rebuild matters — earlier ones get overwritten.
 
 PLYMOUTH_THEME_DIR="/usr/share/plymouth/themes/omarchy"
 STAGED_DIR="$1"
+LOCKFILE="/tmp/omarchy-plymouth.lock"
 
 if [[ -z $STAGED_DIR || ! -d $STAGED_DIR ]]; then
   echo "Usage: $0 <staged-theme-directory>" >&2
@@ -13,13 +18,21 @@ fi
 
 [[ -d $PLYMOUTH_THEME_DIR ]] || exit 1
 
+# Serialize: only one copy + rebuild at a time
+exec 9>"$LOCKFILE"
+flock 9
+
+# Staged dir may have been replaced by a newer invocation while we waited.
+# If our dir is gone, a newer instance already handled it — nothing to do.
+if [[ ! -d $STAGED_DIR ]]; then
+  exit 0
+fi
+
 cp "$STAGED_DIR"/* "$PLYMOUTH_THEME_DIR/"
 rm -rf "$STAGED_DIR"
 
-# Rebuild initramfs in the background so theme switching isn't blocked.
-# This already runs as root via sudo, so no further auth is needed.
 if command -v limine-mkinitcpio &>/dev/null; then
-  nohup limine-mkinitcpio >/dev/null 2>&1 &
+  limine-mkinitcpio
 else
-  nohup mkinitcpio -P >/dev/null 2>&1 &
+  mkinitcpio -P
 fi

--- a/bin/omarchy-plymouth-update-theme
+++ b/bin/omarchy-plymouth-update-theme
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copies themed plymouth files into the system theme directory and rebuilds
+# the initramfs. Intended to be run via sudo from omarchy-theme-set-plymouth.
+
+PLYMOUTH_THEME_DIR="/usr/share/plymouth/themes/omarchy"
+STAGED_DIR="$1"
+
+if [[ -z $STAGED_DIR || ! -d $STAGED_DIR ]]; then
+  echo "Usage: $0 <staged-theme-directory>" >&2
+  exit 1
+fi
+
+[[ -d $PLYMOUTH_THEME_DIR ]] || exit 1
+
+cp "$STAGED_DIR"/* "$PLYMOUTH_THEME_DIR/"
+rm -rf "$STAGED_DIR"
+
+if command -v limine-mkinitcpio &>/dev/null; then
+  limine-mkinitcpio
+else
+  mkinitcpio -P
+fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -56,6 +56,7 @@ omarchy-theme-set-vscode
 omarchy-theme-set-obsidian
 omarchy-theme-set-keyboard
 omarchy-theme-set-limine
+omarchy-theme-set-plymouth
 
 # Call hook on theme set
 omarchy-hook theme-set "$THEME_NAME"

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -55,6 +55,7 @@ omarchy-theme-set-browser
 omarchy-theme-set-vscode
 omarchy-theme-set-obsidian
 omarchy-theme-set-keyboard
+omarchy-theme-set-limine
 
 # Call hook on theme set
 omarchy-hook theme-set "$THEME_NAME"

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -56,7 +56,9 @@ omarchy-theme-set-vscode
 omarchy-theme-set-obsidian
 omarchy-theme-set-keyboard
 omarchy-theme-set-limine
-omarchy-theme-set-plymouth
 
 # Call hook on theme set
 omarchy-hook theme-set "$THEME_NAME"
+
+# Plymouth rebuild is slow (~30s) so run it detached after everything else
+setsid omarchy-theme-set-plymouth >/dev/null 2>&1 &

--- a/bin/omarchy-theme-set-limine
+++ b/bin/omarchy-theme-set-limine
@@ -2,8 +2,55 @@
 
 LIMINE_CONF="/boot/limine.conf"
 LIMINE_THEME="$HOME/.config/omarchy/current/theme/limine.theme"
+ALACRITTY_FILE="$HOME/.config/omarchy/current/theme/alacritty.toml"
 
 [[ -f $LIMINE_CONF ]] || exit 0
-[[ -f $LIMINE_THEME ]] || exit 0
 
-sudo /usr/local/bin/omarchy-limine-update-colors <"$LIMINE_THEME"
+# If the template engine generated limine.theme, use it directly
+if [[ -f $LIMINE_THEME ]]; then
+  sudo /usr/local/bin/omarchy-limine-update-colors <"$LIMINE_THEME"
+  exit 0
+fi
+
+# Fallback: generate limine color values from alacritty.toml
+[[ -f $ALACRITTY_FILE ]] || exit 0
+
+strip_hash() { echo "${1#\#}"; }
+
+get_color() {
+  grep -E "^\s*$1\s*=" "$ALACRITTY_FILE" | head -1 | sed 's/.*=\s*"#\?//;s/".*//'
+}
+
+# Get normal colors (first occurrence)
+background=$(get_color background)
+foreground=$(get_color foreground)
+color0=$(get_color black)
+color1=$(get_color red)
+color2=$(get_color green)
+color3=$(get_color yellow)
+color4=$(get_color blue)
+color5=$(get_color magenta)
+color6=$(get_color cyan)
+color7=$(get_color white)
+
+# Get bright colors (second occurrence)
+color8=$(grep -E "^\s*black\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+color9=$(grep -E "^\s*red\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+color10=$(grep -E "^\s*green\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+color11=$(grep -E "^\s*yellow\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+color12=$(grep -E "^\s*blue\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+color13=$(grep -E "^\s*magenta\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+color14=$(grep -E "^\s*cyan\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+color15=$(grep -E "^\s*white\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+
+[[ $background && $foreground && $color0 ]] || exit 0
+
+{
+  echo "term_background=$background"
+  echo "backdrop=$background"
+  echo "term_palette=${color0};${color1};${color2};${color3};${color4};${color5};${color6};${color7}"
+  echo "term_palette_bright=${color8};${color9};${color10};${color11};${color12};${color13};${color14};${color15}"
+  echo "term_foreground=$foreground"
+  echo "term_foreground_bright=$foreground"
+  echo "term_background_bright=$color8"
+} | sudo /usr/local/bin/omarchy-limine-update-colors

--- a/bin/omarchy-theme-set-limine
+++ b/bin/omarchy-theme-set-limine
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+LIMINE_CONF="/boot/limine.conf"
+LIMINE_THEME="$HOME/.config/omarchy/current/theme/limine.theme"
+
+[[ -f $LIMINE_CONF ]] || exit 0
+[[ -f $LIMINE_THEME ]] || exit 0
+
+sudo /usr/local/bin/omarchy-limine-update-colors <"$LIMINE_THEME"

--- a/bin/omarchy-theme-set-limine
+++ b/bin/omarchy-theme-set-limine
@@ -2,6 +2,7 @@
 
 LIMINE_CONF="/boot/limine.conf"
 LIMINE_THEME="$HOME/.config/omarchy/current/theme/limine.theme"
+GHOSTTY_FILE="$HOME/.config/omarchy/current/theme/ghostty.conf"
 ALACRITTY_FILE="$HOME/.config/omarchy/current/theme/alacritty.toml"
 
 [[ -f $LIMINE_CONF ]] || exit 0
@@ -12,36 +13,63 @@ if [[ -f $LIMINE_THEME ]]; then
   exit 0
 fi
 
-# Fallback: generate limine color values from alacritty.toml
-[[ -f $ALACRITTY_FILE ]] || exit 0
-
+# Fallback: generate limine color values from terminal config
 strip_hash() { echo "${1#\#}"; }
 
-get_color() {
-  grep -E "^\s*$1\s*=" "$ALACRITTY_FILE" | head -1 | sed 's/.*=\s*"#\?//;s/".*//'
-}
+if [[ -f $GHOSTTY_FILE ]]; then
+  get_color() {
+    grep -E "^$1\s*=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=\s*#\?//'
+  }
 
-# Get normal colors (first occurrence)
-background=$(get_color background)
-foreground=$(get_color foreground)
-color0=$(get_color black)
-color1=$(get_color red)
-color2=$(get_color green)
-color3=$(get_color yellow)
-color4=$(get_color blue)
-color5=$(get_color magenta)
-color6=$(get_color cyan)
-color7=$(get_color white)
+  get_palette() {
+    grep -E "^palette\s*=\s*$1=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=#\?//'
+  }
 
-# Get bright colors (second occurrence)
-color8=$(grep -E "^\s*black\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
-color9=$(grep -E "^\s*red\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
-color10=$(grep -E "^\s*green\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
-color11=$(grep -E "^\s*yellow\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
-color12=$(grep -E "^\s*blue\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
-color13=$(grep -E "^\s*magenta\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
-color14=$(grep -E "^\s*cyan\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
-color15=$(grep -E "^\s*white\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  background=$(get_color background)
+  foreground=$(get_color foreground)
+  color0=$(get_palette 0)
+  color1=$(get_palette 1)
+  color2=$(get_palette 2)
+  color3=$(get_palette 3)
+  color4=$(get_palette 4)
+  color5=$(get_palette 5)
+  color6=$(get_palette 6)
+  color7=$(get_palette 7)
+  color8=$(get_palette 8)
+  color9=$(get_palette 9)
+  color10=$(get_palette 10)
+  color11=$(get_palette 11)
+  color12=$(get_palette 12)
+  color13=$(get_palette 13)
+  color14=$(get_palette 14)
+  color15=$(get_palette 15)
+elif [[ -f $ALACRITTY_FILE ]]; then
+  get_color() {
+    grep -E "^\s*$1\s*=" "$ALACRITTY_FILE" | head -1 | sed 's/.*=\s*"#\?//;s/".*//'
+  }
+
+  background=$(get_color background)
+  foreground=$(get_color foreground)
+  color0=$(get_color black)
+  color1=$(get_color red)
+  color2=$(get_color green)
+  color3=$(get_color yellow)
+  color4=$(get_color blue)
+  color5=$(get_color magenta)
+  color6=$(get_color cyan)
+  color7=$(get_color white)
+
+  color8=$(grep -E "^\s*black\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  color9=$(grep -E "^\s*red\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  color10=$(grep -E "^\s*green\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  color11=$(grep -E "^\s*yellow\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  color12=$(grep -E "^\s*blue\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  color13=$(grep -E "^\s*magenta\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  color14=$(grep -E "^\s*cyan\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+  color15=$(grep -E "^\s*white\s*=" "$ALACRITTY_FILE" | tail -1 | sed 's/.*=\s*"#\?//;s/".*//')
+else
+  exit 0
+fi
 
 [[ $background && $foreground && $color0 ]] || exit 0
 

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -33,26 +33,30 @@ get_alacritty_color() {
 if [[ -f $COLORS_FILE ]]; then
   background=$(get_color background)
   foreground=$(get_color foreground)
-  accent=$(get_color accent)
+  cursor=$(get_color cursor)
   color0=$(get_color color0)
+  color2=$(get_color color2)
 elif [[ -f $GHOSTTY_FILE ]]; then
   background=$(get_ghostty_color background)
   foreground=$(get_ghostty_color foreground)
+  cursor=$(get_ghostty_color cursor-color)
   # palette line format: "palette = N=#RRGGBB"
-  accent=$(grep -E "^palette\s*=\s*4=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=//')
   color0=$(grep -E "^palette\s*=\s*0=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=//')
+  color2=$(grep -E "^palette\s*=\s*2=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=//')
 elif [[ -f $ALACRITTY_FILE ]]; then
   background=$(get_alacritty_color background)
   foreground=$(get_alacritty_color foreground)
-  accent=$(get_alacritty_color blue)
+  cursor=$(get_alacritty_color cursor)
   color0=$(get_alacritty_color black)
+  color2=$(get_alacritty_color green)
 else
   exit 0
 fi
 
 [[ $background && $foreground ]] || exit 0
-: "${accent:=$foreground}"
+: "${cursor:=$foreground}"
 : "${color0:=$background}"
+: "${color2:=$foreground}"
 
 # Convert hex color to plymouth float RGB (e.g., "#1e1e2e" -> "0.117, 0.117, 0.180")
 hex_to_float_rgb() {
@@ -90,10 +94,10 @@ sed \
   "$PLYMOUTH_SOURCE/omarchy.plymouth" >"$STAGED/omarchy.plymouth"
 
 # Recolor PNG assets
-magick "$PLYMOUTH_SOURCE/logo.png" -fill "$accent" -colorize 100% "$STAGED/logo.png"
-magick "$PLYMOUTH_SOURCE/lock.png" -fill "$foreground" -colorize 100% "$STAGED/lock.png"
-magick "$PLYMOUTH_SOURCE/entry.png" -fill "$foreground" -colorize 100% "$STAGED/entry.png"
-magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$foreground" -colorize 100% "$STAGED/bullet.png"
+magick "$PLYMOUTH_SOURCE/logo.png" -fill "$color2" -colorize 100% "$STAGED/logo.png"
+magick "$PLYMOUTH_SOURCE/lock.png" -fill "$cursor" -colorize 100% "$STAGED/lock.png"
+magick "$PLYMOUTH_SOURCE/entry.png" -fill "$cursor" -colorize 100% "$STAGED/entry.png"
+magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$cursor" -colorize 100% "$STAGED/bullet.png"
 magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGED/progress_bar.png"
 magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "$color0" -colorize 100% "$STAGED/progress_box.png"
 

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -6,6 +6,7 @@
 
 THEME_DIR="$HOME/.config/omarchy/current/theme"
 COLORS_FILE="$THEME_DIR/colors.toml"
+GHOSTTY_FILE="$THEME_DIR/ghostty.conf"
 ALACRITTY_FILE="$THEME_DIR/alacritty.toml"
 PLYMOUTH_SOURCE="$OMARCHY_PATH/default/plymouth"
 
@@ -19,6 +20,11 @@ get_color() {
   grep -E "^$1\s*=" "$COLORS_FILE" | head -1 | sed 's/.*=\s*"//;s/".*//'
 }
 
+# Parse a color value from ghostty.conf (key = value format, no quotes)
+get_ghostty_color() {
+  grep -E "^$1\s*=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=\s*//'
+}
+
 # Parse a color value from alacritty.toml (first occurrence of key)
 get_alacritty_color() {
   grep -E "^\s*$1\s*=" "$ALACRITTY_FILE" | head -1 | sed 's/.*=\s*"//;s/".*//'
@@ -29,10 +35,15 @@ if [[ -f $COLORS_FILE ]]; then
   foreground=$(get_color foreground)
   accent=$(get_color accent)
   color0=$(get_color color0)
+elif [[ -f $GHOSTTY_FILE ]]; then
+  background=$(get_ghostty_color background)
+  foreground=$(get_ghostty_color foreground)
+  # palette line format: "palette = N=#RRGGBB"
+  accent=$(grep -E "^palette\s*=\s*4=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=//')
+  color0=$(grep -E "^palette\s*=\s*0=" "$GHOSTTY_FILE" | head -1 | sed 's/.*=//')
 elif [[ -f $ALACRITTY_FILE ]]; then
   background=$(get_alacritty_color background)
   foreground=$(get_alacritty_color foreground)
-  # Use blue as accent fallback since alacritty.toml has no accent key
   accent=$(get_alacritty_color blue)
   color0=$(get_alacritty_color black)
 else

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -101,5 +101,5 @@ magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$cursor" -colorize 100% "$STAGED/bul
 magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGED/progress_bar.png"
 magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "$color0" -colorize 100% "$STAGED/progress_box.png"
 
-# Deploy and rebuild initramfs (detached so it survives if the parent is killed)
-nohup sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED" >/dev/null 2>&1 &
+# Deploy and rebuild initramfs
+sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED"

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Themes the plymouth boot splash and disk encryption screen to match
+# the current omarchy theme. Recolors PNG assets with ImageMagick and
+# substitutes colors in the plymouth script, then rebuilds the initramfs.
+
+THEME_DIR="$HOME/.config/omarchy/current/theme"
+COLORS_FILE="$THEME_DIR/colors.toml"
+PLYMOUTH_SOURCE="$OMARCHY_PATH/default/plymouth"
+
+[[ -f $COLORS_FILE ]] || exit 0
+command -v magick &>/dev/null || exit 0
+
+# Parse a color value from colors.toml, returns hex with # prefix
+get_color() {
+  local val
+  val=$(grep -E "^$1\s*=" "$COLORS_FILE" | head -1 | sed 's/.*=\s*"//;s/".*//')
+  echo "$val"
+}
+
+background=$(get_color background)
+foreground=$(get_color foreground)
+accent=$(get_color accent)
+color0=$(get_color color0)
+
+[[ $background && $foreground && $accent ]] || exit 0
+
+# Convert hex color to plymouth float RGB (e.g., "#1e1e2e" -> "0.117, 0.117, 0.180")
+hex_to_float_rgb() {
+  local hex="${1#\#}"
+  local r=$((16#${hex:0:2}))
+  local g=$((16#${hex:2:2}))
+  local b=$((16#${hex:4:2}))
+  printf "%.3f, %.3f, %.3f" "$(echo "scale=3; $r/255" | bc)" "$(echo "scale=3; $g/255" | bc)" "$(echo "scale=3; $b/255" | bc)"
+}
+
+# Convert hex to 0xRRGGBB format for plymouth config
+hex_to_plymouth() {
+  echo "0x${1#\#}"
+}
+
+bg_float=$(hex_to_float_rgb "$background")
+bg_plymouth=$(hex_to_plymouth "$background")
+
+# Stage themed files in a temp directory
+STAGED=$(mktemp -d)
+
+# Generate themed omarchy.script
+sed \
+  -e "s|Window.SetBackgroundTopColor(.*);|Window.SetBackgroundTopColor($bg_float);|" \
+  -e "s|Window.SetBackgroundBottomColor(.*);|Window.SetBackgroundBottomColor($bg_float);|" \
+  "$PLYMOUTH_SOURCE/omarchy.script" >"$STAGED/omarchy.script"
+
+# Generate themed omarchy.plymouth
+sed \
+  -e "s|ConsoleLogBackgroundColor=.*|ConsoleLogBackgroundColor=$bg_plymouth|" \
+  "$PLYMOUTH_SOURCE/omarchy.plymouth" >"$STAGED/omarchy.plymouth"
+
+# Recolor PNG assets
+magick "$PLYMOUTH_SOURCE/logo.png" -fill "$accent" -colorize 100% "$STAGED/logo.png"
+magick "$PLYMOUTH_SOURCE/lock.png" -fill "$foreground" -colorize 100% "$STAGED/lock.png"
+magick "$PLYMOUTH_SOURCE/entry.png" -fill "$foreground" -colorize 100% "$STAGED/entry.png"
+magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$foreground" -colorize 100% "$STAGED/bullet.png"
+magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGED/progress_bar.png"
+magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "${color0:-$background}" -colorize 100% "$STAGED/progress_box.png"
+
+# Deploy and rebuild initramfs in the background
+sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED" &

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -101,5 +101,5 @@ magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$cursor" -colorize 100% "$STAGED/bul
 magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGED/progress_bar.png"
 magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "$color0" -colorize 100% "$STAGED/progress_box.png"
 
-# Deploy and rebuild initramfs
-sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED"
+# Deploy and rebuild initramfs (detached so it survives if the parent is killed)
+nohup sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED" >/dev/null 2>&1 &

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -97,5 +97,5 @@ magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$foreground" -colorize 100% "$STAGED
 magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGED/progress_bar.png"
 magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "$color0" -colorize 100% "$STAGED/progress_box.png"
 
-# Deploy and rebuild initramfs in the background
-sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED" &
+# Deploy and rebuild initramfs
+sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED"

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -6,37 +6,59 @@
 
 THEME_DIR="$HOME/.config/omarchy/current/theme"
 COLORS_FILE="$THEME_DIR/colors.toml"
+ALACRITTY_FILE="$THEME_DIR/alacritty.toml"
 PLYMOUTH_SOURCE="$OMARCHY_PATH/default/plymouth"
 
-[[ -f $COLORS_FILE ]] || exit 0
 command -v magick &>/dev/null || exit 0
 
-# Parse a color value from colors.toml, returns hex with # prefix
+# Strip leading # from hex color
+strip_hash() { echo "${1#\#}"; }
+
+# Parse a color value from colors.toml
 get_color() {
-  local val
-  val=$(grep -E "^$1\s*=" "$COLORS_FILE" | head -1 | sed 's/.*=\s*"//;s/".*//')
-  echo "$val"
+  grep -E "^$1\s*=" "$COLORS_FILE" | head -1 | sed 's/.*=\s*"//;s/".*//'
 }
 
-background=$(get_color background)
-foreground=$(get_color foreground)
-accent=$(get_color accent)
-color0=$(get_color color0)
+# Parse a color value from alacritty.toml (first occurrence of key)
+get_alacritty_color() {
+  grep -E "^\s*$1\s*=" "$ALACRITTY_FILE" | head -1 | sed 's/.*=\s*"//;s/".*//'
+}
 
-[[ $background && $foreground && $accent ]] || exit 0
+if [[ -f $COLORS_FILE ]]; then
+  background=$(get_color background)
+  foreground=$(get_color foreground)
+  accent=$(get_color accent)
+  color0=$(get_color color0)
+elif [[ -f $ALACRITTY_FILE ]]; then
+  background=$(get_alacritty_color background)
+  foreground=$(get_alacritty_color foreground)
+  # Use blue as accent fallback since alacritty.toml has no accent key
+  accent=$(get_alacritty_color blue)
+  color0=$(get_alacritty_color black)
+else
+  exit 0
+fi
+
+[[ $background && $foreground ]] || exit 0
+: "${accent:=$foreground}"
+: "${color0:=$background}"
 
 # Convert hex color to plymouth float RGB (e.g., "#1e1e2e" -> "0.117, 0.117, 0.180")
 hex_to_float_rgb() {
-  local hex="${1#\#}"
+  local hex
+  hex=$(strip_hash "$1")
   local r=$((16#${hex:0:2}))
   local g=$((16#${hex:2:2}))
   local b=$((16#${hex:4:2}))
-  printf "%.3f, %.3f, %.3f" "$(echo "scale=3; $r/255" | bc)" "$(echo "scale=3; $g/255" | bc)" "$(echo "scale=3; $b/255" | bc)"
+  printf "%d.%03d, %d.%03d, %d.%03d" \
+    $((r * 1000 / 255 / 1000)) $((r * 1000 / 255 % 1000)) \
+    $((g * 1000 / 255 / 1000)) $((g * 1000 / 255 % 1000)) \
+    $((b * 1000 / 255 / 1000)) $((b * 1000 / 255 % 1000))
 }
 
 # Convert hex to 0xRRGGBB format for plymouth config
 hex_to_plymouth() {
-  echo "0x${1#\#}"
+  echo "0x$(strip_hash "$1")"
 }
 
 bg_float=$(hex_to_float_rgb "$background")
@@ -62,7 +84,7 @@ magick "$PLYMOUTH_SOURCE/lock.png" -fill "$foreground" -colorize 100% "$STAGED/l
 magick "$PLYMOUTH_SOURCE/entry.png" -fill "$foreground" -colorize 100% "$STAGED/entry.png"
 magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$foreground" -colorize 100% "$STAGED/bullet.png"
 magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGED/progress_bar.png"
-magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "${color0:-$background}" -colorize 100% "$STAGED/progress_box.png"
+magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "$color0" -colorize 100% "$STAGED/progress_box.png"
 
 # Deploy and rebuild initramfs in the background
 sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED" &

--- a/bin/omarchy-theme-set-plymouth
+++ b/bin/omarchy-theme-set-plymouth
@@ -3,12 +3,17 @@
 # Themes the plymouth boot splash and disk encryption screen to match
 # the current omarchy theme. Recolors PNG assets with ImageMagick and
 # substitutes colors in the plymouth script, then rebuilds the initramfs.
+#
+# Rapid theme switches are handled by staging to a fixed directory and
+# using flock in the root helper. The last theme to finish staging before
+# the rebuild starts is the one that takes effect.
 
 THEME_DIR="$HOME/.config/omarchy/current/theme"
 COLORS_FILE="$THEME_DIR/colors.toml"
 GHOSTTY_FILE="$THEME_DIR/ghostty.conf"
 ALACRITTY_FILE="$THEME_DIR/alacritty.toml"
 PLYMOUTH_SOURCE="$OMARCHY_PATH/default/plymouth"
+STAGED="/tmp/omarchy-plymouth-staged"
 
 command -v magick &>/dev/null || exit 0
 
@@ -79,27 +84,33 @@ hex_to_plymouth() {
 bg_float=$(hex_to_float_rgb "$background")
 bg_plymouth=$(hex_to_plymouth "$background")
 
-# Stage themed files in a temp directory
-STAGED=$(mktemp -d)
+# Stage themed files in a temp dir, then atomically move into the
+# well-known staged path. This avoids racing with the root helper
+# that may be copying from STAGED while we overwrite it.
+STAGING_TMP=$(mktemp -d)
 
 # Generate themed omarchy.script
 sed \
   -e "s|Window.SetBackgroundTopColor(.*);|Window.SetBackgroundTopColor($bg_float);|" \
   -e "s|Window.SetBackgroundBottomColor(.*);|Window.SetBackgroundBottomColor($bg_float);|" \
-  "$PLYMOUTH_SOURCE/omarchy.script" >"$STAGED/omarchy.script"
+  "$PLYMOUTH_SOURCE/omarchy.script" >"$STAGING_TMP/omarchy.script"
 
 # Generate themed omarchy.plymouth
 sed \
   -e "s|ConsoleLogBackgroundColor=.*|ConsoleLogBackgroundColor=$bg_plymouth|" \
-  "$PLYMOUTH_SOURCE/omarchy.plymouth" >"$STAGED/omarchy.plymouth"
+  "$PLYMOUTH_SOURCE/omarchy.plymouth" >"$STAGING_TMP/omarchy.plymouth"
 
 # Recolor PNG assets
-magick "$PLYMOUTH_SOURCE/logo.png" -fill "$color2" -colorize 100% "$STAGED/logo.png"
-magick "$PLYMOUTH_SOURCE/lock.png" -fill "$cursor" -colorize 100% "$STAGED/lock.png"
-magick "$PLYMOUTH_SOURCE/entry.png" -fill "$cursor" -colorize 100% "$STAGED/entry.png"
-magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$cursor" -colorize 100% "$STAGED/bullet.png"
-magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGED/progress_bar.png"
-magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "$color0" -colorize 100% "$STAGED/progress_box.png"
+magick "$PLYMOUTH_SOURCE/logo.png" -fill "$color2" -colorize 100% "$STAGING_TMP/logo.png"
+magick "$PLYMOUTH_SOURCE/lock.png" -fill "$cursor" -colorize 100% "$STAGING_TMP/lock.png"
+magick "$PLYMOUTH_SOURCE/entry.png" -fill "$cursor" -colorize 100% "$STAGING_TMP/entry.png"
+magick "$PLYMOUTH_SOURCE/bullet.png" -fill "$cursor" -colorize 100% "$STAGING_TMP/bullet.png"
+magick "$PLYMOUTH_SOURCE/progress_bar.png" -fill "$foreground" -colorize 100% "$STAGING_TMP/progress_bar.png"
+magick "$PLYMOUTH_SOURCE/progress_box.png" -fill "$color0" -colorize 100% "$STAGING_TMP/progress_box.png"
 
-# Deploy and rebuild initramfs
+# Atomically swap into the well-known staged path
+rm -rf "$STAGED"
+mv "$STAGING_TMP" "$STAGED"
+
+# Deploy and rebuild initramfs (root helper uses flock to serialize)
 sudo /usr/local/bin/omarchy-plymouth-update-theme "$STAGED"

--- a/default/themed/limine.theme.tpl
+++ b/default/themed/limine.theme.tpl
@@ -1,0 +1,7 @@
+term_background={{ background_strip }}
+backdrop={{ background_strip }}
+term_palette={{ color0_strip }};{{ color1_strip }};{{ color2_strip }};{{ color3_strip }};{{ color4_strip }};{{ color5_strip }};{{ color6_strip }};{{ color7_strip }}
+term_palette_bright={{ color8_strip }};{{ color9_strip }};{{ color10_strip }};{{ color11_strip }};{{ color12_strip }};{{ color13_strip }};{{ color14_strip }};{{ color15_strip }}
+term_foreground={{ foreground_strip }}
+term_foreground_bright={{ foreground_strip }}
+term_background_bright={{ color8_strip }}

--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -45,6 +45,14 @@ EOF
   # We overwrite the whole thing knowing the limine-update will add the entries for us
   sudo cp $OMARCHY_PATH/default/limine/limine.conf /boot/limine.conf
 
+  # Install limine theme color helper for passwordless theme updates
+  sudo cp "$OMARCHY_PATH/bin/omarchy-limine-update-colors" /usr/local/bin/omarchy-limine-update-colors
+  sudo chmod 755 /usr/local/bin/omarchy-limine-update-colors
+  sudo chown root:root /usr/local/bin/omarchy-limine-update-colors
+
+  echo "%wheel ALL=(root) NOPASSWD: /usr/local/bin/omarchy-limine-update-colors" | sudo tee /etc/sudoers.d/omarchy-limine >/dev/null
+  sudo chmod 440 /etc/sudoers.d/omarchy-limine
+
   # Match Snapper configs if not installing from the ISO
   if [[ -z ${OMARCHY_CHROOT_INSTALL:-} ]]; then
     if ! sudo snapper list-configs 2>/dev/null | grep -q "root"; then

--- a/migrations/1772121367.sh
+++ b/migrations/1772121367.sh
@@ -1,0 +1,10 @@
+echo "Install limine bootloader theme color support"
+
+if [[ -f /boot/limine.conf ]]; then
+  sudo cp "$OMARCHY_PATH/bin/omarchy-limine-update-colors" /usr/local/bin/omarchy-limine-update-colors
+  sudo chmod 755 /usr/local/bin/omarchy-limine-update-colors
+  sudo chown root:root /usr/local/bin/omarchy-limine-update-colors
+
+  echo "%wheel ALL=(root) NOPASSWD: /usr/local/bin/omarchy-limine-update-colors" | sudo tee /etc/sudoers.d/omarchy-limine >/dev/null
+  sudo chmod 440 /etc/sudoers.d/omarchy-limine
+fi

--- a/migrations/1772121368.sh
+++ b/migrations/1772121368.sh
@@ -6,3 +6,14 @@ sudo chown root:root /usr/local/bin/omarchy-plymouth-update-theme
 
 echo "%wheel ALL=(root) NOPASSWD: /usr/local/bin/omarchy-plymouth-update-theme *" | sudo tee /etc/sudoers.d/omarchy-plymouth >/dev/null
 sudo chmod 440 /etc/sudoers.d/omarchy-plymouth
+
+# Apply current theme to limine and plymouth, preserving the user's wallpaper
+current_bg=$(readlink "$HOME/.config/omarchy/current/background" 2>/dev/null)
+
+omarchy-theme-refresh
+
+if [[ -n $current_bg && -f $current_bg ]]; then
+  ln -nsf "$current_bg" "$HOME/.config/omarchy/current/background"
+  pkill -x swaybg
+  setsid uwsm-app -- swaybg -i "$HOME/.config/omarchy/current/background" -m fill >/dev/null 2>&1 &
+fi

--- a/migrations/1772121368.sh
+++ b/migrations/1772121368.sh
@@ -1,9 +1,5 @@
-if [[ $(plymouth-set-default-theme) != "omarchy" ]]; then
-  sudo cp -r "$HOME/.local/share/omarchy/default/plymouth" /usr/share/plymouth/themes/omarchy/
-  sudo plymouth-set-default-theme omarchy
-fi
+echo "Install plymouth theme color support"
 
-# Install plymouth theme color helper for passwordless theme updates
 sudo cp "$OMARCHY_PATH/bin/omarchy-plymouth-update-theme" /usr/local/bin/omarchy-plymouth-update-theme
 sudo chmod 755 /usr/local/bin/omarchy-plymouth-update-theme
 sudo chown root:root /usr/local/bin/omarchy-plymouth-update-theme


### PR DESCRIPTION
## Summary

Automatically updates the Limine bootloader menu and Plymouth boot splash / disk encryption screen colors to match the active Omarchy desktop theme.

## What it does

- **Limine bootloader:** Updates background, foreground, and wallpaper colors in `/boot/limine.conf` on every theme change. Takes effect immediately on next boot.
- **Plymouth splash & encryption screen:** Recolors all PNG assets (logo, lock, entry, bullet, progress bar/box) with ImageMagick and updates the `.script`/`.plymouth` background colors, then rebuilds the initramfs via `limine-mkinitcpio`.

## Color source fallback

For themes without `colors.toml` (e.g. custom user themes), colors are read with this priority:
1. `colors.toml`
2. `ghostty.conf`
3. `alacritty.toml`

## Security model

Root access for writing to `/boot/limine.conf` and `/usr/share/plymouth/themes/` is handled via dedicated helper scripts installed to `/usr/local/bin/` with corresponding sudoers rules in `/etc/sudoers.d/` (passwordless, scoped to the specific helper).

## Known limitation

The Plymouth initramfs rebuild takes ~20-30s and runs in the background after a theme change. If the user reboots before the rebuild finishes, the encryption/splash screen will still show the previous theme's colors. The next completed theme change will correct it.

## Files

| File | Description |
|------|-------------|
| `bin/omarchy-theme-set-limine` | Orchestrator: reads theme colors, applies to Limine |
| `bin/omarchy-limine-update-colors` | Root helper: seds `/boot/limine.conf` |
| `bin/omarchy-theme-set-plymouth` | Orchestrator: recolors PNGs, seds scripts, stages files |
| `bin/omarchy-plymouth-update-theme` | Root helper: copies staged files, rebuilds initramfs with flock serialization |
| `bin/omarchy-theme-set` | Modified: calls limine + plymouth updaters |
| `default/themed/limine.theme.tpl` | Template mapping colors.toml to Limine format |
| `migrations/1772121367.sh` | Installs Limine helper + sudoers rule |
| `migrations/1772121368.sh` | Installs Plymouth helper + sudoers rule, runs initial theme refresh |
| `install/login/limine-snapper.sh` | Fresh install: Limine helper + sudoers |
| `install/login/plymouth.sh` | Fresh install: Plymouth helper + sudoers |