### PR TITLE
Update bash rc source order

### DIFF
--- a/default/bash/rc
+++ b/default/bash/rc
@@ -1,6 +1,6 @@
+source ~/.local/share/omarchy/default/bash/envs
 source ~/.local/share/omarchy/default/bash/shell
 source ~/.local/share/omarchy/default/bash/aliases
 source ~/.local/share/omarchy/default/bash/functions
 source ~/.local/share/omarchy/default/bash/init
-source ~/.local/share/omarchy/default/bash/envs
 [[ $- == *i* ]] && bind -f ~/.local/share/omarchy/default/bash/inputrc


### PR DESCRIPTION
Follow-up to #4763 and https://github.com/basecamp/omarchy/commit/d0084ff10d95a4dbe498a568d3d3cfc5528459ba

While `envs` now contains the necessary paths for SSH sessions, it was being sourced after `functions` in `rc`. This caused the shell to error out on login because `$OMARCHY_PATH` was still empty when `functions` attempted to expand its glob.

This change moves `envs` to the top of the sourcing order to ensure all variables are exported before they are called by other shell scripts.