### PR TITLE
Add Little Snitch for Linux to Install > Service menu

### DIFF
--- a/bin/omarchy-install-littlesnitch
+++ b/bin/omarchy-install-littlesnitch
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Install Little Snitch for Linux, an application firewall and network monitor.
+
+echo "Installing Little Snitch..."
+omarchy-pkg-aur-add littlesnitch-bin
+
+echo "Enabling Little Snitch service..."
+sudo systemctl enable --now littlesnitch
+
+echo -e "\nLittle Snitch installed! Open http://localhost:3031 to access the web UI."

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -318,7 +318,8 @@ show_install_menu() {
 }
 
 show_install_service_menu() {
-  case $(menu "Install" "  Dropbox\n  Tailscale\n󱇱  NordVPN [AUR]\n󰏖  ONCE\n󰟵  Bitwarden\n  Chromium Account") in
+  case $(menu "Install" "󰖟  Little Snitch [AUR]\n  Dropbox\n  Tailscale\n󱇱  NordVPN [AUR]\n󰏖  ONCE\n󰟵  Bitwarden\n  Chromium Account") in
+  *Little*Snitch*) present_terminal omarchy-install-littlesnitch ;;
   *Dropbox*) present_terminal omarchy-install-dropbox ;;
   *Tailscale*) present_terminal omarchy-install-tailscale ;;
   *NordVPN*) present_terminal omarchy-install-nordvpn ;;


### PR DESCRIPTION
## Summary
- Add [Little Snitch for Linux](https://obdev.at/products/littlesnitch-linux/) as an installable service
- Little Snitch for Linux was released on April 8, 2026 — it's a network monitor and application firewall that shows which processes make network connections and lets you block them with rules
- Written in Rust, uses eBPF for kernel-level traffic interception, web-based UI on localhost:3031
- Requires kernel 6.12+ with BTF support (which Omarchy has)
- Free to use, eBPF component and UI are open source

## Changes
- New install script `bin/omarchy-install-littlesnitch` (downloads .pkg.tar.zst from obdev.at, enables the service)
- Menu entry in `Install > Service` alongside Tailscale, NordVPN, etc.