### PR TITLE
Fix missing limine-mkinitcpio in migration script

### DIFF
--- a/migrations/1774401148.sh
+++ b/migrations/1774401148.sh
@@ -2,4 +2,5 @@ echo "Fix KERNEL_CMDLINE merge behavior in /etc/default/limine"
 
 if [[ -f /etc/default/limine ]]; then
   sudo sed -i 's/^KERNEL_CMDLINE\[default\]="/KERNEL_CMDLINE[default]+="/' /etc/default/limine
+  sudo limine-mkinitcpio
 fi


### PR DESCRIPTION
Follow up to #5114, I forgot to regenerate the `/boot/limine.conf` file during the migration.