### PR TITLE
Forward WAYLAND_DISPLAY environment variable so clipboard works inside tmux

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -68,7 +68,7 @@ set -g set-clipboard on
 set -g allow-passthrough on
 setw -g aggressive-resize on
 set -g detach-on-destroy off
-set -ag update-environment "WAYLAND_DISPLAY XDG_SESSION_TYPE DBUS_SESSION_BUS_ADDRESS"
+set -ag update-environment "WAYLAND_DISPLAY"
 
 # Status bar
 set -g status-position top

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -68,7 +68,7 @@ set -g set-clipboard on
 set -g allow-passthrough on
 setw -g aggressive-resize on
 set -g detach-on-destroy off
-set -ag update-environment "WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE DBUS_SESSION_BUS_ADDRESS"
+set -ag update-environment "WAYLAND_DISPLAY XDG_SESSION_TYPE DBUS_SESSION_BUS_ADDRESS"
 
 # Status bar
 set -g status-position top

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -68,6 +68,7 @@ set -g set-clipboard on
 set -g allow-passthrough on
 setw -g aggressive-resize on
 set -g detach-on-destroy off
+set -ag update-environment "WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE DBUS_SESSION_BUS_ADDRESS"
 
 # Status bar
 set -g status-position top


### PR DESCRIPTION
## Problem

tmux's default `update-environment` list doesn't include `WAYLAND_DISPLAY` causing `wl-copy` and `wl-paste` to fail.

Check defaults with: 
```bash 
tmux -Lclean -f /dev/null new-session -d \; show-options -g update-environment \; kill-server
```

## Fix

```tmux
set -ag update-environment "WAYLAND_DISPLAY"
```

See [tmux(1)](https://man.archlinux.org/man/tmux.1#update-environment__)

---

NB: `XDG_SESSION_TYPE` might be useful for other applications.

---

Sorry for the small commit spam!— First time contributor and First time doing this from CLI with Claude.

Let me know if you want me to open a separate clean PR.