### PR TITLE
Prevent empty passwords in omarchy-drive-set-password

### DIFF
--- a/bin/omarchy-drive-set-password
+++ b/bin/omarchy-drive-set-password
@@ -25,7 +25,7 @@ if [[ -n $encrypted_drives ]]; then
     fi
 
     echo "Changing full-disk encryption password for $drive_to_change"
-    echo "$new_password" | sudo cryptsetup luksChangeKey --pbkdf argon2id --iter-time 2000 "$drive_to_change"
+    printf '%s' "$new_password" | sudo cryptsetup luksChangeKey --pbkdf argon2id --iter-time 2000 "$drive_to_change"
   else
     echo "No drive selected."
   fi

--- a/bin/omarchy-drive-set-password
+++ b/bin/omarchy-drive-set-password
@@ -5,15 +5,27 @@
 encrypted_drives=$(blkid -t TYPE=crypto_LUKS -o device)
 
 if [[ -n $encrypted_drives ]]; then
-  if (( $(wc -l <<<encrypted_drives) == 1 )); then
+  if (($(wc -l <<<encrypted_drives) == 1)); then
     drive_to_change="$encrypted_drives"
   else
     drive_to_change="$(omarchy-drive-select "$encrypted_drives")"
   fi
 
   if [[ -n $drive_to_change ]]; then
+    new_password=$(gum input --password --header="New encryption password:")
+    if [[ -z $new_password ]]; then
+      echo "Password cannot be empty."
+      exit 1
+    fi
+
+    confirm_password=$(gum input --password --header="Confirm new encryption password:")
+    if [[ "$new_password" != "$confirm_password" ]]; then
+      echo "Passwords do not match."
+      exit 1
+    fi
+
     echo "Changing full-disk encryption password for $drive_to_change"
-    sudo cryptsetup luksChangeKey --pbkdf argon2id --iter-time 2000 "$drive_to_change"
+    echo "$new_password" | sudo cryptsetup luksChangeKey --pbkdf argon2id --iter-time 2000 "$drive_to_change"
   else
     echo "No drive selected."
   fi


### PR DESCRIPTION
Fixes #4964, related to #1848
omarchy-drive-set-password previously delegated all input handling directly to cryptsetup luksChangeKey, which accepts empty passphrases as valid. This caused an unrecoverable state: the LUKS boot prompt cannot submit an empty string, effectively bricking the machine and forcing a full OS reinstall.
This fix captures the new password via gum input --password before passing it to cryptsetup, adding two guards: rejection of empty passwords (which also handles Ctrl+C cancellation, per omarchy convention), and confirmation mismatch detection.
Some lines were auto-formated on save.