### PR TITLE
Persist update log across reboots

### DIFF
--- a/bin/omarchy-update-analyze-logs
+++ b/bin/omarchy-update-analyze-logs
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-update_log="/tmp/omarchy-update.log"
+update_log="$HOME/.local/state/omarchy/update.log"
 
 # Check for initramfs generation failure
 if grep -q "Updating linux initcpios" "$update_log"; then

--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -7,7 +7,7 @@ hyprctl dispatch tagwindow +noidle &>/dev/null || true
 
 # Capture update logs (CLICOLOR_FORCE keeps gum styled when stdout is piped through tee)
 export CLICOLOR_FORCE=1
-exec > >(tee "/tmp/omarchy-update.log") 2>&1
+exec > >(tee "$HOME/.local/state/omarchy/update.log") 2>&1
 
 # Perform all update steps
 omarchy-update-keyring


### PR DESCRIPTION
When the update includes a kernel upgrade, `omarchy-update-restart` triggers a reboot which wipes `/tmp`. The update log written by `omarchy-update-perform` is lost before the user can review it.

This moves the log from `/tmp/omarchy-update.log` to `~/.local/state/omarchy/update.log`. That directory already exists and is used for migration state, toggles, and first-run tracking — it follows XDG conventions and survives reboots.

Two-line change across two files:
- `bin/omarchy-update-perform` (writes the log)
- `bin/omarchy-update-analyze-logs` (reads the log)

Fixes #4965