### PR TITLE
Add ASUS TUF laptop support for asusctl and keyboard RGB

### DIFF
--- a/bin/omarchy-hw-asus-tuf
+++ b/bin/omarchy-hw-asus-tuf
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Detect whether the computer is an Asus TUF machine.
+
+[[ $(cat /sys/class/dmi/id/sys_vendor 2>/dev/null) == "ASUSTeK COMPUTER INC." ]] &&
+   grep -q "TUF" /sys/class/dmi/id/product_family 2>/dev/null

--- a/bin/omarchy-theme-set-keyboard-asus-rog
+++ b/bin/omarchy-theme-set-keyboard-asus-rog
@@ -3,5 +3,11 @@
 ASUSCTL_THEME=~/.config/omarchy/current/theme/keyboard.rgb
 
 if omarchy-cmd-present asusctl; then
+  # TUF keyboards need a mode cycle to flush color changes to hardware
+  if omarchy-hw-asus-tuf; then
+    asusctl aura effect --next-mode
+    sleep 0.3
+  fi
+
   asusctl aura effect static -c $(sed 's/^#//' $ASUSCTL_THEME)
 fi

--- a/bin/omarchy-theme-set-keyboard-asus-rog
+++ b/bin/omarchy-theme-set-keyboard-asus-rog
@@ -3,11 +3,5 @@
 ASUSCTL_THEME=~/.config/omarchy/current/theme/keyboard.rgb
 
 if omarchy-cmd-present asusctl; then
-  # TUF keyboards need a mode cycle to flush color changes to hardware
-  if omarchy-hw-asus-tuf; then
-    asusctl aura effect --next-mode
-    sleep 0.3
-  fi
-
   asusctl aura effect static -c $(sed 's/^#//' $ASUSCTL_THEME)
 fi

--- a/install/packaging/asus-rog.sh
+++ b/install/packaging/asus-rog.sh
@@ -1,3 +1,3 @@
-if omarchy-hw-asus-rog; then
+if omarchy-hw-asus-rog || omarchy-hw-asus-tuf; then
   omarchy-pkg-add asusctl
 fi


### PR DESCRIPTION
## Summary

- Add `omarchy-hw-asus-tuf` detection script for TUF Gaming laptops (`TUF` in product_family)
- Include TUF laptops in `asusctl` auto-install packaging alongside ROG

The existing `omarchy-theme-set-keyboard-asus-rog` script works as-is on TUF hardware — no changes needed there. The only issue is that `asusctl` is never auto-installed because `omarchy-hw-asus-rog` doesn't detect TUF laptops.

Closes #5019

## Test plan

- [ ] Verify `omarchy-hw-asus-tuf` returns true on TUF laptops and false on non-TUF
- [ ] Verify `asusctl` is auto-installed on TUF laptops during setup
- [ ] Verify keyboard RGB color changes on theme switch on TUF hardware
- [ ] Verify no regression on ROG hardware