### PR TITLE
chore : Properly set timeout for screen lock to 5 minutes

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -11,7 +11,7 @@ listener {
 }
 
 listener {
-    timeout = 151                      # 5min
+    timeout = 300                      # 5min
     on-timeout = loginctl lock-session # lock screen when timeout has passed
 }
 


### PR DESCRIPTION
Timeout for screen lock was not properly set to 5 minutes. Was set as 151 seconds, 2.51 mins