### PR TITLE
Fix recently broken jq reference to "$p" value in omarchy-launch-or-focus

### DIFF
--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -10,7 +10,7 @@ fi
 
 WINDOW_PATTERN="$1"
 LAUNCH_COMMAND="${2:-"uwsm-app -- $WINDOW_PATTERN"}"
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"


### PR DESCRIPTION
In https://github.com/basecamp/omarchy/commit/7514ae7dcff654ff555862ea95b7033ea740924f that went out with the 3.4.0 release buried in the changes to  _Use consistent bash5 style for conditionals and quoting_ we can see that commit accidentally stripped the `$` from first `$p` reference when testing the class name. This can be easily reproduced:

```
~/code/tmp ❯ omarchy-launch-or-focus code 
jq: error: p/0 is not defined at <top-level>, line 1, column 33:
    .[]|select((.class|test("\\b" + p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address```
```

With this fix, it works:
```
[master] ~/code/devnotes ❯ omarchy-launch-or-focus code
ok
```
