### PR TITLE
Rename local path variable in ga() to avoid clobbering zsh PATH

### DIFF
--- a/default/bash/fns/worktrees
+++ b/default/bash/fns/worktrees
@@ -7,11 +7,11 @@ ga() {
 
   local branch="$1"
   local base="$(basename "$PWD")"
-  local path="../${base}--${branch}"
+  local wt_path="../${base}--${branch}"
 
-  git worktree add -b "$branch" "$path"
-  mise trust "$path"
-  cd "$path"
+  git worktree add -b "$branch" "$wt_path"
+  mise trust "$wt_path"
+  cd "$wt_path"
 }
 
 # Remove worktree and branch from within active worktree directory.


### PR DESCRIPTION
In zsh, `path` is a special array tied to the `PATH` environment variable. Using `local path=...` in `ga()` shadows this array, which causes `git`, `mise`, and `zoxide` to fail with "command not found" on the lines that follow.

Renames the variable to `wt_path`. No effect in bash where `path` has no special meaning.