### PR TITLE
Replace slashes in worktree path with dashes

### DIFF
--- a/default/bash/fns/worktrees
+++ b/default/bash/fns/worktrees
@@ -7,7 +7,7 @@ ga() {
 
   local branch="$1"
   local base="$(basename "$PWD")"
-  local path="../${base}--${branch}"
+  local path="../${base}--${branch//\//-}"
 
   git worktree add -b "$branch" "$path"
   mise trust "$path"

--- a/default/bash/fns/worktrees
+++ b/default/bash/fns/worktrees
@@ -24,7 +24,7 @@ gd() {
 
     # split on first `--`
     root="${worktree%%--*}"
-    branch="${worktree#*--}"
+    branch="$(git rev-parse --abbrev-ref HEAD)"
 
     # Protect against accidentally nuking a non-worktree directory
     if [[ "$root" != "$worktree" ]]; then


### PR DESCRIPTION
To be able to handle branches "release/toto" without creating subdir. Maybe not useful, just a suggestion because it better fits my workflow.