### PR TITLE
fix snapshot delete on failed update

### DIFF
--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -6,7 +6,7 @@ COMMAND="$1"
 OMARCHY_PATH=${OMARCHY_PATH:-$HOME/.local/share/omarchy}
 
 if [[ -z $COMMAND ]]; then
-  echo "Usage: omarchy-snapshot <create|restore>" >&2
+  echo "Usage: omarchy-snapshot <create|restore|delete>" >&2
   exit 1
 fi
 
@@ -26,9 +26,12 @@ create)
   for config in "${CONFIGS[@]}"; do
     sudo snapper -c "$config" create -c number -d "$DESC"
   done
+
   echo
   ;;
 restore)
   sudo limine-snapper-restore
   ;;
+delete)
+  sudo snapper delete $(echo $(sudo snapper list | tail -n 1) | awk '{print substr($0,0,2)}') # gets the number of the most recent snapshot and deletes it
 esac

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -2,7 +2,7 @@
 
 set -e
 
-trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR
+trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"; omarchy-snapshot delete' ERR
 
 if [[ $1 == "-y" ]] || omarchy-update-confirm; then
   omarchy-snapshot create || (( $? == 127 ))


### PR DESCRIPTION
My bad on the last pr (https://github.com/basecamp/omarchy/pull/4531), i wrongfully assumed that the latest snapshot was the first one which doesn't make a lot of sense in hindsight, this time it should actually work, it uses tail and awk to get the latest generation id from `snapper list` and then remove it, i tested it locally ( probably should've done that before) and it does work as intended for me. Also, this is a bit less important but my handle is @Mrid22 not my display name, ty! btw thanks @ryanrhughes for catching this 