### PR TITLE
Fix Super+Ctrl+Backspace to cycle monitor scaling

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling-cycle
+++ b/bin/omarchy-hyprland-monitor-scaling-cycle
@@ -8,11 +8,11 @@ WIDTH=$(echo "$MONITOR_INFO" | jq -r '.width')
 HEIGHT=$(echo "$MONITOR_INFO" | jq -r '.height')
 REFRESH_RATE=$(echo "$MONITOR_INFO" | jq -r '.refreshRate')
 
-# Cycle through scales: 1 → 1.6 → 2 → 3 → 1
+# Cycle through scales: 1 → 1.5 → 2 → 3 → 1
 CURRENT_INT=$(awk -v s="$CURRENT_SCALE" 'BEGIN { printf "%.0f", s * 10 }')
 
 case "$CURRENT_INT" in
-10) NEW_SCALE=1.6 ;;
+10) NEW_SCALE=1.5 ;;
 16) NEW_SCALE=2 ;;
 20) NEW_SCALE=3 ;;
 *) NEW_SCALE=1 ;;

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -15,7 +15,8 @@ bindd = SUPER CTRL, SPACE, Theme background menu, exec, omarchy-menu background
 bindd = SUPER SHIFT CTRL, SPACE, Theme menu, exec, omarchy-menu theme
 bindd = SUPER, BACKSPACE, Toggle window transparency, exec, omarchy-hyprland-active-window-transparency-toggle
 bindd = SUPER SHIFT, BACKSPACE, Toggle window gaps, exec, omarchy-hyprland-window-gaps-toggle
-bindd = SUPER CTRL, BACKSPACE, Toggle single-window square aspect, exec, omarchy-hyprland-window-single-square-aspect-toggle
+bindd = SUPER CTRL, BACKSPACE, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle
+bindd = SUPER CTRL ALT, BACKSPACE, Toggle single-window square aspect, exec, omarchy-hyprland-window-single-square-aspect-toggle
 
 # Notifications
 bindd = SUPER, COMMA, Dismiss last notification, exec, makoctl dismiss


### PR DESCRIPTION
## Summary
- Fix Super+Ctrl+Backspace to cycle monitor scaling between 1x, 1.5x, 2x

## Changes
- default/hypr/bindings/utilities.conf: Update binding description