### PR TITLE
Update icons.theme to use Yaru-dark instead of Yaru-gray

### DIFF
--- a/themes/vantablack/icons.theme
+++ b/themes/vantablack/icons.theme
@@ -1,1 +1,1 @@
-Yaru-gray
+Yaru-dark


### PR DESCRIPTION
Since "Yaru-gray" does not exist in the default Yaru package, the theme unintentionally falls back to Adwaita. This fixes the issue by switching to "Yaru-dark", the closest available replacement for the theme's