### PR TITLE
Fix omarchy-windows-vm username/password handling for dollar signs

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -148,6 +148,10 @@ EOF
     PASSWORD_DISPLAY="(user-defined)"
   fi
 
+  # Escape dollar signs for docker-compose interpolation.
+  COMPOSE_USERNAME=${USERNAME//$/\$\$}
+  COMPOSE_PASSWORD=${PASSWORD//$/\$\$}
+
   # Display configuration summary
   gum style \
     --border normal \
@@ -183,8 +187,8 @@ services:
       RAM_SIZE: "$SELECTED_RAM"
       CPU_CORES: "$SELECTED_CORES"
       DISK_SIZE: "$SELECTED_DISK"
-      USERNAME: "$USERNAME"
-      PASSWORD: "$PASSWORD"
+      USERNAME: "$COMPOSE_USERNAME"
+      PASSWORD: "$COMPOSE_PASSWORD"
       TZ: "$(timedatectl show -p Timezone --value 2>/dev/null || echo UTC)"
       ARGUMENTS: "-rtc base=localtime,clock=host,driftfix=slew"
     devices:
@@ -276,6 +280,10 @@ launch_windows() {
   # Extract credentials from compose file
   WIN_USER=$(grep "USERNAME:" "$COMPOSE_FILE" | sed 's/.*USERNAME: "\(.*\)"/\1/')
   WIN_PASS=$(grep "PASSWORD:" "$COMPOSE_FILE" | sed 's/.*PASSWORD: "\(.*\)"/\1/')
+
+  # Unescape docker-compose dollar-sign escaping.
+  WIN_USER=${WIN_USER//\$\$/\$}
+  WIN_PASS=${WIN_PASS//\$\$/\$}
 
   # Use defaults if not found
   [[ -z $WIN_USER ]] && WIN_USER="docker"


### PR DESCRIPTION
### The Issue
omarchy-windows-vm doesn't escape $ symbols in passwords so it thinks they are variables. It sets a chopped up version of the password in the Windows VM but uses the full password you passed in the docker compose file. 

I noticed these messages during the omarchy-windows-vm install process, which tipped me off.

```
Starting Windows VM with docker-compose...
WARN[0000] The "t3rD" variable is not set. Defaulting to a blank string.
WARN[0000] The "R" variable is not set. Defaulting to a blank string.
```

So the manual fix was:
1. `omarchy-windows-vm remove`
2. `omarchy-windows-vm install`
3. Use a password without dollar signs.

### The Fix
 Fixed omarchy-windows-vm to properly handle $ in usernames/passwords by escaping dollar signs before writing docker-compose.yml, so Docker Compose doesn’t treat them as variable interpolation. Then on launch, it unescapes when reading credentials back for RDP login. This keeps the Windows account password and the stored compose config consistent.