### PR TITLE
Only match window class in omarchy-launch-or-focus

### DIFF
--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -10,7 +10,7 @@ fi
 
 WINDOW_PATTERN="$1"
 LAUNCH_COMMAND="${2:-"uwsm-app -- $WINDOW_PATTERN"}"
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select(.class|test("\\b" + $p + "\\b";"i"))|.address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"


### PR DESCRIPTION
If you have a browser tab titled something like `Neovide configuration tips` or `Spotify Wrapped`, `omarchy-launch-or-focus` can focus the browser instead of the actual app.

This drops the title fallback and only matches on `.class`.

Fixes #4927.
Fixes #3669.
