### PR TITLE
Update cx alias to use new --permission-mode flag

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -44,7 +44,7 @@ alias ....='cd ../../..'
 
 # Tools
 alias c='opencode'
-alias cx='printf "\033[2J\033[3J\033[H" && claude --allow-dangerously-skip-permissions'
+alias cx='printf "\033[2J\033[3J\033[H" && claude --permission-mode bypassPermissions'
 alias d='docker'
 alias r='rails'
 alias t='tmux attach || tmux new -s Work'


### PR DESCRIPTION
## Summary

- The `--allow-dangerously-skip-permissions` flag has been replaced by `--permission-mode bypassPermissions` in Claude Code
- Updates the `cx` alias in `default/bash/aliases` to use the new flag

## Test plan

- [ ] Run `cx` and verify Claude Code launches with permissions bypassed