### PR TITLE
fix(hardware): add Alienware Area-51 iwd boot-delay workaround

### DIFF
--- a/default/systemd/system/iwd.service.d/delay-start.conf
+++ b/default/systemd/system/iwd.service.d/delay-start.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/sleep 3

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -60,5 +60,6 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-alienware-area51-wifi-boot-delay.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-tuxedo-backlight.sh

--- a/install/config/hardware/fix-alienware-area51-wifi-boot-delay.sh
+++ b/install/config/hardware/fix-alienware-area51-wifi-boot-delay.sh
@@ -1,0 +1,14 @@
+# Delay iwd startup on Alienware Area-51 to avoid intermittent boot-time
+# WLAN_STATUS_ANTI_CLOG_REQUIRED auth failures (status 77).
+
+system_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+
+if echo "$system_vendor" | grep -qi "^alienware$" && echo "$product_name" | grep -Eqi "^(alienware 18 area-51|aa18250)$"; then
+  echo "Detected $system_vendor $product_name. Applying iwd startup delay workaround."
+
+  sudo install -d /etc/systemd/system/iwd.service.d
+  sudo cp "$OMARCHY_PATH/default/systemd/system/iwd.service.d/delay-start.conf" /etc/systemd/system/iwd.service.d/delay-start.conf
+
+  sudo systemctl daemon-reload
+fi


### PR DESCRIPTION
## Problem

On Alienware Area-51 AA18250 systems (Intel BE200D2W Wi-Fi 7 adapter, `iwlwifi` + `iwlmld` op_mode), Wi-Fi intermittently fails to authenticate on cold boot. The AP responds with `WLAN_STATUS_ANTI_CLOG_REQUIRED` (status 77), a SAE/WPA3 anti-clogging rejection, because `iwd` initiates authentication before the AP has cleared its anti-clog state.

Kernel log signature on affected boots:
```
wlan0: send auth to <bssid> (try 1/3)
wlan0: <bssid> denied authentication (status 77)
wlan0: authenticated        ← succeeds on retry
```

This is a timing race — the hardware and driver load correctly every time. The issue is purely in connection initiation timing.

## Fix

Adds a 3-second `ExecStartPre` delay to the `iwd` service on affected hardware, giving the AP time to clear its anti-clog window before authentication is attempted.

The fix is hardware-gated on DMI vendor (`alienware`) and product name (`area-51` / `aa18250`) so it has no effect on other systems.

## Hardware

- Machine: Alienware 18 Area-51 AA18250
- BIOS: Dell 1.10.1
- CPU: Intel Core Ultra 9 275HX
- Wi-Fi: Intel BE200D2W (PCI `8086:272b`), driver `iwlwifi` + `iwlmld`, firmware `101.6e695a70.0`
- Kernel: 6.19.6-arch1-1, OS: Omarchy (Arch-based)
- Network stack: `iwd` + `systemd-networkd` (no NetworkManager)

## Testing

Tested stable across repeated cold boots on the hardware described above. Boot-time Wi-Fi authentication failure eliminated after applying the delay.