### PR TITLE
Fix Neovide black background when syncing Omarchy theme

### DIFF
--- a/migrations/1774489385.sh
+++ b/migrations/1774489385.sh
@@ -13,6 +13,9 @@ end
 
 EOF
 
-  cat "$TRANSPARENCY_FILE" >>"$temp_file"
-  mv "$temp_file" "$TRANSPARENCY_FILE"
+  if cat "$TRANSPARENCY_FILE" >>"$temp_file"; then
+    mv "$temp_file" "$TRANSPARENCY_FILE"
+  else
+    rm -f "$temp_file"
+  fi
 fi

--- a/migrations/1774489385.sh
+++ b/migrations/1774489385.sh
@@ -3,7 +3,8 @@ echo "Disable Neovide transparency overrides in nvim"
 TRANSPARENCY_FILE="$HOME/.config/nvim/plugin/after/transparency.lua"
 
 if [[ -f $TRANSPARENCY_FILE ]] && ! grep -q "vim.g.neovide" "$TRANSPARENCY_FILE"; then
-  temp_file=$(mktemp)
+  temp_file_dir=$(dirname "$TRANSPARENCY_FILE")
+  temp_file=$(mktemp "$temp_file_dir/transparency.lua.XXXXXX")
 
   cat >"$temp_file" <<'EOF'
 if vim.g.neovide then

--- a/migrations/1774489385.sh
+++ b/migrations/1774489385.sh
@@ -2,7 +2,7 @@ echo "Disable Neovide transparency overrides in nvim"
 
 TRANSPARENCY_FILE="$HOME/.config/nvim/plugin/after/transparency.lua"
 
-if [[ -f $TRANSPARENCY_FILE ]] && ! grep -q "vim.g.neovide" "$TRANSPARENCY_FILE"; then
+if [[ -f "$TRANSPARENCY_FILE" ]] && ! grep -Fq 'vim.g.neovide' "$TRANSPARENCY_FILE"; then
   temp_file_dir=$(dirname "$TRANSPARENCY_FILE")
   temp_file=$(mktemp "$temp_file_dir/transparency.lua.XXXXXX")
 

--- a/migrations/1774489385.sh
+++ b/migrations/1774489385.sh
@@ -1,0 +1,17 @@
+echo "Disable Neovide transparency overrides in nvim"
+
+TRANSPARENCY_FILE="$HOME/.config/nvim/plugin/after/transparency.lua"
+
+if [[ -f $TRANSPARENCY_FILE ]] && ! grep -q "vim.g.neovide" "$TRANSPARENCY_FILE"; then
+  temp_file=$(mktemp)
+
+  cat >"$temp_file" <<'EOF'
+if vim.g.neovide then
+  return
+end
+
+EOF
+
+  cat "$TRANSPARENCY_FILE" >>"$temp_file"
+  mv "$temp_file" "$TRANSPARENCY_FILE"
+fi


### PR DESCRIPTION
## Summary
- add a migration that updates `~/.config/nvim/plugin/after/transparency.lua` to skip transparency overrides when running in Neovide
- prevent `Normal`/`NormalNC` background from becoming transparent in Neovide, which avoids the black `#000000` background
- keep existing transparency behavior unchanged for terminal Neovim

## Testing
- `bash -n migrations/1774489385.sh`
- run the migration twice in a temporary `$HOME` and verify the `vim.g.neovide` guard is added once

Closes #5107