### PR TITLE
Add Thorium to list of valid 'omarchy-launch-webapp' browsers that work with '--app'

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -5,7 +5,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium* | thorium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 

--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -1,5 +1,5 @@
 # Browser types
-windowrule = tag +chromium-based-browser, match:class ((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)
+windowrule = tag +chromium-based-browser, match:class ((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium|[tT]horium-browser)
 windowrule = tag +firefox-based-browser, match:class ([fF]irefox|zen|librewolf)
 windowrule = tag -default-opacity, match:tag chromium-based-browser
 windowrule = tag -default-opacity, match:tag firefox-based-browser


### PR DESCRIPTION
Thorium works with --app, similar to other Chromium-based browsers. This PR adds thorium to the omarchy-launch-webapp script so a separate Chromium browser does not need to be launched if the user is already using Thorium.