### PR TITLE
Install intel-media-driver for Arc 130T/140T (intel 255H)

### DIFF
--- a/install/config/hardware/intel.sh
+++ b/install/config/hardware/intel.sh
@@ -1,7 +1,7 @@
 # This installs hardware video acceleration for Intel GPUs
 # Check if we have an Intel GPU at all
 if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel'); then
-  # HD Graphics and newer uses intel-media-driver
+  # HD Graphics / Iris / Xe / Arc use intel-media-driver
   if [[ ${INTEL_GPU,,} =~ "hd graphics"|"xe"|"iris"|"arc" ]]; then
     omarchy-pkg-add intel-media-driver
   elif [[ ${INTEL_GPU,,} =~ "gma" ]]; then


### PR DESCRIPTION
For Slimbook Executive with Intel Ultra 7 255H processor the `intel-media-driver` package was not installed by default with omarchy 3.4.1 (latest stable version).

This caused some problems with the graphics, especially when it was unplugged from the charger.
The browser refresh rate was slow, and the mouse lagged as if it were 10 FPS.
Installing the package fixed all the problems.

My `INTEL_GPU` string is:
```
00:02.0 VGA compatible controller: Intel Corporation Arrow Lake-P [Arc Pro 130T/140T] (rev 03)
```

More details about the graphic card:
```
❯ lspci -nnk | grep -iE 'vga|3d|display' -A 3
00:02.0 VGA compatible controller [0300]: Intel Corporation Arrow Lake-P [Arc Pro 130T/140T] [8086:7d51] (rev 03)
        Subsystem: AIstone Global Limited Device [1d05:5001]
        Kernel driver in use: i915
        Kernel modules: i915, xe
```

---

Can it be a reason for the issues for panther lake graphics?