### PR TITLE
Add ThinkPad mic mute LED sync following XPS hardware handler pattern

### DIFF
--- a/bin/omarchy-cmd-mic-mute
+++ b/bin/omarchy-cmd-mic-mute
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# Toggle microphone mute. Dell XPS systems get special handling for the hardware LED.
+# Toggle microphone mute. Dell XPS and ThinkPad systems get special handling for the hardware LED.
 
 if omarchy-hw-match "XPS"; then
   omarchy-cmd-mic-mute-xps
+elif omarchy-hw-match "ThinkPad"; then
+  omarchy-cmd-mic-mute-thinkpad
 else
   swayosd-client --monitor "$(omarchy-hyprland-monitor-focused)" --input-volume mute-toggle
 fi

--- a/bin/omarchy-cmd-mic-mute-thinkpad
+++ b/bin/omarchy-cmd-mic-mute-thinkpad
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Toggle microphone mute on ThinkPad systems. Uses wpctl for reliable toggling
+# and syncs the platform::micmute LED via brightnessctl.
+
+wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle >/dev/null
+
+if pactl get-source-mute @DEFAULT_SOURCE@ | grep -q 'yes'; then
+  osd_message='Microphone muted'
+  osd_icon='microphone-sensitivity-muted-symbolic'
+  led_value=1
+else
+  osd_message='Microphone on'
+  osd_icon='audio-input-microphone-symbolic'
+  led_value=0
+fi
+
+brightnessctl --device="platform::micmute" set "$led_value" >/dev/null 2>&1 || true
+
+swayosd-client \
+  --monitor "$(omarchy-hyprland-monitor-focused)" \
+  --custom-message "$osd_message" \
+  --custom-icon "$osd_icon"

--- a/bin/omarchy-hw-match
+++ b/bin/omarchy-hw-match
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# Match against the computer's DMI product name (case-insensitive).
-# Usage: omarchy-hw-match "XPS"
+# Match against the computer's DMI product name or product family (case-insensitive).
+# Usage: omarchy-hw-match "XPS" or omarchy-hw-match "ThinkPad"
 
-grep -qi "$1" /sys/class/dmi/id/product_name 2>/dev/null
+grep -qi "$1" /sys/class/dmi/id/product_name 2>/dev/null ||
+grep -qi "$1" /sys/class/dmi/id/product_family 2>/dev/null


### PR DESCRIPTION
`swayosd --input-volume mute-toggle` is silently broken for all users on swayosd 0.3.0 (current Arch package) due to a `pulsectl-rs` regression: basecamp/omarchy#4831, ErikReider/SwayOSD#210, ErikReider/SwayOSD#213, ErikReider/SwayOSD#225.

Fix uses `wpctl` (native PipeWire, already on every Arch system) for the actual toggle, swayosd only for OSD display.

Bonus: syncs mic mute LED on laptops that have one (ThinkPad etc.) via a `-w` guard.

No migration needed, the binding in `media.conf` is sourced automatically.