### PR TITLE
Fix battery remaining time displaying minutes as hours

### DIFF
--- a/bin/omarchy-battery-remaining-time
+++ b/bin/omarchy-battery-remaining-time
@@ -5,12 +5,22 @@
 battery_info=$(upower -i $(upower -e | grep BAT))
 
 echo "$battery_info" | awk '/time to (empty|full)/ {
-    hours = int($4)
-    minutes = int(($4 - hours) * 60)
-    if (minutes > 0) {
-        printf "%dh %dm", hours, minutes
+    value = $4
+    unit = $5
+
+    if (unit ~ /hour/) {
+        hours = int(value)
+        minutes = int((value - hours) * 60)
+        if (minutes > 0) {
+            printf "%dh %dm", hours, minutes
+        } else {
+            printf "%dh", hours
+        }
+    } else if (unit ~ /minute/) {
+        minutes = int(value)
+        printf "%dm", minutes
     } else {
-        printf "%dh", hours
+        printf "%s %s", value, unit
     }
     exit
 }'


### PR DESCRIPTION
upower reports time in different units depending on battery state — it can output X hours or X minutes. The script assumed the value was always in hours, so when the battery was low enough for upower to switch to minutes, it would display e.g. 25h instead of 25m.
This fix reads the unit field from upower's output and formats accordingly.