### PR TITLE
Add zsh support with aliases and shell config

### DIFF
--- a/bin/omarchy-reinstall-configs
+++ b/bin/omarchy-reinstall-configs
@@ -13,6 +13,11 @@ cp -R ~/.local/share/omarchy/config/* ~/.config/
 cp ~/.local/share/omarchy/default/bashrc ~/.bashrc
 echo '[[ -f ~/.bashrc ]] && . ~/.bashrc' | tee ~/.bash_profile >/dev/null
 
+if grep -q zsh "$SHELL" 2>/dev/null; then
+  cp ~/.local/share/omarchy/default/zsh/rc ~/.zshrc
+  echo '[[ -f ~/.zshrc ]] && . ~/.zshrc' | tee ~/.zprofile >/dev/null
+fi
+
 $(bash $OMARCHY_PATH/install/config/theme.sh)
 
 omarchy-refresh-limine

--- a/default/zsh/aliases
+++ b/default/zsh/aliases
@@ -1,0 +1,57 @@
+# File system
+if command -v eza &> /dev/null; then
+  alias ls='eza -lh --group-directories-first --icons=auto'
+  alias lsa='ls -a'
+  alias lt='eza --tree --level=2 --long --icons --git'
+  alias lta='lt -a'
+fi
+
+if [[ "$TERM" == "xterm-kitty" ]]; then
+  alias ff="fzf --preview 'case \$(file --mime-type -b {}) in image/*) kitty icat --clear --transfer-mode=memory --stdin=no --place=\${FZF_PREVIEW_COLUMNS}x\${FZF_PREVIEW_LINES}@0x0 {} ;; *) bat --style=numbers --color=always {} ;; esac'"
+else
+  alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
+fi
+alias eff='$EDITOR "$(ff)"'
+sff() { if (( $# == 0 )); then echo "Usage: sff <destination> (e.g. sff host:/tmp/)"; return 1; fi; local file; file=$(find . -type f -printf '%T@\t%p\n' | sort -rn | cut -f2- | ff) && [ -n "$file" ] && scp "$file" "$1"; }
+
+if command -v zoxide &> /dev/null; then
+  alias cd="zd"
+  zd() {
+    if (( $# == 0 )); then
+      builtin cd ~ || return
+    elif [[ -d $1 ]]; then
+      builtin cd "$1" || return
+    else
+      if ! z "$@"; then
+        echo "Error: Directory not found"
+        return 1
+      fi
+
+      printf "\U000F17A9 "
+      pwd
+    fi
+  }
+fi
+
+open() (
+  xdg-open "$@" >/dev/null 2>&1 &
+)
+
+# Directories
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+
+# Tools
+alias c='opencode'
+alias cx='printf "\033[2J\033[3J\033[H" && claude --allow-dangerously-skip-permissions'
+alias d='docker'
+alias r='rails'
+alias t='tmux attach || tmux new -s Work'
+n() { if [ "$#" -eq 0 ]; then command nvim . ; else command nvim "$@"; fi; }
+
+# Git
+alias g='git'
+alias gcm='git commit -m'
+alias gcam='git commit -a -m'
+alias gcad='git commit -a --amend'

--- a/default/zsh/envs
+++ b/default/zsh/envs
@@ -1,0 +1,7 @@
+# Editor used by CLI
+export SUDO_EDITOR="$EDITOR"
+export BAT_THEME=ansi
+
+# Duplicated from .config/uwsm/env so SSH works too
+export OMARCHY_PATH=$HOME/.local/share/omarchy
+export PATH=$OMARCHY_PATH/bin:$PATH:$HOME/.local/bin

--- a/default/zsh/functions
+++ b/default/zsh/functions
@@ -1,0 +1,1 @@
+for f in $OMARCHY_PATH/default/bash/fns/*; do source "$f"; done

--- a/default/zsh/init
+++ b/default/zsh/init
@@ -1,0 +1,24 @@
+if command -v mise &> /dev/null; then
+  eval "$(mise activate zsh)"
+fi
+
+if command -v starship &> /dev/null; then
+  eval "$(starship init zsh)"
+fi
+
+if command -v zoxide &> /dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
+if command -v try &> /dev/null; then
+  eval "$(SHELL=/bin/zsh command try init ~/Work/tries)"
+fi
+
+if command -v fzf &> /dev/null; then
+  if [[ -f /usr/share/fzf/completion.zsh ]]; then
+    source /usr/share/fzf/completion.zsh
+  fi
+  if [[ -f /usr/share/fzf/key-bindings.zsh ]]; then
+    source /usr/share/fzf/key-bindings.zsh
+  fi
+fi

--- a/default/zsh/rc
+++ b/default/zsh/rc
@@ -1,0 +1,6 @@
+source ~/.local/share/omarchy/default/zsh/envs
+source ~/.local/share/omarchy/default/zsh/shell
+source ~/.local/share/omarchy/default/zsh/aliases
+source ~/.local/share/omarchy/default/zsh/functions
+source ~/.local/share/omarchy/default/zsh/init
+bindkey -e

--- a/default/zsh/shell
+++ b/default/zsh/shell
@@ -1,0 +1,13 @@
+# History control
+setopt APPEND_HISTORY
+setopt HIST_IGNORE_SPACE
+setopt HIST_IGNORE_DUPS
+HISTSIZE=32768
+HISTFILE=~/.zsh_history
+
+# Autocompletion
+autoload -Uz compinit
+compinit
+
+# Ensure command hashing is off for mise
+set +h

--- a/install/config/config.sh
+++ b/install/config/config.sh
@@ -4,3 +4,8 @@ cp -R ~/.local/share/omarchy/config/* ~/.config/
 
 # Use default bashrc from Omarchy
 cp ~/.local/share/omarchy/default/bashrc ~/.bashrc
+
+# If using zsh, also copy zshrc
+if [[ -n "$ZSH_VERSION" ]] || grep -q zsh "$SHELL" 2>/dev/null; then
+  cp ~/.local/share/omarchy/default/zsh/rc ~/.zshrc
+fi


### PR DESCRIPTION
## Summary
- Add zsh configuration files in default/zsh/ (aliases, envs, shell, functions, init, rc)
- Update install/config/config.sh to detect zsh and copy zshrc
- Update omarchy-reinstall-configs to handle zsh setup
- Fix zsh compatibility: replace HISTCONTROL with setopt equivalents, use zsh arithmetic syntax