### PR TITLE
Add keybind to move window out of scratchpad

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -57,6 +57,7 @@ bindd = SUPER SHIFT ALT, code:19, Move window silently to workspace 10, movetowo
 # Control scratchpad
 bindd = SUPER, S, Toggle scratchpad, togglespecialworkspace, scratchpad
 bindd = SUPER ALT, S, Move window to scratchpad, movetoworkspacesilent, special:scratchpad
+bindd = SUPER SHIFT, S, Move window out of scratchpad, movetoworkspacesilent, e+0
 
 # TAB between workspaces
 bindd = SUPER, TAB, Next workspace, workspace, e+1


### PR DESCRIPTION
There was no keybind to eject a window from the scratchpad back to the current workspace. 
Added `Super + Shift + S` to remove active window from scratchpad, logical complement to `Super + Alt + S` (send to scratchpad).