### PR TITLE
Toggle waybar clock format from keyboard

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -168,12 +168,13 @@ show_share_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n󰛧  Laptop Display") in
+  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n󰥔  Clock Format\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n󰛧  Laptop Display") in
 
   *Screensaver*) omarchy-toggle-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
   *Idle*) omarchy-toggle-idle ;;
   *Bar*) omarchy-toggle-waybar ;;
+  *Clock*) omarchy-toggle-waybar-clock ;;
   *Layout*) omarchy-hyprland-workspace-layout-toggle ;;
   *Ratio*) omarchy-hyprland-window-single-square-aspect-toggle ;;
   *Gaps*) omarchy-hyprland-window-gaps-toggle ;;

--- a/bin/omarchy-toggle-waybar-clock
+++ b/bin/omarchy-toggle-waybar-clock
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+STATE_FILE=~/.local/state/omarchy/toggles/waybar-clock
+
+if [[ -f $STATE_FILE ]]; then
+  rm -f $STATE_FILE
+  notify-send -u low "󰥔   Day and time format"
+else
+  mkdir -p "$(dirname $STATE_FILE)"
+  touch $STATE_FILE
+  notify-send -u low "󰥔   Date format"
+fi
+
+pkill -RTMIN+11 waybar

--- a/bin/omarchy-waybar-clock
+++ b/bin/omarchy-waybar-clock
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+STATE_FILE=~/.local/state/omarchy/toggles/waybar-clock
+CONFIG_FILE="${OMARCHY_PATH:-$HOME/.local/share/omarchy}/config/waybar/config.jsonc"
+
+# Read format from waybar config (strip {:L prefix if present)
+format=$(grep -A2 '"clock":' "$CONFIG_FILE" | grep '"format"' | head -1 | sed 's/.*: "\{:L\?\([^}]*\)}".*/\1/')
+format_alt=$(grep -A3 '"clock":' "$CONFIG_FILE" | grep '"format-alt"' | head -1 | sed 's/.*: "\{:L\?\([^}]*\)}".*/\1/')
+
+# Fallback if parsing fails
+[[ -z $format ]] && format="%A %H:%M"
+[[ -z $format_alt ]] && format_alt="%d %B W%V %Y"
+
+if [[ -f $STATE_FILE ]]; then
+  text=$(date +"$format_alt")
+else
+  text=$(date +"$format")
+fi
+
+echo "{\"text\": \"$text\"}"

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -5,7 +5,7 @@
   "spacing": 0,
   "height": 26,
   "modules-left": ["custom/omarchy", "hyprland/workspaces"],
-  "modules-center": ["clock", "custom/update", "custom/voxtype", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-center": ["custom/clock", "custom/update", "custom/voxtype", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
   "modules-right": [
     "group/tray-expander",
     "bluetooth",
@@ -60,10 +60,14 @@
     "on-click": "omarchy-launch-or-focus-tui btop",
     "on-click-right": "alacritty"
   },
-  "clock": {
+  "custom/clock": {
     "format": "{:L%A %H:%M}",
     "format-alt": "{:L%d %B W%V %Y}",
-    "tooltip": false,
+    "exec": "omarchy-waybar-clock",
+    "interval": 30,
+    "return-type": "json",
+    "signal": 11,
+    "on-click": "omarchy-toggle-waybar-clock",
     "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
   },
   "network": {

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -27,6 +27,7 @@ bindd = SUPER SHIFT ALT, COMMA, Restore last notification, exec, makoctl restore
 # Toggles
 bindd = SUPER CTRL, I, Toggle locking on idle, exec, omarchy-toggle-idle
 bindd = SUPER CTRL, N, Toggle nightlight, exec, omarchy-toggle-nightlight
+bindd = SUPER CTRL, D, Toggle clock format, exec, omarchy-toggle-waybar-clock
 
 # Control Apple Display brightness
 bindd = CTRL, F1, Apple Display brightness down, exec, omarchy-brightness-display-apple -5000


### PR DESCRIPTION
From the Omarchy manual: "_Everything in Omarchy happens via the keyboard — EVERYTHING!_" 

Well... not quite everything! When online, sometimes you want to quickly check what the date is while filling in a form. Currently, you're forced to touch the mouse (😔) to click on the clock. This PR adds a keyboard shortcut for toggling the waybar clock on `SUPER CTRL + D`.

Combination with CTRL key to be consistent with the other toggles. "D" is not used yet and can represent "Date". 

This toggle is also added to the Toggle Menu on `SUPER CTRL + O`.