### PR TITLE
Add desktop app install and remove scripts

### DIFF
--- a/bin/omarchy-desktop-app-install
+++ b/bin/omarchy-desktop-app-install
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+
+ICON_DIR="$HOME/.local/share/applications/icons"
+
+if (( $# < 3 )); then
+  echo -e "\e[32mLet's create a new desktop app you can start with the app launcher.\n\e[0m"
+  APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite app")
+  APP_EXEC=$(gum input --prompt "Executable> " --placeholder "/usr/bin/my-app")
+  ICON_REF=$(gum input --prompt "Icon> " --placeholder "PNG icon URL or local path (see https://dashboardicons.com)")
+  TERMINAL=$(gum choose --header "Run in terminal?" "false" "true")
+  MIME_TYPES=""
+  INTERACTIVE_MODE=true
+else
+  APP_NAME="$1"
+  APP_EXEC="$2"
+  ICON_REF="$3"
+  TERMINAL="${4:-false}" # Optional: "true" or "false"
+  MIME_TYPES="$5" # Optional mime types
+  INTERACTIVE_MODE=false
+fi
+
+# Ensure valid execution
+if [[ -z $APP_NAME || -z $APP_EXEC ]]; then
+  echo "You must set app name and executable!"
+  exit 1
+fi
+
+# Resolve icon from URL or from a local path/icon name.
+mkdir -p "$ICON_DIR"
+
+if [[ $ICON_REF =~ ^https?:// ]]; then
+  ICON_PATH="$ICON_DIR/$APP_NAME.png"
+  if ! curl -fsSL -o "$ICON_PATH" "$ICON_REF" || [[ ! -s $ICON_PATH ]]; then
+    echo "Error: Failed to download icon."
+    exit 1
+  fi
+elif [[ $ICON_REF == /* ]]; then
+  ICON_PATH="$ICON_REF"
+else
+  ICON_PATH="$ICON_DIR/$ICON_REF"
+fi
+
+# Create application .desktop file
+DESKTOP_FILE="$HOME/.local/share/applications/$APP_NAME.desktop"
+
+cat >"$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Version=1.0
+Name=$APP_NAME
+Comment=$APP_NAME
+Exec=$APP_EXEC
+Terminal=$TERMINAL
+Type=Application
+Icon=$ICON_PATH
+StartupNotify=true
+X-Omarchy-Source=desktop-app-install
+EOF
+
+# Add mime types if provided
+if [[ -n $MIME_TYPES ]]; then
+  echo "MimeType=$MIME_TYPES" >>"$DESKTOP_FILE"
+fi
+
+if [[ $INTERACTIVE_MODE == "true" ]]; then
+  echo -e "You can now find $APP_NAME using the app launcher (SUPER + SPACE)\n"
+fi

--- a/bin/omarchy-desktop-app-remove
+++ b/bin/omarchy-desktop-app-remove
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+ICON_DIR="$HOME/.local/share/applications/icons"
+DESKTOP_DIR="$HOME/.local/share/applications/"
+
+if (( $# == 0 )); then
+  # Find all desktop apps installed via omarchy-desktop-app-install
+  while IFS= read -r -d '' file; do
+    if grep -q '^X-Omarchy-Source=desktop-app-install' "$file"; then
+      DESKTOP_APPS+=("$(basename "${file%.desktop}")")
+    fi
+  done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0)
+
+  if ((${#DESKTOP_APPS[@]})); then
+    IFS=$'\n' SORTED_DESKTOP_APPS=($(sort <<<"${DESKTOP_APPS[*]}"))
+    unset IFS
+    APP_NAMES_STRING=$(gum choose --no-limit --header "Select desktop app to remove..." --selected-prefix="✗ " "${SORTED_DESKTOP_APPS[@]}")
+    # Convert newline-separated string to array
+    APP_NAMES=()
+    while IFS= read -r line; do
+      [[ -n $line ]] && APP_NAMES+=("$line")
+    done <<< "$APP_NAMES_STRING"
+  else
+    echo "No desktop apps to remove."
+    exit 1
+  fi
+else
+  # Use array to preserve spaces in app names
+  APP_NAMES=("$@")
+fi
+
+if (( ${#APP_NAMES[@]} == 0 )); then
+  echo "You must select at least one desktop app to remove."
+  exit 1
+fi
+
+for APP_NAME in "${APP_NAMES[@]}"; do
+  rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
+  rm -f "$ICON_DIR/$APP_NAME.png"
+  echo "Removed $APP_NAME"
+done

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -290,9 +290,10 @@ show_setup_system_menu() {
 }
 
 show_install_menu() {
-  case $(menu "Install" "󰣇  Package\n󰣇  AUR\n  Web App\n  TUI\n  Service\n  Style\n󰵮  Development\n  Editor\n  Terminal\n󱚤  AI\n󰍲  Windows\n  Gaming") in
+  case $(menu "Install" "󰣇  Package\n󰣇  AUR\n  Desktop App\n  Web App\n  TUI\n  Service\n  Style\n󰵮  Development\n  Editor\n  Terminal\n󱚤  AI\n󰍲  Windows\n  Gaming") in
   *Package*) terminal omarchy-pkg-install ;;
   *AUR*) terminal omarchy-pkg-aur-install ;;
+  *Desktop*) terminal omarchy-desktop-app-install ;;
   *Web*) present_terminal omarchy-webapp-install ;;
   *TUI*) present_terminal omarchy-tui-install ;;
   *Service*) show_install_service_menu ;;
@@ -439,8 +440,9 @@ show_install_elixir_menu() {
 }
 
 show_remove_menu() {
-  case $(menu "Remove" "󰣇  Package\n  Web App\n  TUI\n󰵮  Development\n󰏓  Preinstalls\n  Dictation\n󰸌  Theme\n󰍲  Windows\n󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Remove" "󰣇  Package\n  Desktop App\n  Web App\n  TUI\n󰵮  Development\n󰏓  Preinstalls\n  Dictation\n󰸌  Theme\n󰍲  Windows\n󰈷  Fingerprint\n  Fido2") in
   *Package*) terminal omarchy-pkg-remove ;;
+  *Desktop*) present_terminal omarchy-desktop-app-remove ;;
   *Web*) present_terminal omarchy-webapp-remove ;;
   *TUI*) present_terminal omarchy-tui-remove ;;
   *Development*) show_remove_development_menu ;;


### PR DESCRIPTION
Analog to `omarchy-webapp-install`, allows installing local executables as desktop apps with icon and terminal support. Adds corresponding remove script and menu entries for both install and remove.