### PR TITLE
Suppress Chromium/Brave stderr noise during theme switch

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -14,11 +14,11 @@ if omarchy-cmd-present chromium || omarchy-cmd-present brave; then
 
   if omarchy-cmd-present chromium; then
     echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/chromium/policies/managed/color.json" >/dev/null
-    chromium --refresh-platform-policy --no-startup-window >/dev/null
+    chromium --refresh-platform-policy --no-startup-window &>/dev/null
   fi
 
   if omarchy-cmd-present brave; then
     echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/brave/policies/managed/color.json" >/dev/null
-    brave --refresh-platform-policy --no-startup-window >/dev/null
+    brave --refresh-platform-policy --no-startup-window &>/dev/null
   fi
 fi


### PR DESCRIPTION
## Summary
- Redirect stderr to `/dev/null` (using `&>` instead of `>`) when running `chromium --refresh-platform-policy` and `brave --refresh-platform-policy`
- Prevents `shared_memory_switch.cc` errors from Chromium internals from cluttering the terminal during theme changes

## Test plan
- [ ] Run `omarchy-theme-set <theme>` and verify no Chromium stderr errors appear in terminal