### PR TITLE
feat: show message when config is sourced

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -4,7 +4,7 @@ set -g prefix2 C-b
 bind C-Space send-prefix
 
 # Reload config
-bind q source-file ~/.config/tmux/tmux.conf \; display "configuration sourced"
+bind q source-file ~/.config/tmux/tmux.conf \; display "Configuration reloaded"
 
 # Vi mode for copy
 setw -g mode-keys vi

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -4,7 +4,7 @@ set -g prefix2 C-b
 bind C-Space send-prefix
 
 # Reload config
-bind q source-file ~/.config/tmux/tmux.conf
+bind q source-file ~/.config/tmux/tmux.conf \; display "configuration sourced"
 
 # Vi mode for copy
 setw -g mode-keys vi


### PR DESCRIPTION
This pull request makes a small usability improvement to the tmux configuration. When the configuration is reloaded with the `q` binding, a message is now displayed to confirm that the configuration was sourced.