### PR TITLE
Fix try interactive selector appearing on bashrc re-source

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -11,7 +11,7 @@ if command -v zoxide &> /dev/null; then
 fi
 
 if command -v try &> /dev/null; then
-  eval "$(SHELL=/bin/bash try init ~/Work/tries)"
+  eval "$(SHELL=/bin/bash command try init ~/Work/tries)"
 fi
 
 if command -v fzf &> /dev/null; then


### PR DESCRIPTION
## Summary

- `try init` defines a shell function named `try`. On subsequent `source ~/.bashrc`, the shell function shadows the binary, so `try init` launches the interactive selector instead of outputting the function definition. Adding `command` bypasses the function and always invokes the binary.

## Details

The one-word change (`command try` instead of `try`) is a standard bash pattern — `command` skips shell functions/aliases and runs the external binary directly. This is the same reason `command -v` is used in the guard condition above it.

The other `eval "$(... init ...)"` lines in this file (mise, starship, zoxide) don't have this problem because they don't define a shell function with the same name as the binary.

## Test plan

- [ ] Open a fresh terminal — verify `try` works normally
- [ ] Run `source ~/.bashrc` — verify no interactive selector popup
- [ ] Run `try` — verify interactive selector still works as expected

Fixes #4876
Also reported by umaru-sama on Discord (2026-03-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)