### PR TITLE
Fix: typo in migration 1774366575

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -35,7 +35,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/usb-autosuspend.sh
 run_logged $OMARCHY_INSTALL/config/hardware/ignore-power-button.sh
 run_logged $OMARCHY_INSTALL/config/hardware/nvidia.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/video-acceleration.sh
-run_logged $OMARCHY_INSTALL/config/hardware/intel/lmp.sh
+run_logged $OMARCHY_INSTALL/config/hardware/intel/lpmd.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/thermald.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/ipu7-camera.sh
 run_logged $OMARCHY_INSTALL/config/hardware/vulkan.sh

--- a/migrations/1774366575.sh
+++ b/migrations/1774366575.sh
@@ -1,3 +1,3 @@
 echo "Install Intel Low Power Mode for Intel CPUs"
 
-source "$OMARCHY_PATH/install/config/hardware/intel/lmp.sh"
+source "$OMARCHY_PATH/install/config/hardware/intel/lpmd.sh"


### PR DESCRIPTION
The migration script and install config reference `lmp.sh` but the actual file is named `lpmd.sh`. This causes the migration to fail with `No such file or directory`.

**Files changed:**
- `migrations/1774366575.sh` - Fixed typo in migration
- `install/config/all.sh` - Fixed same typo in install config