### PR TITLE
Use wpctl instead of pactl to switch default audio sink

### DIFF
--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -57,7 +57,8 @@ fi
 next_sink_volume_icon="sink-volume-${icon_state}-symbolic"
 
 if [[ $next_sink_name != $current_sink_name ]]; then
-  pactl set-default-sink "$next_sink_name"
+  next_sink_wpid=$(echo "$next_sink" | jq -r '.properties."object.id"')
+  wpctl set-default "$next_sink_wpid"
 fi
 
 swayosd-client \


### PR DESCRIPTION
## Summary

`pactl set-default-sink` only updates PipeWire's `default.audio.sink` metadata, but WirePlumber immediately overrides it back because `default.configured.audio.sink` remains unchanged. This makes `omarchy-cmd-audio-switch` appear to do nothing — the OSD notification shows but audio doesn't actually switch.

`wpctl set-default` updates both metadata keys, making the switch persist.

## Test plan

- Connect 2+ audio output devices (e.g. speakers + USB headset + Bluetooth)
- Press Super + Mute to cycle between them
- Verify the default sink actually changes (`pactl get-default-sink`)
- Verify audio plays through the newly selected device