### PR TITLE
Restore custom ratio when toggling using "1-Window Ratio" shortcut

### DIFF
--- a/bin/omarchy-hyprland-window-single-square-aspect-toggle
+++ b/bin/omarchy-hyprland-window-single-square-aspect-toggle
@@ -1,13 +1,20 @@
 #!/bin/bash
 
-# Check current single_window_aspect_ratio setting
-CURRENT_VALUE=$(hyprctl getoption "layout:single_window_aspect_ratio" 2>/dev/null | head -1)
+STATE_FILE="/tmp/omarchy-single-window-ratio"
 
-# Parse vec2 output: "vec2: [1, 1]" or "vec2: [0, 0]"
-if [[ $CURRENT_VALUE == *"[1, 1]"* ]]; then
-  hyprctl keyword layout:single_window_aspect_ratio "0 0"
-  notify-send "    Disable single-window square aspect ratio"
+CURRENT_RATIO=$(hyprctl -j getoption "layout:single_window_aspect_ratio" 2>/dev/null | jq -r '[.vec2[] | tostring] | join(" ")')
+
+# Load saved ratio (if any), defaulting to 1 1 (square)
+SAVED_RATIO=$(cat "$STATE_FILE" 2>/dev/null)
+if [[ -z "$SAVED_RATIO" ]]; then
+  SAVED_RATIO="1 1"
+fi
+
+if [[ "$CURRENT_RATIO" == "0 0" ]]; then
+  hyprctl keyword layout:single_window_aspect_ratio "$SAVED_RATIO"
+  notify-send "    Enable single-window ${SAVED_RATIO// /:} aspect ratio"
 else
-  hyprctl keyword layout:single_window_aspect_ratio "1 1"
-  notify-send "    Enable single-window square aspect"
+  echo "$CURRENT_RATIO" > "$STATE_FILE"
+  hyprctl keyword layout:single_window_aspect_ratio "0 0"
+  notify-send "    Disable single-window ${CURRENT_RATIO// /:} aspect ratio"
 fi


### PR DESCRIPTION
Makes the 1-Window Ratio aware of existing custom 1 window aspect ratios. Defaults 1:1 ratio if no custom ratio has been set.

For example I currently have this in my  `~/.config/hypr/looknfeel.conf`. Using  "1-Window Ratio"  currently forces 1:1 ratio and my custom 16:9 is lost. With this change it instead toggles between 16:19 and full width.
```
layout {
    # Avoid overly wide single-window layouts on wide screens
    single_window_aspect_ratio = 16 9
}
```