### PR TITLE
Add opt-in screenshot hook

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -124,10 +124,14 @@ if [[ $PROCESSING == "slurp" ]]; then
   grim -g "$SELECTION" "$FILEPATH" || exit 1
   wl-copy <"$FILEPATH"
 
-  (
-    ACTION=$(notify-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" -t 10000 -i "$FILEPATH" -A "default=edit")
-    [[ $ACTION == "default" ]] && open_editor "$FILEPATH"
-  ) &
+  if [[ -f ~/.config/omarchy/hooks/screenshot ]]; then
+    omarchy-hook screenshot "$FILEPATH" &
+  else
+    (
+      ACTION=$(notify-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" -t 10000 -i "$FILEPATH" -A "default=edit")
+      [[ $ACTION == "default" ]] && open_editor "$FILEPATH"
+    ) &
+  fi
 else
   grim -g "$SELECTION" - | wl-copy
 fi

--- a/config/omarchy/hooks/screenshot.sample
+++ b/config/omarchy/hooks/screenshot.sample
@@ -4,7 +4,9 @@
 # captured and copied to clipboard. It replaces the default notify-send
 # notification. To put it into use, remove .sample from the name.
 #
-# Example: macOS-style draggable preview thumbnail (AUR: omarchy-screenshot-preview)
-#   omarchy-screenshot-preview "$1"
+# Requires: omarchy-screenshot-preview (AUR)
+#   yay -S omarchy-screenshot-preview
 
-notify-send "Screenshot copied & saved" "$1" -t 5000 -i "$1"
+if omarchy-cmd-present omarchy-screenshot-preview; then
+  omarchy-screenshot-preview "$1"
+fi

--- a/config/omarchy/hooks/screenshot.sample
+++ b/config/omarchy/hooks/screenshot.sample
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This hook is called with the screenshot filepath after a screenshot is
+# captured and copied to clipboard. It replaces the default notify-send
+# notification. To put it into use, remove .sample from the name.
+#
+# Example: macOS-style draggable preview thumbnail (AUR: omarchy-screenshot-preview)
+#   omarchy-screenshot-preview "$1"
+
+notify-send "Screenshot copied & saved" "$1" -t 5000 -i "$1"

--- a/migrations/1773783805.sh
+++ b/migrations/1773783805.sh
@@ -1,0 +1,7 @@
+echo "Add sample screenshot hook"
+
+mkdir -p ~/.config/omarchy/hooks
+
+if [[ ! -f ~/.config/omarchy/hooks/screenshot.sample ]]; then
+  cp "$OMARCHY_PATH/config/omarchy/hooks/screenshot.sample" ~/.config/omarchy/hooks/screenshot.sample
+fi


### PR DESCRIPTION
## Problem

After taking a screenshot, the notification in the top-right corner is easy to miss and doesn't support drag-and-drop. On macOS, a draggable thumbnail appears in the bottom-right corner — you can drag it directly into appsw or click it to edit.

## Solution

Add an opt-in `screenshot` hook to `omarchy-cmd-screenshot`, following the same pattern as the `battery-low` hook (#4945).

**Changes:**
- Call `omarchy-hook screenshot` from the screenshot command with the filepath
- Add a sample hook that uses [`omarchy-screenshot-preview`](https://aur.archlinux.org/packages/omarchy-screenshot-preview) (AUR package)
- Add a migration to copy the sample hook for existing users

**Default behavior is unchanged** — the hook file does not exist by default. Users opt in by renaming `screenshot.sample` to `screenshot` in `~/.config/omarchy/hooks/`.

## How it works

1. User installs the AUR package: `yay -S omarchy-screenshot-preview`
2. Enables the hook: `mv ~/.config/omarchy/hooks/screenshot.sample ~/.config/omarchy/hooks/screenshot`
3. Print Screen now shows a macOS-style thumbnail that can be:
   - **Dragged** to any app ( file manager, browser, etc.)
   - **Clicked** to open in the screenshot editor (satty)
   - **Auto-dismissed** after 5 seconds (hover pauses the timer)

The preview is a lightweight Rust binary (420K) using GTK4 + gtk4-layer-shell.

Source: https://github.com/rodrigo-sntg/omarchy-screenshot-preview