### PR TITLE
Add battery identifier to Waybar config

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -80,6 +80,7 @@
     "on-click": "omarchy-launch-wifi"
   },
   "battery": {
+    "bat": "BAT0",
     "format": "{capacity}% {icon}",
     "format-discharging": "{icon}",
     "format-charging": "{icon}",


### PR DESCRIPTION
Just a quick fix for the default waybar profile in omarchy, this wouldn't be a problem is building your own config but hey, Waybar crashes with a `std::runtime_error (core dumped)` when a Logitec  G Pro dongle is unplugged. This happens because Waybar attempts to watch the `hidpp_battery udev` events, which disappear instantly upon removal.

```
Discharging
Discharging
Discharging
Discharging
Discharging
Discharging
Discharging
terminate called after throwing an instance of 'std::runtime_error'
what():  Could not watch events for /sys/class/power_supply/hidpp_battery_6
Aborted  (core dumped) waybar -l trace 
```

Set `"bat": "BAT0"` in the battery module of waybar. This ensures it only tracks the primary system battery and ignores HID power supplies.