### PR TITLE
feat: add tmux-powerkit framework for automatic theme synchronization

### DIFF
--- a/bin/omarchy-refresh-tmux
+++ b/bin/omarchy-refresh-tmux
@@ -3,7 +3,7 @@
 # Overwrite the user tmux config with the Omarchy default and reload tmux.
 
 omarchy-refresh-config tmux/tmux.conf
-
-if pgrep -x tmux; then
+if tmux ls >/dev/null 2>&1; then
   tmux source-file ~/.config/tmux/tmux.conf
+  omarchy-theme-set-tmux
 fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -55,6 +55,7 @@ omarchy-theme-set-browser
 omarchy-theme-set-vscode
 omarchy-theme-set-obsidian
 omarchy-theme-set-keyboard
+omarchy-theme-set-tmux
 
 # Call hook on theme set
 omarchy-hook theme-set "$THEME_NAME"

--- a/bin/omarchy-theme-set-tmux
+++ b/bin/omarchy-theme-set-tmux
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+THEME_FILE="$HOME/.config/omarchy/current/theme/powerkit.theme"
+TMUX_THEME_FILE="$HOME/.config/tmux/powerkit-theme.conf"
+TMUX_CONF="$HOME/.config/tmux/tmux.conf"
+
+[[ -f "$THEME_FILE" ]] || exit 0
+
+IFS='|' read -r base variant <"$THEME_FILE"
+
+cat >"$TMUX_THEME_FILE" <<EOF
+set -g @powerkit_theme "$base"
+set -g @powerkit_theme_variant "$variant"
+EOF
+
+if tmux ls >/dev/null 2>&1; then
+  tmux source-file "$TMUX_CONF"
+fi

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -5,7 +5,7 @@ set -e
 trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR
 
 if [[ $1 == "-y" ]] || omarchy-update-confirm; then
-  omarchy-snapshot create || (( $? == 127 ))
+  omarchy-snapshot create || (($? == 127))
   omarchy-update-git
   omarchy-update-perform
 fi

--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -3,7 +3,7 @@
 set -e
 
 # Ensure screensaver/sleep doesn't set in during updates
-hyprctl dispatch tagwindow +noidle &> /dev/null || true
+hyprctl dispatch tagwindow +noidle &>/dev/null || true
 
 # Capture update logs
 exec > >(tee "/tmp/omarchy-update.log") 2>&1
@@ -13,6 +13,7 @@ omarchy-update-time
 omarchy-update-keyring
 omarchy-update-available-reset
 omarchy-update-system-pkgs
+omarchy-update-powerkit
 omarchy-migrate
 omarchy-update-aur-pkgs
 omarchy-update-orphan-pkgs
@@ -23,4 +24,4 @@ omarchy-update-analyze-logs
 omarchy-update-restart
 
 # Re-enable screensaver/sleep after updates
-hyprctl dispatch tagwindow -- -noidle &> /dev/null || true
+hyprctl dispatch tagwindow -- -noidle &>/dev/null || true

--- a/bin/omarchy-update-powerkit
+++ b/bin/omarchy-update-powerkit
@@ -1,0 +1,9 @@
+#!/bin/env bash
+set -euo pipefail
+
+POWERKIT_DIR="$HOME/.config/tmux/plugins/tmux-powerkit"
+
+if [[ -d "$POWERKIT_DIR/.git" ]]; then
+  echo "Updating tmux-powerkit..."
+  git -C "$POWERKIT_DIR" pull --ff-only
+fi

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -70,15 +70,9 @@ set -g status-left-length 30
 set -g status-right-length 50
 set -g window-status-separator ""
 
-# Theme
-set -g status-style "bg=default,fg=default"
-set -g status-left "#[fg=black,bg=blue,bold] #S #[bg=default] "
-set -g status-right "#[fg=blue]#{?client_prefix,PREFIX ,}#[fg=brightblack]#h "
-set -g window-status-format "#[fg=brightblack] #I:#W "
-set -g window-status-current-format "#[fg=blue,bold] #I:#W "
-set -g pane-border-style "fg=brightblack"
-set -g pane-active-border-style "fg=blue"
-set -g message-style "bg=default,fg=blue"
-set -g message-command-style "bg=default,fg=blue"
-set -g mode-style "bg=blue,fg=black"
-setw -g clock-mode-colour blue
+# Load powerkit (if present)
+if-shell "[ -f ~/.config/tmux/plugins/tmux-powerkit/tmux-powerkit.tmux ]" \
+  "run-shell ~/.config/tmux/plugins/tmux-powerkit/tmux-powerkit.tmux"
+
+# Load powerkit
+run-shell ~/.config/tmux/plugins/tmux-powerkit/tmux-powerkit.tmux

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -43,3 +43,4 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-asus-rog-mic.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/framework16-qmk-hid.sh
+run_logged $OMARCHY_INSTALL/config/powerkit.sh

--- a/install/config/powerkit.sh
+++ b/install/config/powerkit.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Install tmux-powerkit plugin"
+if [[ ! -d "$HOME/.config/tmux/plugins/tmux-powerkit" ]]; then
+  mkdir -p "$HOME/.config/tmux/plugins"
+  git clone --depth 1 \
+    https://github.com/fabioluciano/tmux-powerkit.git \
+    "$HOME/.config/tmux/plugins/tmux-powerkit"
+fi

--- a/migrations/1772250960.sh
+++ b/migrations/1772250960.sh
@@ -1,0 +1,7 @@
+echo "Install tmux-powerkit plugin"
+if [[ ! -d "$HOME/.config/tmux/plugins/tmux-powerkit" ]]; then
+  mkdir -p "$HOME/.config/tmux/plugins"
+  git clone --depth 1 \
+    https://github.com/fabioluciano/tmux-powerkit.git \
+    "$HOME/.config/tmux/plugins/tmux-powerkit"
+fi

--- a/themes/catppuccin-latte/powerkit.theme
+++ b/themes/catppuccin-latte/powerkit.theme
@@ -1,0 +1,1 @@
+catppuccin|latte

--- a/themes/catppuccin/powerkit.theme
+++ b/themes/catppuccin/powerkit.theme
@@ -1,0 +1,1 @@
+catppuccin|mocha

--- a/themes/ethereal/powerkit.theme
+++ b/themes/ethereal/powerkit.theme
@@ -1,0 +1,1 @@
+ethereal|default

--- a/themes/everforest/powerkit.theme
+++ b/themes/everforest/powerkit.theme
@@ -1,0 +1,1 @@
+everforest|dark

--- a/themes/flexoki-light/powerkit.theme
+++ b/themes/flexoki-light/powerkit.theme
@@ -1,0 +1,1 @@
+flexoki|light

--- a/themes/gruvbox/powerkit.theme
+++ b/themes/gruvbox/powerkit.theme
@@ -1,0 +1,1 @@
+gruvbox|dark

--- a/themes/hackerman/powerkit.theme
+++ b/themes/hackerman/powerkit.theme
@@ -1,0 +1,1 @@
+hackerman|default

--- a/themes/kanagawa/powerkit.theme
+++ b/themes/kanagawa/powerkit.theme
@@ -1,0 +1,1 @@
+kanagawa|dragon

--- a/themes/matte-black/powerkit.theme
+++ b/themes/matte-black/powerkit.theme
@@ -1,0 +1,1 @@
+matte-black|default

--- a/themes/miasma/powerkit.theme
+++ b/themes/miasma/powerkit.theme
@@ -1,0 +1,1 @@
+miasma|default

--- a/themes/nord/powerkit.theme
+++ b/themes/nord/powerkit.theme
@@ -1,0 +1,1 @@
+nord|dark

--- a/themes/osaka-jade/powerkit.theme
+++ b/themes/osaka-jade/powerkit.theme
@@ -1,0 +1,1 @@
+osaka-jade|default

--- a/themes/ristretto/powerkit.theme
+++ b/themes/ristretto/powerkit.theme
@@ -1,0 +1,1 @@
+ristretto|default

--- a/themes/rose-pine/powerkit.theme
+++ b/themes/rose-pine/powerkit.theme
@@ -1,0 +1,1 @@
+rose-pine|dawn

--- a/themes/tokyo-night/powerkit.theme
+++ b/themes/tokyo-night/powerkit.theme
@@ -1,0 +1,1 @@
+tokyo-night|night

--- a/themes/vantablack/powerkit.theme
+++ b/themes/vantablack/powerkit.theme
@@ -1,0 +1,1 @@
+vantablack|default

--- a/themes/white/powerkit.theme
+++ b/themes/white/powerkit.theme
@@ -1,0 +1,1 @@
+white|default


### PR DESCRIPTION
## feat: Add tmux-powerkit framework for automatic theme synchronization

### Overview

Integrates [tmux-powerkit](https://github.com/fabioluciano/tmux-powerkit) — a contract-based tmux status bar framework with 43 plugins, 43 themes and 71 variants — to automatically synchronize the tmux theme whenever the user switches Omarchy themes.

Each Omarchy theme ships with a `powerkit.theme` file mapping to its tmux-powerkit equivalent. A new `omarchy-theme-set-tmux` script reads this file on every theme change and writes a dynamic `powerkit-theme.conf` that is loaded by `tmux.conf` — no `sed`, no file rewriting, no manual intervention required.

### Screenshots

#### Tmux-powerkit in action:

<img width="3420" height="2145" alt="image" src="https://github.com/user-attachments/assets/6fc5cb57-5f99-4363-abfe-e9a9d1529665" />

#### Tokyo Night — basic configuration:

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/7f9b8e0a-441f-45a9-8ca2-a33e57563aad" />


### Changes

**`bin/omarchy-theme-set`** — calls `omarchy-theme-set-tmux` alongside the other `omarchy-theme-set-*` scripts

**`bin/omarchy-theme-set-tmux`** *(new)* — reads `powerkit.theme` and writes `powerkit-theme.conf`, then reloads tmux:
```bash
#!/bin/env bash
set -euo pipefail
THEME_FILE="$HOME/.config/omarchy/current/theme/powerkit.theme"
TMUX_THEME_FILE="$HOME/.config/tmux/powerkit-theme.conf"
TMUX_CONF="$HOME/.config/tmux/tmux.conf"
[[ -f "$THEME_FILE" ]] || exit 0
IFS='|' read -r base variant <"$THEME_FILE"
cat >"$TMUX_THEME_FILE" <<EOF
set -g @powerkit_theme "$base"
set -g @powerkit_theme_variant "$variant"
EOF
if tmux ls >/dev/null 2>&1; then
  tmux source-file "$TMUX_CONF"
fi
```

**`bin/omarchy-refresh-tmux`** — restores default config, reapplies current theme, and reloads tmux:
```bash
#!/bin/bash
omarchy-refresh-config tmux/tmux.conf
if tmux ls >/dev/null 2>&1; then
  tmux source-file ~/.config/tmux/tmux.conf
  omarchy-theme-set-tmux
fi
```

**`bin/omarchy-update-powerkit`** *(new)* — updates tmux-powerkit during `omarchy-update`:
```bash
#!/bin/env bash
set -euo pipefail
POWERKIT_DIR="$HOME/.config/tmux/plugins/tmux-powerkit"
if [[ -d "$POWERKIT_DIR/.git" ]]; then
  echo "Updating tmux-powerkit..."
  git -C "$POWERKIT_DIR" pull --ff-only
fi
```

**`bin/omarchy-update-perform`** — adds `omarchy-update-powerkit` to the update flow

**`install/config/powerkit.sh`** *(new)* — installs tmux-powerkit via `git clone --depth 1`:
```bash
#!/bin/env bash
if [[ ! -d "$HOME/.config/tmux/plugins/tmux-powerkit" ]]; then
  git clone --depth 1 \
    https://github.com/fabioluciano/tmux-powerkit.git \
    "$HOME/.config/tmux/plugins/tmux-powerkit"
fi
```

**`install/config/all.sh`** — adds `run_logged $OMARCHY_INSTALL/config/powerkit.sh`

**`config/tmux/tmux.conf`** — replaces the hardcoded `# Theme` block with dynamic theme loading:
```bash
# Load powerkit theme (if present)
if-shell "[ -f ~/.config/tmux/powerkit-theme.conf ]" \
  "source-file ~/.config/tmux/powerkit-theme.conf"

# Load powerkit plugin
run-shell ~/.config/tmux/plugins/tmux-powerkit/tmux-powerkit.tmux
```

**`themes/*/powerkit.theme`** — added for all 17 Omarchy themes

### [TPM](https://github.com/tmux-plugins/tpm) Compatibility

Users who already manage tmux plugins via [TPM](https://github.com/tmux-plugins/tpm) are fully supported. The installation script checks if `~/.config/tmux/plugins/tmux-powerkit` already exists before cloning — so TPM users who already have PowerKit installed won't have any conflict. The `powerkit-theme.conf` only sets `@powerkit_theme` and `@powerkit_theme_variant`, which work regardless of how the plugin was installed.

### Default Configuration

Out of the box, tmux ships with a minimal, sensible setup. Users can extend it in their `~/.config/tmux/tmux.conf`:

**Grouped plugins with shared background colors:**
```bash
set -g @powerkit_plugins "group(cpu,memory),datetime,battery,hostname"
```

**Centered windows layout:**
```bash
set -g @powerkit_status_order "session,windows,plugins"
```

**Separator styles** (`normal`, `rounded`, `flame`, `pixel`, `honeycomb`, `none`):
```bash
set -g @powerkit_separator_style "rounded"
set -g @powerkit_edge_separator_style "rounded:all"
```

**Show plugins only when above threshold:**
```bash
set -g @powerkit_plugin_cpu_show_only_on_threshold "true"
set -g @powerkit_plugin_memory_show_only_on_threshold "true"
set -g @powerkit_plugin_battery_show_only_on_threshold "true"
```

**Transparent background:**
```bash
set -g @powerkit_transparent "true"
```

Full documentation at [tmux-powerkit wiki](https://github.com/fabioluciano/tmux-powerkit/wiki)

### Theme Coverage

All 17 Omarchy themes have a native tmux-powerkit equivalent. The three themes that were missing (`white`, `vantablack`, `miasma`) were contributed upstream in [fabioluciano/tmux-powerkit#200](https://github.com/fabioluciano/tmux-powerkit/pull/200). When new Omarchy themes are added in the future, the same pattern applies: a `powerkit.theme` file in the theme folder plus a PR upstream.

### Design Decisions

- **No TPM required** — installed via `git clone --depth 1`, consistent with how Omarchy manages other tools. TPM users are fully compatible
- **`tmux.conf` is never modified on theme change** — the theme is written to a separate `powerkit-theme.conf` and loaded dynamically via `if-shell`
- **Non-invasive** — users with their own tmux config are not affected; `omarchy-theme-set-tmux` exits silently if `powerkit.theme` doesn't exist
- **Follows Omarchy patterns** — `omarchy-theme-set-tmux` and `omarchy-update-powerkit` follow the exact same structure as the other `omarchy-theme-set-*` and `omarchy-update-*` scripts
- **Auto-updates** — `omarchy-update-powerkit` is called during `omarchy-update`, keeping tmux-powerkit up to date automatically
- **Extensible** — new Omarchy themes only need a `powerkit.theme` file, with a corresponding PR to tmux-powerkit for native support