### PR TITLE
SDDM with Wayland as display manager

### DIFF
--- a/install/login/sddm.sh
+++ b/install/login/sddm.sh
@@ -11,6 +11,9 @@ Session=hyprland-uwsm
 
 [Theme]
 Current=omarchy
+
+[General]
+DisplayServer=wayland
 EOF
 fi
 

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -131,6 +131,7 @@ unzip
 usage
 uwsm
 waybar
+weston
 whois
 wireless-regdb
 wiremix

--- a/migrations/1775236589.sh
+++ b/migrations/1775236589.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eu
+
+CONFIG_DIR="/etc/sddm.conf.d"
+
+DEFAULT_CONFIG_FILE="$CONFIG_DIR/autologin.conf"
+CONFIG_FILE="$CONFIG_DIR/50-wayland.conf"
+
+# Ensure weston exists
+omarchy-pkg-add weston
+
+# Only create config if it doesn't exist
+if ! rg -q "DisplayServer=wayland" "$DEFAULT_CONFIG_FILE"; then
+  echo "Add SDDM Wayland config."
+  echo "Now, TTY2 will be available on next boot."
+
+  sudo tee "$CONFIG_FILE" > /dev/null <<'EOF'
+[General]
+DisplayServer=wayland
+EOF
+
+else
+  echo "Config already exists for SDDM Wayland."
+fi
+


### PR DESCRIPTION
Both for existing installations and a migration.
This prevents TTY2 having an orphaned Xorg instance.

Issue: #5079 