### PR TITLE
Add changelog viewer to update prompt and menu

### DIFF
--- a/bin/omarchy-changelog
+++ b/bin/omarchy-changelog
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Display the latest Omarchy release notes from GitHub
+gh release view --repo basecamp/omarchy

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -507,7 +507,7 @@ show_remove_elixir_menu() {
 }
 
 show_update_menu() {
-  case $(menu "Update" "  Omarchy\n󰔫  Channel\n  Config\n󰸌  Extra Themes\n  Process\n󰇅  Hardware\n  Firmware\n  Password\n  Timezone\n  Time") in
+  case $(menu "Update" "  Omarchy\n󰔫  Channel\n  Config\n󰸌  Extra Themes\n  Process\n󰇅  Hardware\n  Firmware\n  Password\n  Timezone\n  Time\n󰋽  Changelog") in
   *Omarchy*) present_terminal omarchy-update ;;
   *Channel*) show_update_channel_menu ;;
   *Config*) show_update_config_menu ;;
@@ -518,6 +518,7 @@ show_update_menu() {
   *Timezone*) present_terminal omarchy-tz-select ;;
   *Time*) present_terminal omarchy-update-time ;;
   *Password*) show_update_password_menu ;;
+  *Changelog*) present_terminal omarchy-changelog ;;
   *) show_main_menu ;;
   esac
 }

--- a/bin/omarchy-update-confirm
+++ b/bin/omarchy-update-confirm
@@ -10,7 +10,36 @@ gum style --border normal --border-foreground 6 --padding "1 2" \
 
 echo
 
-if ! gum confirm "Continue with update?"; then
-  echo "Update cancelled"
-  exit 1
-fi
+while true; do
+  if gum confirm --affirmative="Continue with update" --negative="View changes"; then
+    break
+  fi
+
+  current="v$(omarchy-version)"
+  tags=$(gh release list --repo basecamp/omarchy --limit 50 2>/dev/null | awk '{print $1}')
+
+  if [[ -z "$tags" ]]; then
+    xdg-open "https://github.com/basecamp/omarchy/releases"
+    continue
+  fi
+
+  behind=0
+  for tag in $tags; do
+    [[ "$tag" == "$current" ]] && break
+    behind=$((behind + 1))
+  done
+
+  if [[ $behind -eq 0 ]]; then
+    echo "You're on the latest release ($current)"
+    echo
+    gh release view "$current" --repo basecamp/omarchy
+  else
+    echo "You are $behind release(s) behind (current: $current)"
+    echo
+    for tag in $tags; do
+      [[ "$tag" == "$current" ]] && break
+      gh release view "$tag" --repo basecamp/omarchy
+      echo
+    done
+  fi
+done


### PR DESCRIPTION
## Summary

- Replace the yes/no update confirmation with **"Continue with update" / "View changes"** buttons using `gum confirm`
- "View changes" detects how many releases behind the user is and displays all missed release notes inline via `gh release view`
- Falls back to opening the GitHub releases page in the browser if `gh` fails
- Add a **Changelog** entry to the Update section of the Omarchy menu for viewing release notes anytime

## Test plan

- [ ] Run `omarchy-update` and verify the two-button prompt appears
- [ ] Click "View changes" and verify release notes are shown inline
- [ ] Verify it loops back to the prompt after viewing
- [ ] Ctrl+C cancels as expected
- [ ] Test with no internet — should fall back to opening browser
- [ ] Test "Changelog" entry in Omarchy menu (Update > Changelog)