### PR TITLE
Make Typora's print dialog float

### DIFF
--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -12,6 +12,7 @@ source = ~/.local/share/omarchy/default/hypr/apps/geforce.conf
 source = ~/.local/share/omarchy/default/hypr/apps/moonlight.conf
 source = ~/.local/share/omarchy/default/hypr/apps/system.conf
 source = ~/.local/share/omarchy/default/hypr/apps/telegram.conf
+source = ~/.local/share/omarchy/default/hypr/apps/typora.conf
 source = ~/.local/share/omarchy/default/hypr/apps/terminals.conf
 source = ~/.local/share/omarchy/default/hypr/apps/walker.conf
 source = ~/.local/share/omarchy/default/hypr/apps/webcam-overlay.conf

--- a/default/hypr/apps/typora.conf
+++ b/default/hypr/apps/typora.conf
@@ -1,0 +1,2 @@
+# Float Typora print dialog
+windowrule = match:class ^Typora$, match:title ^Print$, float on, center on


### PR DESCRIPTION
Make the Typora dialog float as suggested by this [blog post](https://sudomarchy.com/posts/float-that-window). Credits to @pomartel 

<img width="2874" height="1704" alt="image" src="https://github.com/user-attachments/assets/c673b831-9a8a-424b-9a8f-f73ba5741bc4" />
