### PR TITLE
Prevent empty custom themes from replacing the current theme

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -12,6 +12,11 @@ OMARCHY_THEMES_PATH="$OMARCHY_PATH/themes"
 
 THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 
+if [[ -z $THEME_NAME ]]; then
+  echo "Theme name cannot be empty"
+  exit 1
+fi
+
 if [[ ! -d $OMARCHY_THEMES_PATH/$THEME_NAME ]] && [[ ! -d $USER_THEMES_PATH/$THEME_NAME ]]; then
   echo "Theme '$THEME_NAME' does not exist"
   exit 1
@@ -26,7 +31,18 @@ cp -r "$OMARCHY_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 cp -r "$USER_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 
 # Generate dynamic configs
-omarchy-theme-set-templates
+if ! omarchy-theme-set-templates; then
+  echo "Failed to generate theme files for '$THEME_NAME'" >&2
+  rm -rf "$NEXT_THEME_PATH"
+  exit 1
+fi
+
+mapfile -t next_theme_files < <(find "$NEXT_THEME_PATH" -mindepth 1 -type f -print -quit)
+if (( ${#next_theme_files[@]} == 0 )); then
+  echo "Theme '$THEME_NAME' did not generate any theme files" >&2
+  rm -rf "$NEXT_THEME_PATH"
+  exit 1
+fi
 
 # Swap next theme in as current
 rm -rf "$CURRENT_THEME_PATH"

--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -35,10 +35,19 @@ if [[ -f $COLORS_FILE ]]; then
   for tpl in "$USER_TEMPLATES_DIR"/*.tpl "$TEMPLATES_DIR"/*.tpl; do
     filename=$(basename "$tpl" .tpl)
     output_path="$NEXT_THEME_DIR/$filename"
+    temp_output=$(mktemp)
 
     # Don't overwrite configs already exists in the output directory (copied from theme specific folder)
     if [[ ! -f $output_path ]]; then
-      sed -f "$sed_script" "$tpl" >"$output_path"
+      if sed -f "$sed_script" "$tpl" >"$temp_output"; then
+        mv "$temp_output" "$output_path"
+      else
+        rm -f "$temp_output"
+        rm "$sed_script"
+        exit 1
+      fi
+    else
+      rm -f "$temp_output"
     fi
   done
 


### PR DESCRIPTION
Empty user-only theme directories currently pass the existence check in `omarchy-theme-set` and can replace `~/.config/omarchy/current/theme` with an empty theme.

## Summary
- reject empty theme names after sanitization
- fail the theme switch if template generation fails
- write generated theme files through a temporary file before moving them into `next-theme`
- abort the swap if `next-theme` ends up empty
- keep the current theme untouched on failure

Empty overrides on top of an existing built-in theme continue to work as before.

## Testing
- switched between built-in themes
- applied an empty override on top of an existing built-in theme
- applied an empty user-only theme and verified that the active theme stayed unchanged
- tested in both a temp `HOME` and on a live Omarchy system
