### PR TITLE
Add speed test to Setup menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -219,7 +219,7 @@ show_font_menu() {
 }
 
 show_setup_menu() {
-  local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
+  local options="  Audio\n  Wifi\n󰓅  Speed Test\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
   [[ -f ~/.config/hypr/bindings.conf ]] && options="$options\n  Keybindings"
   [[ -f ~/.config/hypr/input.conf ]] && options="$options\n  Input"
   options="$options\n󰱔  DNS\n  Security\n  Config"
@@ -227,6 +227,7 @@ show_setup_menu() {
   case $(menu "Setup" "$options") in
   *Audio*) omarchy-launch-audio ;;
   *Wifi*) omarchy-launch-wifi ;;
+  *Speed*) present_terminal omarchy-speed-test ;;
   *Bluetooth*) omarchy-launch-bluetooth ;;
   *Power*) show_setup_power_menu ;;
   *System*) show_setup_system_menu ;;

--- a/bin/omarchy-speed-test
+++ b/bin/omarchy-speed-test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Run a network speed test, installing speedtest-cli if needed
+omarchy-cmd-missing speedtest-cli && omarchy-pkg-add speedtest-cli
+speedtest-cli


### PR DESCRIPTION
## Summary

- Add a "Speed Test" option to the Setup menu, placed next to Wifi
- Installs `speedtest-cli` on demand if not already present (no new base dependency)
- Runs the standard Ookla-backed `speedtest-cli` in a floating terminal

## Test plan

- [ ] Open Omarchy menu > Setup > Speed Test
- [ ] Verify it prompts to install `speedtest-cli` on first run if not installed
- [ ] Verify speed test runs and displays results
- [ ] Verify it works on subsequent runs without re-installing