### PR TITLE
Split hypridle config

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -1,28 +1,6 @@
-general {
-    lock_cmd = omarchy-lock-screen                         # lock screen and 1password
-    before_sleep_cmd = loginctl lock-session               # lock before suspend.
-    after_sleep_cmd = sleep 1 && hyprctl dispatch dpms on  # delay for PAM readiness, then turn on display.
-    inhibit_sleep = 3                                      # wait until screen is locked
-}
+$screensaver_timeout = 150          # 2.5min
+$lock_timeout = 151                 # 5min
+$keyboard_backlight_timeout = 330   # 5.5min
+$display_off_timeout = 330          # 5.5min
 
-listener {
-    timeout = 150                                             # 2.5min
-    on-timeout = pidof hyprlock || omarchy-launch-screensaver # start screensaver (if we haven't locked already)
-}
-
-listener {
-    timeout = 151                      # 5min
-    on-timeout = loginctl lock-session # lock screen when timeout has passed
-}
-
-listener {
-    timeout = 330                                            # 5.5min
-    on-timeout = brightnessctl -sd '*::kbd_backlight' set 0  # save state and turn off keyboard backlight
-    on-resume = brightnessctl -rd '*::kbd_backlight'         # restore keyboard backlight
-}
-
-listener {
-    timeout = 330                                            # 5.5min
-    on-timeout = hyprctl dispatch dpms off                   # screen off when timeout has passed
-    on-resume = hyprctl dispatch dpms on && brightnessctl -r # screen on when activity is detected
-}
+source = ~/.local/share/omarchy/default/hypr/hypridle.conf

--- a/default/hypr/hypridle.conf
+++ b/default/hypr/hypridle.conf
@@ -1,0 +1,28 @@
+general {
+    lock_cmd = omarchy-lock-screen                         # lock screen and 1password
+    before_sleep_cmd = loginctl lock-session               # lock before suspend.
+    after_sleep_cmd = sleep 1 && hyprctl dispatch dpms on  # delay for PAM readiness, then turn on display.
+    inhibit_sleep = 3                                      # wait until screen is locked
+}
+
+listener {
+    timeout = $screensaver_timeout
+    on-timeout = pidof hyprlock || omarchy-launch-screensaver # start screensaver (if we haven't locked already)
+}
+
+listener {
+    timeout = $lock_timeout
+    on-timeout = loginctl lock-session # lock screen when timeout has passed
+}
+
+listener {
+    timeout = $keyboard_backlight_timeout
+    on-timeout = brightnessctl -sd '*::kbd_backlight' set 0  # save state and turn off keyboard backlight
+    on-resume = brightnessctl -rd '*::kbd_backlight'         # restore keyboard backlight
+}
+
+listener {
+    timeout = $display_off_timeout
+    on-timeout = hyprctl dispatch dpms off                   # screen off when timeout has passed
+    on-resume = hyprctl dispatch dpms on && brightnessctl -r # screen on when activity is detected
+}

--- a/migrations/1774414068.sh
+++ b/migrations/1774414068.sh
@@ -1,0 +1,3 @@
+echo "Split hypridle config"
+
+omarchy-refresh-hypridle


### PR DESCRIPTION
## Description

This PR splits hypridle.conf into:
- user configurable timeouts
- default listener implementations

## Benefits
- Since few users care about listener details, this will improve user experience.
- Easier to make changes without overwriting customized timeouts (as I experienced by the migration in https://github.com/basecamp/omarchy/commit/9b4140abc9fea7eaa69ccbab71bc894092321e7f)

## FAQ
What if the user actually wants to customize a listener implementation?
They can disable the default listener by setting the timeout to a large value, and implement their own in .config/hypridle.conf.

Is it not ironic that a change meant to help avoid overwriting customized timeouts has a migration that does just that?
Yeah, let me know if you'd like me to implement a better migration.

## Testing

- Copied both conf files into place on my Omarchy.
- Restarted hypridle.
- Confirmed screensaver, lock, and display off worked.