### PR TITLE
Fix White theme VS Code name mismatch

### DIFF
--- a/themes/white/vscode.json
+++ b/themes/white/vscode.json
@@ -1,4 +1,4 @@
 {
-  "name": "White Omarchy",
+  "name": "White",
   "extension": "Bjarne.white-theme"
 }


### PR DESCRIPTION
The White theme vscode.json has `"name": "White Omarchy"`, but the actual color theme label in the Bjarne.white-theme extension is just `"White"`.

Because of this, `omarchy-theme-set-vscode` writes `"White Omarchy"` into `workbench.colorTheme`, which doesn't match anything, and the theme never gets applied.

This changes the name to `"White"` to match the extension.

Separate issue: the Bjarne.white-theme extension is not published on [Open VSX](https://open-vsx.org/), so `codium --install-extension` can't find it. VSCodium uses Open VSX instead of the Microsoft marketplace. This affects the other Bjarne extensions too (ethereal-omarchy, hackerman-omarchy, vantablack-omarchy). They only work for users who had them installed before or manually.