### PR TITLE
fix: avoid about info clipping on low-resolution displays

### DIFF
--- a/bin/omarchy-launch-about
+++ b/bin/omarchy-launch-about
@@ -2,4 +2,12 @@
 
 # Launch the fastfetch TUI that gives information about the current system.
 
+if omarchy-cmd-present hyprctl && omarchy-cmd-present jq; then
+  read -r monitor_width monitor_height < <(hyprctl monitors -j 2>/dev/null | jq -r '.[] | select(.focused == true) | "\(.width) \(.height)"')
+
+  if [[ $monitor_width =~ ^[0-9]+$ && $monitor_height =~ ^[0-9]+$ ]] && ((monitor_width <= 1366 || monitor_height <= 768)); then
+    exec omarchy-launch-or-focus-tui "bash -c 'fastfetch --logo none; read -n 1 -s'"
+  fi
+fi
+
 exec omarchy-launch-or-focus-tui "bash -c 'fastfetch; read -n 1 -s'"


### PR DESCRIPTION
## Summary

This PR fixes clipped About information on low-resolution displays (for example 1366x768 laptops).

## What changed

Updated `bin/omarchy-launch-about` to detect the focused monitor resolution (via `hyprctl` + `jq`) and:

- use `fastfetch --logo none` on low-resolution displays (`<= 1366x768`)
- keep existing `fastfetch` behavior on larger displays

## Why

On smaller laptop resolutions, the About screen can be cut off due to logo + content layout.  
Hiding the logo only for low-resolution screens improves readability while preserving the original experience on normal/large displays.

## Scope

- Minimal, targeted change in one script
- No changes to default behavior for normal resolutions

Closes #4981
