### PR TITLE
Restore jetbrains no_follow_mouse

### DIFF
--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -3,6 +3,7 @@ source = ~/.local/share/omarchy/default/hypr/apps/1password.conf
 source = ~/.local/share/omarchy/default/hypr/apps/bitwarden.conf
 source = ~/.local/share/omarchy/default/hypr/apps/browser.conf
 source = ~/.local/share/omarchy/default/hypr/apps/hyprshot.conf
+source = ~/.local/share/omarchy/default/hypr/apps/jetbrains.conf
 source = ~/.local/share/omarchy/default/hypr/apps/localsend.conf
 source = ~/.local/share/omarchy/default/hypr/apps/pip.conf
 source = ~/.local/share/omarchy/default/hypr/apps/qemu.conf

--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -1,0 +1,6 @@
+# Disable mouse focus (see https://github.com/basecamp/omarchy/pull/5183#issuecomment-4189299971)
+windowrule {
+    name = jetbrains-focus
+    no_follow_mouse = on
+    match:class = ^(jetbrains-.*)$
+}


### PR DESCRIPTION
This reverts partially https://github.com/basecamp/omarchy/pull/5183, due to the [following issue](https://github.com/basecamp/omarchy/pull/5183#issuecomment-4189299971) reported by @vmarcinko

https://github.com/user-attachments/assets/624c61c5-6910-427d-8f23-2b774fec9d6e

I am not sure if we should merge that immediately for two reasons:
1. The new lua config change of hyprland will break it.
2. It is unclear whether everybody prefer to fix the behavior of `Find in Files` better than losing the follow mouse focus.


But if it's not merged, it might still help somebody.