### PR TITLE
Fix nvim transparency to preserve foreground colors

### DIFF
--- a/migrations/1772389838.sh
+++ b/migrations/1772389838.sh
@@ -10,8 +10,6 @@ local function make_transparent(name)
 	if ok then
 		hl.bg = nil
 		vim.api.nvim_set_hl(0, name, hl)
-	else
-		vim.api.nvim_set_hl(0, name, { bg = "none" })
 	end
 end
 


### PR DESCRIPTION
## Summary

- The old `transparency.lua` used `vim.api.nvim_set_hl(0, name, { bg = "none" })` which **replaces the entire highlight definition**, wiping out foreground and other attributes — not just the background
- This breaks snacks.nvim's GitHub integration (`<leader>gp` for PRs, `<leader>gi` for issues) which reads the foreground color from `Normal`/`NormalFloat` at module load time, gets `nil`, and crashes with `"Finder not found: gh_pr"`
- The fix uses `nvim_get_hl` to fetch existing attributes first, removes only `bg`, then sets the highlight back — preserving all other attributes

Companion PR for fresh installs (source file): https://github.com/omacom-io/omarchy-pkgs/pull/51

## Root cause

```
snacks/util/init.lua:187: attempt to index local 'fg' (a nil value)
```

The `snacks.gh` module computes diff highlight colors at require-time by calling `Snacks.util.color("Normal")` to get the foreground. Since the transparency script cleared it, `fg` is nil and `Snacks.util.blend(nil, bg, alpha)` crashes. The pcall in the picker's finder resolution catches this, and the picker reports "Finder not found".

## Test plan

- [ ] Open nvim in a git repo and press `<leader>gp` — should open the GitHub PR picker without errors
- [ ] Verify transparent backgrounds still work correctly
- [ ] Verify foreground colors are preserved (text should look the same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)