### PR TITLE
feat: add kbdcolor utility for HP Victus/Omen RGB keyboards (stock hp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
 # Omarchy
 
 Omarchy is a beautiful, modern & opinionated Linux distribution by DHH.
-
 Read more at [omarchy.org](https://omarchy.org).
 
 ## License
 
 Omarchy is released under the [MIT License](https://opensource.org/licenses/MIT).
+
+### HP Victus / Omen RGB Keyboard Colors
+
+HP gaming laptops with RGB keyboards (Victus 15-fa2xxx series and newer Omen models) now have built-in color control using the stock `hp-wmi` driver.
+
+**Usage:**
+```bash
+kbdcolor navy      # or red, green, blue, cyan, yellow, orange, purple, pink, teal, lime, violet, etc.
+
+Recommended one-key binds (add to ~/.config/hypr/bindings.conf):
+
+bindd = SUPER ALT, N, Keyboard Navy,   exec, kbdcolor navy
+bindd = SUPER ALT, R, Keyboard Red,    exec, kbdcolor red
+bindd = SUPER ALT, C, Keyboard Cyan,   exec, kbdcolor cyan
+bindd = SUPER ALT, Y, Keyboard Yellow, exec, kbdcolor yellow
+# add the rest from the full list in the kbdcolor script


### PR DESCRIPTION
Many HP Victus 15-fa2xxx and Omen users have RGB keyboards but no easy control on Omarchy (victus-control breaks Fn+F4).

**Tested on:**
- Omarchy 3.4.2
- Victus by HP Gaming Laptop 15-fa2xxx
- 13th Gen Intel(R) Core(TM) i7-13620H (12+4) @ 4.90 GHz
- NVIDIA GeForce RTX 4060 Max-Q / Mobile [Discrete]
- Intel UHD Graphics @ 1.50 GHz [Integrated]

**Solution:**
- Direct sysfs control via `/sys/class/leds/hp::kbd_backlight/multi_intensity` (no extra modules or patched drivers)
- Tiny `kbdcolor` utility with 14 colors + on/off
- udev rule for no-sudo access (optional, but recommended)
- Omarchy-native `bindd=` shortcuts that appear in the Super+K menu

Fn+F4 still works perfectly for brightness/on-off.

This is zero-overhead and matches Omarchy's philosophy of minimalism and direct file control.

Happy to add auto-detection in install scripts or udev rule if desired.