### PR TITLE
Preserve package download progress during updates

### DIFF
--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -2,12 +2,15 @@
 
 set -e
 
+# Run the update inside a PTY so pacman/yay keep showing download progress
+# while still logging the full session for later analysis.
+if [[ -z $OMARCHY_UPDATE_LOGGED ]]; then
+  script_command=$(printf '%q ' "$0" "$@")
+  exec env OMARCHY_UPDATE_LOGGED=1 script -qefc "$script_command" "/tmp/omarchy-update.log"
+fi
+
 # Ensure screensaver/sleep doesn't set in during updates
 hyprctl dispatch tagwindow +noidle &>/dev/null || true
-
-# Capture update logs (CLICOLOR_FORCE keeps gum styled when stdout is piped through tee)
-export CLICOLOR_FORCE=1
-exec > >(tee "/tmp/omarchy-update.log") 2>&1
 
 # Perform all update steps
 omarchy-update-keyring


### PR DESCRIPTION
## Summary

Fixes the update experience where `omarchy-update` appears stuck at:

```text
:: Proceed with installation? [Y/n]
:: Retrieving packages...
```

for long periods without any visible progress.

## Root cause

`bin/omarchy-update-perform` was redirecting all output through `tee`:

```bash
exec > >(tee "/tmp/omarchy-update.log") 2>&1
```

That causes `pacman` and `yay` to lose their TTY, so they stop rendering interactive download/progress output.

## Fix

Run the update process inside a PTY using `script` instead of piping through `tee`.

This preserves:
- live package download/progress feedback in the terminal
- logging to `/tmp/omarchy-update.log` for post-update analysis

## Notes

- The existing log analysis still works because the session continues to be captured to `/tmp/omarchy-update.log`.
- This change affects both system package updates and AUR updates.
