### PR TITLE
Fix zsh compatibility: HISTCONTROL and arithmetic syntax

### DIFF
--- a/bin/omarchy-reinstall-configs
+++ b/bin/omarchy-reinstall-configs
@@ -13,6 +13,11 @@ cp -R ~/.local/share/omarchy/config/* ~/.config/
 cp ~/.local/share/omarchy/default/bashrc ~/.bashrc
 echo '[[ -f ~/.bashrc ]] && . ~/.bashrc' | tee ~/.bash_profile >/dev/null
 
+if grep -q zsh "$SHELL" 2>/dev/null; then
+  cp ~/.local/share/omarchy/default/zsh/rc ~/.zshrc
+  echo '[[ -f ~/.zshrc ]] && . ~/.zshrc' | tee ~/.zprofile >/dev/null
+fi
+
 $(bash $OMARCHY_PATH/install/config/theme.sh)
 
 omarchy-refresh-limine

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -1,3 +1,6 @@
+# Extended keys for complex bindings (Ctrl+Shift+*, etc)
+set -s extended-keys on
+
 # Prefix
 set -g prefix C-Space
 set -g prefix2 C-b

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -15,7 +15,8 @@ bindd = SUPER CTRL, SPACE, Theme background menu, exec, omarchy-menu background
 bindd = SUPER SHIFT CTRL, SPACE, Theme menu, exec, omarchy-menu theme
 bindd = SUPER, BACKSPACE, Toggle window transparency, exec, omarchy-hyprland-active-window-transparency-toggle
 bindd = SUPER SHIFT, BACKSPACE, Toggle window gaps, exec, omarchy-hyprland-window-gaps-toggle
-bindd = SUPER CTRL, BACKSPACE, Toggle single-window square aspect, exec, omarchy-hyprland-window-single-square-aspect-toggle
+bindd = SUPER CTRL, BACKSPACE, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle
+bindd = SUPER CTRL ALT, BACKSPACE, Toggle single-window square aspect, exec, omarchy-hyprland-window-single-square-aspect-toggle
 
 # Notifications
 bindd = SUPER, COMMA, Dismiss last notification, exec, makoctl dismiss

--- a/default/zsh/aliases
+++ b/default/zsh/aliases
@@ -1,0 +1,57 @@
+# File system
+if command -v eza &> /dev/null; then
+  alias ls='eza -lh --group-directories-first --icons=auto'
+  alias lsa='ls -a'
+  alias lt='eza --tree --level=2 --long --icons --git'
+  alias lta='lt -a'
+fi
+
+if [[ "$TERM" == "xterm-kitty" ]]; then
+  alias ff="fzf --preview 'case \$(file --mime-type -b {}) in image/*) kitty icat --clear --transfer-mode=memory --stdin=no --place=\${FZF_PREVIEW_COLUMNS}x\${FZF_PREVIEW_LINES}@0x0 {} ;; *) bat --style=numbers --color=always {} ;; esac'"
+else
+  alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
+fi
+alias eff='$EDITOR "$(ff)"'
+sff() { if [ $# -eq 0 ]; then echo "Usage: sff <destination> (e.g. sff host:/tmp/)"; return 1; fi; local file; file=$(find . -type f -printf '%T@\t%p\n' | sort -rn | cut -f2- | ff) && [ -n "$file" ] && scp "$file" "$1"; }
+
+if command -v zoxide &> /dev/null; then
+  alias cd="zd"
+  zd() {
+    if (( $# == 0 )); then
+      builtin cd ~ || return
+    elif [[ -d $1 ]]; then
+      builtin cd "$1" || return
+    else
+      if ! z "$@"; then
+        echo "Error: Directory not found"
+        return 1
+      fi
+
+      printf "\U000F17A9 "
+      pwd
+    fi
+  }
+fi
+
+open() (
+  xdg-open "$@" >/dev/null 2>&1 &
+)
+
+# Directories
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+
+# Tools
+alias c='opencode'
+alias cx='printf "\033[2J\033[3J\033[H" && claude --allow-dangerously-skip-permissions'
+alias d='docker'
+alias r='rails'
+alias t='tmux attach || tmux new -s Work'
+n() { if [ "$#" -eq 0 ]; then command nvim . ; else command nvim "$@"; fi; }
+
+# Git
+alias g='git'
+alias gcm='git commit -m'
+alias gcam='git commit -a -m'
+alias gcad='git commit -a --amend'

--- a/default/zsh/aliases
+++ b/default/zsh/aliases
@@ -12,7 +12,7 @@ else
   alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
 fi
 alias eff='$EDITOR "$(ff)"'
-sff() { if [ $# -eq 0 ]; then echo "Usage: sff <destination> (e.g. sff host:/tmp/)"; return 1; fi; local file; file=$(find . -type f -printf '%T@\t%p\n' | sort -rn | cut -f2- | ff) && [ -n "$file" ] && scp "$file" "$1"; }
+sff() { if (( $# == 0 )); then echo "Usage: sff <destination> (e.g. sff host:/tmp/)"; return 1; fi; local file; file=$(find . -type f -printf '%T@\t%p\n' | sort -rn | cut -f2- | ff) && [ -n "$file" ] && scp "$file" "$1"; }
 
 if command -v zoxide &> /dev/null; then
   alias cd="zd"
@@ -48,7 +48,7 @@ alias cx='printf "\033[2J\033[3J\033[H" && claude --allow-dangerously-skip-permi
 alias d='docker'
 alias r='rails'
 alias t='tmux attach || tmux new -s Work'
-n() { if [ "$#" -eq 0 ]; then command nvim . ; else command nvim "$@"; fi; }
+n() { if (( $# == 0 )); then command nvim . ; else command nvim "$@"; fi; }
 
 # Git
 alias g='git'

--- a/default/zsh/envs
+++ b/default/zsh/envs
@@ -1,0 +1,7 @@
+# Editor used by CLI
+export SUDO_EDITOR="$EDITOR"
+export BAT_THEME=ansi
+
+# Duplicated from .config/uwsm/env so SSH works too
+export OMARCHY_PATH=$HOME/.local/share/omarchy
+export PATH=$OMARCHY_PATH/bin:$PATH:$HOME/.local/bin

--- a/default/zsh/functions
+++ b/default/zsh/functions
@@ -1,0 +1,1 @@
+for f in $OMARCHY_PATH/default/bash/fns/*; do source "$f"; done

--- a/default/zsh/init
+++ b/default/zsh/init
@@ -1,0 +1,24 @@
+if command -v mise &> /dev/null; then
+  eval "$(mise activate zsh)"
+fi
+
+if command -v starship &> /dev/null; then
+  eval "$(starship init zsh)"
+fi
+
+if command -v zoxide &> /dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
+if command -v try &> /dev/null; then
+  eval "$(SHELL=/bin/zsh command try init ~/Work/tries)"
+fi
+
+if command -v fzf &> /dev/null; then
+  if [[ -f /usr/share/fzf/completion.zsh ]]; then
+    source /usr/share/fzf/completion.zsh
+  fi
+  if [[ -f /usr/share/fzf/key-bindings.zsh ]]; then
+    source /usr/share/fzf/key-bindings.zsh
+  fi
+fi

--- a/default/zsh/rc
+++ b/default/zsh/rc
@@ -1,0 +1,6 @@
+source ~/.local/share/omarchy/default/zsh/envs
+source ~/.local/share/omarchy/default/zsh/shell
+source ~/.local/share/omarchy/default/zsh/aliases
+source ~/.local/share/omarchy/default/zsh/functions
+source ~/.local/share/omarchy/default/zsh/init
+bindkey -e

--- a/default/zsh/shell
+++ b/default/zsh/shell
@@ -1,6 +1,7 @@
 # History control
 setopt APPEND_HISTORY
-HISTCONTROL=ignoreboth
+setopt HIST_IGNORE_SPACE
+setopt HIST_IGNORE_DUPS
 HISTSIZE=32768
 HISTFILE=~/.zsh_history
 

--- a/default/zsh/shell
+++ b/default/zsh/shell
@@ -1,0 +1,12 @@
+# History control
+setopt APPEND_HISTORY
+HISTCONTROL=ignoreboth
+HISTSIZE=32768
+HISTFILE=~/.zsh_history
+
+# Autocompletion
+autoload -Uz compinit
+compinit
+
+# Ensure command hashing is off for mise
+set +h

--- a/install/config/config.sh
+++ b/install/config/config.sh
@@ -4,3 +4,8 @@ cp -R ~/.local/share/omarchy/config/* ~/.config/
 
 # Use default bashrc from Omarchy
 cp ~/.local/share/omarchy/default/bashrc ~/.bashrc
+
+# If using zsh, also copy zshrc
+if [[ -n "$ZSH_VERSION" ]] || grep -q zsh "$SHELL" 2>/dev/null; then
+  cp ~/.local/share/omarchy/default/zsh/rc ~/.zshrc
+fi


### PR DESCRIPTION
## Summary
Fix zsh compatibility issues after initial zsh support PR:

- Replace `HISTCONTROL=ignoreboth` (bash-only) with zsh equivalents: `setopt HIST_IGNORE_SPACE` + `setopt HIST_IGNORE_DUPS`
- Fix arithmetic syntax: `[ $# -eq 0 ]` → `(( $# == 0 ))` in `sff()` and `n()` functions

This addresses Copilot review feedback.