### PR TITLE
fix: firmware updates failing with Limine bootloader

### DIFF
--- a/bin/omarchy-update-firmware
+++ b/bin/omarchy-update-firmware
@@ -1,10 +1,17 @@
 #!/bin/bash
 
+# Update system firmware using fwupd. Ensures the fwupd EFI binary is installed
+# in the ESP so UEFI capsule updates work with the Limine bootloader.
+
 set -e
 echo -e "\e[32mUpdate Firmware\e[0m"
 
 if omarchy-cmd-missing fwupdmgr; then
   omarchy-pkg-add fwupd
+fi
+
+if [[ -d /sys/firmware/efi ]] && [[ -f /usr/lib/fwupd/efi/fwupdx64.efi ]]; then
+  sudo install -D /usr/lib/fwupd/efi/fwupdx64.efi /boot/EFI/arch/fwupdx64.efi
 fi
 
 fwupdmgr refresh --force


### PR DESCRIPTION
Today I wanted to update my firmware via Update > Firmware and it failed with:

```
failed to write-firmware: cannot find either EFI/systemd or EFI/arch in ESP
```

The issue is that fwupd expects either `EFI/systemd` (systemd-boot) or `EFI/arch` (GRUB) in the ESP to stage UEFI capsule updates. Since Omarchy uses Limine, which creates `EFI/limine/`, fwupd can't find a recognized bootloader directory to place its EFI binary.

The fix installs `/usr/lib/fwupd/efi/fwupdx64.efi` into `/boot/EFI/arch/` before running the update. This only runs on UEFI systems where the fwupd EFI binary is available.

This worked for me on a Lenovo ThinkPad T14s Gen 2a (20XGS04V00), firmware went from 0.1.34 to 0.1.36. The update process takes a while and the actual flash happens on the next reboot, so just let it do its thing. Would be great if someone else could give it a try too.