### PR TITLE
Unmute ALSA capture switch in ASUS ROG mic fix

### DIFF
--- a/install/config/hardware/fix-asus-rog-mic.sh
+++ b/install/config/hardware/fix-asus-rog-mic.sh
@@ -7,7 +7,7 @@ if omarchy-hw-asus-rog; then
     if grep -q "ALC285" "$card" 2>/dev/null; then
       cardnum=$(echo "$card" | grep -oP 'card\K\d+')
       amixer -c "$cardnum" set 'Internal Mic Boost' 0 >/dev/null 2>&1 || true
-      amixer -c "$cardnum" set 'Capture' 70% >/dev/null 2>&1 || true
+      amixer -c "$cardnum" set 'Capture' 70% unmute >/dev/null 2>&1 || true
       sudo alsactl store "$cardnum" 2>/dev/null || true
       break
     fi


### PR DESCRIPTION
## Summary
- The `fix-asus-rog-mic.sh` script sets capture volume to 70% but doesn't unmute the ALSA capture switch
- With `api.alsa.soft-mixer = true`, PipeWire no longer manages the hardware mixer, so the Realtek ALC285's default capture-muted state persists
- Adds `unmute` to the `amixer set 'Capture'` command so the hardware capture path is enabled

## Test plan
- [ ] On an ASUS ROG laptop with ALC285, run the script and verify `amixer -c 0 get 'Capture'` shows `[on]`
- [ ] Record audio and confirm the internal mic captures sound

🤖 Generated with [Claude Code](https://claude.com/claude-code)