### PR TITLE
Skip starship init for dumb bash sessions

### DIFF
--- a/default/bash/init
+++ b/default/bash/init
@@ -2,7 +2,7 @@ if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 
-if command -v starship &> /dev/null; then
+if [[ $- == *i* ]] && [[ ${TERM:-} != "dumb" ]] && command -v starship &> /dev/null; then
   eval "$(starship init bash)"
 fi
 


### PR DESCRIPTION
## What changed

This guards `starship init bash` so it only runs in interactive Bash sessions with a non-`dumb` terminal.

## Why

Omarchy currently initializes Starship from `default/bash/init` unconditionally when `starship` is installed. In non-interactive shells started with `TERM=dumb`, Starship prints a warning like:

```
[ERROR] - (starship::print): Under a 'dumb' terminal (TERM=dumb).
```

That leaks prompt noise into scripts and tool runners even though no prompt is needed.

## Impact

Interactive terminals keep the existing Starship prompt behavior.
Non-interactive or `TERM=dumb` Bash sessions stay quiet.

## Validation

- `bash -n default/bash/init`
- `TERM=dumb bash --noprofile --norc -lc 'source default/bash/init; printf ok'`
