### PR TITLE
tmux: attach to session on tmux terminal startup

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -1,6 +1,6 @@
 # Application bindings
 bindd = SUPER, RETURN, Terminal, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)"
-bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" bash -c 'tmux attach || tmux new -s Work'
+bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" bash -c "tmux attach || tmux new -s Work"
 bindd = SUPER SHIFT, F, File manager, exec, uwsm-app -- nautilus --new-window
 bindd = SUPER ALT SHIFT, F, File manager (cwd), exec, uwsm-app -- nautilus --new-window "$(omarchy-cmd-terminal-cwd)"
 bindd = SUPER SHIFT, B, Browser, exec, omarchy-launch-browser

--- a/migrations/1771847961.sh
+++ b/migrations/1771847961.sh
@@ -3,5 +3,5 @@ echo "Add Tmux binding (Super+Alt+Return) to hypr/bindings.conf"
 bindings_file="$HOME/.config/hypr/bindings.conf"
 
 if [[ -f $bindings_file ]] && ! grep -qE '^bindd?\s*=\s*SUPER\s+ALT\s*,\s*RETURN' "$bindings_file"; then
-  sed -i '1a bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" tmux new' "$bindings_file"
+  sed -i '1a bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" bash -c "tmux attach || tmux new -s Work"' "$bindings_file"
 fi


### PR DESCRIPTION
This pull request makes a small but useful update to the terminal keybinding for launching `tmux` session.
Now, when you use the `SUPER+ALT+RETURN` shortcut, it will attempt to attach to an existing `tmux` session, or create a new one called "Work" if none exists. Makes it consistent with `t` alias.