### PR TITLE
Lumon color.toml updated for better visibility of selected text

### DIFF
--- a/themes/lumon/colors.toml
+++ b/themes/lumon/colors.toml
@@ -1,5 +1,5 @@
 # Accent and UI colors
-accent = "#f2fcff"
+accent = "#8bc9eb"
 active_border_color = "#f2fcff"
 active_tab_background = "#6fb8e3"
 


### PR DESCRIPTION
The accent and foreground colors in Lumon were very similar to each other making the selections indistinguishable.
For example:-
Before:
<img width="1188" height="586" alt="screenshot-2026-04-10_13-47-37" src="https://github.com/user-attachments/assets/32e1a745-4345-4132-ac74-10fe002b18d6" />

I changed the accent color to the color5 present in the color.toml, while respecting the monotone theme.
<img width="1197" height="592" alt="screenshot-2026-04-10_14-30-59" src="https://github.com/user-attachments/assets/88c14152-f2f9-4d5a-8f1a-3457bc123628" />

Happy to adjust if this doesn’t match the intended design. First contribution here 