### PR TITLE
ADD: Toggle Layout

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -161,7 +161,7 @@ show_share_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n  Window Gaps\n  1-Window Ratio\n󰍹  Display Scaling") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n  Window Gaps\n  1-Window Ratio\n󰍹  Display Scaling\n   Layout") in
 
   *Screensaver*) omarchy-toggle-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
@@ -170,7 +170,25 @@ show_toggle_menu() {
   *Ratio*) omarchy-hyprland-window-single-square-aspect-toggle ;;
   *Gaps*) omarchy-hyprland-window-gaps-toggle ;;
   *Scaling*) omarchy-hyprland-monitor-scaling-toggle ;;
+  *Layout*) show_layout_menu ;;
   *) back_to show_trigger_menu ;;
+  esac
+}
+
+show_layout_menu() {
+  local current
+  current=$(omarchy-toggle-layout --get)
+
+  local options="󰕰  Dwindle\n  Master\n  Monocle\n󱒇   Scrolling"
+  local preselect
+  preselect=$(echo -e "$options" | grep -i "$current")
+
+  case $(menu "Layout" "$options" "" "$preselect") in
+  *Dwindle*) omarchy-toggle-layout --set=dwindle ;;
+  *Master*) omarchy-toggle-layout --set=master ;;
+  *Monocle*) omarchy-toggle-layout --set=monocle ;;
+  *Scrolling*) omarchy-toggle-layout --set=scrolling ;;
+  *) back_to show_toggle_menu ;;
   esac
 }
 

--- a/bin/omarchy-toggle-layout
+++ b/bin/omarchy-toggle-layout
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+LAYOUTS=("scrolling" "master" "monocle" "dwindle")
+
+get_layout() {
+  hyprctl getoption general:layout -j 2>/dev/null |
+    python3 -c "import sys,json; print(json.load(sys.stdin)['str'])" 2>/dev/null
+}
+
+set_layout() {
+  local layout="$1"
+  local valid=false
+  for l in "${LAYOUTS[@]}"; do
+    [[ "$l" == "$layout" ]] && valid=true && break
+  done
+
+  if [[ "$valid" == "false" ]]; then
+    notify-send "Invalid layout: $layout" \
+      "Valid options: ${LAYOUTS[*]}" -u critical -t 3000
+    exit 1
+  fi
+
+  hyprctl keyword general:layout "$layout"
+  notify-send "Layout → ${layout^}" -t 2000
+}
+
+for arg in "$@"; do
+  case "$arg" in
+  --set=*) set_layout "${arg#*=}" ;;
+  --get) get_layout ;;
+  esac
+done


### PR DESCRIPTION
As per February 28, 2026, [hyprland](https://hypr.land/news/update54/) move hyprscrolling into their core. So I add new toggle in [omarchy-menu > trigger > toggle][(https://github.com/dhms013/omarchy/blob/ff5d177f42da9590ce8f4978108dac7813fda994/bin/omarchy-menu#L168](https://github.com/dhms013/omarchy/blob/73ff417e18dcc52299c875146e1d585a01445678/bin/omarchy-menu#L173)) that execute new [omarchy-toggle-layout](https://github.com/dhms013/omarchy/blob/73ff417e18dcc52299c875146e1d585a01445678/bin/omarchy-toggle-layout).

Goals :
- Make user able to switch between dwindle-scrolling via keybinds or menu

here's the preview

https://github.com/user-attachments/assets/e6dd20da-d793-4f8b-9ed0-ea21e513fa43

