### PR TITLE
Fix: Limine drop-in config should not be overridden by default limine conf

### DIFF
--- a/default/limine/default.conf
+++ b/default/limine/default.conf
@@ -2,7 +2,7 @@ TARGET_OS_NAME="Omarchy"
 
 ESP_PATH="/boot"
 
-KERNEL_CMDLINE[default]="@@CMDLINE@@"
+KERNEL_CMDLINE[default]+="@@CMDLINE@@"
 KERNEL_CMDLINE[default]+=" quiet splash"
 
 ENABLE_UKI=yes

--- a/migrations/1774401148.sh
+++ b/migrations/1774401148.sh
@@ -1,0 +1,5 @@
+echo "Fix KERNEL_CMDLINE merge behavior in /etc/default/limine"
+
+if [[ -f /etc/default/limine ]]; then
+  sudo sed -i 's/^KERNEL_CMDLINE\[default\]="/KERNEL_CMDLINE[default]+="/' /etc/default/limine
+fi


### PR DESCRIPTION
Limine drop-in config are overridden by `/etc/default/limine`.

It may cause some hibernation setup to not work as expected, as the `resume=` parameter is getting overriden. (You can check if it is for you by checking if it appears in `/boot/limine.conf`)

You can see an instance of this problem on https://github.com/basecamp/omarchy/discussions/4695 where @nunix notes

> Due to another potential issue with the kernel command line drop-in not being loaded (/etc/limine-entry-tool.d/t2-mac.conf), I added its content directly to this file and added the option mem_sleep_default=s2idle at the end.
This allowed the power management method to be permanently changed as intended.

You can test it by modifying `/etc/default/limine` and then running `sudo limine-mkinitcpio`.
Then you check if `/boot/limine.conf` has the expected kernel options.

I believe this also impact some people hibernation setup, as the `resume=` wouldn't get applied.