### PR TITLE
Add ONCE to Install->Service menu

### DIFF
--- a/bin/omarchy-install-once
+++ b/bin/omarchy-install-once
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Install the ONCE service, enable its background service, and launch the TUI.
+
+echo "Installing ONCE..."
+omarchy-pkg-add once-bin
+
+echo "Enabling ONCE background service..."
+sudo systemctl enable --now once-background.service
+
+echo -e "\nLaunching ONCE..."
+once

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -317,12 +317,13 @@ show_install_menu() {
 }
 
 show_install_service_menu() {
-  case $(menu "Install" "  Dropbox\n  Tailscale\n󱇱  NordVPN [AUR]\n󰟵  Bitwarden\n  Chromium Account") in
+  case $(menu "Install" "  Dropbox\n  Tailscale\n󱇱  NordVPN [AUR]\n󰟵  Bitwarden\n  Chromium Account\n󰏖  ONCE") in
   *Dropbox*) present_terminal omarchy-install-dropbox ;;
   *Tailscale*) present_terminal omarchy-install-tailscale ;;
   *NordVPN*) present_terminal omarchy-install-nordvpn ;;
   *Bitwarden*) install_and_launch "Bitwarden" "bitwarden bitwarden-cli" "bitwarden" ;;
   *Chromium*) present_terminal omarchy-install-chromium-google-account ;;
+  *ONCE*) present_terminal omarchy-install-once ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
Adds an entry to the Service menu that installs the ONCE package, registers its background service, and launches the TUI.
