### PR TITLE
Update default repeat_delay to improve holding delete and vim motions

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -11,7 +11,7 @@ input {
 
   # Change speed of keyboard repeat
   repeat_rate = 40
-  repeat_delay = 600
+  repeat_delay = 250
 
   # Start with numlock on by default
   numlock_by_default = true


### PR DESCRIPTION
In my testing, this is the lowest you can go without causing any issues with double key presses.

@ryanrhughes and I were chatting at Omacon and I demoed this for him and he said I should submit this change.

It really improves the experience of needing to delete a line of text (if you're not in vim) and need to hold the delete key down. At 600ms there is a (IMO very frustrating) delay until you're able to see the "output" of a held key. 

This also works well if you need to move many lines in vim and don't want to use a "proper" motion command and "just want to hold `j` to get down 10 lines".

Another use-case could be writing an ascii table by holding ------------- to create the outlines, etc. 