### PR TITLE
Fix missing sudo for btrfs map-swapfile in hibernation setup

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -73,7 +73,7 @@ if [[ ! -f $RESUME_DROP_IN ]]; then
   echo "Adding resume kernel parameters"
   sudo swapon -p 0 "$SWAP_FILE" 2>/dev/null
   RESUME_DEVICE=$(findmnt -no SOURCE -T "$SWAP_FILE" | sed 's/\[.*\]//')
-  RESUME_OFFSET=$(btrfs inspect-internal map-swapfile -r "$SWAP_FILE")
+  RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE")
   sudo mkdir -p /etc/limine-entry-tool.d
   echo "KERNEL_CMDLINE[default]+=\" resume=$RESUME_DEVICE resume_offset=$RESUME_OFFSET\"" | sudo tee "$RESUME_DROP_IN" >/dev/null
 fi

--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -75,7 +75,13 @@ if [[ ! -f $RESUME_DROP_IN ]]; then
   RESUME_DEVICE=$(findmnt -no SOURCE -T "$SWAP_FILE" | sed 's/\[.*\]//')
   RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE")
   sudo mkdir -p /etc/limine-entry-tool.d
-  echo "KERNEL_CMDLINE[default]+=\" resume=$RESUME_DEVICE resume_offset=$RESUME_OFFSET\"" | sudo tee "$RESUME_DROP_IN" >/dev/null
+  RESUME_CMDLINE="KERNEL_CMDLINE[default]+=\" resume=$RESUME_DEVICE resume_offset=$RESUME_OFFSET\""
+  echo "$RESUME_CMDLINE" | sudo tee "$RESUME_DROP_IN" >/dev/null
+
+  # Also append to /etc/default/limine if it exists, since it overrides drop-in configs
+  if [[ -f /etc/default/limine ]] && ! grep -q 'resume=' /etc/default/limine; then
+    echo "$RESUME_CMDLINE" | sudo tee -a /etc/default/limine >/dev/null
+  fi
 fi
 
 # Use ACPI alarm for RTC wakeup on s2idle systems (needed for suspend-then-hibernate)
@@ -84,7 +90,13 @@ if grep -q "\[s2idle\]" /sys/power/mem_sleep 2>/dev/null; then
   if [[ ! -f $LIMINE_DROP_IN ]]; then
     echo "Enabling ACPI RTC alarm for s2idle suspend"
     sudo mkdir -p /etc/limine-entry-tool.d
-    echo 'KERNEL_CMDLINE[default]+=" rtc_cmos.use_acpi_alarm=1"' | sudo tee "$LIMINE_DROP_IN" >/dev/null
+    RTC_CMDLINE='KERNEL_CMDLINE[default]+=" rtc_cmos.use_acpi_alarm=1"'
+    echo "$RTC_CMDLINE" | sudo tee "$LIMINE_DROP_IN" >/dev/null
+
+    # Also append to /etc/default/limine if it exists, since it overrides drop-in configs
+    if [[ -f /etc/default/limine ]] && ! grep -q 'rtc_cmos.use_acpi_alarm' /etc/default/limine; then
+      echo "$RTC_CMDLINE" | sudo tee -a /etc/default/limine >/dev/null
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Fix missing `sudo` for `btrfs inspect-internal map-swapfile` in `omarchy-hibernation-setup`, which caused `resume_offset` to be empty in `resume.conf` due to "Permission Denied"
## Details
The `btrfs inspect-internal map-swapfile -r` command on line 76 requires root privileges to read the swap file's physical offset on btrfs. Without `sudo`, the command silently fails, producing a broken config:
KERNEL_CMDLINE[default]+=" resume=/dev/mapper/root resume_offset="

This results in a blue screen when waking from hibernation. Every other `btrfs` call in the script already uses `sudo` — this was simply an oversight.
Fixes #4974


