### PR TITLE
omarchy-refresh-config shouldn't override symlinked file content

### DIFF
--- a/bin/omarchy-refresh-config
+++ b/bin/omarchy-refresh-config
@@ -23,19 +23,18 @@ default_config_file="${HOME}/.local/share/omarchy/config/$config_file"
 backup_config_file="$user_config_file.bak.$(date +%s)"
 
 if [[ -f $user_config_file ]]; then
-  # Create preliminary backup
-  cp -f "$user_config_file" "$backup_config_file" 2>/dev/null
-
-  # Replace config with new default
-  cp -f "$default_config_file" "$user_config_file" 2>/dev/null
-
-  # Compare and delete/inform accordingly
-  if cmp -s "$user_config_file" "$backup_config_file"; then
-    rm "$backup_config_file"
-  else
-    echo -e "\e[31mReplaced $user_config_file with new Omarchy default.\nSaved backup as ${backup_config_file}.\n\n\e[32mChanges:\e[0m"
-    diff "$user_config_file" "$backup_config_file" || true
+  if cmp -s "$(realpath "$user_config_file")" "$default_config_file"; then
+    exit 0
   fi
+
+  # Create backup
+  cp -fd "$user_config_file" "$backup_config_file" 2>/dev/null
+
+  # Replace config with default content (--remove-destination is used to prevent symlinked content override if $user_config_file is a symlink)
+  cp --remove-destination "$default_config_file" "$user_config_file" 2>/dev/null
+
+  echo -e "\e[31mReplaced $user_config_file with new Omarchy default.\nSaved backup as ${backup_config_file}.\n\n\e[32mChanges:\e[0m"
+  diff "$user_config_file" "$backup_config_file" || true
 else
   # Config file did not exist already
   cp -f "$default_config_file" "$user_config_file" 2>/dev/null


### PR DESCRIPTION
Recently switched to Omarchy.
Some of my `.config` files are symlinks (managed by gnu stow).

## Problem
There is 3 main problems with the current implementation of `omarchy-refresh-config` when working with symlinks : 
- When creating a backup of the original file, if the file is a symlink, the backup is a copy of the file pointed by the symlink instead of a backup of the symlink.
- When the default config is copied over, it override the file pointed by the symlink and not the actual symlink file
- The `cmp` utility doesn't follow symlink. When it compare a symlink file with a "normal" file, it will always show some difference
  - This didn't cause issue in the current implementation because of the first point in this list but need to be changed for the new implementation

## Changes in this PR:
- We now use `cp -d` to backup the symlink instead of the file pointed by the symlink.
- We now use `cp --remove-destination` so that the symlink is removed before copying the default file.
  - Note that `-f` is redundant when using `--remove-destination`.
- `cmp` now use `realpath` to compare the content of the symlinked file instead of the symlink itself.
  - I also reversed the logic of the `no changes` comparison. 
    - We don't need to backup the file before comparing and then delete the backup file if there was no changes. 
    - We can simply check if there is changes before attempting the refresh and exit early if there isn't. 