### PR TITLE
Add LocalSend send action in Nautilus

### DIFF
--- a/default/nautilus-python/extensions/localsend.py
+++ b/default/nautilus-python/extensions/localsend.py
@@ -26,9 +26,8 @@ class SendViaLocalSendAction(GObject.GObject, Nautilus.MenuProvider):
         if localsend:
             return [localsend, "--headless", "send"]
 
-        flatpak = "/usr/bin/flatpak"
-        flatpak_app = Gio.DesktopAppInfo.new("org.localsend.localsend_app.desktop")
-        if os.path.exists(flatpak) and flatpak_app is not None:
+        flatpak = shutil.which("flatpak")
+        if flatpak and self._has_flatpak_app(flatpak, "org.localsend.localsend_app"):
             return [
                 flatpak,
                 "run",
@@ -38,6 +37,13 @@ class SendViaLocalSendAction(GObject.GObject, Nautilus.MenuProvider):
             ]
 
         return None
+
+    def _has_flatpak_app(self, flatpak, app_id):
+        process = Gio.Subprocess.new(
+            [flatpak, "info", app_id],
+            Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_SILENCE,
+        )
+        return process.wait_check()
 
     def _selected_paths(self, files):
         paths = []

--- a/default/nautilus-python/extensions/localsend.py
+++ b/default/nautilus-python/extensions/localsend.py
@@ -27,7 +27,8 @@ class SendViaLocalSendAction(GObject.GObject, Nautilus.MenuProvider):
             return [localsend, "--headless", "send"]
 
         flatpak = "/usr/bin/flatpak"
-        if os.path.exists(flatpak):
+        flatpak_app = Gio.DesktopAppInfo.new("org.localsend.localsend_app.desktop")
+        if os.path.exists(flatpak) and flatpak_app is not None:
             return [
                 flatpak,
                 "run",

--- a/default/nautilus-python/extensions/localsend.py
+++ b/default/nautilus-python/extensions/localsend.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from gi import require_version
 
@@ -21,8 +22,9 @@ class SendViaLocalSendAction(GObject.GObject, Nautilus.MenuProvider):
         Gio.Subprocess.new(command, Gio.SubprocessFlags.NONE)
 
     def _resolve_command(self):
-        if os.path.exists("/usr/bin/localsend"):
-            return ["/usr/bin/localsend", "--headless", "send"]
+        localsend = shutil.which("localsend")
+        if localsend:
+            return [localsend, "--headless", "send"]
 
         flatpak = "/usr/bin/flatpak"
         if os.path.exists(flatpak):

--- a/default/nautilus-python/extensions/localsend.py
+++ b/default/nautilus-python/extensions/localsend.py
@@ -1,0 +1,75 @@
+import os
+
+from gi import require_version
+
+require_version("Nautilus", "4.1")
+
+from gi.repository import GObject, Gio, Nautilus
+
+
+class SendViaLocalSendAction(GObject.GObject, Nautilus.MenuProvider):
+    def _launch_localsend(self, paths):
+        command = self._resolve_command()
+        if not command:
+            return
+
+        if command[-1] == "@@":
+            command = command + paths + ["@@"]
+        else:
+            command = command + paths
+
+        Gio.Subprocess.new(command, Gio.SubprocessFlags.NONE)
+
+    def _resolve_command(self):
+        if os.path.exists("/usr/bin/localsend"):
+            return ["/usr/bin/localsend", "--headless", "send"]
+
+        flatpak = "/usr/bin/flatpak"
+        if os.path.exists(flatpak):
+            return [
+                flatpak,
+                "run",
+                "--file-forwarding",
+                "org.localsend.localsend_app",
+                "@@",
+            ]
+
+        return None
+
+    def _selected_paths(self, files):
+        paths = []
+
+        for file in files:
+            location = file.get_location()
+            if not location:
+                continue
+
+            path = location.get_path()
+            if path and path not in paths:
+                paths.append(path)
+
+        return paths
+
+    def _make_item(self, paths):
+        label = (
+            "Send via LocalSend" if len(paths) == 1 else "Send selected via LocalSend"
+        )
+        item = Nautilus.MenuItem(
+            name="LocalSendNautilus::send_via_localsend",
+            label=label,
+            icon="localsend",
+        )
+        item.connect("activate", self._on_activate, paths)
+        return item
+
+    def _on_activate(self, _menu, paths):
+        self._launch_localsend(paths)
+
+    def get_file_items(self, *args):
+        files = args[0] if len(args) == 1 else args[1]
+        paths = self._selected_paths(files)
+
+        if not paths or not self._resolve_command():
+            return []
+
+        return [self._make_item(paths)]

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -14,6 +14,7 @@ run_logged $OMARCHY_INSTALL/config/mise-work.sh
 run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
+run_logged $OMARCHY_INSTALL/config/nautilus-python.sh
 run_logged $OMARCHY_INSTALL/config/remove-fcitx5-autostart.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/walker-elephant.sh

--- a/install/config/nautilus-python.sh
+++ b/install/config/nautilus-python.sh
@@ -1,4 +1,4 @@
 EXTENSIONS_DIR="$HOME/.local/share/nautilus-python/extensions"
 
 mkdir -p "$EXTENSIONS_DIR"
-cp ~/.local/share/omarchy/default/nautilus-python/extensions/localsend.py "$EXTENSIONS_DIR/"
+cp "$OMARCHY_PATH/default/nautilus-python/extensions/localsend.py" "$EXTENSIONS_DIR/"

--- a/install/config/nautilus-python.sh
+++ b/install/config/nautilus-python.sh
@@ -1,0 +1,4 @@
+EXTENSIONS_DIR="$HOME/.local/share/nautilus-python/extensions"
+
+mkdir -p "$EXTENSIONS_DIR"
+cp ~/.local/share/omarchy/default/nautilus-python/extensions/localsend.py "$EXTENSIONS_DIR/"

--- a/migrations/1773017819.sh
+++ b/migrations/1773017819.sh
@@ -1,0 +1,6 @@
+echo "Add LocalSend entry to Nautilus context menu"
+
+EXTENSIONS_DIR="$HOME/.local/share/nautilus-python/extensions"
+
+mkdir -p "$EXTENSIONS_DIR"
+cp "$OMARCHY_PATH/default/nautilus-python/extensions/localsend.py" "$EXTENSIONS_DIR/"

--- a/migrations/1773017819.sh
+++ b/migrations/1773017819.sh
@@ -1,6 +1,3 @@
 echo "Add LocalSend entry to Nautilus context menu"
 
-EXTENSIONS_DIR="$HOME/.local/share/nautilus-python/extensions"
-
-mkdir -p "$EXTENSIONS_DIR"
-cp "$OMARCHY_PATH/default/nautilus-python/extensions/localsend.py" "$EXTENSIONS_DIR/"
+source $OMARCHY_PATH/install/config/nautilus-python.sh


### PR DESCRIPTION
- Added `localsend.py`, a Nautilus Python extension that adds a "Send via LocalSend" context menu item for selected files. The extension detects whether LocalSend is installed natively or via Flatpak and launches the appropriate command to send the selected files. (`default/nautilus-python/extensions/localsend.py`)

