### PR TITLE
Set low urgency for immediate-feedback notifications

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -33,7 +33,7 @@ if [[ -n $font_name ]]; then
     omarchy-restart-swayosd
 
     if pgrep -x ghostty; then
-      notify-send "    You must restart Ghostty to see font change"
+      notify-send -u low "    You must restart Ghostty to see font change"
     fi
 
     omarchy-hook font-set "$font_name"

--- a/bin/omarchy-hyprland-monitor-scaling-cycle
+++ b/bin/omarchy-hyprland-monitor-scaling-cycle
@@ -21,4 +21,4 @@ esac
 hyprctl keyword misc:disable_scale_notification true
 hyprctl keyword monitor "$ACTIVE_MONITOR,${WIDTH}x${HEIGHT}@${REFRESH_RATE},auto,$NEW_SCALE"
 hyprctl keyword misc:disable_scale_notification false
-notify-send "󰍹    Display scaling set to ${NEW_SCALE}x"
+notify-send -u low "󰍹    Display scaling set to ${NEW_SCALE}x"

--- a/bin/omarchy-hyprland-window-single-square-aspect-toggle
+++ b/bin/omarchy-hyprland-window-single-square-aspect-toggle
@@ -6,8 +6,8 @@ CURRENT_VALUE=$(hyprctl getoption "layout:single_window_aspect_ratio" 2>/dev/nul
 # Parse vec2 output: "vec2: [1, 1]" or "vec2: [0, 0]"
 if [[ $CURRENT_VALUE == *"[1, 1]"* ]]; then
   hyprctl keyword layout:single_window_aspect_ratio "0 0"
-  notify-send "    Disable single-window square aspect ratio"
+  notify-send -u low "    Disable single-window square aspect ratio"
 else
   hyprctl keyword layout:single_window_aspect_ratio "1 1"
-  notify-send "    Enable single-window square aspect"
+  notify-send -u low "    Enable single-window square aspect"
 fi

--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -11,4 +11,4 @@ case "$CURRENT_LAYOUT" in
 esac
 
 hyprctl keyword workspace $ACTIVE_WORKSPACE, layout:$NEW_LAYOUT
-notify-send "󱂬    Workspace layout set to $NEW_LAYOUT"
+notify-send -u low "󱂬    Workspace layout set to $NEW_LAYOUT"

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -46,7 +46,7 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
       -e omarchy-cmd-screensaver
     ;;
   *)
-    notify-send "✋  Screensaver only runs in Alacritty, Ghostty, or Kitty"
+    notify-send -u low "✋  Screensaver only runs in Alacritty, Ghostty, or Kitty"
     ;;
   esac
 done

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -54,7 +54,7 @@ present_terminal() {
 }
 
 open_in_editor() {
-  notify-send "Editing config file" "$1"
+  notify-send -u low "Editing config file" "$1"
   omarchy-launch-editor "$1"
 }
 

--- a/bin/omarchy-toggle-idle
+++ b/bin/omarchy-toggle-idle
@@ -2,10 +2,10 @@
 
 if pgrep -x hypridle >/dev/null; then
   pkill -x hypridle
-  notify-send "󱫖    Stop locking computer when idle"
+  notify-send -u low "󱫖    Stop locking computer when idle"
 else
   uwsm-app -- hypridle >/dev/null 2>&1 &
-  notify-send "󱫖    Now locking computer when idle"
+  notify-send -u low "󱫖    Now locking computer when idle"
 fi
 
 pkill -RTMIN+9 waybar

--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -21,10 +21,10 @@ restart_nightlighted_waybar() {
 
 if [[ $CURRENT_TEMP == $OFF_TEMP ]]; then
   hyprctl hyprsunset temperature $ON_TEMP
-  notify-send "  Nightlight screen temperature"
+  notify-send -u low "  Nightlight screen temperature"
   restart_nightlighted_waybar
 else
   hyprctl hyprsunset temperature $OFF_TEMP
-  notify-send "   Daylight screen temperature"
+  notify-send -u low "   Daylight screen temperature"
   restart_nightlighted_waybar
 fi

--- a/bin/omarchy-toggle-notification-silencing
+++ b/bin/omarchy-toggle-notification-silencing
@@ -3,9 +3,9 @@
 makoctl mode -t do-not-disturb
 
 if makoctl mode | grep -q 'do-not-disturb'; then
-  notify-send "󰂛    Silenced notifications"
+  notify-send -u low "󰂛    Silenced notifications"
 else
-  notify-send "󰂚    Enabled notifications"
+  notify-send -u low "󰂚    Enabled notifications"
 fi
 
 pkill -RTMIN+10 waybar

--- a/bin/omarchy-toggle-screensaver
+++ b/bin/omarchy-toggle-screensaver
@@ -4,9 +4,9 @@ STATE_FILE=~/.local/state/omarchy/toggles/screensaver-off
 
 if [[ -f $STATE_FILE ]]; then
   rm -f $STATE_FILE
-  notify-send "󱄄   Screensaver enabled"
+  notify-send -u low "󱄄   Screensaver enabled"
 else
   mkdir -p "$(dirname $STATE_FILE)"
   touch $STATE_FILE
-  notify-send "󱄄   Screensaver disabled"
+  notify-send -u low "󱄄   Screensaver disabled"
 fi

--- a/bin/omarchy-toggle-suspend
+++ b/bin/omarchy-toggle-suspend
@@ -4,9 +4,9 @@ STATE_FILE=~/.local/state/omarchy/toggles/suspend-off
 
 if [[ -f $STATE_FILE ]]; then
   rm -f $STATE_FILE
-  notify-send "󰒲   Suspend now available in system menu"
+  notify-send -u low "󰒲   Suspend now available in system menu"
 else
   mkdir -p "$(dirname $STATE_FILE)"
   touch $STATE_FILE
-  notify-send "󰒲   Suspend removed from system menu"
+  notify-send -u low "󰒲   Suspend removed from system menu"
 fi

--- a/config/omarchy/hooks/font-set.sample
+++ b/config/omarchy/hooks/font-set.sample
@@ -4,4 +4,4 @@
 # To put it into use, remove .sample from the name.
 
 # Example: Show the name of the theme that was just set.
-# notify-send "New font" "Your new font is $1"
+# notify-send -u low "New font" "Your new font is $1"

--- a/config/omarchy/hooks/post-update.sample
+++ b/config/omarchy/hooks/post-update.sample
@@ -4,4 +4,4 @@
 # To put it into use, remove .sample from the name.
 
 # Example: Show notification after the system has been updated.
-# notify-send "Update Performed" "Your system is now up to date"
+# notify-send -u low "Update Performed" "Your system is now up to date"

--- a/config/omarchy/hooks/theme-set.sample
+++ b/config/omarchy/hooks/theme-set.sample
@@ -4,4 +4,4 @@
 # To put it into use, remove .sample from the name.
 
 # Example: Show the name of the theme that was just set.
-# notify-send "New theme" "Your new theme is $1"
+# notify-send -u low "New theme" "Your new theme is $1"

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -42,8 +42,8 @@ bindd = SUPER, PRINT, Color picker, exec, pkill hyprpicker || hyprpicker -a
 bindd = SUPER CTRL, S, Share, exec, omarchy-menu share
 
 # Waybar-less information
-bindd = SUPER CTRL ALT, T, Show time, exec, notify-send "    $(date +"%A %H:%M  —  %d %B W%V %Y")"
-bindd = SUPER CTRL ALT, B, Show battery remaining, exec, notify-send "$(omarchy-battery-status)"
+bindd = SUPER CTRL ALT, T, Show time, exec, notify-send -u low "    $(date +"%A %H:%M  —  %d %B W%V %Y")"
+bindd = SUPER CTRL ALT, B, Show battery remaining, exec, notify-send -u low "$(omarchy-battery-status)"
 
 # Control panels
 bindd = SUPER CTRL, A, Audio controls, exec, omarchy-launch-audio


### PR DESCRIPTION
## Description

Some users may choose to disable notification timeout for normal-level notifications to ensure no notifications are missed when the user is away from the screen. However, there are several Omarchy notifications that only serve as an immediate feedback for a user action, such as "Screensaver enabled" or "Editing config file foo.conf", for which disabling the timeout is not desirable. This commit drops the urgency level for such notification to low, allowing configuring a different timeout value for them.

Example mako configuration utilizing the changes:
```
default-timeout=0
[urgency=low]
default-timeout=5000
```

Notifications with an explicitly set timeout are excluded from this commit.

## Alternative designs

#### (Selected) Option 1 - Urgency level

This is the design implemented in this PR.

Pros: simplicity
Cons: broader filter

#### Option 2 - Category field

```notify-send "Screensaver enabled" -c omarchy.toggle```

```
[category=omarchy.toggle]
default-timeout=5000
```

Pros: narrower filter
Cons: new category to manage

See also: https://specifications.freedesktop.org/notification/1.3/categories.html

#### Option 3 - Explicit timeout

```notify-send "Screensaver enabled" -t 5000```

Pros: More opinionated
Cons: Harder for user to override