### PR TITLE
Add optional project scratchpad system

### DIFF
--- a/bin/omarchy-install-project-scratchpads
+++ b/bin/omarchy-install-project-scratchpads
@@ -61,7 +61,7 @@ else
 # BEGIN Project Scratchpads
 bindd = SUPER, SEMICOLON, Toggle project scratchpad, exec, omarchy-project-scratchpad toggle
 bindd = SUPER ALT, SEMICOLON, Send to project scratchpad, exec, omarchy-project-scratchpad send
-bindd = SUPER CTRL, P, Project picker, exec, omarchy-project-picker
+bindd = SUPER SHIFT, P, Project picker, exec, omarchy-project-picker
 
 bindd = CTRL ALT, 1, Switch to project 1, exec, omarchy-project-select 1 && omarchy-project-scratchpad toggle
 bindd = CTRL ALT, 2, Switch to project 2, exec, omarchy-project-select 2 && omarchy-project-scratchpad toggle
@@ -93,11 +93,11 @@ echo ""
 echo "  Add your first project to $CONFIG_FILE:"
 echo "    myapp|myapp|~/dev/myapp|active"
 echo ""
-echo "  Then press Super+Ctrl+P to open the project picker."
+echo "  Then press Super+Shift+P to open the project picker."
 echo ""
 echo "  Keybindings (active immediately — Hyprland auto-reloads on config change):"
 echo "    Super+;              Toggle current project scratchpad"
 echo "    Super+Alt+;          Send window to project scratchpad"
-echo "    Super+Ctrl+P         Project picker (create/switch/shelve)"
+echo "    Super+Shift+P         Project picker (create/switch/shelve)"
 echo "    Ctrl+Alt+1-9         Quick switch to project N"
 echo "    Ctrl+Alt+Shift+1-9   Send window to project N"

--- a/bin/omarchy-install-project-scratchpads
+++ b/bin/omarchy-install-project-scratchpads
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Install the project scratchpad system for managing project-specific
+# special workspaces in Hyprland with tmux session sync.
+
+# Check required dependencies
+if omarchy-cmd-missing tmux; then
+  echo "tmux is required for project scratchpads."
+  echo "Install with: omarchy-pkg-add tmux"
+  exit 1
+fi
+
+if omarchy-cmd-missing jq; then
+  echo "jq is required for project scratchpads."
+  echo "Install with: omarchy-pkg-add jq"
+  exit 1
+fi
+
+if omarchy-cmd-missing fd; then
+  echo "Note: fd not found. Project directory browsing will use 'find' instead."
+  echo "For better results: omarchy-pkg-add fd"
+fi
+
+# Create projects.conf if it doesn't exist
+CONFIG_FILE="$HOME/.config/hypr/projects.conf"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  cat > "$CONFIG_FILE" << 'CONF'
+# Project Scratchpad Configuration
+# Format: project_name|tmux_session|directory|status
+#   - project_name: identifier (alphanumeric, dashes, underscores)
+#   - tmux_session: tmux session name to attach/create
+#   - directory: project root directory
+#   - status: active (shown in picker) or pending (shelved)
+#
+# Examples:
+#   myapp|myapp|~/dev/myapp|active
+#   sideproject|sideproject|~/dev/sideproject|pending
+
+# [settings]
+# focus_mode=false
+# daily_switch_budget=3
+CONF
+  echo "Created $CONFIG_FILE"
+else
+  echo "Config already exists: $CONFIG_FILE"
+fi
+
+# Create state directory
+STATE_DIR="$HOME/.local/state/hyprland/project-scratchpads"
+mkdir -p "$STATE_DIR"
+
+# Append keybindings to bindings.conf if not already present
+BINDINGS_FILE="$HOME/.config/hypr/bindings.conf"
+MARKER="# BEGIN Project Scratchpads"
+
+if [[ -f "$BINDINGS_FILE" ]] && grep -qF "$MARKER" "$BINDINGS_FILE"; then
+  echo "Keybindings already installed in $BINDINGS_FILE"
+else
+  cat >> "$BINDINGS_FILE" << 'BINDINGS'
+
+# BEGIN Project Scratchpads
+bindd = SUPER, SEMICOLON, Toggle project scratchpad, exec, omarchy-project-scratchpad toggle
+bindd = SUPER ALT, SEMICOLON, Send to project scratchpad, exec, omarchy-project-scratchpad send
+bindd = SUPER CTRL, P, Project picker, exec, omarchy-project-picker
+
+bindd = CTRL ALT, 1, Switch to project 1, exec, omarchy-project-select 1 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 2, Switch to project 2, exec, omarchy-project-select 2 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 3, Switch to project 3, exec, omarchy-project-select 3 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 4, Switch to project 4, exec, omarchy-project-select 4 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 5, Switch to project 5, exec, omarchy-project-select 5 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 6, Switch to project 6, exec, omarchy-project-select 6 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 7, Switch to project 7, exec, omarchy-project-select 7 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 8, Switch to project 8, exec, omarchy-project-select 8 && omarchy-project-scratchpad toggle
+bindd = CTRL ALT, 9, Switch to project 9, exec, omarchy-project-select 9 && omarchy-project-scratchpad toggle
+
+bindd = CTRL ALT SHIFT, 1, Send to project 1, exec, omarchy-project-scratchpad send-to 1
+bindd = CTRL ALT SHIFT, 2, Send to project 2, exec, omarchy-project-scratchpad send-to 2
+bindd = CTRL ALT SHIFT, 3, Send to project 3, exec, omarchy-project-scratchpad send-to 3
+bindd = CTRL ALT SHIFT, 4, Send to project 4, exec, omarchy-project-scratchpad send-to 4
+bindd = CTRL ALT SHIFT, 5, Send to project 5, exec, omarchy-project-scratchpad send-to 5
+bindd = CTRL ALT SHIFT, 6, Send to project 6, exec, omarchy-project-scratchpad send-to 6
+bindd = CTRL ALT SHIFT, 7, Send to project 7, exec, omarchy-project-scratchpad send-to 7
+bindd = CTRL ALT SHIFT, 8, Send to project 8, exec, omarchy-project-scratchpad send-to 8
+bindd = CTRL ALT SHIFT, 9, Send to project 9, exec, omarchy-project-scratchpad send-to 9
+# END Project Scratchpads
+BINDINGS
+  echo "Keybindings added to $BINDINGS_FILE"
+fi
+
+echo ""
+echo "Project Scratchpads installed!"
+echo ""
+echo "  Add your first project to $CONFIG_FILE:"
+echo "    myapp|myapp|~/dev/myapp|active"
+echo ""
+echo "  Then press Super+Ctrl+P to open the project picker."
+echo ""
+echo "  Keybindings (active immediately — Hyprland auto-reloads on config change):"
+echo "    Super+;              Toggle current project scratchpad"
+echo "    Super+Alt+;          Send window to project scratchpad"
+echo "    Super+Ctrl+P         Project picker (create/switch/shelve)"
+echo "    Ctrl+Alt+1-9         Quick switch to project N"
+echo "    Ctrl+Alt+Shift+1-9   Send window to project N"

--- a/bin/omarchy-project-indicator
+++ b/bin/omarchy-project-indicator
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Project indicator for waybar — shows current project name and window count.
+# Waybar integration — add to ~/.config/waybar/config.jsonc:
+#   "custom/project": {
+#     "exec": "omarchy-project-indicator",
+#     "return-type": "json",
+#     "interval": 1,
+#     "on-click": "omarchy-project-scratchpad toggle",
+#     "tooltip": true
+#   }
+
+STATE_DIR="$HOME/.local/state/hyprland/project-scratchpads"
+VISIBLE_FILE="$STATE_DIR/project-indicator-visible"
+CONFIG_FILE="$HOME/.config/hypr/projects.conf"
+
+# Check if indicator should be visible
+visible=$(cat "$VISIBLE_FILE" 2>/dev/null || echo "0")
+
+if [[ "$visible" != "1" ]]; then
+  echo '{"text": "", "tooltip": "", "class": "hidden"}'
+  exit 0
+fi
+
+project=$(cat "$STATE_DIR/current-project" 2>/dev/null || echo "none")
+
+# Get project position (1-based index in config)
+position=$(grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | cut -d'|' -f1 | grep -n "^${project}$" | cut -d: -f1)
+position=${position:-"?"}
+
+# Count windows in this project's scratchpad
+count=$(hyprctl clients -j 2>/dev/null | jq "[.[] | select(.workspace.name == \"special:project:$project\")] | length" 2>/dev/null || echo 0)
+
+if (( count > 0 )); then
+  printf '{"text": "%s: %s (%s)", "tooltip": "Project %s: %s - %s windows\\nCtrl+Alt+%s to switch", "class": "%s"}\n' \
+    "$position" "$project" "$count" "$position" "$project" "$count" "$position" "$project"
+else
+  printf '{"text": "%s: %s", "tooltip": "Project %s: %s\\nCtrl+Alt+%s to switch", "class": "%s"}\n' \
+    "$position" "$project" "$position" "$project" "$position" "$project"
+fi

--- a/bin/omarchy-project-picker
+++ b/bin/omarchy-project-picker
@@ -1,0 +1,537 @@
+#!/bin/bash
+
+# Project Picker — CRUD interface for project scratchpads via walker
+# Config format: name|session|dir|status (status defaults to "active" if missing)
+
+CONFIG_FILE="$HOME/.config/hypr/projects.conf"
+STATE_DIR="$HOME/.local/state/hyprland/project-scratchpads"
+SWITCH_LOG="$STATE_DIR/switch-log"
+FOCUS_FILE="$STATE_DIR/focus-mode"
+SERVER_CACHE="$STATE_DIR/server-cache"
+SERVER_CACHE_TTL=600
+
+# Ensure state directory exists
+mkdir -p "$STATE_DIR"
+
+# Get 80% of screen height for walker
+SCREEN_HEIGHT=$(hyprctl monitors -j | jq '.[0].height')
+WALKER_HEIGHT=$((SCREEN_HEIGHT * 80 / 100))
+
+# Read a setting from the [settings] block in config, with default
+get_setting() {
+  local key="$1" default="$2"
+  local value
+  value=$(sed -n '/^# \[settings\]/,/^$/{ s/^# '"$key"'=//p }' "$CONFIG_FILE" | head -1)
+  echo "${value:-$default}"
+}
+
+# Daily switch tracking
+DAILY_SWITCH_BUDGET=$(get_setting "daily_switch_budget" "3")
+
+# Initialize focus mode from settings if state file doesn't exist
+if [[ ! -f "$FOCUS_FILE" ]]; then
+  default_focus=$(get_setting "focus_mode" "false")
+  [[ "$default_focus" == "true" ]] && echo "1" > "$FOCUS_FILE" || echo "0" > "$FOCUS_FILE"
+fi
+
+# Menu actions
+ACTION_NEW="➕ New project"
+ACTION_TOGGLE="🔄 Toggle status"
+ACTION_DELETE="🗑️ Delete project"
+ACTION_EDIT="✏️ Edit config"
+ACTION_SHELVED="📦 Shelved projects..."
+ACTION_FOCUS="󰈈  Focus mode"
+ACTION_REFRESH="🔃 Refresh servers"
+SEPARATOR="───────────────"
+
+# Status indicators
+STATUS_ACTIVE="●"
+STATUS_PENDING="○"
+
+# Parse config: extract project names (first field before pipe)
+get_projects() {
+  grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | cut -d'|' -f1
+}
+
+# Log action to switch-log: timestamp|action|project|details
+log_action() {
+  local action="$1" project="${2:-}" details="${3:-}"
+  printf '%s|%s|%s|%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$action" "$project" "$details" >> "$SWITCH_LOG"
+}
+
+get_today_switch_count() {
+  local today
+  today=$(date '+%Y-%m-%d')
+  grep -c "^${today}.*|switch|" "$SWITCH_LOG" 2>/dev/null || echo 0
+}
+
+# Detect tmux sessions with running dev servers (bun, pnpm, uv, node, python)
+# Returns newline-separated list of session names that have active servers
+# Results are cached to avoid redundant /proc walks
+get_sessions_with_servers() {
+  # Quick process count as cache fingerprint (~1ms)
+  local current_count
+  current_count=$(pgrep -xc "bun|node|pnpm|python|uv" 2>/dev/null || echo 0)
+
+  # Return cached results if fresh AND process count unchanged
+  if [[ -f "$SERVER_CACHE" ]]; then
+    local cache_age cached_count
+    cache_age=$(( $(date +%s) - $(stat -c %Y "$SERVER_CACHE" 2>/dev/null || echo 0) ))
+    cached_count=$(head -1 "$SERVER_CACHE" 2>/dev/null || echo "")
+    if [[ "$cache_age" -lt "$SERVER_CACHE_TTL" && "$cached_count" == "#$current_count" ]]; then
+      tail -n +2 "$SERVER_CACHE" 2>/dev/null
+      return
+    fi
+  fi
+
+  # Build PID -> session mapping from all tmux panes
+  declare -A pid_to_session
+  while IFS=' ' read -r pid sess; do
+    pid_to_session["$pid"]="$sess"
+  done < <(tmux list-panes -a -F '#{pane_pid} #{session_name}' 2>/dev/null)
+
+  # Find dev server processes
+  local server_pids
+  server_pids=$(pgrep -x "bun|node|pnpm|python|uv" 2>/dev/null || true)
+  if [[ -z "$server_pids" ]]; then
+    printf '#%s\n' "$current_count" > "$SERVER_CACHE"
+    return
+  fi
+
+  # Walk parent chain for each server PID to find its tmux session
+  declare -A found_sessions
+  for spid in $server_pids; do
+    local current="$spid"
+    while [[ "$current" -gt 1 ]]; do
+      if [[ -n "${pid_to_session[$current]:-}" ]]; then
+        found_sessions["${pid_to_session[$current]}"]=1
+        break
+      fi
+      # Walk up to parent
+      current=$(awk '{print $4}' "/proc/$current/stat" 2>/dev/null || echo 1)
+    done
+  done
+
+  # Write cache (count header + session names) and output
+  { printf '#%s\n' "$current_count"; printf '%s\n' "${!found_sessions[@]}"; } > "$SERVER_CACHE"
+  printf '%s\n' "${!found_sessions[@]}"
+}
+
+# Get projects with status and window count, in config-file order
+# Shows workspace number for easy window targeting
+get_projects_with_status() {
+  local idx=0
+
+  # Fetch all clients once for efficiency
+  local clients_json
+  clients_json=$(hyprctl clients -j 2>/dev/null || echo "[]")
+
+  # Detect which tmux sessions have running dev servers
+  local server_sessions
+  server_sessions=$(get_sessions_with_servers)
+
+  while IFS='|' read -r name session dir status; do
+    [[ -z "$name" ]] && continue
+    ((idx++))
+    # Default to "active" if status field is missing (backwards compat)
+    [[ -z "$status" ]] && status="active"
+
+    # Count windows in this project's scratchpad
+    local count
+    count=$(echo "$clients_json" | jq "[.[] | select(.workspace.name == \"special:project:$name\")] | length")
+
+    # Check if this project's tmux session has a running dev server
+    local server_indicator=""
+    if echo "$server_sessions" | grep -qx "$session"; then
+      server_indicator=" ▶"
+    fi
+
+    # Format: "idx status name [▶] (count)" or "idx status name [▶]" if no windows
+    if [[ "$count" -gt 0 ]]; then
+      echo "$idx $([[ "$status" == "active" ]] && echo "$STATUS_ACTIVE" || echo "$STATUS_PENDING") $name${server_indicator} ($count)"
+    else
+      echo "$idx $([[ "$status" == "active" ]] && echo "$STATUS_ACTIVE" || echo "$STATUS_PENDING") $name${server_indicator}"
+    fi
+  done < <(grep -v '^#' "$CONFIG_FILE" | grep -v '^$')
+}
+
+# Get only ACTIVE projects with status — for the main menu
+# idx still counts ALL projects so it maps correctly to config-file line numbers
+get_active_projects_with_status() {
+  local idx=0
+
+  local clients_json
+  clients_json=$(hyprctl clients -j 2>/dev/null || echo "[]")
+
+  local server_sessions
+  server_sessions=$(get_sessions_with_servers)
+
+  while IFS='|' read -r name session dir status; do
+    [[ -z "$name" ]] && continue
+    ((idx++))
+    [[ -z "$status" ]] && status="active"
+    [[ "$status" != "active" ]] && continue
+
+    local count
+    count=$(echo "$clients_json" | jq "[.[] | select(.workspace.name == \"special:project:$name\")] | length")
+
+    local server_indicator=""
+    if echo "$server_sessions" | grep -qx "$session"; then
+      server_indicator=" ▶"
+    fi
+
+    if [[ "$count" -gt 0 ]]; then
+      echo "$idx $STATUS_ACTIVE $name${server_indicator} ($count)"
+    else
+      echo "$idx $STATUS_ACTIVE $name${server_indicator}"
+    fi
+  done < <(grep -v '^#' "$CONFIG_FILE" | grep -v '^$')
+}
+
+# Show shelved (pending) projects in a submenu, auto-activate on selection
+shelved_projects() {
+  local idx=0
+  local pending_list=""
+
+  while IFS='|' read -r name session dir status; do
+    [[ -z "$name" ]] && continue
+    ((idx++))
+    [[ -z "$status" ]] && status="active"
+    [[ "$status" != "pending" ]] && continue
+    pending_list+="$idx $STATUS_PENDING $name"$'\n'
+  done < <(grep -v '^#' "$CONFIG_FILE" | grep -v '^$')
+
+  if [[ -z "$pending_list" ]]; then
+    notify-send "Project Picker" "No shelved projects"
+    exit 0
+  fi
+
+  local selected
+  selected=$(echo "$pending_list" | omarchy-launch-walker --dmenu --width 295 --minheight 1 --maxheight "$WALKER_HEIGHT" -p "📦 Shelved…" 2>/dev/null)
+
+  [[ -z "$selected" ]] && exit 0
+
+  local project_name
+  project_name=$(strip_status "$selected")
+
+  # Ask why — creates accountability friction
+  local reason
+  reason=$(prompt_input "Why switch to $project_name?")
+  if [[ -z "$reason" ]]; then
+    log_action "unshelve-cancel" "$project_name" "cancelled at why prompt"
+    exit 0
+  fi
+
+  # Switch budget: extra confirmation if over daily limit
+  local switch_count
+  switch_count=$(get_today_switch_count)
+  if [[ "$switch_count" -ge "$DAILY_SWITCH_BUDGET" ]]; then
+    log_action "budget-hit" "$project_name" "count=$switch_count budget=$DAILY_SWITCH_BUDGET"
+    local budget_confirm
+    budget_confirm=$(printf "Yes, switch anyway\nNo, stay focused" | omarchy-launch-walker --dmenu --width 350 --minheight 1 --maxheight 2 -p "⚠️ $switch_count switches today. Over budget ($DAILY_SWITCH_BUDGET)!" 2>/dev/null)
+    if [[ "$budget_confirm" != "Yes, switch anyway" ]]; then
+      log_action "unshelve-cancel" "$project_name" "stopped by budget gate"
+      exit 0
+    fi
+    log_action "budget-override" "$project_name" "count=$switch_count"
+  fi
+
+  log_action "switch" "$project_name" "unshelve: $reason"
+
+  # Auto-activate: flip status from pending -> active
+  local current_line
+  current_line=$(grep "^${project_name}|" "$CONFIG_FILE")
+  local act_name act_session act_dir
+  act_name=$(echo "$current_line" | cut -d'|' -f1)
+  act_session=$(echo "$current_line" | cut -d'|' -f2)
+  act_dir=$(echo "$current_line" | cut -d'|' -f3)
+  sed -i --follow-symlinks "s#^${project_name}|.*#${act_name}|${act_session}|${act_dir}|active#" "$CONFIG_FILE"
+  log_action "activate" "$project_name" "via unshelve"
+
+  # Switch to the project
+  local sel_idx
+  sel_idx=$(get_selection_idx "$selected")
+  omarchy-project-select "$sel_idx"
+  notify-send "Project Picker" "Activated & switched to: $project_name"
+}
+
+# Extract project name from "idx status name (count)" format
+strip_status() {
+  echo "$1" | sed 's/^[0-9]* [●○] //' | sed 's/ ▶//' | sed 's/ ([0-9]*)$//'
+}
+
+# Extract index from "idx status name" format
+get_selection_idx() {
+  echo "$1" | cut -d' ' -f1
+}
+
+# Build menu with active projects + actions
+build_menu() {
+  get_active_projects_with_status
+  echo "$SEPARATOR"
+  local focus_mode
+  focus_mode=$(cat "$FOCUS_FILE" 2>/dev/null || echo "0")
+  if [[ "$focus_mode" != "1" ]]; then
+    echo "$ACTION_SHELVED"
+  fi
+  if [[ "$focus_mode" == "1" ]]; then
+    echo "$ACTION_FOCUS ON"
+  else
+    echo "$ACTION_FOCUS OFF"
+  fi
+  echo "$ACTION_NEW"
+  echo "$ACTION_TOGGLE"
+  echo "$ACTION_REFRESH"
+  echo "$ACTION_DELETE"
+  echo "$ACTION_EDIT"
+}
+
+# Prompt for text input via walker
+prompt_input() {
+  local prompt="$1"
+  echo "" | omarchy-launch-walker --dmenu --width 400 --minheight 1 --maxheight 1 -p "$prompt" 2>/dev/null
+}
+
+# Special directory options
+DIR_CUSTOM="📝 Enter custom path"
+DIR_NONE="🚀 No folder yet"
+
+# Browse for directory using walker
+browse_directory() {
+  # Find directories from common locations
+  local dirs=""
+  local search_paths=("$HOME/dev" "$HOME/projects" "$HOME/work")
+
+  for path in "${search_paths[@]}"; do
+    if [[ -d "$path" ]]; then
+      if command -v fd &>/dev/null; then
+        dirs+=$(fd --type d --max-depth 3 --exclude .git --exclude node_modules --exclude .cache --exclude __pycache__ --exclude venv --exclude .venv . "$path" 2>/dev/null)
+      else
+        dirs+=$(find "$path" -maxdepth 3 -type d \
+          ! -path '*/.git/*' ! -path '*/node_modules/*' \
+          ! -path '*/.cache/*' ! -path '*/__pycache__/*' \
+          ! -path '*/venv/*' ! -path '*/.venv/*' 2>/dev/null)
+      fi
+      dirs+=$'\n'
+    fi
+  done
+
+  # Add special options at the top, then existing directories
+  {
+    echo "$DIR_CUSTOM"
+    echo "$DIR_NONE"
+    echo "$SEPARATOR"
+    echo "$dirs" | grep -v '^$' | sort -u
+  } | omarchy-launch-walker --dmenu --width 600 --minheight 1 --maxheight "$WALKER_HEIGHT" -p "📂 Select directory:" 2>/dev/null
+}
+
+# Create new project
+create_project() {
+  # Step 1: Select directory (or special option)
+  local project_dir
+  local selection
+  selection=$(browse_directory)
+  [[ -z "$selection" || "$selection" == "$SEPARATOR" ]] && exit 0
+
+  # Handle special options
+  case "$selection" in
+    "$DIR_CUSTOM")
+      # Prompt for custom path
+      project_dir=$(prompt_input "Enter path:")
+      [[ -z "$project_dir" ]] && exit 0
+      # Expand ~ to home directory
+      project_dir="${project_dir/#\~/$HOME}"
+      ;;
+    "$DIR_NONE")
+      # Use ~/dev as placeholder
+      project_dir="$HOME/dev"
+      ;;
+    *)
+      project_dir="$selection"
+      ;;
+  esac
+
+  # Step 2: Auto-suggest name from directory basename (or prompt if ~/dev placeholder)
+  local suggested_name
+  if [[ "$selection" == "$DIR_NONE" ]]; then
+    suggested_name=""
+  else
+    suggested_name=$(basename "$project_dir" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+  fi
+
+  local name
+  name=$(echo "$suggested_name" | omarchy-launch-walker --dmenu --width 400 --minheight 1 --maxheight 1 -p "Project name:" 2>/dev/null)
+  [[ -z "$name" ]] && name="$suggested_name"
+
+  # Validate: no pipes, alphanumeric + dashes/underscores
+  if [[ ! "$name" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    notify-send "Project Picker" "Invalid name. Use only letters, numbers, - and _"
+    exit 1
+  fi
+
+  # Check if already exists
+  if grep -q "^${name}|" "$CONFIG_FILE"; then
+    notify-send "Project Picker" "Project '$name' already exists"
+    exit 1
+  fi
+
+  # Auto-detect tmux session: look for existing session matching directory name
+  local tmux_session="$name"
+  local existing_sessions
+  existing_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)
+  if [[ -n "$existing_sessions" ]]; then
+    local matching
+    matching=$(echo "$existing_sessions" | grep -i "$(basename "$project_dir")" | head -1 || true)
+    [[ -n "$matching" ]] && tmux_session="$matching"
+  fi
+
+  # Create the project (default status: active)
+  echo "${name}|${tmux_session}|${project_dir}|active" >> "$CONFIG_FILE"
+  log_action "create" "$name" "dir=$project_dir session=$tmux_session"
+  notify-send "Project Picker" "Created: $name → $tmux_session"
+
+  # Switch to the new project
+  omarchy-project-select "$(get_projects | grep -n "^${name}$" | cut -d: -f1)"
+}
+
+# Delete project
+delete_project() {
+  local projects
+  projects=$(get_projects_with_status)
+
+  [[ -z "$projects" ]] && notify-send "Project Picker" "No projects to delete" && exit 0
+
+  local selected
+  selected=$(echo "$projects" | omarchy-launch-walker --dmenu --width 295 --minheight 1 --maxheight "$WALKER_HEIGHT" -p "Delete which?" 2>/dev/null)
+
+  [[ -z "$selected" ]] && exit 0
+
+  # Strip status prefix
+  local project_name
+  project_name=$(strip_status "$selected")
+
+  # Confirm deletion
+  local confirm
+  confirm=$(printf "Yes, delete\nNo, cancel" | omarchy-launch-walker --dmenu --width 295 --minheight 1 --maxheight 2 -p "Delete '$project_name'?" 2>/dev/null)
+
+  [[ "$confirm" != "Yes, delete" ]] && exit 0
+
+  # Remove from config (matches lines starting with "project|")
+  sed -i --follow-symlinks "/^${project_name}|/d" "$CONFIG_FILE"
+  log_action "delete" "$project_name"
+  notify-send "Project Picker" "Deleted: $project_name"
+}
+
+# Toggle project status between active/pending
+toggle_status() {
+  local projects
+  projects=$(get_projects_with_status)
+
+  [[ -z "$projects" ]] && notify-send "Project Picker" "No projects" && exit 0
+
+  local selected
+  selected=$(echo "$projects" | omarchy-launch-walker --dmenu --width 295 --minheight 1 --maxheight "$WALKER_HEIGHT" -p "Toggle which?" 2>/dev/null)
+
+  [[ -z "$selected" ]] && exit 0
+
+  # Strip status prefix to get project name
+  local project_name
+  project_name=$(strip_status "$selected")
+
+  # Get current line and determine new status
+  local current_line
+  current_line=$(grep "^${project_name}|" "$CONFIG_FILE")
+  [[ -z "$current_line" ]] && exit 1
+
+  # Parse current status (field 4, default to "active")
+  local current_status
+  current_status=$(echo "$current_line" | cut -d'|' -f4)
+  [[ -z "$current_status" ]] && current_status="active"
+
+  # Toggle status
+  local new_status
+  if [[ "$current_status" == "active" ]]; then
+    new_status="pending"
+  else
+    new_status="active"
+  fi
+
+  # Build new line with updated status
+  local name session dir
+  name=$(echo "$current_line" | cut -d'|' -f1)
+  session=$(echo "$current_line" | cut -d'|' -f2)
+  dir=$(echo "$current_line" | cut -d'|' -f3)
+  local new_line="${name}|${session}|${dir}|${new_status}"
+
+  # Replace in config (use # as delimiter to avoid escaping pipes)
+  sed -i --follow-symlinks "s#^${project_name}|.*#${new_line}#" "$CONFIG_FILE"
+  log_action "$([[ "$new_status" == "active" ]] && echo "activate" || echo "shelve")" "$project_name" "via toggle"
+  notify-send "Project Picker" "$project_name → $new_status"
+}
+
+# Edit config in editor
+edit_config() {
+  omarchy-launch-tui "${EDITOR:-nano}" "$CONFIG_FILE"
+}
+
+# Toggle focus mode on/off
+focus_toggle() {
+  local current
+  current=$(cat "$FOCUS_FILE" 2>/dev/null || echo "0")
+  if [[ "$current" == "1" ]]; then
+    echo "0" > "$FOCUS_FILE"
+    log_action "focus-off" "" ""
+    notify-send "Project Picker" "Focus mode OFF"
+  else
+    echo "1" > "$FOCUS_FILE"
+    log_action "focus-on" "" ""
+    notify-send "Project Picker" "󰈈 Focus mode ON — shelved projects hidden"
+  fi
+}
+
+# Main picker
+main() {
+  local selected
+  selected=$(build_menu | omarchy-launch-walker --dmenu --width 295 --minheight 1 --maxheight "$WALKER_HEIGHT" -p "Project…" 2>/dev/null)
+
+  case "$selected" in
+    "$ACTION_SHELVED")
+      shelved_projects
+      ;;
+    "$ACTION_FOCUS ON"|"$ACTION_FOCUS OFF")
+      focus_toggle
+      ;;
+    "$ACTION_NEW")
+      create_project
+      ;;
+    "$ACTION_TOGGLE")
+      toggle_status
+      ;;
+    "$ACTION_REFRESH")
+      rm -f "$SERVER_CACHE"
+      main
+      ;;
+    "$ACTION_DELETE")
+      delete_project
+      ;;
+    "$ACTION_EDIT")
+      edit_config
+      ;;
+    "$SEPARATOR"|"")
+      exit 0
+      ;;
+    *)
+      # Regular project selection — get index directly from selection
+      local idx
+      idx=$(get_selection_idx "$selected")
+      if [[ -n "$idx" && "$idx" =~ ^[0-9]+$ ]]; then
+        omarchy-project-select "$idx"
+      fi
+      ;;
+  esac
+}
+
+case "${1:-}" in
+  focus-toggle) focus_toggle ;;
+  *) main ;;
+esac

--- a/bin/omarchy-project-scratchpad
+++ b/bin/omarchy-project-scratchpad
@@ -1,0 +1,204 @@
+#!/bin/bash
+
+# Project Scratchpad Manager
+# Manages project-specific special workspaces in Hyprland
+# Config format: name|session|dir|status (status defaults to "active" if missing)
+
+STATE_DIR="$HOME/.local/state/hyprland/project-scratchpads"
+STATE_FILE="$STATE_DIR/current-project"
+CONFIG_FILE="$HOME/.config/hypr/projects.conf"
+
+# Ensure state directory exists
+mkdir -p "$STATE_DIR"
+
+# Parse config line: project_name|tmux_session|dirs|status
+# Returns: the requested field (1=name, 2=session, 3=dirs, 4=status)
+get_config_field() {
+  local line="$1"
+  local field="$2"
+  echo "$line" | cut -d'|' -f"$field"
+}
+
+# Get project status (defaults to "active" if missing — backwards compat)
+get_project_status() {
+  local line="$1"
+  local status
+  status=$(get_config_field "$line" 4)
+  if [[ -z "$status" ]]; then
+    echo "active"
+  else
+    echo "$status"
+  fi
+}
+
+# Get project line by name
+get_project_line() {
+  local name="$1"
+  grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | grep "^${name}|" | head -1
+}
+
+# Get project line by index (1-based)
+get_project_line_by_index() {
+  local idx="$1"
+  grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | sed -n "${idx}p"
+}
+
+# Get current project (default to first project if not set)
+get_current_project() {
+  if [[ -f "$STATE_FILE" ]]; then
+    cat "$STATE_FILE"
+  else
+    # Default to first project in config
+    grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | head -1 | cut -d'|' -f1
+  fi
+}
+
+# Get tmux session name for current project
+get_tmux_session() {
+  local project="${1:-$(get_current_project)}"
+  local line
+  line=$(get_project_line "$project")
+  if [[ -n "$line" ]]; then
+    get_config_field "$line" 2
+  else
+    echo "$project"  # fallback to project name
+  fi
+}
+
+# Get first directory for current project
+get_project_dir() {
+  local project="${1:-$(get_current_project)}"
+  local line
+  line=$(get_project_line "$project")
+  if [[ -n "$line" ]]; then
+    local dir
+    dir=$(get_config_field "$line" 3 | cut -d',' -f1)
+    # Fallback to ~/dev if directory doesn't exist
+    if [[ -d "$dir" ]]; then
+      echo "$dir"
+    else
+      echo "$HOME/dev"
+    fi
+  else
+    echo "$HOME/dev"  # fallback
+  fi
+}
+
+# Get all directories for a project (comma-separated)
+get_project_dirs() {
+  local project="${1:-$(get_current_project)}"
+  local line
+  line=$(get_project_line "$project")
+  if [[ -n "$line" ]]; then
+    get_config_field "$line" 3
+  fi
+}
+
+# List all projects from config (names only, all statuses)
+list_projects() {
+  grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | cut -d'|' -f1
+}
+
+# Set current project by index (1-based)
+set_project_by_index() {
+  local idx="$1"
+  local line
+  line=$(get_project_line_by_index "$idx")
+
+  if [[ -z "$line" ]]; then
+    notify-send "Project Scratchpad" "Invalid project index: $idx"
+    exit 1
+  fi
+
+  local project
+  project=$(get_config_field "$line" 1)
+  echo "$project" > "$STATE_FILE"
+  notify-send "Project Mode" "Switched to: $project"
+}
+
+# Toggle current project's scratchpad
+toggle_scratchpad() {
+  local project
+  project=$(get_current_project)
+
+  if [[ -z "$project" ]]; then
+    notify-send "Project Scratchpad" "No project configured"
+    exit 1
+  fi
+
+  hyprctl dispatch togglespecialworkspace "project:$project"
+}
+
+# Send current window to project scratchpad
+send_to_scratchpad() {
+  local project
+  project=$(get_current_project)
+
+  if [[ -z "$project" ]]; then
+    notify-send "Project Scratchpad" "No project configured"
+    exit 1
+  fi
+
+  hyprctl dispatch movetoworkspacesilent "special:project:$project"
+}
+
+# Send current window to specific project by index (without switching)
+send_to_project_by_index() {
+  local idx="$1"
+  local line
+  line=$(get_project_line_by_index "$idx")
+
+  if [[ -z "$line" ]]; then
+    notify-send "Project Scratchpad" "Invalid project index: $idx"
+    exit 1
+  fi
+
+  local project
+  project=$(get_config_field "$line" 1)
+  hyprctl dispatch movetoworkspacesilent "special:project:$project"
+}
+
+# Show current project
+show_current() {
+  local project
+  project=$(get_current_project)
+  notify-send "Current Project" "$project"
+}
+
+# Main command dispatch
+case "${1:-toggle}" in
+  toggle)
+    toggle_scratchpad
+    ;;
+  send)
+    send_to_scratchpad
+    ;;
+  send-to)
+    send_to_project_by_index "${2:-1}"
+    ;;
+  set)
+    set_project_by_index "${2:-1}"
+    ;;
+  current)
+    get_current_project
+    ;;
+  tmux-session)
+    get_tmux_session "${2:-}"
+    ;;
+  dir)
+    get_project_dir "${2:-}"
+    ;;
+  dirs)
+    get_project_dirs "${2:-}"
+    ;;
+  show)
+    show_current
+    ;;
+  list)
+    list_projects
+    ;;
+  *)
+    echo "Usage: omarchy-project-scratchpad [toggle|send|send-to <index>|set <index>|current|tmux-session [name]|dir [name]|dirs [name]|show|list]"
+    exit 1
+    ;;
+esac

--- a/bin/omarchy-project-select
+++ b/bin/omarchy-project-select
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Switch project context including tmux session.
+# Usage: omarchy-project-select <index>
+# Reads project config from ~/.config/hypr/projects.conf (format: project|tmux_session|dirs)
+
+STATE_DIR="$HOME/.local/state/hyprland/project-scratchpads"
+CONFIG_FILE="$HOME/.config/hypr/projects.conf"
+
+mkdir -p "$STATE_DIR"
+
+idx="$1"
+
+# Get the full line: project_name|tmux_session|dirs
+line=$(grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | sed -n "${idx}p")
+
+if [[ -z "$line" ]]; then
+  notify-send "Project Scratchpad" "No project at index $idx"
+  exit 1
+fi
+
+# Parse config line: project|tmux_session|dirs
+project=$(echo "$line" | cut -d'|' -f1)
+tmux_session=$(echo "$line" | cut -d'|' -f2)
+project_dir=$(echo "$line" | cut -d'|' -f3 | cut -d',' -f1)
+
+# Fallback to ~/dev if directory doesn't exist
+if [[ ! -d "$project_dir" ]]; then
+  project_dir="$HOME/dev"
+fi
+
+# Save current project
+echo "$project" > "$STATE_DIR/current-project"
+echo "1" > "$STATE_DIR/project-indicator-visible"
+
+# Switch tmux session if tmux is running and has clients attached
+if command -v tmux &> /dev/null && tmux list-clients &> /dev/null; then
+  # Check if target session exists
+  if tmux has-session -t "$tmux_session" 2>/dev/null; then
+    # Switch all attached clients to the new session
+    tmux switch-client -t "$tmux_session" 2>/dev/null || true
+  else
+    # Session doesn't exist - create it (will be used when terminal opens)
+    tmux new-session -d -s "$tmux_session" -c "$project_dir" 2>/dev/null || true
+  fi
+fi
+
+# Log the switch for daily tracking (4-field format: timestamp|action|project|details)
+printf '%s|switch|%s|direct\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$project" >> "$STATE_DIR/switch-log"
+
+notify-send "Project Mode" "Switched to: $project"

--- a/bin/omarchy-project-stats
+++ b/bin/omarchy-project-stats
@@ -25,8 +25,8 @@ get_setting() {
 DAILY_SWITCH_BUDGET=$(get_setting "daily_switch_budget" "3")
 
 # Count active projects
-active_count=$(grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | grep '|active$' | wc -l)
-total_count=$(grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | wc -l)
+active_count=$(grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | grep -c '|active$')
+total_count=$(grep -cv '^#\|^$' "$CONFIG_FILE")
 
 # Count today's switches (only actual switches, not other actions)
 today=$(date '+%Y-%m-%d')
@@ -53,7 +53,7 @@ fi
 
 # Recent activity in tooltip (4-field format: timestamp|action|project|details)
 if [[ -f "$SWITCH_LOG" ]]; then
-  recent=$(grep "^${today}" "$SWITCH_LOG" 2>/dev/null | tail -8 | while IFS='|' read -r time action proj details; do
+  recent=$(grep "^${today}" "$SWITCH_LOG" 2>/dev/null | tail -8 | while IFS='|' read -r time action proj _details; do
     printf '%s %s %s\\n' "${time#* }" "$action" "$proj"
   done)
   if [[ -n "$recent" ]]; then

--- a/bin/omarchy-project-stats
+++ b/bin/omarchy-project-stats
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Focus stats for waybar — shows active project count and daily switch count.
+# Outputs JSON for waybar's custom module format.
+#
+# Waybar integration — add to ~/.config/waybar/config.jsonc:
+#   "custom/projects": {
+#     "exec": "omarchy-project-stats",
+#     "interval": 5,
+#     "return-type": "json"
+#   }
+
+CONFIG_FILE="$HOME/.config/hypr/projects.conf"
+STATE_DIR="$HOME/.local/state/hyprland/project-scratchpads"
+SWITCH_LOG="$STATE_DIR/switch-log"
+FOCUS_FILE="$STATE_DIR/focus-mode"
+
+# Read daily_switch_budget from [settings] block in config, default 3
+get_setting() {
+  local key="$1" default="$2"
+  local value
+  value=$(sed -n '/^# \[settings\]/,/^$/{ s/^# '"$key"'=//p }' "$CONFIG_FILE" | head -1)
+  echo "${value:-$default}"
+}
+DAILY_SWITCH_BUDGET=$(get_setting "daily_switch_budget" "3")
+
+# Count active projects
+active_count=$(grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | grep '|active$' | wc -l)
+total_count=$(grep -v '^#' "$CONFIG_FILE" | grep -v '^$' | wc -l)
+
+# Count today's switches (only actual switches, not other actions)
+today=$(date '+%Y-%m-%d')
+switch_count=$(grep -c "^${today}.*|switch|" "$SWITCH_LOG" 2>/dev/null || echo 0)
+
+# Check focus mode
+focus_mode=$(cat "$FOCUS_FILE" 2>/dev/null || echo "0")
+
+# Build display text
+if [[ "$focus_mode" == "1" ]]; then
+  text="󰈈 ${active_count}/${total_count}"
+  class="focus-on"
+else
+  text="● ${active_count}/${total_count}"
+  class="focus-off"
+fi
+
+# Build tooltip
+tooltip="Active: ${active_count}/${total_count} projects"
+tooltip+="\\nSwitches today: ${switch_count}/${DAILY_SWITCH_BUDGET}"
+if [[ "$focus_mode" == "1" ]]; then
+  tooltip+="\\n\\n󰈈 Focus mode ON"
+fi
+
+# Recent activity in tooltip (4-field format: timestamp|action|project|details)
+if [[ -f "$SWITCH_LOG" ]]; then
+  recent=$(grep "^${today}" "$SWITCH_LOG" 2>/dev/null | tail -8 | while IFS='|' read -r time action proj details; do
+    printf '%s %s %s\\n' "${time#* }" "$action" "$proj"
+  done)
+  if [[ -n "$recent" ]]; then
+    tooltip+="\\n\\nRecent:\\n${recent}"
+  fi
+fi
+
+printf '{"text": "%s", "tooltip": "%s", "class": "%s"}\n' "$text" "$tooltip" "$class"

--- a/bin/omarchy-project-terminal
+++ b/bin/omarchy-project-terminal
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Project Terminal - Opens terminal attached to current project's tmux session
+# Syncs terminal context with project scratchpad system
+
+# Get current project info
+PROJECT=$(omarchy-project-scratchpad current)
+TMUX_SESSION=$(omarchy-project-scratchpad tmux-session)
+PROJECT_DIR=$(omarchy-project-scratchpad dir)
+
+# Check if tmux session exists
+if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+  # Session exists - attach to it
+  exec omarchy-launch-tui tmux attach-session -t "$TMUX_SESSION"
+else
+  # Session doesn't exist - create it in project directory
+  exec omarchy-launch-tui tmux new-session -s "$TMUX_SESSION" -c "$PROJECT_DIR"
+fi

--- a/bin/omarchy-project-terminal
+++ b/bin/omarchy-project-terminal
@@ -3,7 +3,6 @@
 # Syncs terminal context with project scratchpad system
 
 # Get current project info
-PROJECT=$(omarchy-project-scratchpad current)
 TMUX_SESSION=$(omarchy-project-scratchpad tmux-session)
 PROJECT_DIR=$(omarchy-project-scratchpad dir)
 

--- a/bin/omarchy-uninstall-project-scratchpads
+++ b/bin/omarchy-uninstall-project-scratchpads
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Uninstall the project scratchpad system.
+# Removes keybindings and state files. Keeps projects.conf (user data).
+
+echo "This will remove project scratchpad keybindings and state files."
+echo "Your project list (~/.config/hypr/projects.conf) will be kept."
+echo ""
+read -rp "Continue? [y/N] " confirm
+
+if [[ ! "$confirm" =~ ^[yY]$ ]]; then
+  echo "Cancelled."
+  exit 0
+fi
+
+# Remove keybinding block from bindings.conf
+BINDINGS_FILE="$HOME/.config/hypr/bindings.conf"
+if [[ -f "$BINDINGS_FILE" ]] && grep -qF "# BEGIN Project Scratchpads" "$BINDINGS_FILE"; then
+  sed -i --follow-symlinks '/^# BEGIN Project Scratchpads$/,/^# END Project Scratchpads$/d' "$BINDINGS_FILE"
+  # Remove trailing blank line left by the block
+  sed -i --follow-symlinks -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$BINDINGS_FILE"
+  echo "Removed keybindings from $BINDINGS_FILE"
+else
+  echo "No keybinding block found in $BINDINGS_FILE"
+fi
+
+# Remove state directory
+STATE_DIR="$HOME/.local/state/hyprland/project-scratchpads"
+if [[ -d "$STATE_DIR" ]]; then
+  rm -rf "$STATE_DIR"
+  echo "Removed state directory: $STATE_DIR"
+fi
+
+echo ""
+echo "Uninstalled. Keybindings removed (Hyprland auto-reloads)."
+echo "Project list kept at: ~/.config/hypr/projects.conf"


### PR DESCRIPTION
## The problem

When you work on multiple projects, switching context is painful. You lose track of which windows belong to which project, your terminal is in the wrong directory, and your tmux session is attached to yesterday's work. Alt-tabbing through 20 windows to find the right ones kills flow.

## The solution

Project scratchpads give each project its own special workspace — a dedicated container for its windows, linked to a tmux session and project directory. Switch projects and everything follows: your workspace, your terminal, your context.

I've been using this system daily for the past 3 months across 7 active projects. This PR is the cleaned-up, omarchy-convention-compliant version of what's been running on my machine since January.

```
~/.config/hypr/projects.conf:

myapp|myapp|~/dev/myapp|active
sideproject|sideproject|~/dev/sideproject|pending
```

**Install:** `omarchy-install-project-scratchpads`
**Uninstall:** `omarchy-uninstall-project-scratchpads` (keeps your project list)

## What you get

- **Per-project special workspaces** — each project gets `special:project:<name>`, toggle it like a scratchpad
- **Tmux session sync** — switching projects switches your tmux session (creates one if missing)
- **Walker-based picker** — create, delete, shelve/unshelve projects through a fuzzy menu
- **Quick switch** — `Ctrl+Alt+1-9` jumps to project N instantly
- **Focus mode** (opt-in) — hides shelved projects, adds a daily switch budget with "why are you switching?" prompts
- **Server detection** — shows a `▶` indicator next to projects with running dev servers (bun, node, python, etc.)
- **Waybar widgets** — project name indicator + focus stats with daily activity log

## Keybindings (added by installer)

| Binding | Action |
|---------|--------|
| `Super+;` | Toggle project scratchpad |
| `Super+Alt+;` | Send window to scratchpad |
| `Super+Shift+P` | Project picker |
| `Ctrl+Alt+1-9` | Quick switch to project N |
| `Ctrl+Alt+Shift+1-9` | Send window to project N |

## Dependencies

- **Required:** tmux, jq (installer checks and tells you how to install)
- **Optional:** fd (faster directory browsing when creating projects, falls back to find)

## Files added

```
bin/omarchy-install-project-scratchpads     # Installer
bin/omarchy-uninstall-project-scratchpads   # Uninstaller (with confirmation)
bin/omarchy-project-scratchpad              # Core: toggle, send, state queries
bin/omarchy-project-select                  # Quick switch + tmux sync
bin/omarchy-project-picker                  # Walker CRUD interface
bin/omarchy-project-terminal                # Terminal in project context
bin/omarchy-project-indicator               # Waybar: current project name
bin/omarchy-project-stats                   # Waybar: focus stats + activity
```

8 self-contained scripts, 1,051 lines. No existing files modified. All follow omarchy conventions (`omarchy-` prefix, `#!/bin/bash`, 2-space indent, no shared libs).

## Test plan

- [x] Fresh install on clean omarchy
- [x] Re-run installer (idempotent — no duplicates)
- [x] Create project via picker
- [x] Switch projects (Ctrl+Alt+1-9)
- [x] Toggle scratchpad (Super+;)
- [x] Shelve/unshelve with budget gate
- [x] Project terminal opens correct tmux session
- [x] Waybar widgets output valid JSON
- [x] Shellcheck clean (0 warnings)
- [x] Uninstall + reinstall cycle

---

Open to feedback — happy to adjust keybindings, rename scripts, refactor approaches, or split this into smaller PRs if that's easier to review. If anyone sees opportunities to make this faster or more idiomatic, I'm all ears.