### PR TITLE
Add rounded webcam option to screen recording

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -17,6 +17,7 @@ DESKTOP_AUDIO="false"
 MICROPHONE_AUDIO="false"
 WEBCAM="false"
 WEBCAM_DEVICE=""
+ROUNDED_WEBCAM="false"
 RESOLUTION=""
 STOP_RECORDING="false"
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
@@ -27,6 +28,7 @@ for arg in "$@"; do
   --with-microphone-audio) MICROPHONE_AUDIO="true" ;;
   --with-webcam) WEBCAM="true" ;;
   --webcam-device=*) WEBCAM_DEVICE="${arg#*=}" ;;
+  --rounded-webcam) ROUNDED_WEBCAM="true" ;;
   --resolution=*) RESOLUTION="${arg#*=}" ;;
   --stop-recording) STOP_RECORDING="true" ;;
   esac
@@ -62,9 +64,12 @@ start_webcam_overlay() {
     fi
   done
 
+  local window_title="WebcamOverlay"
+  [[ $ROUNDED_WEBCAM == "true" ]] && window_title="WebcamOverlayRounded"
+
   ffplay -f v4l2 $video_size_arg -framerate 30 "$WEBCAM_DEVICE" \
     -vf "crop=iw/2:ih,scale=${target_width}:-1" \
-    -window_title "WebcamOverlay" \
+    -window_title "$window_title" \
     -noborder \
     -fflags nobuffer -flags low_delay \
     -probesize 32 -analyzeduration 0 \

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -152,7 +152,16 @@ show_screenrecord_menu() {
       back_to show_capture_menu
       return
     }
-    omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam --webcam-device="$device"
+    local shape_args=()
+    case $(menu "Webcam shape" "  Square\n  Rounded") in
+    *Rounded) shape_args+=(--rounded-webcam) ;;
+    *Square) ;;
+    *)
+      back_to show_capture_menu
+      return
+      ;;
+    esac
+    omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam --webcam-device="$device" "${shape_args[@]}"
     ;;
   *) back_to show_capture_menu ;;
   esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -152,15 +152,24 @@ show_screenrecord_menu() {
       back_to show_capture_menu
       return
     }
+    local shape_file="$HOME/.config/omarchy/screenrecord/webcam-shape"
+    local shape
+    if [[ -f $shape_file ]]; then
+      shape=$(<"$shape_file")
+    else
+      case $(menu "Webcam shape" "  Square\n  Rounded") in
+      *Rounded) shape="rounded" ;;
+      *Square) shape="square" ;;
+      *)
+        back_to show_capture_menu
+        return
+        ;;
+      esac
+      mkdir -p "$(dirname "$shape_file")"
+      echo "$shape" >"$shape_file"
+    fi
     local shape_args=()
-    case $(menu "Webcam shape" "  Square\n  Rounded") in
-    *Rounded) shape_args+=(--rounded-webcam) ;;
-    *Square) ;;
-    *)
-      back_to show_capture_menu
-      return
-      ;;
-    esac
+    [[ $shape == "rounded" ]] && shape_args+=(--rounded-webcam)
     omarchy-cmd-screenrecord --with-desktop-audio --with-microphone-audio --with-webcam --webcam-device="$device" "${shape_args[@]}"
     ;;
   *) back_to show_capture_menu ;;

--- a/default/hypr/apps/webcam-overlay.conf
+++ b/default/hypr/apps/webcam-overlay.conf
@@ -1,6 +1,7 @@
 # Webcam overlay for screen recording
-windowrule = float on, match:title WebcamOverlay
-windowrule = pin on, match:title WebcamOverlay
-windowrule = no_initial_focus on, match:title WebcamOverlay
-windowrule = no_dim on, match:title WebcamOverlay
-windowrule = move (monitor_w-window_w-40) (monitor_h-window_h-40), match:title WebcamOverlay
+windowrule = float on, match:title WebcamOverlay(Rounded)?
+windowrule = pin on, match:title WebcamOverlay(Rounded)?
+windowrule = no_initial_focus on, match:title WebcamOverlay(Rounded)?
+windowrule = no_dim on, match:title WebcamOverlay(Rounded)?
+windowrule = move (monitor_w-window_w-40) (monitor_h-window_h-40), match:title WebcamOverlay(Rounded)?
+windowrule = rounding 20, match:title WebcamOverlayRounded


### PR DESCRIPTION
Adds an opt-in rounded-corner variant for the webcam overlay shown during screen recording. Square stays the default, so nothing changes for existing users unless they ask for it.

After picking the webcam option in the screenrecord menu, you now get a second prompt for Square or Rounded. There's also a matching `--rounded-webcam` flag on `omarchy-cmd-screenrecord` for anyone scripting it directly.

Under the hood the rounded variant just uses a distinct ffplay window title (`WebcamOverlayRounded`) so a single extra Hyprland windowrule applies `rounding 20`. The existing float/pin/position rules are widened with a regex to match both titles.