### PR TITLE
Fix copy-url extension clipboard on recent Chromium/Brave

### DIFF
--- a/default/chromium/extensions/copy-url/background.js
+++ b/default/chromium/extensions/copy-url/background.js
@@ -1,21 +1,45 @@
-chrome.commands.onCommand.addListener((command) => {
-  if (command === 'copy-url') {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const currentTab = tabs[0];
+chrome.commands.onCommand.addListener(async (command) => {
+  if (command !== 'copy-url') return;
 
-      chrome.scripting.executeScript({
-        target: { tabId: currentTab.id },
-        func: () => {
-          navigator.clipboard.writeText(window.location.href);
-        }
-      }).then(() => {
-        chrome.notifications.create({
-          type: 'basic',
-          iconUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
-          title: '   URL copied to clipboard',
-          message: ''
-        });
-      });
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab) return;
+
+    // Copy via offscreen document — works on all pages including
+    // restricted ones (chrome://, brave://) and doesn't require
+    // user activation in the page context.
+    const contexts = await chrome.runtime.getContexts({
+      contextTypes: ['OFFSCREEN_DOCUMENT']
     });
+    if (!contexts.length) {
+      await chrome.offscreen.createDocument({
+        url: 'offscreen.html',
+        reasons: ['CLIPBOARD'],
+        justification: 'Copy URL to clipboard'
+      });
+    }
+
+    const result = await chrome.runtime.sendMessage({ target: 'offscreen', text: tab.url });
+
+    if (result?.success) {
+      chrome.notifications.create({
+        type: 'basic',
+        iconUrl: 'icon.png',
+        title: 'URL copied to clipboard',
+        message: tab.url
+      });
+    } else {
+      chrome.notifications.create({
+        type: 'basic',
+        iconUrl: 'icon.png',
+        title: 'Failed to copy URL',
+        message: 'Clipboard write failed'
+      });
+    }
+
+    // Close the offscreen document — no need to keep it alive
+    chrome.offscreen.closeDocument().catch(() => {});
+  } catch (e) {
+    console.error('copy-url:', e);
   }
 });

--- a/default/chromium/extensions/copy-url/manifest.json
+++ b/default/chromium/extensions/copy-url/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Copy URL",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Copy current URL to clipboard, this extension is installed by Omarchy",
-  "permissions": ["activeTab", "scripting", "notifications"],
+  "permissions": ["activeTab", "notifications", "clipboardWrite", "offscreen"],
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/default/chromium/extensions/copy-url/offscreen.html
+++ b/default/chromium/extensions/copy-url/offscreen.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="offscreen.js"></script>

--- a/default/chromium/extensions/copy-url/offscreen.js
+++ b/default/chromium/extensions/copy-url/offscreen.js
@@ -1,0 +1,16 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.target !== 'offscreen' || !msg.text) return;
+  const ta = document.createElement('textarea');
+  ta.value = msg.text;
+  document.body.appendChild(ta);
+  ta.select();
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch (e) {
+    success = false;
+  }
+  ta.remove();
+  sendResponse({ success });
+  return true;
+});


### PR DESCRIPTION
## Problem

The copy-url extension stopped working on recent Chromium and Brave versions. The extension uses `navigator.clipboard.writeText()` injected into the active page via `scripting.executeScript()`, but recent browser updates tightened the Clipboard API's user activation requirement — an extension keyboard shortcut no longer counts as a user gesture in the page context, so the write silently fails.

Additionally, the old approach fails entirely on restricted pages (`chrome://`, `brave://`, extension pages, Web Store).

## Fix

Switch to an offscreen document approach:

1. Read `tab.url` from the tabs API (no page injection needed)
2. Create a hidden offscreen document with the `CLIPBOARD` reason
3. Use `document.execCommand('copy')` in the offscreen context, backed by the `clipboardWrite` permission
4. Report success/failure back via `sendResponse` — only show "copied" notification on success
5. Close the offscreen document after use to avoid keeping an extra context alive
6. Drop the unused `scripting` permission (no longer injecting into pages)

This works on all pages regardless of their clipboard permissions or activation state.

## Changes

- `manifest.json`: Replace `scripting` with `clipboardWrite` and `offscreen` permissions, bump version to 1.1
- `background.js`: Replace `executeScript` + `navigator.clipboard` with offscreen document message passing; only notify on confirmed success; close offscreen document after copy
- `offscreen.html` / `offscreen.js`: New files — minimal offscreen document that handles clipboard writes and reports success/failure

## Testing

Tested on Brave 1.76 (Chromium 134) on Linux (Hyprland/Wayland). Confirmed working on:
- Regular web pages
- PWAs
- Pages that previously triggered clipboard permission prompts