### PR TITLE
Make omarchy menu and cpu buttons "infinitely wide" for easier clicking

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -15,8 +15,16 @@
   margin-left: 0;
 }
 
+#custom-omarchy {
+  padding-left: 8px;
+}
+
 .modules-right {
-  margin-right: 8px;
+  margin-right: 0;
+}
+
+#cpu {
+  padding-right: 8px;
 }
 
 #workspaces button {

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -12,7 +12,7 @@
 }
 
 .modules-left {
-  margin-left: 8px;
+  margin-left: 0;
 }
 
 .modules-right {


### PR DESCRIPTION
This is a simple quality of life improvement that pads the omarchy menu button to the top left corner of the screen and the cpu widget to the top right corner of the screen (with no unclickable gaps). This makes it possible to yank the mouse to the desired corner and click to get the desired action (previously one had to aim carefully as you would otherwise have the pointer in an 8px gap).

The layout is unchanged.

See https://en.wikipedia.org/wiki/Fitts%27s_law#Implications_for_UI_design