### PR TITLE
Add Alt+-/= pane resize bindings to tmux

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -26,6 +26,11 @@ bind -n C-M-S-Down resize-pane -D 5
 bind -n C-M-S-Up resize-pane -U 5
 bind -n C-M-S-Right resize-pane -R 5
 
+bind -n M-- resize-pane -L 5
+bind -n M-= resize-pane -R 5
+bind -n M-_ resize-pane -U 5
+bind -n M-+ resize-pane -D 5
+
 # Window navigation
 bind r command-prompt -I "#W" "rename-window -- '%%'"
 bind c new-window -c "#{pane_current_path}"

--- a/migrations/1772307908.sh
+++ b/migrations/1772307908.sh
@@ -1,0 +1,17 @@
+echo "Add Alt+-/= keybindings for tmux pane resizing"
+
+TMUX_CONF=~/.config/tmux/tmux.conf
+
+if [[ -f $TMUX_CONF ]]; then
+  # Add M--/M-=/M-_/M-+ after C-M-S-Right resize-pane if not present
+  if ! grep -q "bind -n M-- resize-pane" "$TMUX_CONF"; then
+    sed -i '/bind -n C-M-S-Right resize-pane -R 5/a\
+\
+bind -n M-- resize-pane -L 5\
+bind -n M-= resize-pane -R 5\
+bind -n M-_ resize-pane -U 5\
+bind -n M-+ resize-pane -D 5' "$TMUX_CONF"
+  fi
+
+  omarchy-restart-tmux
+fi


### PR DESCRIPTION
# Summary

Tmux pane resize keybindings that mirror Hyprland's window resize convention:

- `Alt + -` / `Alt + =` for horizontal resize (left/right)
- `Alt + Shift + -` / `Alt + Shift + =` for vertical resize (up/down)

