### PR TITLE
Update omarchy-reinstall-git to make shallow clone

### DIFF
--- a/bin/omarchy-reinstall-git
+++ b/bin/omarchy-reinstall-git
@@ -3,6 +3,6 @@ set -e
 
 # Reinstall the Omarchy configuration directory from the git source.
 
-git clone "https://github.com/basecamp/omarchy.git" ~/.local/share/omarchy-new >/dev/null
+git clone --depth=1 "https://github.com/basecamp/omarchy.git" ~/.local/share/omarchy-new >/dev/null
 mv $OMARCHY_PATH ~/.local/share/omarchy-old
 mv ~/.local/share/omarchy-new $OMARCHY_PATH


### PR DESCRIPTION
The whole git history of the omarchy repository is not required to, for example, run `omarchy-reinstall`.
If needed later, additional history can be fetched manually with `git fetch --unshallow` and additional branches with `git fetch --all`