### PR TITLE
feat: enable calc provider by default in walker launcher

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -17,6 +17,7 @@ symbols = 1 # providers to be queried by default
 max_results = 256 # 256 should be enough for everyone
 default = [
   "desktopapplications",
+  "calc",
   "websearch",
 ]
 


### PR DESCRIPTION
## Summary
* Adds the `calc` provider to the default providers list in the Walker launcher configuration.
* Allows users to perform simple mathematics as they type without needing the `=` prefix.