### PR TITLE
Fix hyprlock PAM config to prevent freeze on wake

### DIFF
--- a/default/pam.d/hyprlock
+++ b/default/pam.d/hyprlock
@@ -1,0 +1,5 @@
+#%PAM-1.0
+
+auth      include   system-login
+account   include   system-login
+session   include   system-login

--- a/migrations/1773019289.sh
+++ b/migrations/1773019289.sh
@@ -1,0 +1,5 @@
+echo "Fix hyprlock PAM config (missing account/session sections cause freeze on wake)"
+
+if [[ -f /etc/pam.d/hyprlock ]] && ! grep -q "^account" /etc/pam.d/hyprlock; then
+  sudo cp -p "$OMARCHY_PATH/default/pam.d/hyprlock" /etc/pam.d/hyprlock
+fi

--- a/migrations/1773019289.sh
+++ b/migrations/1773019289.sh
@@ -1,5 +1,5 @@
 echo "Fix hyprlock PAM config (missing account/session sections cause freeze on wake)"
 
-if [[ -f /etc/pam.d/hyprlock ]] && ! grep -q "^account" /etc/pam.d/hyprlock; then
-  sudo cp -p "$OMARCHY_PATH/default/pam.d/hyprlock" /etc/pam.d/hyprlock
+if [[ ! -f /etc/pam.d/hyprlock ]] || ! grep -qE "^(account|session)" /etc/pam.d/hyprlock; then
+  sudo install -o root -g root -m 0644 "$OMARCHY_PATH/default/pam.d/hyprlock" /etc/pam.d/hyprlock
 fi


### PR DESCRIPTION
## Problem

Arch's default `/etc/pam.d/hyprlock` only has an `auth` section:

```
auth        include     login
```

The missing `account` and `session` sections cause hyprlock to crash or freeze after PAM authentication completes. This manifests as the lock screen being visible but completely unresponsive to input — no cursor blinking, no keyboard input, no trackpad — requiring a hard reboot. This commonly occurs after waking from suspend.

Documented in [hyprlock #953](https://github.com/hyprwm/hyprlock/issues/953) (Issue 6). Omarchy does not currently manage this file.

## Fix

Ships a complete PAM config at `default/pam.d/hyprlock` with all required sections:

```
#%PAM-1.0

auth      include   system-login
account   include   system-login
session   include   system-login
```

A migration applies it to existing installs, only overwriting if the `account` section is missing (won't clobber custom PAM configs).

## Changes

| File | Action |
|------|--------|
| `default/pam.d/hyprlock` | New default PAM config |
| `migrations/1773019289.sh` | Applies fix to existing installs |

## References

- https://github.com/hyprwm/hyprlock/issues/953 — Comprehensive hyprlock crash investigation, Issue 6
- https://github.com/basecamp/omarchy/issues/4184 — Suspend not working (related: wake freeze after successful suspend)

## Related

This pairs with #4940 (unmount FUSE before suspend) to make the full suspend/wake cycle reliable. This PR should merge first — fixing suspend entry is pointless if wake is broken.