### PR TITLE
Add Copilot key remap support for ASUS ROG devices

### DIFF
--- a/bin/omarchy-setup-makima
+++ b/bin/omarchy-setup-makima
@@ -10,6 +10,8 @@ if [[ ! -f $CONFIG_FILE ]]; then
   mkdir -p "$HOME/.config/makima"
   cp "$OMARCHY_PATH/default/makima/AT Translated Set 2 keyboard.toml" "$CONFIG_FILE"
 
+  omarchy-hw-asus-rog && ln -sf "AT Translated Set 2 keyboard.toml" "$HOME/.config/makima/Asus Keyboard.toml"
+
   sudo mkdir -p /etc/systemd/system/makima.service.d
   sudo tee /etc/systemd/system/makima.service.d/override.conf >/dev/null <<EOF
 [Service]

--- a/migrations/1773172653.sh
+++ b/migrations/1773172653.sh
@@ -1,5 +1,5 @@
 echo "Add ASUS keyboard support for makima key remapping"
 
-if [[ -f "$HOME/.config/makima/AT Translated Set 2 keyboard.toml" ]] && omarchy-hw-asus-rog && [[ ! -L "$HOME/.config/makima/Asus Keyboard.toml" ]]; then
+if [[ -f "$HOME/.config/makima/AT Translated Set 2 keyboard.toml" ]] && omarchy-hw-asus-rog && [[ ! -e "$HOME/.config/makima/Asus Keyboard.toml" ]]; then
   ln -sf "AT Translated Set 2 keyboard.toml" "$HOME/.config/makima/Asus Keyboard.toml"
 fi

--- a/migrations/1773172653.sh
+++ b/migrations/1773172653.sh
@@ -1,0 +1,5 @@
+echo "Add ASUS keyboard support for makima key remapping"
+
+if [[ -f "$HOME/.config/makima/AT Translated Set 2 keyboard.toml" ]] && omarchy-hw-asus-rog && [[ ! -L "$HOME/.config/makima/Asus Keyboard.toml" ]]; then
+  ln -sf "AT Translated Set 2 keyboard.toml" "$HOME/.config/makima/Asus Keyboard.toml"
+fi

--- a/migrations/1773172653.sh
+++ b/migrations/1773172653.sh
@@ -1,4 +1,4 @@
-echo "Add ASUS keyboard support for makima key remapping"
+echo "Add ASUS keyboard support for makima key remapping (ROG devices only)"
 
 if [[ -f "$HOME/.config/makima/AT Translated Set 2 keyboard.toml" ]] && omarchy-hw-asus-rog && [[ ! -e "$HOME/.config/makima/Asus Keyboard.toml" ]]; then
   ln -sf "AT Translated Set 2 keyboard.toml" "$HOME/.config/makima/Asus Keyboard.toml"


### PR DESCRIPTION
ASUS devices with detachable/USB keyboards (like ROG Z13) use "Asus Keyboard" as the device name instead of "AT Translated Set 2 keyboard". This adds support for those devices.

- Add Asus Keyboard.toml symlink pointing to existing config if on ASUS ROG hardware