### PR TITLE
Fix Fcitx5 icon showing up in the waybar (again!)

### DIFF
--- a/config/autostart/org.fcitx.Fcitx5.desktop
+++ b/config/autostart/org.fcitx.Fcitx5.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+Hidden=true

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -15,7 +15,6 @@ run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
 run_logged $OMARCHY_INSTALL/config/nautilus-python.sh
-run_logged $OMARCHY_INSTALL/config/remove-fcitx5-autostart.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/walker-elephant.sh
 run_logged $OMARCHY_INSTALL/config/fast-shutdown.sh

--- a/install/config/remove-fcitx5-autostart.sh
+++ b/install/config/remove-fcitx5-autostart.sh
@@ -1,1 +1,0 @@
-sudo rm -f /etc/xdg/autostart/org.fcitx.Fcitx5.desktop

--- a/migrations/1772120972.sh
+++ b/migrations/1772120972.sh
@@ -1,3 +1,0 @@
-echo "Remove Fcitx5 XDG autostart desktop entry"
-
-source $OMARCHY_PATH/install/config/remove-fcitx5-autostart.sh

--- a/migrations/1775691486.sh
+++ b/migrations/1775691486.sh
@@ -1,0 +1,4 @@
+echo "Copy Fcitx5 autostart desktop file to ~/.config/autostart"
+
+mkdir -p ~/.config/autostart/
+cp "$OMARCHY_PATH/config/autostart/org.fcitx.Fcitx5.desktop" ~/.config/autostart/

--- a/migrations/1775691486.sh
+++ b/migrations/1775691486.sh
@@ -2,3 +2,5 @@ echo "Copy Fcitx5 autostart desktop file to ~/.config/autostart"
 
 mkdir -p ~/.config/autostart/
 cp "$OMARCHY_PATH/config/autostart/org.fcitx.Fcitx5.desktop" ~/.config/autostart/
+
+omarchy-restart-xcompose


### PR DESCRIPTION
Turns out that when the fcitx5 package is updated through pacman, it reinstalls the autostart desktop file `/etc/xdg/autostart/org.fcitx.Fcitx5.desktop`.

Instead of deleting the desktop file, I propose that we override it in `~/.config/autostart` and make sure it does not run.

Fixes #5126 