### PR TITLE
Add WiFi resume hook for T2 MacBooks

### DIFF
--- a/install/config/hardware/apple/fix-t2.sh
+++ b/install/config/hardware/apple/fix-t2.sh
@@ -41,4 +41,15 @@ high_temp=75
 speed_curve=linear
 always_full_speed=false
 EOF
+
+  sudo mkdir -p /etc/systemd/system-sleep
+  cat <<'HOOK' | sudo tee /etc/systemd/system-sleep/wifi-resume >/dev/null
+#!/bin/bash
+if [[ $1 == "post" ]]; then
+  logger -t wifi-resume "Reloading brcmfmac after resume"
+  modprobe -r brcmfmac 2>/dev/null
+  modprobe brcmfmac || logger -t wifi-resume "Failed to reload brcmfmac"
+fi
+HOOK
+  sudo chmod +x /etc/systemd/system-sleep/wifi-resume
 fi

--- a/install/config/hardware/apple/fix-t2.sh
+++ b/install/config/hardware/apple/fix-t2.sh
@@ -42,8 +42,7 @@ speed_curve=linear
 always_full_speed=false
 EOF
 
-  sudo mkdir -p /etc/systemd/system-sleep
-  cat <<'HOOK' | sudo tee /etc/systemd/system-sleep/wifi-resume >/dev/null
+  cat <<'HOOK' | sudo tee /usr/lib/systemd/system-sleep/wifi-resume >/dev/null
 #!/bin/bash
 if [[ $1 == "post" ]]; then
   logger -t wifi-resume "Reloading brcmfmac after resume"
@@ -51,5 +50,5 @@ if [[ $1 == "post" ]]; then
   modprobe brcmfmac || logger -t wifi-resume "Failed to reload brcmfmac"
 fi
 HOOK
-  sudo chmod +x /etc/systemd/system-sleep/wifi-resume
+  sudo chmod +x /usr/lib/systemd/system-sleep/wifi-resume
 fi

--- a/migrations/1774703846.sh
+++ b/migrations/1774703846.sh
@@ -1,0 +1,14 @@
+if lspci -nn | grep -q "106b:180[12]" && [[ ! -f /etc/systemd/system-sleep/wifi-resume ]]; then
+  echo "Installing WiFi resume hook for T2 MacBook"
+
+  sudo mkdir -p /etc/systemd/system-sleep
+  cat <<'HOOK' | sudo tee /etc/systemd/system-sleep/wifi-resume >/dev/null
+#!/bin/bash
+if [[ $1 == "post" ]]; then
+  logger -t wifi-resume "Reloading brcmfmac after resume"
+  modprobe -r brcmfmac 2>/dev/null
+  modprobe brcmfmac || logger -t wifi-resume "Failed to reload brcmfmac"
+fi
+HOOK
+  sudo chmod +x /etc/systemd/system-sleep/wifi-resume
+fi

--- a/migrations/1774703846.sh
+++ b/migrations/1774703846.sh
@@ -1,8 +1,7 @@
-if lspci -nn | grep -q "106b:180[12]" && [[ ! -f /etc/systemd/system-sleep/wifi-resume ]]; then
+if lspci -nn | grep -q "106b:180[12]" && [[ ! -f /usr/lib/systemd/system-sleep/wifi-resume ]]; then
   echo "Installing WiFi resume hook for T2 MacBook"
 
-  sudo mkdir -p /etc/systemd/system-sleep
-  cat <<'HOOK' | sudo tee /etc/systemd/system-sleep/wifi-resume >/dev/null
+  cat <<'HOOK' | sudo tee /usr/lib/systemd/system-sleep/wifi-resume >/dev/null
 #!/bin/bash
 if [[ $1 == "post" ]]; then
   logger -t wifi-resume "Reloading brcmfmac after resume"
@@ -10,5 +9,5 @@ if [[ $1 == "post" ]]; then
   modprobe brcmfmac || logger -t wifi-resume "Failed to reload brcmfmac"
 fi
 HOOK
-  sudo chmod +x /etc/systemd/system-sleep/wifi-resume
+  sudo chmod +x /usr/lib/systemd/system-sleep/wifi-resume
 fi


### PR DESCRIPTION
## Summary

- Installs a systemd system-sleep hook that reloads the Broadcom WiFi driver after waking from suspend

The Broadcom WiFi driver (`brcmfmac`) on T2 MacBooks loses connection state after suspend and silently fails — WiFi appears connected but can't transmit data. This hook unloads and reloads the kernel module on resume, restoring connectivity.

## Tested: 

- Run `fix-t2.sh` on a T2 MacBook
- Suspend and resume the machine
- WiFi reconnects automatically after wake