### PR TITLE
Add migration for T2 fan curve config

### DIFF
--- a/migrations/1775059710.sh
+++ b/migrations/1775059710.sh
@@ -1,6 +1,6 @@
-if lspci -nn | grep -q "106b:180[12]" && [[ ! -f /etc/t2fand.conf ]]; then
-  echo "Installing tuned fan curve for T2 MacBook"
+echo "Install tuned fan curve for T2 MacBook"
 
+if lspci -nn | grep -q "106b:180[12]" && [[ ! -f /etc/t2fand.conf ]]; then
   cat <<EOF | sudo tee /etc/t2fand.conf >/dev/null
 [Fan1]
 low_temp=55

--- a/migrations/1775059710.sh
+++ b/migrations/1775059710.sh
@@ -1,0 +1,11 @@
+if lspci -nn | grep -q "106b:180[12]" && [[ ! -f /etc/t2fand.conf ]]; then
+  echo "Installing tuned fan curve for T2 MacBook"
+
+  cat <<EOF | sudo tee /etc/t2fand.conf >/dev/null
+[Fan1]
+low_temp=55
+high_temp=75
+speed_curve=linear
+always_full_speed=false
+EOF
+fi


### PR DESCRIPTION
## Summary

- Adds a migration to install `t2fand.conf` on existing T2 MacBook installations

Follow-up to #5132 which added the fan curve to `fix-t2.sh` but didn't include a migration for existing installs.

## Test plan

- [ ] Run `omarchy-migrate` on a T2 MacBook without `t2fand.conf`
- [ ] Verify `/etc/t2fand.conf` is created with the correct fan curve
- [ ] Run migration again — verify it's idempotent (skips if file exists)