### PR TITLE
Add Pi to the AI install menu

### DIFF
--- a/bin/omarchy-install-pi
+++ b/bin/omarchy-install-pi
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install the Pi coding agent CLI via an npx wrapper.
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "Pi requires Node.js/npm (npx)."
+  echo "Install Node.js first from Install > Development > JavaScript > Node.js."
+  exit 1
+fi
+
+echo "Installing Pi..."
+omarchy-npx-install @mariozechner/pi-coding-agent pi
+
+echo
+echo "Pi installed. Launch with: pi"
+echo "Then authenticate with /login or set an API key."

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -355,11 +355,12 @@ show_install_ai_menu() {
       echo ollama
   )
 
-  case $(menu "Install" "  Dictation\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush") in
+  case $(menu "Install" "  Dictation\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush\n󱚤  Pi") in
   *Dictation*) present_terminal omarchy-voxtype-install ;;
   *Studio*) install "LM Studio" "lmstudio-bin" ;;
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;
+  *Pi*) present_terminal omarchy-install-pi ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
## Summary

Adds the [Pi coding agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) as an optional installable AI CLI under: `Install -> AI -> Pi`

This adds a dedicated installer command that creates the `pi` CLI via Omarchy’s existing `omarchy-npx-install` wrapper pattern.

## Why

Pi is a popular agent harness (w/ over 26k stars on GitHub) that occupies a different niche than the existing agent harnesses that are installable in the Omarchy AI menu. Pi has a minimal core—just four tools and a small system prompt—and pushes everything else into a TypeScript extension system that users own and shape, which feels very "Omarchy" in nature.

 ## Changes

 - Adds `bin/omarchy-install-pi`
   - checks for `npx`
   - shows a helpful message if Node.js is not installed
   - installs Pi with: `omarchy-npx-install @mariozechner/pi-coding-agent pi`
   - prints brief next-step guidance after install

- Updates `bin/omarchy-menu`
- adds `Pi` to the `Install -> AI` menu
- points to `omarchy-install-pi`

## Notes

- This is intentionally **optional install only**
- Pi is **not** added to `install/packaging/npx.sh`
- Users without Node.js installed will be prompted to install it first from:
  - `Install -> Development -> JavaScript -> Node.js`

## Testing

- Verified the new menu entry is wired under `Install -> AI`
- Verified installer script follows Omarchy bash conventions
- Verified install path uses existing `omarchy-npx-install` helper

## Screenshots
<img width="1970" height="1914" alt="image" src="https://github.com/user-attachments/assets/ba32b893-9492-4be2-9b28-0084366f066c" />