### PR TITLE
Fix changegroupactive offset for Hyprland 0.54

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -118,11 +118,11 @@ bindd = SUPER ALT, mouse_down, Next window in group, changegroupactive, f
 bindd = SUPER ALT, mouse_up, Previous window in group, changegroupactive, b
 
 # Activate window in a group by number
-bindd = SUPER ALT, code:10, Switch to group window 1, changegroupactive, 1
-bindd = SUPER ALT, code:11, Switch to group window 2, changegroupactive, 2
-bindd = SUPER ALT, code:12, Switch to group window 3, changegroupactive, 3
-bindd = SUPER ALT, code:13, Switch to group window 4, changegroupactive, 4
-bindd = SUPER ALT, code:14, Switch to group window 5, changegroupactive, 5
+bindd = SUPER ALT, code:10, Switch to group window 1, changegroupactive, 0
+bindd = SUPER ALT, code:11, Switch to group window 2, changegroupactive, 1
+bindd = SUPER ALT, code:12, Switch to group window 3, changegroupactive, 2
+bindd = SUPER ALT, code:13, Switch to group window 4, changegroupactive, 3
+bindd = SUPER ALT, code:14, Switch to group window 5, changegroupactive, 4
 
 # Cycle monitor scaling
 bindd = SUPER, Slash, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle


### PR DESCRIPTION
Hyprland 0.54 apparently starts counting grouped windows from 0, which caused SUPER + ALT + 1 to highlight the second instead of the first tab.