### PR TITLE
fix: use SUDO_USER for SDDM autologin instead of root

### DIFF
--- a/install/login/sddm.sh
+++ b/install/login/sddm.sh
@@ -6,7 +6,7 @@ sudo mkdir -p /etc/sddm.conf.d
 if [[ ! -f /etc/sddm.conf.d/autologin.conf ]]; then
   cat <<EOF | sudo tee /etc/sddm.conf.d/autologin.conf
 [Autologin]
-User=$USER
+User=${SUDO_USER:-$USER}
 Session=hyprland-uwsm
 
 [Theme]

--- a/migrations/1758487660_change_dm_to_sddm.sh
+++ b/migrations/1758487660_change_dm_to_sddm.sh
@@ -17,7 +17,7 @@ sudo mkdir -p /etc/sddm.conf.d
 
 cat <<EOF | sudo tee /etc/sddm.conf.d/autologin.conf
 [Autologin]
-User=$USER
+User=${SUDO_USER:-$USER}
 Session=hyprland-uwsm
 
 [Theme]


### PR DESCRIPTION
Fix for issue #5044

This pull request makes a small but important change to how the autologin user is set in SDDM configuration scripts. It now writes the correct user, instead of root.

- Updated both `install/login/sddm.sh` and `migrations/1758487660_change_dm_to_sddm.sh` to set the autologin user to `${SUDO_USER:-$USER}` instead of just `$USER`, ensuring the correct user is configured for autologin when running the scripts with `sudo`. [[1]](diffhunk://#diff-19b9c3b7d7cd138b56f70eb86e875cbef91ea7152b4cc5f0f3eead2968e5f18bL9-R9) [[2]](diffhunk://#diff-fdd805fd96e6ca3e69d06402f4d5d972fc80aefdc98438427cb1e600ab12900cL20-R20)