### PR TITLE
Add brave-origin to browser check for omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -5,7 +5,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+google-chrome* | brave-browser* | brave-origin* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 


### PR DESCRIPTION
Brave has recently released brave-origin, which currently only has beta/nightly releases in the AUR, and I'm not sure they've made any kind of official announcement, but essentially it's just an alternative build of Brave with many of the extra features stripped out.

When running omarchy-launch-webapp, with brave-origin as the default browser it still tries to use chromium because it doesn't get caught by this list of supported browsers.