### PR TITLE
Fix battery time showing hours instead of minutes

### DIFF
--- a/bin/omarchy-battery-remaining-time
+++ b/bin/omarchy-battery-remaining-time
@@ -7,19 +7,16 @@ battery_info=$(upower -i $(upower -e | grep BAT))
 echo "$battery_info" | awk '/time to (empty|full)/ {
     value = $4
     unit = $5
-    if (unit == "minutes") {
-        hours = int(value / 60)
-        minutes = int(value % 60)
+    if (unit ~ /^minute/) {
+        printf "%dm", int(value)
     } else {
         hours = int(value)
         minutes = int((value - hours) * 60)
-    }
-    if (hours > 0 && minutes > 0) {
-        printf "%dh %dm", hours, minutes
-    } else if (hours > 0) {
-        printf "%dh", hours
-    } else {
-        printf "%dm", minutes
+        if (minutes > 0) {
+            printf "%dh %dm", hours, minutes
+        } else {
+            printf "%dh", hours
+        }
     }
     exit
 }'


### PR DESCRIPTION
## Summary

- Fix `omarchy-battery-remaining-time` displaying hours instead of minutes when upower reports time in minutes (e.g. "5h 12m" instead of "8m")
- The minutes unit match now uses a regex (`/^minute/`) to handle both "minute" and "minutes"
- When the value is already in minutes, it prints directly instead of going through the hours conversion path

## Before / After

**Before (bug):** Battery shows "5h 12m to full" when it should be minutes
**After (fix):** Battery correctly shows "8m to full"

<img width="966" height="204" alt="screenshot-2026-03-27_16-38-54" src="https://github.com/user-attachments/assets/b36a41c6-2706-47d3-909a-2578c03b0ffb" />
<img width="964" height="314" alt="screenshot-2026-03-27_16-39-35" src="https://github.com/user-attachments/assets/60d50d20-2cbe-495e-a665-21907daea7c4" />
