### PR TITLE
Add ONCE to default install

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -13,6 +13,7 @@ run_logged $OMARCHY_INSTALL/config/xcompose.sh
 run_logged $OMARCHY_INSTALL/config/mise-work.sh
 run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
+run_logged $OMARCHY_INSTALL/config/once.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
 run_logged $OMARCHY_INSTALL/config/remove-fcitx5-autostart.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh

--- a/install/config/once.sh
+++ b/install/config/once.sh
@@ -1,0 +1,2 @@
+# Enable Once background service for managing self-hosted web applications
+chrootable_systemctl_enable once-background.service

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -89,6 +89,7 @@ noto-fonts-emoji
 nss-mdns
 nvim
 obs-studio
+once-bin
 obsidian
 omarchy-nvim
 omarchy-walker

--- a/migrations/1775032365.sh
+++ b/migrations/1775032365.sh
@@ -1,0 +1,4 @@
+echo "Install Once for managing self-hosted web applications"
+
+omarchy-pkg-add once-bin
+sudo systemctl enable --now once-background.service


### PR DESCRIPTION
Adds [ONCE](https://github.com/basecamp/once) to the set of tools installed by default, and enables its background service. 
ONCE is a tool for easily self-hosting Docker-based web applications.

Depends on https://github.com/omacom-io/omarchy-pkgs/pull/70 for adding `once-bin` to the package mirror.
