### PR TITLE
Unmount FUSE filesystems before suspend/hibernate

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -66,6 +66,9 @@ echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
 # Ensure keyboard backlight doesn't prevent sleep
 sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
 
+# Ensure FUSE mounts don't prevent sleep
+sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/
+
 # Add resume= kernel parameters so the initramfs resume hook knows where to find the
 # hibernation image. Without these, resume happens late (after GPU drivers load) and fails.
 RESUME_DROP_IN="/etc/limine-entry-tool.d/resume.conf"

--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -66,9 +66,6 @@ echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
 # Ensure keyboard backlight doesn't prevent sleep
 sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
 
-# Ensure gvfsd-fuse mounts don't prevent sleep
-sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/
-
 # Add resume= kernel parameters so the initramfs resume hook knows where to find the
 # hibernation image. Without these, resume happens late (after GPU drivers load) and fails.
 RESUME_DROP_IN="/etc/limine-entry-tool.d/resume.conf"

--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -67,7 +67,7 @@ echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
 sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
 
 # Ensure FUSE mounts don't prevent sleep
-sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/
+sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/
 
 # Add resume= kernel parameters so the initramfs resume hook knows where to find the
 # hibernation image. Without these, resume happens late (after GPU drivers load) and fails.

--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -66,7 +66,7 @@ echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
 # Ensure keyboard backlight doesn't prevent sleep
 sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
 
-# Ensure FUSE mounts don't prevent sleep
+# Ensure gvfsd-fuse mounts don't prevent sleep
 sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/
 
 # Add resume= kernel parameters so the initramfs resume hook knows where to find the

--- a/default/systemd/system-sleep/unmount-fuse
+++ b/default/systemd/system-sleep/unmount-fuse
@@ -8,6 +8,7 @@
 if [[ $1 == "pre" ]]; then
   while IFS=' ' read -r _ mountpoint fstype _; do
     if [[ $fstype == fuse.* ]]; then
+      mountpoint=$(printf '%b' "$mountpoint")
       fusermount3 -uz "$mountpoint" 2>/dev/null || fusermount -uz "$mountpoint" 2>/dev/null || true
     fi
   done < /proc/mounts
@@ -28,4 +29,5 @@ if [[ $1 == "post" ]]; then
       fi
     done
   ) &
+  disown
 fi

--- a/default/systemd/system-sleep/unmount-fuse
+++ b/default/systemd/system-sleep/unmount-fuse
@@ -3,7 +3,7 @@
 # Lazy-unmount all FUSE filesystems before suspend/hibernate to prevent the
 # kernel's process freeze from timing out. FUSE daemons (like gvfsd-fuse from
 # Nautilus) can block in uninterruptible sleep during freeze, causing suspend
-# to silently fail. The FUSE daemons restart automatically on wake.
+# to silently fail. After wake, restart gvfs so the FUSE mount is restored.
 
 if [[ $1 == "pre" ]]; then
   while IFS=' ' read -r _ mountpoint fstype _; do
@@ -11,4 +11,16 @@ if [[ $1 == "pre" ]]; then
       fusermount3 -uz "$mountpoint" 2>/dev/null || fusermount -uz "$mountpoint" 2>/dev/null || true
     fi
   done < /proc/mounts
+fi
+
+if [[ $1 == "post" ]]; then
+  for uid_dir in /run/user/*; do
+    uid=$(basename "$uid_dir")
+    if [[ -S $uid_dir/bus ]]; then
+      sudo -u "#$uid" \
+        DBUS_SESSION_BUS_ADDRESS="unix:path=$uid_dir/bus" \
+        XDG_RUNTIME_DIR="$uid_dir" \
+        systemctl --user restart gvfs-daemon.service 2>/dev/null || true
+    fi
+  done
 fi

--- a/default/systemd/system-sleep/unmount-fuse
+++ b/default/systemd/system-sleep/unmount-fuse
@@ -6,7 +6,7 @@
 # to silently fail. The FUSE daemons restart automatically on wake.
 
 if [[ $1 == "pre" ]]; then
-  while IFS=' ' read -r _ mountpoint _ fstype _; do
+  while IFS=' ' read -r _ mountpoint fstype _; do
     if [[ $fstype == fuse.* ]]; then
       fusermount3 -uz "$mountpoint" 2>/dev/null || fusermount -uz "$mountpoint" 2>/dev/null || true
     fi

--- a/default/systemd/system-sleep/unmount-fuse
+++ b/default/systemd/system-sleep/unmount-fuse
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Lazy-unmount all FUSE filesystems before suspend/hibernate to prevent the
+# kernel's process freeze from timing out. FUSE daemons (like gvfsd-fuse from
+# Nautilus) can block in uninterruptible sleep during freeze, causing suspend
+# to silently fail. The FUSE daemons restart automatically on wake.
+
+if [[ $1 == "pre" ]]; then
+  while IFS=' ' read -r _ mountpoint _ fstype _; do
+    if [[ $fstype == fuse.* ]]; then
+      fusermount3 -uz "$mountpoint" 2>/dev/null || fusermount -uz "$mountpoint" 2>/dev/null || true
+    fi
+  done < /proc/mounts
+fi

--- a/default/systemd/system-sleep/unmount-fuse
+++ b/default/systemd/system-sleep/unmount-fuse
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# Lazy-unmount all FUSE filesystems before suspend/hibernate to prevent the
+# Lazy-unmount gvfsd-fuse filesystems before suspend/hibernate to prevent the
 # kernel's process freeze from timing out. FUSE daemons (like gvfsd-fuse from
 # Nautilus) can block in uninterruptible sleep during freeze, causing suspend
 # to silently fail. After wake, restart gvfs so the FUSE mount is restored.
 
 if [[ $1 == "pre" ]]; then
   while IFS=' ' read -r _ mountpoint fstype _; do
-    if [[ $fstype == fuse.* ]]; then
+    if [[ $fstype == fuse.gvfsd-fuse ]]; then
       mountpoint=$(printf '%b' "$mountpoint")
       fusermount3 -uz "$mountpoint" 2>/dev/null || fusermount -uz "$mountpoint" 2>/dev/null || true
     fi
@@ -22,7 +22,7 @@ if [[ $1 == "post" ]]; then
     for uid_dir in /run/user/*; do
       uid=$(basename "$uid_dir")
       if [[ -S $uid_dir/bus ]]; then
-        sudo -u "#$uid" \
+        sudo -u "#$uid" env \
           DBUS_SESSION_BUS_ADDRESS="unix:path=$uid_dir/bus" \
           XDG_RUNTIME_DIR="$uid_dir" \
           systemctl --user restart gvfs-daemon.service 2>/dev/null || true

--- a/default/systemd/system-sleep/unmount-fuse
+++ b/default/systemd/system-sleep/unmount-fuse
@@ -14,13 +14,18 @@ if [[ $1 == "pre" ]]; then
 fi
 
 if [[ $1 == "post" ]]; then
-  for uid_dir in /run/user/*; do
-    uid=$(basename "$uid_dir")
-    if [[ -S $uid_dir/bus ]]; then
-      sudo -u "#$uid" \
-        DBUS_SESSION_BUS_ADDRESS="unix:path=$uid_dir/bus" \
-        XDG_RUNTIME_DIR="$uid_dir" \
-        systemctl --user restart gvfs-daemon.service 2>/dev/null || true
-    fi
-  done
+  # Run in background — user.slice is still frozen at this point, so a
+  # synchronous restart would block the thaw for up to 90 seconds.
+  (
+    sleep 5
+    for uid_dir in /run/user/*; do
+      uid=$(basename "$uid_dir")
+      if [[ -S $uid_dir/bus ]]; then
+        sudo -u "#$uid" \
+          DBUS_SESSION_BUS_ADDRESS="unix:path=$uid_dir/bus" \
+          XDG_RUNTIME_DIR="$uid_dir" \
+          systemctl --user restart gvfs-daemon.service 2>/dev/null || true
+      fi
+    done
+  ) &
 fi

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -18,6 +18,7 @@ run_logged $OMARCHY_INSTALL/config/remove-fcitx5-autostart.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/walker-elephant.sh
 run_logged $OMARCHY_INSTALL/config/fast-shutdown.sh
+run_logged $OMARCHY_INSTALL/config/unmount-fuse.sh
 run_logged $OMARCHY_INSTALL/config/sudoless-asdcontrol.sh
 run_logged $OMARCHY_INSTALL/config/input-group.sh
 run_logged $OMARCHY_INSTALL/config/makima.sh

--- a/install/config/unmount-fuse.sh
+++ b/install/config/unmount-fuse.sh
@@ -1,0 +1,2 @@
+sudo mkdir -p /usr/lib/systemd/system-sleep
+sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/

--- a/migrations/1773012889.sh
+++ b/migrations/1773012889.sh
@@ -1,4 +1,4 @@
 echo "Install system-sleep hook to unmount FUSE before suspend/hibernate"
 
 sudo mkdir -p /usr/lib/systemd/system-sleep
-sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/
+sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/

--- a/migrations/1773012889.sh
+++ b/migrations/1773012889.sh
@@ -1,4 +1,4 @@
-echo "Install system-sleep hook to unmount FUSE before suspend/hibernate"
+echo "Install system-sleep hook to unmount gvfsd-fuse before suspend/hibernate"
 
 sudo mkdir -p /usr/lib/systemd/system-sleep
 sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/

--- a/migrations/1773012889.sh
+++ b/migrations/1773012889.sh
@@ -1,0 +1,4 @@
+echo "Install system-sleep hook to unmount FUSE before suspend/hibernate"
+
+sudo mkdir -p /usr/lib/systemd/system-sleep
+sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/unmount-fuse" /usr/lib/systemd/system-sleep/


### PR DESCRIPTION
## Problem

FUSE daemons — primarily `gvfsd-fuse` from Nautilus — can block the kernel's process freeze during suspend/hibernate. The daemon gets stuck in uninterruptible sleep (D state) waiting for FUSE I/O responses, the freeze times out after 20 seconds, and suspend silently fails. The system stays fully awake while appearing suspended, draining the battery.

This affects every Omarchy system since Nautilus (and therefore gvfs/fuse) is installed by default. It was confirmed as the root cause of excessive battery drain on Framework 13 AMD in #4184, and likely contributes to other suspend issues reported in #1556 and #2501.

## Fix

Adds a systemd system-sleep hook that lazy-unmounts all FUSE filesystems before suspend/hibernate, following the same pattern as the existing `keyboard-backlight` and `force-igpu` hooks.

- Fires on `pre` for both suspend and hibernate
- Parses `/proc/mounts` generically — handles all users, all FUSE types (gvfsd-fuse, portal, rclone, sshfs)
- `fusermount3 -uz` returns immediately (lazy unmount), non-destructive
- On `post`, restarts gvfs-daemon for each logged-in user in the background (gvfsd-fuse doesn't self-restart; backgrounded with a delay to avoid blocking user.slice thaw)
- Harmless no-op if no FUSE mounts exist

## Blast radius

- **During normal usage:** Zero impact — the hook only runs during suspend/hibernate
- **Pre-sleep unmount:** Every Omarchy system has gvfsd-fuse (via Nautilus), so this benefits all users. Systems without FUSE mounts are unaffected (no-op)
- **Post-sleep restart:** Backgrounded with a 5-second delay, cannot block resume. Silently fails if gvfs-daemon.service doesn't exist
- **Edge case:** If a user is actively copying files over MTP/NFS/SMB via Nautilus when suspend triggers, the lazy unmount will interrupt that transfer. The alternative (suspend failing entirely) is worse, and this is an unlikely scenario

## Changes

| File | Action |
|------|--------|
| `default/systemd/system-sleep/unmount-fuse` | New hook script |
| `migrations/1773012889.sh` | Installs hook on existing systems |
| `bin/omarchy-hibernation-setup` | Also installs hook during fresh hibernation setup |

## Testing

Tested on Framework 13 AMD (Ryzen, s2idle only):
- Process freeze completes in 0.001s (previously timed out at 20s)
- Resume completes instantly (no userspace thaw delay)
- gvfs-daemon restarts automatically ~5s after wake
- Nautilus and file manager features work normally after wake

## References

- #4184 — Suspend not working, confirmed FUSE as root cause
- #4184 [comment by @gulp](https://github.com/basecamp/omarchy/issues/4184#issuecomment-3751288516) — original workaround
- #4184 [comment by @erikwb](https://github.com/basecamp/omarchy/issues/4184#issuecomment-3751288516) — confirmed fix on Framework 13 AMD