### PR TITLE
Adds theme colors in the Hyprland context

### DIFF
--- a/default/themed/hyprland.conf.tpl
+++ b/default/themed/hyprland.conf.tpl
@@ -22,7 +22,7 @@ $color13 = rgb({{ color13_strip }})
 $color14 = rgb({{ color14_strip }})
 $color15 = rgb({{ color15_strip }})
 
-$activeBorderColor = rgb({{ accent_strip }})
+$activeBorderColor = $accent
 
 general {
     col.active_border = $activeBorderColor


### PR DESCRIPTION
This pull request enhances the `hyprland.conf.tpl` configuration template by introducing theme color variables, improving the consistency and manageability of color values across all sourced Hyprland configuration files.

**Key changes include:**

- Added theme variables for accent, cursor, foreground, background, selection foreground/background, and colors 0–15, utilizing RGB values derived from template placeholders.
- These variables are now globally accessible across all sourced Hyprland configuration files, enabling a unified and streamlined approach to theming.

As noted in the linked discussion, exposing color scheme variables directly within `hyprland.conf` provides users with greater flexibility when customizing visual elements such as borders and other UI components.

[discussion](https://github.com/basecamp/omarchy/discussions/4636)