### PR TITLE
fix(hardware): add Alienware Area-51 Realtek/SOF audio quirk workaround

### DIFF
--- a/default/systemd/system/fix-sof-audio.service
+++ b/default/systemd/system/fix-sof-audio.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Reload SOF audio driver to fix initialization race
+Wants=sound.target
+After=sound.target
+ConditionPathExists=!/proc/asound/sofsoundwire
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -eu -c '\
+  sleep 2 && \
+  modprobe -r snd_soc_sof_sdw snd_sof_pci_intel_mtl && \
+  sleep 1 && \
+  modprobe snd_sof_pci_intel_mtl && \
+  sleep 5 && \
+  card=$(awk "/sofsoundwire|sof-soundwire/ { print \$1; exit }" /proc/asound/cards) && \
+  [ -n "$card" ] || { echo "fix-sof-audio: SOF card not found" >&2; exit 1; } && \
+  amixer -c "$card" cset name="rt1320 Amp 1 Switch" on && \
+  amixer -c "$card" cset name="rt1320 Amp 2 Switch" on'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/default/systemd/system/iwd.service.d/delay-start.conf
+++ b/default/systemd/system/iwd.service.d/delay-start.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/sleep 3

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -61,5 +61,6 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-alienware-area51-wifi-boot-delay.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-alienware-area51-realtek-audio.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-tuxedo-backlight.sh

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -60,5 +60,6 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-alienware-area51-wifi-boot-delay.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-tuxedo-backlight.sh

--- a/install/config/hardware/fix-alienware-area51-realtek-audio.sh
+++ b/install/config/hardware/fix-alienware-area51-realtek-audio.sh
@@ -1,0 +1,32 @@
+# Work around SOF/SoundWire init race and RT1320 UCM mismatch on
+# Alienware Area-51 AA18250 systems.
+
+system_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+
+if echo "$system_vendor" | grep -qi "^alienware$" && echo "$product_name" | grep -Eqi "^(alienware 18 area-51|aa18250)$"; then
+  echo "Detected $system_vendor $product_name. Applying SOF/RT1320 audio workaround."
+
+  sudo cp "$OMARCHY_PATH/default/systemd/system/fix-sof-audio.service" /etc/systemd/system/fix-sof-audio.service
+  sudo systemctl daemon-reload
+  chrootable_systemctl_enable fix-sof-audio.service
+
+  # Write UCM override to /etc/alsa/ucm2/ so it survives alsa-ucm-conf upgrades.
+  source_ucm="/usr/share/alsa/ucm2/sof-soundwire/rt1320.conf"
+  override_ucm="/etc/alsa/ucm2/sof-soundwire/rt1320.conf"
+  if [[ -f "$source_ucm" ]]; then
+    sudo mkdir -p "$(dirname "$override_ucm")"
+    if [[ ! -f "$override_ucm" ]]; then
+      sudo cp "$source_ucm" "$override_ucm"
+    fi
+
+    # Remove nonexistent rt1320-2 control reference.
+    sudo sed -i '/Macro\.num3\.rt1320spk/d' "$override_ucm"
+
+    # Fix stereo routing for second amp: L,L -> L,R.
+    sudo sed -i '/Macro\.num2\.rt1320spk[[:space:]]*{/,/}/{s/Sel "L,L"/Sel "L,R"/;}' "$override_ucm"
+    if sudo grep -qE 'Sel "L,L"' "$override_ucm"; then
+      echo "Warning: RT1320 UCM stereo patch may not have applied cleanly — verify $override_ucm" >&2
+    fi
+  fi
+fi

--- a/install/config/hardware/fix-alienware-area51-wifi-boot-delay.sh
+++ b/install/config/hardware/fix-alienware-area51-wifi-boot-delay.sh
@@ -1,0 +1,14 @@
+# Delay iwd startup on Alienware Area-51 to avoid intermittent boot-time
+# WLAN_STATUS_ANTI_CLOG_REQUIRED auth failures (status 77).
+
+system_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+
+if echo "$system_vendor" | grep -qi "^alienware$" && echo "$product_name" | grep -Eqi "^(alienware 18 area-51|aa18250)$"; then
+  echo "Detected $system_vendor $product_name. Applying iwd startup delay workaround."
+
+  sudo install -d /etc/systemd/system/iwd.service.d
+  sudo cp "$OMARCHY_PATH/default/systemd/system/iwd.service.d/delay-start.conf" /etc/systemd/system/iwd.service.d/delay-start.conf
+
+  sudo systemctl daemon-reload
+fi


### PR DESCRIPTION
## Problem

On Alienware Area-51 AA18250 systems, audio is silent after boot due to two compounding issues:

1. **SOF/SoundWire init race** — the `snd_sof_pci_intel_mtl` driver initialises before the SoundWire bus is stable, leaving `/proc/asound/sofsoundwire` absent and the codec unconfigured.

2. **RT1320 UCM mismatch** — the system ships with two RT1320 amplifiers, but the stock `rt1320.conf` UCM file references a third (`Macro.num3.rt1320spk`) that does not exist on this board, and uses incorrect channel routing (`L,L`) for the second amp instead of `L,R`.

## Fix

Two-part, hardware-gated workaround (DMI-matched on `^alienware$` / `^(alienware 18 area-51|aa18250)$`):

**1. `fix-sof-audio.service`** — a oneshot systemd service (`Wants=+After=sound.target`, gated on `ConditionPathExists=!/proc/asound/sofsoundwire`) that:
- Unloads and reloads `snd_sof_pci_intel_mtl` to resolve the init race
- Detects the SOF card dynamically via `/proc/asound/cards`
- Re-enables the RT1320 amplifier controls by name (`rt1320 Amp 1 Switch` / `rt1320 Amp 2 Switch`)

**2. UCM override** — copies `/usr/share/alsa/ucm2/sof-soundwire/rt1320.conf` to `/etc/alsa/ucm2/sof-soundwire/rt1320.conf` (only if not already present), then patches the override in-place:
- Removes the nonexistent `rt1320-2` control reference
- Corrects channel routing for the second amp from `L,L` → `L,R`

Writing to `/etc/alsa/ucm2/` ensures the override survives `alsa-ucm-conf` package upgrades.

## Hardware

- Machine: Alienware 18 Area-51 AA18250
- CPU: Intel Core Ultra 9 275HX
- Audio: Realtek RT1320 × 2 via SoundWire, SOF firmware (`snd_sof_pci_intel_mtl`)
- Kernel: 6.19.6-arch1-1, OS: Omarchy (Arch-based)

## Testing

Tested stable on the hardware described above. Audio output functional after boot without manual intervention.