### PR TITLE
Support AMD ISP4 camera with suspend/resume fix

### DIFF
--- a/bin/omarchy-hw-amd-isp4
+++ b/bin/omarchy-hw-amd-isp4
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Detect whether the computer has an AMD ISP4 camera.
+
+grep -q "AMDI0105" /sys/bus/acpi/devices/*/hid 2>/dev/null

--- a/default/systemd/system-sleep/omarchy-isp-suspend
+++ b/default/systemd/system-sleep/omarchy-isp-suspend
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+MODULES="amd_isp4_capture i2c_designware_amdisp pinctrl_amdisp amd_isp4"
+
+case $1 in
+  pre)
+    modprobe -rq $MODULES 2>/dev/null || true
+    ;;
+  post)
+    for mod in $MODULES; do
+      modprobe -q $mod 2>/dev/null || true
+    done
+    ;;
+esac

--- a/default/systemd/system-sleep/omarchy-isp-suspend
+++ b/default/systemd/system-sleep/omarchy-isp-suspend
@@ -1,14 +1,20 @@
 #!/bin/bash
 
+# List of modules to cycle
 MODULES="amd_isp4_capture i2c_designware_amdisp pinctrl_amdisp amd_isp4"
 
-case $1 in
-  pre)
-    modprobe -rq $MODULES 2>/dev/null || true
-    ;;
-  post)
-    for mod in $MODULES; do
-      modprobe -q $mod 2>/dev/null || true
-    done
-    ;;
-esac
+# Loop through modules for pre (unload) and post (load)
+for mod in $MODULES; do
+    case "$1" in
+        pre)
+            if modinfo $mod >/dev/null 2>&1; then
+                modprobe -rq $mod 2>/dev/null || true
+            fi
+            ;;
+        post)
+            if modinfo $mod >/dev/null 2>&1; then
+                modprobe -q $mod 2>/dev/null || true
+            fi
+            ;;
+    esac
+done

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -57,6 +57,8 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 
+run_logged $OMARCHY_INSTALL/config/hardware/amd/fix-isp4-suspend.sh
+
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh

--- a/install/config/hardware/amd/fix-isp4-suspend.sh
+++ b/install/config/hardware/amd/fix-isp4-suspend.sh
@@ -3,25 +3,13 @@ omarchy-hw-amd-isp4 || exit 0
 # Install AMD ISP4 camera driver and fix modules failing to resume from sleep.
 # Affects laptops with RYZEN AI MAX+ and ISP4 webcams (e.g. HP ZBook Ultra G1a).
 
-omarchy-pkg-add linux-headers
+KERNEL_HEADERS="$(pacman -Qqs '^linux(-zen|-lts|-hardened)?$' | head -1)-headers"
+
+omarchy-pkg-add "$KERNEL_HEADERS"
 omarchy-pkg-aur-add amdisp4-dkms
 
 # The ISP4 modules need to be unloaded before suspend and reloaded in order after resume.
-sudo tee /usr/lib/systemd/system-sleep/omarchy-isp-suspend >/dev/null <<'EOF'
-#!/bin/bash
-
-MODULES="amd_isp4_capture i2c_designware_amdisp pinctrl_amdisp amd_isp4"
-
-case $1 in
-  pre)
-    modprobe -rq $MODULES 2>/dev/null || true
-    ;;
-  post)
-    for mod in $MODULES; do
-      modprobe -q $mod 2>/dev/null || true
-    done
-    ;;
-esac
-EOF
-
-sudo chmod +x /usr/lib/systemd/system-sleep/omarchy-isp-suspend
+sudo mkdir -p /usr/lib/systemd/system-sleep
+sudo install -m 0755 -o root -g root \
+  "$OMARCHY_PATH/default/systemd/system-sleep/omarchy-isp-suspend" \
+  /usr/lib/systemd/system-sleep/omarchy-isp-suspend

--- a/install/config/hardware/amd/fix-isp4-suspend.sh
+++ b/install/config/hardware/amd/fix-isp4-suspend.sh
@@ -10,6 +10,7 @@ omarchy-pkg-aur-add amdisp4-dkms
 
 # The ISP4 modules need to be unloaded before suspend and reloaded in order after resume.
 sudo mkdir -p /usr/lib/systemd/system-sleep
+sudo mkdir -p /usr/lib/systemd/system-sleep
 sudo install -m 0755 -o root -g root \
   "$OMARCHY_PATH/default/systemd/system-sleep/omarchy-isp-suspend" \
   /usr/lib/systemd/system-sleep/omarchy-isp-suspend

--- a/install/config/hardware/amd/fix-isp4-suspend.sh
+++ b/install/config/hardware/amd/fix-isp4-suspend.sh
@@ -1,0 +1,27 @@
+omarchy-hw-amd-isp4 || exit 0
+
+# Install AMD ISP4 camera driver and fix modules failing to resume from sleep.
+# Affects laptops with RYZEN AI MAX+ and ISP4 webcams (e.g. HP ZBook Ultra G1a).
+
+omarchy-pkg-add linux-headers
+omarchy-pkg-aur-add amdisp4-dkms
+
+# The ISP4 modules need to be unloaded before suspend and reloaded in order after resume.
+sudo tee /usr/lib/systemd/system-sleep/omarchy-isp-suspend >/dev/null <<'EOF'
+#!/bin/bash
+
+MODULES="amd_isp4_capture i2c_designware_amdisp pinctrl_amdisp amd_isp4"
+
+case $1 in
+  pre)
+    modprobe -rq $MODULES 2>/dev/null || true
+    ;;
+  post)
+    for mod in $MODULES; do
+      modprobe -q $mod 2>/dev/null || true
+    done
+    ;;
+esac
+EOF
+
+sudo chmod +x /usr/lib/systemd/system-sleep/omarchy-isp-suspend


### PR DESCRIPTION
Detects AMD ISP4 webcams through ACPI and installs the `amdisp4-dkms` driver. A systemd sleep hook unloads the ISP4 modules before suspend and reloads them on resume so the camera works after waking. Found the issue on an HP ZBook Ultra G1a with Strix Halo, but it affects any machine with this hardware.

## What changed

| File | What it does |
|------|-------------|
| `bin/omarchy-hw-amd-isp4` | Hardware detector — matches ACPI HID `AMDI0105` |
| `install/config/hardware/amd/fix-isp4-suspend.sh` | Installs driver + sleep hook |
| `install/config/all.sh` | Wires in the new config script |

## Detection

Checks `/sys/bus/acpi/devices/*/hid` for `AMDI0105`, same approach as the Intel IPU7 camera detection (`OVTI08F4`). No vendor lock-in — works on any machine exposing this ACPI device.

## What the install script does

1. Installs `linux-headers` (pacman) then `amdisp4-dkms` (AUR) — order matters because DKMS builds at install time
2. Drops a sleep hook at `/usr/lib/systemd/system-sleep/omarchy-isp-suspend`:

```bash
MODULES="amd_isp4_capture i2c_designware_amdisp pinctrl_amdisp amd_isp4"

case $1 in
  pre)   modprobe -rq $MODULES 2>/dev/null || true ;;
  post)  for mod in $MODULES; do modprobe -q $mod 2>/dev/null || true; done ;;
esac
```

On suspend, all four modules are unloaded at once. On resume, they're loaded one by one in dependency order. Without this, the ISP4 camera fails to reinitialize after sleep.

## Tested on

- HP ZBook Ultra G1a 14" (AMD Ryzen AI MAX+ PRO 395 / Strix Halo)
- Omarchy 3.4.2, kernel 6.19.9-arch1-1