### PR TITLE
add i2c_hid modules to initramfs for laptops with I2C HID keyboards

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -58,6 +58,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-i2c-hid-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh

--- a/install/config/hardware/fix-i2c-hid-keyboard.sh
+++ b/install/config/hardware/fix-i2c-hid-keyboard.sh
@@ -1,0 +1,7 @@
+# Detect laptops with I2C HID built-in keyboards that require i2c_hid modules
+# in the initramfs to function at the LUKS passphrase prompt (Plymouth).
+# The standard `keyboard` mkinitcpio hook only bundles PS/2 and USB HID drivers.
+if find /sys/bus/i2c/drivers/i2c_hid_acpi -maxdepth 1 -name 'i2c-*' 2>/dev/null | grep -q .; then
+  echo "Detected I2C HID keyboard, adding i2c_hid modules to initramfs"
+  echo "MODULES=(i2c_hid i2c_hid_acpi)" | sudo tee /etc/mkinitcpio.conf.d/i2c_hid_keyboard.conf >/dev/null
+fi

--- a/migrations/1775684426.sh
+++ b/migrations/1775684426.sh
@@ -1,0 +1,7 @@
+echo "Add i2c_hid modules to initramfs for laptops with I2C HID built-in keyboards"
+
+if find /sys/bus/i2c/drivers/i2c_hid_acpi -maxdepth 1 -name 'i2c-*' 2>/dev/null | grep -q .; then
+  echo "Detected I2C HID keyboard, adding i2c_hid modules to initramfs"
+  echo "MODULES=(i2c_hid i2c_hid_acpi)" | sudo tee /etc/mkinitcpio.conf.d/i2c_hid_keyboard.conf >/dev/null
+  sudo limine-mkinitcpio
+fi


### PR DESCRIPTION
Closes #5261 