### PR TITLE
Screensaver slide animation instead of popin

### DIFF
--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -13,3 +13,6 @@ source = ~/.local/share/omarchy/default/hypr/apps.conf
 
 # Apply default opacity after apps have had a chance to opt out
 windowrule = opacity 0.97 0.9, match:tag default-opacity
+
+# Sliding animation for the screensaver instead of popin
+windowrule = animation slide, match:class org.omarchy.screensaver


### PR DESCRIPTION
When `omarchy-cmd-screensaver` finishes or is interrupted, hyprlands slide animation looks more polished - in my opinion - than the popin animation.