### PR TITLE
Fix NVIDIA suspend hard-freeze when hyprlock is active

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -1,7 +1,7 @@
 general {
     lock_cmd = omarchy-lock-screen                         # lock screen and 1password
     before_sleep_cmd = loginctl lock-session               # lock before suspend.
-    after_sleep_cmd = omarchy-lock-screen; sleep 2; hyprctl dispatch dpms on  # relock, wait for render, then turn on display.
+    after_sleep_cmd = omarchy-lock-screen && sleep 2 && hyprctl dispatch dpms on  # relock, wait for render, then turn on display.
     inhibit_sleep = 3                                      # wait until screen is locked
 }
 

--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -1,7 +1,7 @@
 general {
     lock_cmd = omarchy-lock-screen                         # lock screen and 1password
     before_sleep_cmd = loginctl lock-session               # lock before suspend.
-    after_sleep_cmd = sleep 1 && hyprctl dispatch dpms on  # delay for PAM readiness, then turn on display.
+    after_sleep_cmd = omarchy-lock-screen; sleep 2; hyprctl dispatch dpms on  # relock, wait for render, then turn on display.
     inhibit_sleep = 3                                      # wait until screen is locked
 }
 

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -6,17 +6,24 @@
 # See: github.com/basecamp/omarchy/issues/5277
 
 if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
-  active_user=$(
-    loginctl list-sessions --no-legend 2>/dev/null \
-      | awk '$3 != "" && $4 ~ /^seat/ { print $3; exit }'
+  active_users=$(
+    while IFS= read -r session_id; do
+      [[ -z "$session_id" ]] && continue
+      active=$(loginctl show-session "$session_id" -p Active --value 2>/dev/null)
+      state=$(loginctl show-session "$session_id" -p State --value 2>/dev/null)
+      remote=$(loginctl show-session "$session_id" -p Remote --value 2>/dev/null)
+      [[ "$active" == "yes" && "$state" == "active" && "$remote" == "no" ]] || continue
+      loginctl show-session "$session_id" -p Name --value 2>/dev/null
+    done < <(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}')
   )
 
-  if [[ -z "$active_user" ]]; then
-    active_user=$(logname 2>/dev/null || true)
+  if [[ -z "$active_users" ]]; then
+    active_users=$(logname 2>/dev/null || true)
   fi
 
-  if [[ -n "$active_user" ]]; then
+  while IFS= read -r active_user; do
+    [[ -z "$active_user" ]] && continue
     pkill -u "$active_user" -x hyprlock 2>/dev/null || true
-  fi
+  done <<< "$active_users"
   sleep 0.5
 fi

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -8,7 +8,7 @@
 if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
   active_user=$(
     loginctl list-sessions --no-legend 2>/dev/null \
-      | awk '$3 != "" && $0 ~ /seat/ { print $3; exit }'
+      | awk '$3 != "" && $4 ~ /^seat/ { print $3; exit }'
   )
 
   if [[ -z "$active_user" ]]; then

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -5,7 +5,9 @@
 # after hypridle's inhibit_sleep window but before the kernel DRM checkpoint.
 # See: github.com/basecamp/omarchy/issues/5277
 
-if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
+lsmod | grep -q "^nvidia " || exit 0
+
+if [[ $1 == "pre" ]]; then
   active_users=$(
     while IFS= read -r session_id; do
       [[ -z "$session_id" ]] && continue
@@ -28,7 +30,7 @@ if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
   sleep 0.5
 fi
 
-if [[ $1 == "post" ]] && lsmod | grep -q "^nvidia "; then
+if [[ $1 == "post" ]]; then
   # Re-lock sessions after resume as a safety net in case hypridle's
   # after_sleep_cmd didn't fire (e.g. hypridle crashed). Runs in background
   # with a delay so user sessions are fully thawed before the signal is sent.

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -27,3 +27,10 @@ if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
   done <<< "$active_users"
   sleep 0.5
 fi
+
+if [[ $1 == "post" ]] && lsmod | grep -q "^nvidia "; then
+  # Re-lock sessions after resume as a safety net in case hypridle's
+  # after_sleep_cmd didn't fire (e.g. hypridle crashed). Runs in background
+  # with a delay so user sessions are fully thawed before the signal is sent.
+  (sleep 5 && loginctl lock-sessions 2>/dev/null || true) &
+fi

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -6,6 +6,17 @@
 # See: github.com/basecamp/omarchy/issues/5277
 
 if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
-  pkill -x hyprlock 2>/dev/null || true
+  active_user=$(
+    loginctl list-sessions --no-legend 2>/dev/null \
+      | awk '$3 != "" && $0 ~ /seat/ { print $3; exit }'
+  )
+
+  if [[ -z "$active_user" ]]; then
+    active_user=$(logname 2>/dev/null || true)
+  fi
+
+  if [[ -n "$active_user" ]]; then
+    pkill -u "$active_user" -x hyprlock 2>/dev/null || true
+  fi
   sleep 0.5
 fi

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -27,12 +27,13 @@ if [[ $1 == "pre" ]]; then
     [[ -z "$active_user" ]] && continue
     pkill -u "$active_user" -x hyprlock 2>/dev/null || true
   done <<< "$active_users"
-  sleep 0.5
+  sleep 0.5  # Allow the DRM context to fully release before the kernel checkpoint
 fi
 
 if [[ $1 == "post" ]]; then
   # Re-lock sessions after resume as a safety net in case hypridle's
   # after_sleep_cmd didn't fire (e.g. hypridle crashed). Runs in background
   # with a delay so user sessions are fully thawed before the signal is sent.
-  (sleep 5 && loginctl lock-sessions 2>/dev/null || true) &
+  RELOCK_DELAY=5  # Seconds to wait for user sessions to thaw before relocking
+  (sleep $RELOCK_DELAY && loginctl lock-sessions 2>/dev/null || true) &
 fi

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -14,7 +14,7 @@ if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
       remote=$(loginctl show-session "$session_id" -p Remote --value 2>/dev/null)
       [[ "$active" == "yes" && "$state" == "active" && "$remote" == "no" ]] || continue
       loginctl show-session "$session_id" -p Name --value 2>/dev/null
-    done < <(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}')
+    done < <(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}') | sort -u
   )
 
   if [[ -z "$active_users" ]]; then

--- a/default/systemd/system-sleep/nvidia-hyprlock
+++ b/default/systemd/system-sleep/nvidia-hyprlock
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# On NVIDIA systems, hyprlock holds an active DRM/GBM context that causes the
+# nvidia_drm suspend callback to hang at PM: suspend entry (deep). Kill it here —
+# after hypridle's inhibit_sleep window but before the kernel DRM checkpoint.
+# See: github.com/basecamp/omarchy/issues/5277
+
+if [[ $1 == "pre" ]] && lsmod | grep -q "^nvidia "; then
+  pkill -x hyprlock 2>/dev/null || true
+  sleep 0.5
+fi

--- a/install/config/hardware/nvidia-suspend-hook.sh
+++ b/install/config/hardware/nvidia-suspend-hook.sh
@@ -1,3 +1,3 @@
 # Install system-sleep hook to prevent GPU suspend hang (omarchy#5277)
-sudo mkdir -p /usr/lib/systemd/system-sleep
-sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /usr/lib/systemd/system-sleep/
+sudo mkdir -p /etc/systemd/system-sleep
+sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /etc/systemd/system-sleep/

--- a/install/config/hardware/nvidia-suspend-hook.sh
+++ b/install/config/hardware/nvidia-suspend-hook.sh
@@ -1,0 +1,3 @@
+# Install system-sleep hook to prevent GPU suspend hang (omarchy#5277)
+sudo mkdir -p /usr/lib/systemd/system-sleep
+sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /usr/lib/systemd/system-sleep/

--- a/install/config/hardware/nvidia-suspend-hook.sh
+++ b/install/config/hardware/nvidia-suspend-hook.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Install system-sleep hook to prevent GPU suspend hang (omarchy#5277)
 sudo mkdir -p /etc/systemd/system-sleep
 sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /etc/systemd/system-sleep/

--- a/install/config/hardware/nvidia-suspend-hook.sh
+++ b/install/config/hardware/nvidia-suspend-hook.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Install system-sleep hook to prevent GPU suspend hang (omarchy#5277)
-sudo mkdir -p /etc/systemd/system-sleep
-sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /etc/systemd/system-sleep/
+[ "$(id -u)" -eq 0 ] && SUDO="" || SUDO="sudo"
+$SUDO mkdir -p /etc/systemd/system-sleep
+$SUDO install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /etc/systemd/system-sleep/

--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -50,4 +50,8 @@ env = NVD_BACKEND,egl
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
   fi
+
+  # Install system-sleep hook to prevent GPU suspend hang (omarchy#5277)
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /usr/lib/systemd/system-sleep/
 fi

--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -51,5 +51,5 @@ env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
   fi
 
-  source "$OMARCHY_PATH/install/config/hardware/nvidia-suspend-hook.sh"
+  bash "$OMARCHY_PATH/install/config/hardware/nvidia-suspend-hook.sh"
 fi

--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -51,7 +51,5 @@ env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
   fi
 
-  # Install system-sleep hook to prevent GPU suspend hang (omarchy#5277)
-  sudo mkdir -p /usr/lib/systemd/system-sleep
-  sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" /usr/lib/systemd/system-sleep/
+  source "$OMARCHY_PATH/install/config/hardware/nvidia-suspend-hook.sh"
 fi

--- a/migrations/1776042000.sh
+++ b/migrations/1776042000.sh
@@ -7,7 +7,26 @@ if lspci 2>/dev/null | grep -qi nvidia || lsmod 2>/dev/null | grep -q "^nvidia "
 fi
 
 # Update after_sleep_cmd in hypridle config to relock before enabling the display
-HYPRIDLE_CONF="$HOME/.config/hypr/hypridle.conf"
+TARGET_USER=""
+if [[ -n ${SUDO_USER:-} && ${SUDO_USER} != "root" ]]; then
+  TARGET_USER="$SUDO_USER"
+else
+  LOGNAME_USER="$(logname 2>/dev/null || true)"
+  if [[ -n $LOGNAME_USER && $LOGNAME_USER != "root" ]]; then
+    TARGET_USER="$LOGNAME_USER"
+  fi
+fi
+
+TARGET_HOME=""
+if [[ -n $TARGET_USER ]]; then
+  TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+fi
+
+if [[ -z $TARGET_HOME ]]; then
+  TARGET_HOME="$HOME"
+fi
+
+HYPRIDLE_CONF="$TARGET_HOME/.config/hypr/hypridle.conf"
 if [[ -f $HYPRIDLE_CONF ]] && grep -Eq '^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on([[:space:]]|$)' "$HYPRIDLE_CONF"; then
   sed -Ei 's|^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on.*$|after_sleep_cmd = omarchy-lock-screen \&\& sleep 2 \&\& hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
 fi

--- a/migrations/1776042000.sh
+++ b/migrations/1776042000.sh
@@ -6,27 +6,28 @@ if lspci 2>/dev/null | grep -qi nvidia || lsmod 2>/dev/null | grep -q "^nvidia "
   bash "$OMARCHY_PATH/install/config/hardware/nvidia-suspend-hook.sh"
 fi
 
-# Update after_sleep_cmd in hypridle config to relock before enabling the display
+# Resolve the actual desktop user (migrations may run under sudo)
 TARGET_USER=""
-if [[ -n ${SUDO_USER:-} && ${SUDO_USER} != "root" ]]; then
+if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
   TARGET_USER="$SUDO_USER"
 else
   LOGNAME_USER="$(logname 2>/dev/null || true)"
-  if [[ -n $LOGNAME_USER && $LOGNAME_USER != "root" ]]; then
+  if [[ -n "$LOGNAME_USER" && "$LOGNAME_USER" != "root" ]]; then
     TARGET_USER="$LOGNAME_USER"
   fi
 fi
 
 TARGET_HOME=""
-if [[ -n $TARGET_USER ]]; then
+if [[ -n "$TARGET_USER" ]]; then
   TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
 fi
 
-if [[ -z $TARGET_HOME ]]; then
+if [[ -z "$TARGET_HOME" ]]; then
   TARGET_HOME="$HOME"
 fi
 
+# Update after_sleep_cmd in hypridle config to relock before enabling the display
 HYPRIDLE_CONF="$TARGET_HOME/.config/hypr/hypridle.conf"
-if [[ -f $HYPRIDLE_CONF ]] && grep -Eq '^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on([[:space:]]|$)' "$HYPRIDLE_CONF"; then
+if [[ -f "$HYPRIDLE_CONF" ]] && grep -Eq '^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on([[:space:]]|$)' "$HYPRIDLE_CONF"; then
   sed -Ei 's|^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on.*$|after_sleep_cmd = omarchy-lock-screen \&\& sleep 2 \&\& hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
 fi

--- a/migrations/1776042000.sh
+++ b/migrations/1776042000.sh
@@ -3,7 +3,7 @@ echo "Fix NVIDIA suspend hard-freeze caused by hyprlock holding DRM context (oma
 
 # Install system-sleep hook on NVIDIA systems
 if lspci 2>/dev/null | grep -qi nvidia || lsmod 2>/dev/null | grep -q "^nvidia "; then
-  source "$OMARCHY_PATH/install/config/hardware/nvidia-suspend-hook.sh"
+  bash "$OMARCHY_PATH/install/config/hardware/nvidia-suspend-hook.sh"
 fi
 
 # Update after_sleep_cmd in hypridle config to relock before enabling the display

--- a/migrations/1776042000.sh
+++ b/migrations/1776042000.sh
@@ -10,6 +10,6 @@ fi
 
 # Update after_sleep_cmd in hypridle config to relock before enabling the display
 HYPRIDLE_CONF="$HOME/.config/hypr/hypridle.conf"
-if [[ -f $HYPRIDLE_CONF ]] && grep -q "after_sleep_cmd = sleep 1 && hyprctl dispatch dpms on" "$HYPRIDLE_CONF"; then
-  sed -i 's|after_sleep_cmd = sleep 1 && hyprctl dispatch dpms on.*|after_sleep_cmd = omarchy-lock-screen; sleep 2; hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
+if [[ -f $HYPRIDLE_CONF ]] && grep -Eq '^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on([[:space:]]|$)' "$HYPRIDLE_CONF"; then
+  sed -Ei 's|^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on.*$|after_sleep_cmd = omarchy-lock-screen; sleep 2; hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
 fi

--- a/migrations/1776042000.sh
+++ b/migrations/1776042000.sh
@@ -28,6 +28,6 @@ fi
 
 # Update after_sleep_cmd in hypridle config to relock before enabling the display
 HYPRIDLE_CONF="$TARGET_HOME/.config/hypr/hypridle.conf"
-if [[ -f "$HYPRIDLE_CONF" ]] && grep -Eq '^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on([[:space:]]|$)' "$HYPRIDLE_CONF"; then
-  sed -Ei 's|^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on.*$|after_sleep_cmd = omarchy-lock-screen \&\& sleep 2 \&\& hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
+if [[ -f "$HYPRIDLE_CONF" ]] && grep -Eq '^[[:space:]]*after_sleep_cmd[[:space:]]*=[[:space:]]*sleep[[:space:]]+1[[:space:]]*&&[[:space:]]*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on[[:space:]]*$' "$HYPRIDLE_CONF"; then
+  sed -Ei 's|^[[:space:]]*after_sleep_cmd[[:space:]]*=[[:space:]]*sleep[[:space:]]+1[[:space:]]*&&[[:space:]]*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on[[:space:]]*$|after_sleep_cmd = omarchy-lock-screen \&\& sleep 2 \&\& hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
 fi

--- a/migrations/1776042000.sh
+++ b/migrations/1776042000.sh
@@ -1,15 +1,13 @@
+#!/bin/bash
 echo "Fix NVIDIA suspend hard-freeze caused by hyprlock holding DRM context (omarchy#5277)"
 
 # Install system-sleep hook on NVIDIA systems
 if lspci 2>/dev/null | grep -qi nvidia || lsmod 2>/dev/null | grep -q "^nvidia "; then
-  sudo mkdir -p /usr/lib/systemd/system-sleep
-  sudo install -m 0755 -o root -g root \
-    "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" \
-    /usr/lib/systemd/system-sleep/
+  source "$OMARCHY_PATH/install/config/hardware/nvidia-suspend-hook.sh"
 fi
 
 # Update after_sleep_cmd in hypridle config to relock before enabling the display
 HYPRIDLE_CONF="$HOME/.config/hypr/hypridle.conf"
 if [[ -f $HYPRIDLE_CONF ]] && grep -Eq '^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on([[:space:]]|$)' "$HYPRIDLE_CONF"; then
-  sed -Ei 's|^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on.*$|after_sleep_cmd = omarchy-lock-screen; sleep 2; hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
+  sed -Ei 's|^[[:space:]]*after_sleep_cmd[[:space:]]*=.*hyprctl[[:space:]]+dispatch[[:space:]]+dpms[[:space:]]+on.*$|after_sleep_cmd = omarchy-lock-screen \&\& sleep 2 \&\& hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
 fi

--- a/migrations/1776042000.sh
+++ b/migrations/1776042000.sh
@@ -1,0 +1,15 @@
+echo "Fix NVIDIA suspend hard-freeze caused by hyprlock holding DRM context (omarchy#5277)"
+
+# Install system-sleep hook on NVIDIA systems
+if lspci 2>/dev/null | grep -qi nvidia || lsmod 2>/dev/null | grep -q "^nvidia "; then
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  sudo install -m 0755 -o root -g root \
+    "$OMARCHY_PATH/default/systemd/system-sleep/nvidia-hyprlock" \
+    /usr/lib/systemd/system-sleep/
+fi
+
+# Update after_sleep_cmd in hypridle config to relock before enabling the display
+HYPRIDLE_CONF="$HOME/.config/hypr/hypridle.conf"
+if [[ -f $HYPRIDLE_CONF ]] && grep -q "after_sleep_cmd = sleep 1 && hyprctl dispatch dpms on" "$HYPRIDLE_CONF"; then
+  sed -i 's|after_sleep_cmd = sleep 1 && hyprctl dispatch dpms on.*|after_sleep_cmd = omarchy-lock-screen; sleep 2; hyprctl dispatch dpms on  # relock, wait for render, then turn on display.|' "$HYPRIDLE_CONF"
+fi


### PR DESCRIPTION
hyprlock holds an active DRM/GBM context on the GPU that prevents the nvidia_drm suspend callback from checkpointing GPU state cleanly. The kernel hangs at PM: suspend entry (deep) with no recovery possible.

Add a system-sleep hook (nvidia-hyprlock) that kills hyprlock just before the kernel DRM checkpoint fires — after hypridle's inhibit_sleep window, so the session is already locked. Also update after_sleep_cmd to relaunch hyprlock before enabling the display on resume, preventing a window where the unlocked desktop is briefly visible.

Fixes #5277