### PR TITLE
Use percentage-based step for keyboard backlight brightness

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -23,14 +23,19 @@ fi
 max_brightness="$(brightnessctl -d "$device" max)"
 current_brightness="$(brightnessctl -d "$device" get)"
 
-# Calculate step as one unit (keyboards typically have discrete levels like 0-3).
+# Calculate step as 10% of max brightness. Keyboards with many levels (e.g. 512)
+# need larger steps; keyboards with few levels (e.g. 3) fall back to step=1.
+step=$(( max_brightness / 10 ))
+(( step < 1 )) && step=1
+
 if [[ $direction == "cycle" ]]; then
-  new_brightness=$(( (current_brightness + 1) % (max_brightness + 1) ))
+  new_brightness=$(( current_brightness + step ))
+  (( new_brightness > max_brightness )) && new_brightness=0
 elif [[ $direction == "up" ]]; then
-  new_brightness=$((current_brightness + 1))
+  new_brightness=$(( current_brightness + step ))
   (( new_brightness > max_brightness )) && new_brightness=$max_brightness
 else
-  new_brightness=$((current_brightness - 1))
+  new_brightness=$(( current_brightness - step ))
   (( new_brightness < 0 )) && new_brightness=0
 fi
 


### PR DESCRIPTION
## Summary

- Replaces the fixed `+1` brightness step with a 10%-of-max step in `omarchy-brightness-keyboard`

The current script steps by 1 unit, assuming keyboards have 3-4 discrete levels. Keyboards with many levels (e.g. T2 MacBooks have 512) change brightness by ~0.2% per keypress — effectively invisible. The fix calculates the step as `max / 10` (10% per keypress), with a minimum of 1 to preserve behavior on keyboards that do have only a few levels.

This is a universal improvement, not T2-specific.

Fixes #2291

## Test plan

- [x] Test on a keyboard with many brightness levels (e.g. MacBook) — each keypress should produce a visible change
- [ ] Test on a keyboard with few levels (e.g. 0-3) — behavior should be unchanged (step=1)
- [ ] Verify cycle mode wraps around correctly