### PR TITLE
feat: add smart tmux session management

### DIFF
--- a/bin/omarchy-tmux-smart-attach
+++ b/bin/omarchy-tmux-smart-attach
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+get_next_scratch() {
+  local i=1
+  while tmux has-session -t "scratch-$i" 2>/dev/null; do
+    i=$((i + 1))
+  done
+  echo "scratch-$i"
+}
+
+if tmux ls 2>/dev/null | grep -q 'Work.*(attached)'; then
+  FREE=$(tmux ls 2>/dev/null | grep -v '(attached)' | grep -v '^Work:' | head -1 | cut -d: -f1)
+  if [ -n "$FREE" ]; then
+    tmux attach -t "$FREE"
+  else
+    tmux new-session -s "$(get_next_scratch)"
+  fi
+else
+  tmux new-session -As Work
+fi

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -1,6 +1,6 @@
 # Application bindings
 bindd = SUPER, RETURN, Terminal, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)"
-bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" bash -c "tmux attach || tmux new -s Work"
+bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" omarchy-tmux-smart-attach
 bindd = SUPER SHIFT, RETURN, Browser, exec, omarchy-launch-browser
 bindd = SUPER SHIFT, F, File manager, exec, uwsm-app -- nautilus --new-window
 bindd = SUPER ALT SHIFT, F, File manager (cwd), exec, uwsm-app -- nautilus --new-window "$(omarchy-cmd-terminal-cwd)"


### PR DESCRIPTION
Introduces a script to handle terminal attachment logic. If the main 'Work' session is already occupied, it automatically attaches to an existing idle session or creates a new numbered 'scratch' session. Also binds the logic to SUPER+ALT+RETURN in Hyprland.