### PR TITLE
fix: small localsend window

### DIFF
--- a/default/hypr/apps/localsend.conf
+++ b/default/hypr/apps/localsend.conf
@@ -1,4 +1,4 @@
 # Float LocalSend and fzf file picker
 windowrule = float on, match:class (Share|localsend)
 windowrule = center on, match:class (Share|localsend)
-windowrule = size 1100 700, match:class (Share|localsend)
+windowrule = size 1100 700, match:class localsend


### PR DESCRIPTION
currently the localsend window size is too small and everytime i have to press `super + t` to tile it

## before
<img width="2160" height="1440" alt="image" src="https://github.com/user-attachments/assets/82ab245d-f2da-4047-b353-408945a2eef6" />

## after
<img width="2160" height="1440" alt="image" src="https://github.com/user-attachments/assets/54e6abec-22e1-4451-aa50-5938f3fb6637" />

this could be the fact that im using a 14inch laptop but im sure the bigger display users wont wind as well :)