### PR TITLE
Support Google Chrome theme color

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -2,7 +2,7 @@
 
 CHROMIUM_THEME=~/.config/omarchy/current/theme/chromium.theme
 
-if omarchy-cmd-present chromium || omarchy-cmd-present brave; then
+if omarchy-cmd-present chromium || omarchy-cmd-present brave || omarchy-cmd-present google-chrome-stable; then
   if [[ -f $CHROMIUM_THEME ]]; then
     THEME_RGB_COLOR=$(<$CHROMIUM_THEME)
     THEME_HEX_COLOR=$(printf '#%02x%02x%02x' ${THEME_RGB_COLOR//,/ })
@@ -20,5 +20,10 @@ if omarchy-cmd-present chromium || omarchy-cmd-present brave; then
   if omarchy-cmd-present brave; then
     echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/brave/policies/managed/color.json" >/dev/null
     brave --refresh-platform-policy --no-startup-window >/dev/null
+  fi
+
+  if omarchy-cmd-present google-chrome-stable; then
+    echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/opt/chrome/policies/managed/color.json" >/dev/null
+    google-chrome-stable --refresh-platform-policy --no-startup-window >/dev/null
   fi
 fi

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -22,3 +22,6 @@ sudo chmod a+rw /etc/chromium/policies/managed
 
 sudo mkdir -p /etc/brave/policies/managed
 sudo chmod a+rw /etc/brave/policies/managed
+
+sudo mkdir -p /etc/opt/chrome/policies/managed
+sudo chmod a+rw /etc/opt/chrome/policies/managed


### PR DESCRIPTION
## Summary

- Add `google-chrome-stable` support to `omarchy-theme-set-browser` so theme color changes apply to Google Chrome via its managed policy path (`/etc/opt/chrome/policies/managed/`)
- Create the Chrome policy directory during install in `install/config/theme.sh`, matching the existing setup for Chromium and Brave