### PR TITLE
Preserve monitor position when cycling scale

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling-cycle
+++ b/bin/omarchy-hyprland-monitor-scaling-cycle
@@ -4,6 +4,8 @@
 MONITOR_INFO=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)')
 ACTIVE_MONITOR=$(echo "$MONITOR_INFO" | jq -r '.name')
 CURRENT_SCALE=$(echo "$MONITOR_INFO" | jq -r '.scale')
+POSITION_X=$(echo "$MONITOR_INFO" | jq -r '.x')
+POSITION_Y=$(echo "$MONITOR_INFO" | jq -r '.y')
 WIDTH=$(echo "$MONITOR_INFO" | jq -r '.width')
 HEIGHT=$(echo "$MONITOR_INFO" | jq -r '.height')
 REFRESH_RATE=$(echo "$MONITOR_INFO" | jq -r '.refreshRate')
@@ -18,5 +20,5 @@ case "$CURRENT_INT" in
 *) NEW_SCALE=1 ;;
 esac
 
-hyprctl keyword monitor "$ACTIVE_MONITOR,${WIDTH}x${HEIGHT}@${REFRESH_RATE},auto,$NEW_SCALE"
+hyprctl keyword monitor "$ACTIVE_MONITOR,${WIDTH}x${HEIGHT}@${REFRESH_RATE},${POSITION_X}x${POSITION_Y},$NEW_SCALE"
 notify-send -u low "󰍹    Display scaling set to ${NEW_SCALE}x"


### PR DESCRIPTION
## The bug

On a multi-monitor setup, pressing `Super + /` to cycle display scaling swaps monitor positions. Every press flips the focused monitor to `0x0` and shoves the others out of place. Fixes #4785.

## Repro

Dual 1920x1080: `HDMI-A-1` at `0x0`, `DP-2` at `1920x0`. Each press of `Super + /` flips `DP-2` to `0x0` and pushes `HDMI-A-1` aside.

## Root cause

`bin/omarchy-hyprland-monitor-scaling-cycle` issues:

```bash
hyprctl keyword monitor "$ACTIVE_MONITOR,${WIDTH}x${HEIGHT}@${REFRESH_RATE},auto,$NEW_SCALE"
```

`auto` in the position field tells Hyprland to place the monitor as if it were freshly attached — which on multi-monitor setups uses hardware detection order rather than the existing layout.

## Fix

Read the monitor's current `.x` / `.y` from `hyprctl monitors -j` (same query already used for name/scale/mode) and pass them explicitly in place of `auto`. Single-monitor setups are unaffected — position stays `0x0`.

Tested on a dual 1920x1080 setup (`HDMI-A-1` @ 60Hz + `DP-2` @ 240Hz). Cycling scale 1 → 1.6 → 2 → 3 → 1 on each monitor no longer touches positions.

## Relation to #4778

#4778 proposes a more comprehensive fix (also handles logical-width gaps between monitors, operation ordering, and looknfeel re-sourcing), but was opened the day before commit `8f5c1ee5` renamed the file from `-toggle` to `-cycle`, and hasn't been rebased since. That PR currently targets a path that no longer exists upstream, so it can't auto-merge. I've commented there asking @tmn73 if they're around to rebase — if they are, this minimal PR can be closed in their favor.