### PR TITLE
Update jetbrains.conf to capture find windows with singular space title

### DIFF
--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -14,7 +14,7 @@ windowrule {
 windowrule {
     name = jetbrains-popup
     match:class = ^(jetbrains-.*)
-    match:title = ^()$
+    match:title = ^(| )$
     match:float = 1
     tag = +jetbrains
     center = on


### PR DESCRIPTION
Some find windows like "find everywhere" has initial title that consists of a singular space. Update title matching expression to capture that case as well.