### PR TITLE
Fix udev RUN commands to use systemd-run

### DIFF
--- a/install/config/powerprofilesctl-rules.sh
+++ b/install/config/powerprofilesctl-rules.sh
@@ -12,8 +12,8 @@ if omarchy-battery-present; then
     battery_profile="${profiles[1]}"
 
     cat <<EOF | sudo tee "/etc/udev/rules.d/99-power-profile.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/powerprofilesctl set $battery_profile"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/powerprofilesctl set $ac_profile"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/systemd-run --no-block /usr/bin/powerprofilesctl set $battery_profile"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/systemd-run --no-block /usr/bin/powerprofilesctl set $ac_profile"
 EOF
 
     sudo udevadm control --reload

--- a/install/config/powerprofilesctl-rules.sh
+++ b/install/config/powerprofilesctl-rules.sh
@@ -12,8 +12,8 @@ if omarchy-battery-present; then
     battery_profile="${profiles[1]}"
 
     cat <<EOF | sudo tee "/etc/udev/rules.d/99-power-profile.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/systemd-run --no-block /usr/bin/powerprofilesctl set $battery_profile"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/systemd-run --no-block /usr/bin/powerprofilesctl set $ac_profile"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/systemd-run --quiet --collect --no-block --unit=powerprofilesctl-on-battery.service /usr/bin/powerprofilesctl set $battery_profile"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/systemd-run --quiet --collect --no-block --unit=powerprofilesctl-on-ac.service /usr/bin/powerprofilesctl set $ac_profile"
 EOF
 
     sudo udevadm control --reload

--- a/install/config/wifi-powersave-rules.sh
+++ b/install/config/wifi-powersave-rules.sh
@@ -1,7 +1,7 @@
 if omarchy-battery-present; then
   cat <<EOF | sudo tee "/etc/udev/rules.d/99-wifi-powersave.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/systemd-run --no-block $HOME/.local/share/omarchy/bin/omarchy-wifi-powersave on"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/systemd-run --no-block $HOME/.local/share/omarchy/bin/omarchy-wifi-powersave off"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/systemd-run --no-block --quiet --unit=omarchy-wifi-powersave-on --collect $HOME/.local/share/omarchy/bin/omarchy-wifi-powersave on"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/systemd-run --no-block --quiet --unit=omarchy-wifi-powersave-off --collect $HOME/.local/share/omarchy/bin/omarchy-wifi-powersave off"
 EOF
 
   sudo udevadm control --reload

--- a/install/config/wifi-powersave-rules.sh
+++ b/install/config/wifi-powersave-rules.sh
@@ -1,7 +1,7 @@
 if omarchy-battery-present; then
   cat <<EOF | sudo tee "/etc/udev/rules.d/99-wifi-powersave.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="$HOME/.local/share/omarchy/bin/omarchy-wifi-powersave on"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="$HOME/.local/share/omarchy/bin/omarchy-wifi-powersave off"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/systemd-run --no-block $HOME/.local/share/omarchy/bin/omarchy-wifi-powersave on"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/systemd-run --no-block $HOME/.local/share/omarchy/bin/omarchy-wifi-powersave off"
 EOF
 
   sudo udevadm control --reload


### PR DESCRIPTION
I was getting errors in the powersaver udev rule handling script. I think it's because udev runs in sandbox mode or something ([docs](https://www.freedesktop.org/software/systemd/man/latest/udev.html?__goaway_challenge=meta-refresh&__goaway_id=9523b5dbc9faac15267d48f16179ffa4#:~:text=Note%20that%20running%20programs,processes%20is%20not%20allowed)), so it can't access the scripts in /home/{user}/...

This change hands-off the scripts to systemd-run, which will run them outside the sandbox mode. The --no-block returns immediatelly so it doesn't block udev event processing.

Here's the error I was getting:

```
Mar 27 23:42:10 [REDACTED] (udev-worker)[567]: AC: Process '/usr/bin/powerprofilesctl set balanced' failed with exit code 2.
Mar 27 23:42:10 [REDACTED] (udev-worker)[567]: AC: Process '/home/[REDACTED]/.local/share/omarchy/bin/omarchy-wifi-powersave on' failed with exit code 237.
```

With the command:

```
journalctl -u systemd-udevd -e
```

---

I've been getting weird Wifi issues since the update that contained these powersaver rules. Hoping this gets it fixed.