### PR TITLE
Run hyprpm update after system package updates

### DIFF
--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -16,6 +16,7 @@ hyprctl dispatch tagwindow +noidle &>/dev/null || true
 omarchy-update-keyring
 omarchy-update-available-reset
 omarchy-update-system-pkgs
+hyprpm update &>/dev/null || true
 omarchy-migrate
 omarchy-update-aur-pkgs
 omarchy-update-orphan-pkgs


### PR DESCRIPTION
## Summary
- Adds `hyprpm update` to the update pipeline in `bin/omarchy-update-perform`, running after system packages are updated
- Keeps Hyprland plugin headers in sync with the current Hyprland version, preventing plugin build failures after Hyprland upgrades

## Test plan
- [ ] Run `omarchy-update-perform` and verify `hyprpm update` executes after system package updates
- [ ] Confirm that plugins (e.g. dynamic-cursors) rebuild successfully against the updated headers