### PR TITLE
Add Orca screen reader with Piper TTS

### DIFF
--- a/bin/omarchy-setup-piper-tts
+++ b/bin/omarchy-setup-piper-tts
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Download and configure Piper TTS as the speech-dispatcher backend for Orca.
+# Run once during setup — downloads ~60MB of voice data.
+
+set -e
+
+piper_dir="$HOME/.local/share/piper"
+voice_dir="$piper_dir/voices"
+mkdir -p "$voice_dir"
+
+# Download Piper binary if not present
+if [[ ! -x $piper_dir/piper ]]; then
+  echo "Downloading Piper TTS..."
+  curl -sL "https://github.com/rhasspy/piper/releases/latest/download/piper_linux_x86_64.tar.gz" | \
+    tar xz -C "$piper_dir" --strip-components=1
+fi
+
+# Download a natural English voice if not present
+voice_name="en_US-lessac-medium"
+if [[ ! -f $voice_dir/$voice_name.onnx ]]; then
+  echo "Downloading voice model ($voice_name)..."
+  curl -sL "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/$voice_name.onnx" \
+    -o "$voice_dir/$voice_name.onnx"
+  curl -sL "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/$voice_name.onnx.json" \
+    -o "$voice_dir/$voice_name.onnx.json"
+fi
+
+# Configure speech-dispatcher to use Piper
+sd_conf_dir="$HOME/.config/speech-dispatcher/modules"
+mkdir -p "$sd_conf_dir"
+
+cat <<EOF > "$HOME/.config/speech-dispatcher/speechd.conf"
+DefaultModule piper
+DefaultLanguage en
+DefaultRate 0
+EOF
+
+cat <<EOF > "$sd_conf_dir/piper.conf"
+GenericExecuteSynth "$piper_dir/piper --model $voice_dir/$voice_name.onnx --output-raw | paplay --raw --rate=22050 --channels=1 --format=s16le"
+EOF
+
+echo "Piper TTS configured. Toggle Orca with omarchy-toggle-orca."

--- a/bin/omarchy-toggle-orca
+++ b/bin/omarchy-toggle-orca
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if ! command -v orca >/dev/null 2>&1; then
+  notify-send "Screen reader unavailable" "Install orca and speech-dispatcher to use this shortcut."
+  exit 0
+fi
+
+if pgrep -x orca >/dev/null; then
+  orca --quit 2>/dev/null
+  pkill -x orca 2>/dev/null
+else
+  orca &
+fi

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -27,6 +27,7 @@ bindd = SUPER SHIFT ALT, COMMA, Restore last notification, exec, makoctl restore
 # Toggles
 bindd = SUPER CTRL, I, Toggle locking on idle, exec, omarchy-toggle-idle
 bindd = SUPER CTRL, N, Toggle nightlight, exec, omarchy-toggle-nightlight
+bindd = SUPER CTRL, R, Toggle screen reader, exec, omarchy-toggle-orca
 
 # Control Apple Display brightness
 bindd = CTRL, F1, Apple Display brightness down, exec, omarchy-brightness-display-apple -5000

--- a/install/config/accessibility.sh
+++ b/install/config/accessibility.sh
@@ -1,0 +1,1 @@
+omarchy-pkg-add orca speech-dispatcher

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -26,6 +26,7 @@ run_logged $OMARCHY_INSTALL/config/kernel-modules-hook.sh
 run_logged $OMARCHY_INSTALL/config/powerprofilesctl-rules.sh
 run_logged $OMARCHY_INSTALL/config/wifi-powersave-rules.sh
 run_logged $OMARCHY_INSTALL/config/plocate-ac-only.sh
+run_logged $OMARCHY_INSTALL/config/accessibility.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/network.sh
 run_logged $OMARCHY_INSTALL/config/hardware/set-wireless-regdom.sh


### PR DESCRIPTION
## Summary

- Adds `omarchy-toggle-orca` to start/stop the Orca screen reader with a single keypress
- Adds `omarchy-setup-piper-tts` to download Piper TTS and configure it as the speech-dispatcher backend (replaces espeak-ng's robotic voice with a natural-sounding neural voice)
- Installs `orca` and `speech-dispatcher` via new `install/config/accessibility.sh` for all users
- Binds F3 to toggle the screen reader

A nice-to-have accessibility addition — for users who benefit from a screen reader, this pairs Orca with Piper TTS so the voice sounds natural instead of the default robotic espeak-ng output.