### PR TITLE
Update outdated keybind description for opening the background selection menu

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -10,7 +10,7 @@ bindd = , XF86Calculator, Calculator, exec, gnome-calculator
 
 # Aesthetics
 bindd = SUPER SHIFT, SPACE, Toggle top bar, exec, omarchy-toggle-waybar
-bindd = SUPER CTRL, SPACE, Next background in theme, exec, omarchy-menu background
+bindd = SUPER CTRL, SPACE, Theme background menu, exec, omarchy-menu background
 bindd = SUPER SHIFT CTRL, SPACE, Theme menu, exec, omarchy-menu theme
 bindd = SUPER, BACKSPACE, Toggle window transparency, exec, hyprctl dispatch setprop "address:$(hyprctl activewindow -j | jq -r '.address')" opaque toggle
 bindd = SUPER SHIFT, BACKSPACE, Toggle workspace gaps, exec, omarchy-hyprland-workspace-toggle-gaps


### PR DESCRIPTION
Omarchy 3.4.0 added a new visual background picker, yet the keybind description for this still reflects the previous way to change background. This pull request updates the description to reflect the current method.