### PR TITLE
Fix: Prevent malformed input on theme install by trimming whitespace from URL

### DIFF
--- a/bin/omarchy-theme-install
+++ b/bin/omarchy-theme-install
@@ -10,6 +10,8 @@ else
   REPO_URL="$1"
 fi
 
+REPO_URL=$(printf '%s' "$REPO_URL" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+
 if [[ -z $REPO_URL ]]; then
   exit 1
 fi


### PR DESCRIPTION
Leading or trailing whitespace in a url causes a "malformed input" error when trying to install a theme via Install -> Style -> Theme

<img width="1100" height="758" alt="screenshot-2026-04-14_17-35-48" src="https://github.com/user-attachments/assets/51d87ed5-5d4c-497d-9d36-0c0a21e22219" />
