### PR TITLE
Show active power profile in menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -241,11 +241,24 @@ show_setup_menu() {
 }
 
 show_setup_power_menu() {
-  profile=$(menu "Power Profile" "$(omarchy-powerprofiles-list)" "" "$(powerprofilesctl get)")
+  local current_profile
+  current_profile=$(powerprofilesctl get)
+
+  local options
+  options=$(omarchy-powerprofiles-list | while IFS= read -r line; do
+    if [[ "$line" == "$current_profile" ]]; then
+      echo "$line (active)"
+    else
+      echo "$line"
+    fi
+  done)
+
+  profile=$(menu "Power Profile" "$options" "" "$current_profile (active)")
 
   if [[ $profile == "CNCLD" || -z $profile ]]; then
     back_to show_setup_menu
   else
+    profile="${profile% (active)}"
     powerprofilesctl set "$profile"
   fi
 }


### PR DESCRIPTION
## Summary
- The power profile menu didn't clearly indicate which profile was currently active — walker's cursor always starts on the first item (power-saver), making it look like that was the current mode
- Appends "(active)" to the current profile name so users can tell at a glance which mode they're in

## Test plan
- [ ] Click the battery icon in waybar to open the power profile menu
- [ ] Verify the currently active profile (e.g. "performance") shows "(active)" next to it
- [ ] Select a different profile and reopen the menu to confirm the label moves
- [ ] Verify selecting the active profile (with the suffix) doesn't break `powerprofilesctl set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)