### PR TITLE
add odin to installable development environments

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -3,7 +3,7 @@
 # Install one of the supported development environments. Usually called via Install > Development > * in the Omarchy Menu.
 
 if [[ -z $1 ]]; then
-  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>" >&2
+  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala|odin>" >&2
   exit 1
 fi
 
@@ -147,5 +147,9 @@ scala)
   mise use --global java@latest
   mise use --global scala@latest
   mise use --global scala-cli@latest
+  ;;
+odin)
+  echo -e "Installing Odin...\n"
+  mise use --global odin@dev-2026-03
   ;;
 esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -400,7 +400,7 @@ show_install_font_menu() {
 }
 
 show_install_development_menu() {
-  case $(menu "Install" "󰫏  Ruby on Rails\n  Docker DB\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala") in
+  case $(menu "Install" "󰫏  Ruby on Rails\n  Docker DB\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala\n󱐌  Odin") in
   *Rails*) present_terminal "omarchy-install-dev-env ruby" ;;
   *Docker*) present_terminal omarchy-install-docker-dbs ;;
   *JavaScript*) show_install_javascript_menu ;;
@@ -415,6 +415,7 @@ show_install_development_menu() {
   *OCaml*) present_terminal "omarchy-install-dev-env ocaml" ;;
   *Clojure*) present_terminal "omarchy-install-dev-env clojure" ;;
   *Scala*) present_terminal "omarchy-install-dev-env scala" ;;
+  *Odin*) present_terminal "omarchy-install-dev-env odin" ;;
   *) show_install_menu ;;
   esac
 }
@@ -462,7 +463,7 @@ show_remove_menu() {
 }
 
 show_remove_development_menu() {
-  case $(menu "Remove" "󰫏  Ruby on Rails\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala") in
+  case $(menu "Remove" "󰫏  Ruby on Rails\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala\n󱐌  Odin") in
   *Rails*) present_terminal "omarchy-remove-dev-env ruby" ;;
   *JavaScript*) show_remove_javascript_menu ;;
   *Go*) present_terminal "omarchy-remove-dev-env go" ;;
@@ -476,6 +477,7 @@ show_remove_development_menu() {
   *OCaml*) present_terminal "omarchy-remove-dev-env ocaml" ;;
   *Clojure*) present_terminal "omarchy-remove-dev-env clojure" ;;
   *Scala*) present_terminal "omarchy-remove-dev-env scala" ;;
+  *Odin*) present_terminal "omarchy-remove-dev-env odin" ;;
   *) show_remove_menu ;;
   esac
 }

--- a/bin/omarchy-remove-dev-env
+++ b/bin/omarchy-remove-dev-env
@@ -4,7 +4,7 @@
 # Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala>
 
 if [[ -z $1 ]]; then
-  echo "Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala>" >&2
+  echo "Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala|odin>" >&2
   exit 1
 fi
 
@@ -102,6 +102,11 @@ scala)
   mise uninstall scala-cli --all
   mise rm -g scala
   mise rm -g scala-cli
+  ;;
+odin)
+  echo -e "Removing Odin...\n"
+  mise uninstall odin --all
+  mise rm -g odin
   ;;
 *)
   echo "Unknown environment: $1"


### PR DESCRIPTION
This PR adds "odin" as a supported option in the Omarchy development environment installer.

Changes include:
- bin/omarchy-install-dev-env — updated usage message to include Odin
- bin/omarchy-menu — added Odin to the menu options
- bin/omarchy-remove-dev-env — ensure Odin can be removed if installed

Tested locally with Odin environment to confirm installation and removal work as expected.

This is a minor addition and does not affect existing functionality for other environments.