### PR TITLE
Fix layout toggle for special workspaces

### DIFF
--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -1,14 +1,22 @@
 #!/bin/bash
 
 # Toggle the layout on the current active workspace between dwindle and scrolling
+# activeworkspace doesn't report special workspaces, so first check monitors instead
+SPECIAL_NAME=$(hyprctl monitors -j | jq -r '.[0].specialWorkspace.name')
+SPECIAL_ID=$(hyprctl monitors -j | jq -r '.[0].specialWorkspace.id')
 
-ACTIVE_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
-CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+if [ -n "$SPECIAL_NAME" ] && [ "$SPECIAL_ID" != "0" ]; then
+  WORKSPACE_ID=$SPECIAL_ID
+  CURRENT_LAYOUT=$(hyprctl workspaces -j | jq -r --argjson id "$WORKSPACE_ID" '.[] | select(.id == $id) | .tiledLayout')
+else
+  WORKSPACE_ID=$(hyprctl activeworkspace -j | jq -r '.id')
+  CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+fi
 
 case "$CURRENT_LAYOUT" in
   dwindle) NEW_LAYOUT=scrolling ;;
   *) NEW_LAYOUT=dwindle ;;
 esac
 
-hyprctl keyword workspace $ACTIVE_WORKSPACE, layout:$NEW_LAYOUT
+hyprctl keyword workspace $WORKSPACE_ID, layout:$NEW_LAYOUT
 notify-send "󱂬    Workspace layout set to $NEW_LAYOUT"


### PR DESCRIPTION
`hyprctl activeworkspace` doesnt return special workspaces. This caused the layout toggle to apply to the wrong workspace.

Fix: Check `hyprctl monitors` before `hyprctl activeworkspace` for an active special workspace.

Fixes #4881