### PR TITLE
Fix: Super+C copy not working in neovim

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -20,6 +20,5 @@ decorations = "None"
 [keyboard]
 bindings = [
 { key = "Insert", mods = "Shift", action = "Paste" },
-{ key = "Insert", mods = "Control", action = "Copy" },
 { key = "Return", mods = "Shift", chars = "\u001B\r" }
 ]

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -24,6 +24,7 @@ shell-integration-features = no-cursor,ssh-env
 
 # Keyboard bindings
 keybind = shift+insert=paste_from_clipboard
+keybind = control+insert=unbind
 keybind = super+control+shift+alt+arrow_down=resize_split:down,100
 keybind = super+control+shift+alt+arrow_up=resize_split:up,100
 keybind = super+control+shift+alt+arrow_left=resize_split:left,100

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -24,7 +24,7 @@ shell-integration-features = no-cursor,ssh-env
 
 # Keyboard bindings
 keybind = shift+insert=paste_from_clipboard
-keybind = control+insert=copy_to_clipboard
+keybind = control+insert=unconsumed:copy_to_clipboard
 keybind = super+control+shift+alt+arrow_down=resize_split:down,100
 keybind = super+control+shift+alt+arrow_up=resize_split:up,100
 keybind = super+control+shift+alt+arrow_left=resize_split:left,100

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -24,7 +24,6 @@ shell-integration-features = no-cursor,ssh-env
 
 # Keyboard bindings
 keybind = shift+insert=paste_from_clipboard
-keybind = control+insert=unconsumed:copy_to_clipboard
 keybind = super+control+shift+alt+arrow_down=resize_split:down,100
 keybind = super+control+shift+alt+arrow_up=resize_split:up,100
 keybind = super+control+shift+alt+arrow_left=resize_split:left,100

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -11,7 +11,6 @@ hide_window_decorations yes
 confirm_os_window_close 0
 
 # Keybindings
-map ctrl+insert copy_to_clipboard
 map shift+insert paste_from_clipboard
 
 # Allow remote access

--- a/migrations/1775666877.sh
+++ b/migrations/1775666877.sh
@@ -5,9 +5,9 @@ if [[ -f ~/.config/kitty/kitty.conf ]]; then
   sed -i '/map ctrl+insert copy_to_clipboard/d' ~/.config/kitty/kitty.conf
 fi
 
-# Remove ctrl+insert copy binding from Ghostty (let the key pass through to neovim)
+# Unbind ghostty's ctrl+insert (has a built-in default, so deleting the line isn't enough)
 if [[ -f ~/.config/ghostty/config ]]; then
-  sed -i '/control+insert=.*copy_to_clipboard/d' ~/.config/ghostty/config
+  sed -i 's/control+insert=.*copy_to_clipboard/control+insert=unbind/' ~/.config/ghostty/config
 fi
 
 # Remove ctrl+insert copy binding from Alacritty

--- a/migrations/1775666877.sh
+++ b/migrations/1775666877.sh
@@ -1,13 +1,19 @@
 echo "Fix Super+C copy in neovim by letting Ctrl+Insert pass through to the terminal app"
 
 # Remove ctrl+insert copy binding from Kitty (let the key pass through to neovim)
-sed -i '/map ctrl+insert copy_to_clipboard/d' ~/.config/kitty/kitty.conf
+if [[ -f ~/.config/kitty/kitty.conf ]]; then
+  sed -i '/map ctrl+insert copy_to_clipboard/d' ~/.config/kitty/kitty.conf
+fi
 
-# Change Ghostty ctrl+insert to unconsumed: so it passes through to neovim when there's no terminal selection
-sed -i 's/control+insert=copy_to_clipboard/control+insert=unconsumed:copy_to_clipboard/' ~/.config/ghostty/config
+# Remove ctrl+insert copy binding from Ghostty (let the key pass through to neovim)
+if [[ -f ~/.config/ghostty/config ]]; then
+  sed -i '/control+insert=.*copy_to_clipboard/d' ~/.config/ghostty/config
+fi
 
 # Remove ctrl+insert copy binding from Alacritty
-sed -i '/mods = "Control", action = "Copy"/d' ~/.config/alacritty/alacritty.toml
+if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
+  sed -i '/mods = "Control", action = "Copy"/d' ~/.config/alacritty/alacritty.toml
+fi
 
 # Add neovim keymap so Ctrl+Insert (sent by Hyprland for Super+C) copies visual selection to system clipboard
 if [[ -f ~/.config/nvim/lua/config/keymaps.lua ]]; then

--- a/migrations/1775666877.sh
+++ b/migrations/1775666877.sh
@@ -1,0 +1,21 @@
+echo "Fix Super+C copy in neovim by letting Ctrl+Insert pass through to the terminal app"
+
+# Remove ctrl+insert copy binding from Kitty (let the key pass through to neovim)
+sed -i '/map ctrl+insert copy_to_clipboard/d' ~/.config/kitty/kitty.conf
+
+# Change Ghostty ctrl+insert to unconsumed: so it passes through to neovim when there's no terminal selection
+sed -i 's/control+insert=copy_to_clipboard/control+insert=unconsumed:copy_to_clipboard/' ~/.config/ghostty/config
+
+# Remove ctrl+insert copy binding from Alacritty
+sed -i '/mods = "Control", action = "Copy"/d' ~/.config/alacritty/alacritty.toml
+
+# Add neovim keymap so Ctrl+Insert (sent by Hyprland for Super+C) copies visual selection to system clipboard
+if [[ -f ~/.config/nvim/lua/config/keymaps.lua ]]; then
+  if ! grep -q 'C-Insert' ~/.config/nvim/lua/config/keymaps.lua; then
+    cat >> ~/.config/nvim/lua/config/keymaps.lua << 'EOF'
+
+-- Copy visual selection to system clipboard with Ctrl+Insert (triggered by Super+C via Hyprland)
+vim.keymap.set("v", "<C-Insert>", '"+y', { desc = "Copy to system clipboard" })
+EOF
+  fi
+fi


### PR DESCRIPTION
## Summary
Fixes #5251

- Terminal emulators (kitty, alacritty, ghostty) were intercepting `Ctrl+Insert` (sent by Hyprland for `Super+C`) before neovim could receive it, so nothing was copied
- Removed the `Ctrl+Insert → copy` interception from kitty and alacritty so the keystroke passes through to neovim
- Explicitly unbound `Ctrl+Insert` in ghostty (deleting the config line isn't enough since ghostty has a built-in default for `ctrl+insert=copy_to_clipboard` that would still intercept the key)
- Added a neovim keymap (`<C-Insert>` → `"+y` in visual mode) so neovim copies the visual selection to the system clipboard
- Includes migration for existing installations

## Test plan
- [ ] Open neovim in kitty/ghostty/alacritty
- [ ] Select text in visual mode (`v` + movement)
- [ ] Press `Super+C`
- [ ] Paste with `Super+V` in another app — should contain the selected text
- [ ] Verify `Super+C` still works outside terminals (browser, file manager, etc.)
- [ ] Verify `Super+V` paste still works everywhere