### PR TITLE
rename tmux pane to running command where possible

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -78,7 +78,7 @@ set -g status-left-length 30
 set -g status-right-length 50
 set -g window-status-separator ""
 set -gw automatic-rename on
-set -gw automatic-rename-format '#{b:pane_current_path}'
+set -gw automatic-rename-format '#{?#{m|r:^(bash|zsh|fish|sh|nu)$,#{pane_current_command}},#{b:pane_current_path},#{pane_current_command}}'
 
 # Theme
 set -g status-style "bg=default,fg=default"

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -78,7 +78,7 @@ set -g status-left-length 30
 set -g status-right-length 50
 set -g window-status-separator ""
 set -gw automatic-rename on
-set -gw automatic-rename-format '#{?#{m|r:^(bash|zsh|fish|sh|nu)$,#{pane_current_command}},#{b:pane_current_path},#{pane_current_command}}'
+set -gw automatic-rename-format '#{?#{m/r:^(bash|zsh|fish|sh|nu)$,#{pane_current_command}},#{b:pane_current_path},#{pane_current_command}}'
 
 # Theme
 set -g status-style "bg=default,fg=default"


### PR DESCRIPTION
https://github.com/basecamp/omarchy/pull/4910 broke my tmux, and here's a "fix". I think this is a "better" solution.

if pane command is a shell -> show current dir name, otherwise -> show running command name