### PR TITLE
Fix Bluetooth on T2 Macs by loading hci_bcm4377 module

### DIFF
--- a/install/config/hardware/apple/fix-t2.sh
+++ b/install/config/hardware/apple/fix-t2.sh
@@ -19,6 +19,7 @@ if lspci -nn | grep -q "106b:180[12]"; then
   sudo systemctl enable tiny-dfr.service
 
   echo "apple-bce" | sudo tee /etc/modules-load.d/t2.conf >/dev/null
+  echo "hci_bcm4377" | sudo tee -a /etc/modules-load.d/t2.conf >/dev/null
 
   echo "MODULES+=(apple-bce usbhid hid_apple hid_generic xhci_pci xhci_hcd)" | sudo tee /etc/mkinitcpio.conf.d/apple-t2.conf >/dev/null
 

--- a/migrations/1774642699.sh
+++ b/migrations/1774642699.sh
@@ -1,0 +1,7 @@
+echo "Load Bluetooth driver module on T2 Macs"
+
+if lspci -nn | grep -q "106b:180[12]"; then
+  if ! grep -q "hci_bcm4377" /etc/modules-load.d/t2.conf 2>/dev/null; then
+    echo "hci_bcm4377" | sudo tee -a /etc/modules-load.d/t2.conf >/dev/null
+  fi
+fi


### PR DESCRIPTION
## Summary

- Bluetooth doesn't work on T2 Macs because the `hci_bcm4377` kernel module isn't auto-loaded
- The `apple-bcm-firmware` package is already installed but the driver module was missing from `/etc/modules-load.d/t2.conf`
- Adds `hci_bcm4377` to the T2 install script for new installs
- Adds a migration to append the module for existing T2 installs (with detection + idempotency guard)

Fixes #4402

## Test plan

- [x] Tested on MacBook Pro T2 — Bluetooth devices connect successfully after reboot
- [x] Migration is a no-op on non-T2 hardware (PCI ID check gates it)
- [x] Migration is idempotent (grep guard prevents duplicate entries)