### PR TITLE
Add ddcutil fallback for brightness on desktops without backlight device

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Adjust brightness on the most likely display device.
+# Falls back to DDC/CI (ddcutil) for external monitors when no backlight device exists.
 # Usage: omarchy-brightness-display <step>
 
 step="${1:-+5%}"
@@ -14,8 +15,127 @@ for candidate in amdgpu_bl* intel_backlight acpi_video*; do
   fi
 done
 
-# Set the actual brightness of the display device.
-brightnessctl -d "$device" set "$step" >/dev/null
+# Native backlight path — unchanged when a device is found.
+if [[ -n "$device" ]]; then
+  brightnessctl -d "$device" set "$step" >/dev/null
+  omarchy-swayosd-brightness "$(brightnessctl -d "$device" -m | cut -d',' -f4 | tr -d '%')"
+  exit 0
+fi
 
-# Use SwayOSD to display the new brightness setting.
-omarchy-swayosd-brightness "$(brightnessctl -d "$device" -m | cut -d',' -f4 | tr -d '%')"
+# No backlight device — fall back to DDC/CI on external monitors.
+omarchy-cmd-present ddcutil || exit 0
+
+# Parse step: "+5%", "5%-", "+1%", "1%-" — percentage of each display's max VCP value.
+if [[ "$step" == +* ]]; then
+  delta="${step#+}"
+  delta="${delta%%%}"
+  direction=1
+elif [[ "$step" == *- ]]; then
+  delta="${step%%-}"
+  delta="${delta%%%}"
+  direction=-1
+else
+  exit 1
+fi
+
+readonly CACHE_TTL=300
+runtime="${XDG_RUNTIME_DIR:-/run/user/$UID}"
+[[ -d "$runtime" ]] || mkdir -p "$runtime"
+
+lock_file="$runtime/omarchy-ddc-brightness.lock"
+bus_cache="$runtime/omarchy-ddc-buses"
+state_cache="$runtime/omarchy-ddc-state"
+target_file="$runtime/omarchy-ddc-target"
+
+cache_fresh() {
+  [[ -f "$1" ]] && (( EPOCHSECONDS - $(stat -c %Y "$1") < CACHE_TTL ))
+}
+
+# Serialize key repeats; the debounce worker does not inherit the lock (9>&- below).
+exec 9>"$lock_file"
+flock 9
+
+if cache_fresh "$bus_cache"; then
+  mapfile -t buses < "$bus_cache"
+else
+  mapfile -t buses < <(ddcutil detect 2>/dev/null | awk '/I2C bus:/{gsub(/\/dev\/i2c-/, "", $NF); print $NF}')
+  printf "%s\n" "${buses[@]}" > "$bus_cache"
+fi
+
+(( ${#buses[@]} == 0 )) && exit 0
+
+# State cache lets bursts skip the cold getvcp round-trip; TTL bounds drift
+# if brightness changes via the monitor's physical button or DPMS reset.
+declare -A cached_cur cached_max
+if cache_fresh "$state_cache"; then
+  while IFS='=' read -r key val; do
+    case "$key" in
+      cur_*) cached_cur[${key#cur_}]=$val ;;
+      max_*) cached_max[${key#max_}]=$val ;;
+    esac
+  done < "$state_cache"
+fi
+
+reported_percent=""
+declare -A new_cur
+
+for bus in "${buses[@]}"; do
+  current="${cached_cur[$bus]:-}"
+  max="${cached_max[$bus]:-}"
+
+  if [[ -z "$current" || -z "$max" ]]; then
+    read -r _ _ _ current max < <(ddcutil --bus "$bus" getvcp 10 --brief --sleep-multiplier 0.04 2>/dev/null)
+    if [[ -z "$current" || -z "$max" ]]; then
+      echo "omarchy-brightness-display: skip i2c-$bus (no VCP 0x10)" >&2
+      continue
+    fi
+  fi
+
+  new=$(( current + direction * delta * max / 100 ))
+  (( new < 0 )) && new=0
+  (( new > max )) && new=$max
+
+  new_cur[$bus]=$new
+  cached_max[$bus]=$max
+  [[ -z "$reported_percent" ]] && reported_percent=$(( new * 100 / max ))
+done
+
+(( ${#new_cur[@]} == 0 )) && exit 0
+
+{
+  for bus in "${!new_cur[@]}"; do
+    printf 'cur_%s=%s\nmax_%s=%s\n' "$bus" "${new_cur[$bus]}" "$bus" "${cached_max[$bus]}"
+  done
+} > "$state_cache"
+
+# Debounce setvcp to one write per gesture (KDE PowerDevil precedent):
+# cuts monitor NVRAM wear and keeps OSD in sync with a single clean
+# transition instead of chasing each tap over slow i2c.
+now_ms=$(( ${EPOCHREALTIME/./} / 1000 ))
+{
+  printf 'ts=%s\n' "$now_ms"
+  for bus in "${!new_cur[@]}"; do
+    printf 'target_%s=%s\n' "$bus" "${new_cur[$bus]}"
+  done
+} > "$target_file"
+
+[[ -n "$reported_percent" ]] && omarchy-swayosd-brightness "$reported_percent"
+
+(
+  sleep 0.25
+  [[ -f "$target_file" ]] || exit 0
+  current_ts=""
+  worker_targets=()
+  while IFS='=' read -r key val; do
+    case "$key" in
+      ts) current_ts=$val ;;
+      target_*) worker_targets+=("${key#target_} $val") ;;
+    esac
+  done < "$target_file"
+  [[ "$current_ts" == "$now_ms" ]] || exit 0
+  for entry in "${worker_targets[@]}"; do
+    ddcutil --bus "${entry% *}" setvcp 10 "${entry#* }" \
+      --sleep-multiplier 0.04 --noverify 2>/dev/null
+  done
+) 9>&- >/dev/null 2>&1 &
+disown

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -21,6 +21,7 @@ cups
 cups-browsed
 cups-filters
 cups-pdf
+ddcutil
 docker
 docker-buildx
 docker-compose

--- a/migrations/1776070000.sh
+++ b/migrations/1776070000.sh
@@ -1,0 +1,15 @@
+set -e
+
+echo "Install ddcutil for DDC brightness fallback"
+
+if omarchy-pkg-missing ddcutil; then
+  omarchy-pkg-add ddcutil
+fi
+
+# ddcutil ships /usr/lib/modules-load.d/ddcutil.conf and
+# /usr/lib/udev/rules.d/60-ddcutil-i2c.rules. Load the module now so the
+# current session can use DDC without a reboot, and re-run udev so the
+# upstream uaccess rule applies to already-enumerated i2c-dev buses.
+sudo modprobe i2c-dev
+sudo udevadm control --reload-rules
+sudo udevadm trigger --subsystem-match=i2c-dev


### PR DESCRIPTION
## Summary

`XF86MonBrightnessDown/Up` silently fails on systems without `/sys/class/backlight` — desktops, NUCs, mini-PCs, and laptops where the driver doesn't register a backlight device (common on NVIDIA and some AMD hybrid setups — see #5067). This PR extends `omarchy-brightness-display` with a DDC/CI fallback via `ddcutil`, so the same keybindings that work on laptops also work on external monitors, out of the box.

Zero user setup: the Arch `ddcutil` package already ships `modules-load.d/ddcutil.conf` (auto-loads `i2c-dev` at boot) and a `60-ddcutil-i2c.rules` udev rule that grants `uaccess` to display-class i2c buses. This PR leans on that — the migration just installs the package and kicks the module + udev for users whose current session was already running.

## What's in the PR

### Script (`bin/omarchy-brightness-display`)

- A third branch after the existing ACPI and Apple paths: iterate `ddcutil`-detected i2c buses, read/write VCP `0x10`, step all monitors together, report a unified percent to `swayosd`.
- **Bus + state cache in `$XDG_RUNTIME_DIR`** (300s TTL) so repeats skip the ~1 s `ddcutil detect` and the per-monitor `getvcp` round-trip.
- **Blocking `flock`** (not `-n`) serializes key repeats through the cache read-modify-write. `-n` silently drops taps during the cold path and users feel it as "one of my three presses didn't register". The debounce worker does not inherit the lock (`9>&-`).
- **Debounced `setvcp`** — rapid taps coalesce into a single `setvcp` per gesture via a timestamp + atomic target-file + background worker (250 ms window). This is the same pattern KDE PowerDevil uses ([D8626](https://phabricator.kde.org/D8626)), for the same reasons:
  - the OSD stays in sync instead of the monitor chasing stale values over slow i2c,
  - writes to the monitor's NVRAM (limited write cycles per `ddcutil` docs) are minimized.
- `--sleep-multiplier 0.04 --noverify` on `setvcp` for responsive interactive use.
- Bash 5+ `EPOCHSECONDS` / `EPOCHREALTIME` builtins — no `date` forks on the hot path.

### Package + migration

- `ddcutil` added to `install/omarchy-base.packages` (alphabetical).
- `migrations/1776070000.sh` — upgrade path for existing users:
  - `omarchy-pkg-add ddcutil` if missing.
  - `modprobe i2c-dev` so the current session can use DDC without a reboot.
  - `udevadm control --reload-rules && udevadm trigger --subsystem-match=i2c-dev` so the upstream package's uaccess rule applies to already-enumerated i2c buses in the active seat.
  - `set -e` so a failing `omarchy-pkg-add` or `modprobe` doesn't get silently marked as applied by `omarchy-migrate`.

No fresh-install hook is needed: pacman running during install drops `modules-load.d/ddcutil.conf`, which `systemd-modules-load.service` picks up on the first boot into the installed system, and the bundled udev rule processes all i2c buses on that same boot — so first login comes up with `/dev/i2c-*` already ACL-tagged for the active seat user.

## Measurements

BenQ EX2780Q + Dell U2415, NVIDIA proprietary on Hyprland:

| Path | Time |
|---|---|
| Warm (cached bus + state, debounced) | **21–22 ms** |
| Cold (TTL expired, full `ddcutil detect`) | ~750 ms, once per 5-min window |
| `getvcp` physical floor, BenQ, multiplier 0.04 | 465 ms |
| `setvcp` physical floor, BenQ, multiplier 0.04 | 487 ms |

The 300–500 ms per VCP op is physical DDC/CI wire time — that is why the cache + debounce pattern matters: it keeps that time off the hot path.

## Tested

- Multi-monitor DDC step together, unified percent to `swayosd`: verified live.
- Rapid Fn+F1 burst (10 taps): no drops, single `setvcp` per gesture, monitor slews to the final value once: verified live.
- Cold cache (`rm /run/user/$UID/omarchy-ddc-*`): re-detects buses, re-reads state, one slow tap then warm path: verified live.
- Apple ASdControl path and native backlight path: inspection only — the new branch runs only after both short-circuit, no behavior change on laptops.

## Review iteration

An earlier revision of this PR shipped its own `default/udev/ddcutil-i2c.rules` + an `i2c` group + `install/config/ddcutil-i2c.sh` that copied the rule and added the user to the group (requiring a logout). The Copilot review on `install/config/ddcutil-i2c.sh` and `migrations/1776070000.sh` pushed on the `i2c-dev` module loading question, and digging into that surfaced that the Arch `ddcutil` package already ships both a `modules-load.d` entry **and** its own `60-ddcutil-i2c.rules` with `TAG+="uaccess"` — which is a strictly better approach than the group-based one (no logout, handled by systemd-logind, filtered to display-class buses via `ATTRS{class}=="0x03*"`). This revision leans on that instead. Net result: 3 files + 140 lines instead of 6 files + 169 lines, and no more logout notice.

## Related

- #5201 — @jamerrq's DDC PR, open. Same problem, different architecture (this PR adds blocking-flock drop fix + debounce + multi-monitor iteration). Not trying to replace it; wanted to offer a more end-to-end take.
- #5067 — ASUS TUF driver-level backlight registration bug. This PR is a workaround path for users in that situation.
- #4841 — self-closed by the author, not a technical rejection.