### PR TITLE
Fix Super+Ctrl+Backspace to cycle monitor scaling per v3.4.0 changelog

### DIFF
--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -15,7 +15,8 @@ bindd = SUPER CTRL, SPACE, Theme background menu, exec, omarchy-menu background
 bindd = SUPER SHIFT CTRL, SPACE, Theme menu, exec, omarchy-menu theme
 bindd = SUPER, BACKSPACE, Toggle window transparency, exec, hyprctl dispatch setprop "address:$(hyprctl activewindow -j | jq -r '.address')" opaque toggle
 bindd = SUPER SHIFT, BACKSPACE, Toggle window gaps, exec, omarchy-hyprland-window-gaps-toggle
-bindd = SUPER CTRL, BACKSPACE, Toggle single-window square aspect, exec, omarchy-hyprland-window-single-square-aspect-toggle
+bindd = SUPER CTRL, BACKSPACE, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle
+bindd = SUPER CTRL ALT, BACKSPACE, Toggle single-window square aspect, exec, omarchy-hyprland-window-single-square-aspect-toggle
 
 # Notifications
 bindd = SUPER, COMMA, Dismiss last notification, exec, makoctl dismiss

--- a/migrations/1774162734.sh
+++ b/migrations/1774162734.sh
@@ -1,0 +1,3 @@
+echo "Fix Super+Ctrl+Backspace to cycle monitor scaling; move square aspect toggle to Super+Ctrl+Alt+Backspace"
+
+omarchy-refresh-config hypr/bindings/utilities.conf

--- a/migrations/1774162734.sh
+++ b/migrations/1774162734.sh
@@ -1,3 +1,3 @@
 echo "Fix Super+Ctrl+Backspace to cycle monitor scaling; move square aspect toggle to Super+Ctrl+Alt+Backspace"
 
-omarchy-refresh-config hypr/bindings/utilities.conf
+omarchy-restart-hyprctl


### PR DESCRIPTION
## Problem

The v3.4.0 changelog listed two new keybindings:

- `Super+Ctrl+Backspace` → cycle monitor scaling (1x → 1.6x → 2x → 3x)
- `Super+Ctrl+Alt+Backspace` → toggle single-window square aspect ratio

The `omarchy-hyprland-monitor-scaling-cycle` script was correctly added to `bin/`, but `default/hypr/bindings/utilities.conf` was never updated. Users upgrading via `omarchy-update` got the script but `Super+Ctrl+Backspace` kept triggering the square aspect toggle instead.

Fixes #5094

## Changes

- Updated `default/hypr/bindings/utilities.conf` to assign the bindings as documented in the changelog
- Added a migration to refresh the binding file for existing installs