### PR TITLE
Add window picker and bind it to Super + Ctrl + Alt + Space

### DIFF
--- a/bin/omarchy-cmd-window-picker
+++ b/bin/omarchy-cmd-window-picker
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Window picker: lists open Hyprland windows and focuses the selected one.
+# Displayed as "class [workspace]: title (address)", sorted by class, workspace, title, address.
+
+SELECTED=$(hyprctl clients -j | jq -r 'sort_by(.class, .workspace.name, .title, .address)[] | "\(.class) [\(.workspace.name)]: \(.title) (\(.address))"' | 
+  walker -d -p "󰀻 Window…")
+
+if [[ -n "$SELECTED" ]]; then
+  WINDOW_ADDRESS=$(echo "$SELECTED" | grep -o '(0x[a-f0-9]*)$' | tr -d '()')
+  hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"
+fi

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -4,6 +4,7 @@ bindd = SUPER CTRL, E, Emoji picker, exec, omarchy-launch-walker -m symbols
 bindd = SUPER CTRL, C, Capture menu, exec, omarchy-menu capture
 bindd = SUPER CTRL, O, Toggle menu, exec, omarchy-menu toggle
 bindd = SUPER ALT, SPACE, Omarchy menu, exec, omarchy-menu
+bindd = SUPER CTRL ALT, SPACE, Window picker, exec, omarchy-cmd-window-picker
 bindd = SUPER, ESCAPE, System menu, exec, omarchy-menu system
 bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system
 bindd = SUPER, K, Show key bindings, exec, omarchy-menu-keybindings


### PR DESCRIPTION
Adds `omarchy-cmd-window-picker` to quickly re-focus attention to an existing window.
Windows as listed as `class [workspace]: title (address)` and sorted accordingly.
<img width="3000" height="2000" alt="image" src="https://github.com/user-attachments/assets/c74b59a4-f677-4ad2-ba92-0e4095b332e7" />


Note, that the somewhat verbose address suffix is there to enable walker to disambiguate windows with identical classes and titles on identical workspaces.
