### PR TITLE
Disable PSR1 on XPS IPS and OLED. XPS IPS uses PSR2

### DIFF
--- a/install/config/hardware/dell/fix-xps-ptl-display.sh
+++ b/install/config/hardware/dell/fix-xps-ptl-display.sh
@@ -4,12 +4,12 @@
 if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
   echo "Detected Dell XPS on Panther Lake, applying display power-saving fixes..."
 
-  CMDLINE='KERNEL_CMDLINE[default]+=" xe.enable_psr=0"'
-  COMMENT='Disable Xe PSR on Dell XPS Panther Lake systems'
-
   if omarchy-hw-dell-xps-oled; then
     CMDLINE='KERNEL_CMDLINE[default]+=" xe.enable_psr=0 xe.enable_panel_replay=0"'
     COMMENT='Disable Xe PSR and Panel Replay on Dell XPS Panther Lake OLED systems'
+  else
+    CMDLINE='KERNEL_CMDLINE[default]+=" xe.enable_psr=0"'
+    COMMENT='Disable Xe PSR on Dell XPS Panther Lake systems'
   fi
 
   sudo mkdir -p /etc/limine-entry-tool.d

--- a/install/config/hardware/dell/fix-xps-ptl-display.sh
+++ b/install/config/hardware/dell/fix-xps-ptl-display.sh
@@ -17,15 +17,4 @@ if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
 # $COMMENT
 $CMDLINE
 EOF
-
-  # Also append to /etc/default/limine if it exists, since it overrides drop-in configs
-  if [[ -f /etc/default/limine ]]; then
-    if ! grep -Fq 'xe.enable_psr' /etc/default/limine; then
-      echo 'KERNEL_CMDLINE[default]+=" xe.enable_psr=0"' | sudo tee -a /etc/default/limine >/dev/null
-    fi
-
-    if omarchy-hw-dell-xps-oled && ! grep -Fq 'xe.enable_panel_replay' /etc/default/limine; then
-      echo 'KERNEL_CMDLINE[default]+=" xe.enable_panel_replay=0"' | sudo tee -a /etc/default/limine >/dev/null
-    fi
-  fi
 fi

--- a/install/config/hardware/dell/fix-xps-ptl-display.sh
+++ b/install/config/hardware/dell/fix-xps-ptl-display.sh
@@ -1,18 +1,31 @@
-# Fix display issues on Dell XPS 2026+ with LG OLED panel and Intel Panther Lake (Xe3) GPU.
-# Power-saving features (PSR and Panel Replay) cause freezes and display glitches.
-if omarchy-hw-dell-xps-oled; then
-  echo "Detected Dell XPS with LG OLED panel on Panther Lake, applying display power-saving fix..."
+# Fix display issues on Dell XPS Panther Lake (Xe3) systems.
+# Xe PSR causes freezes and display glitches on both OLED and IPS panels.
+# LG OLED panels also need Panel Replay disabled.
+if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
+  echo "Detected Dell XPS on Panther Lake, applying display power-saving fixes..."
 
-  CMDLINE='KERNEL_CMDLINE[default]+=" xe.enable_psr=0 xe.enable_panel_replay=0"'
+  CMDLINE='KERNEL_CMDLINE[default]+=" xe.enable_psr=0"'
+  COMMENT='Disable Xe PSR on Dell XPS Panther Lake systems'
+
+  if omarchy-hw-dell-xps-oled; then
+    CMDLINE='KERNEL_CMDLINE[default]+=" xe.enable_psr=0 xe.enable_panel_replay=0"'
+    COMMENT='Disable Xe PSR and Panel Replay on Dell XPS Panther Lake OLED systems'
+  fi
 
   sudo mkdir -p /etc/limine-entry-tool.d
   cat <<EOF | sudo tee /etc/limine-entry-tool.d/dell-xps-ptl-display.conf >/dev/null
-# Fix Dell XPS OLED display issues by disabling Xe PSR and Panel Replay power-saving features
+# $COMMENT
 $CMDLINE
 EOF
 
   # Also append to /etc/default/limine if it exists, since it overrides drop-in configs
-  if [ -f /etc/default/limine ] && ! grep -q 'xe.enable_psr' /etc/default/limine; then
-    echo "$CMDLINE" | sudo tee -a /etc/default/limine >/dev/null
+  if [[ -f /etc/default/limine ]]; then
+    if ! grep -Fq 'xe.enable_psr' /etc/default/limine; then
+      echo 'KERNEL_CMDLINE[default]+=" xe.enable_psr=0"' | sudo tee -a /etc/default/limine >/dev/null
+    fi
+
+    if omarchy-hw-dell-xps-oled && ! grep -Fq 'xe.enable_panel_replay' /etc/default/limine; then
+      echo 'KERNEL_CMDLINE[default]+=" xe.enable_panel_replay=0"' | sudo tee -a /etc/default/limine >/dev/null
+    fi
   fi
 fi

--- a/migrations/1776099290.sh
+++ b/migrations/1776099290.sh
@@ -1,9 +1,14 @@
-echo "Add xe.enable_psr=0 to CMDLINE for XPS Panther Lake systems missing it"
+echo "Ensure xe.enable_psr=0 is set in CMDLINE for XPS Panther Lake systems"
 
-if omarchy-hw-dell-xps-oled && [ -f /etc/default/limine ]; then
+if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl && [[ -f /etc/default/limine ]]; then
   UPDATED=false
 
-  if ! grep -q 'xe.enable_psr' /etc/default/limine; then
+  if grep -Fq 'xe.enable_psr=' /etc/default/limine; then
+    if grep -qE 'xe\.enable_psr=[^0[:space:]"]|xe\.enable_psr=0[^[:space:]"]+' /etc/default/limine; then
+      sudo sed -Ei 's/(^|[[:space:]])xe\.enable_psr=[^[:space:]"]+/\1xe.enable_psr=0/g' /etc/default/limine
+      UPDATED=true
+    fi
+  else
     echo 'KERNEL_CMDLINE[default]+=" xe.enable_psr=0"' | sudo tee -a /etc/default/limine >/dev/null
     UPDATED=true
   fi

--- a/migrations/1776099290.sh
+++ b/migrations/1776099290.sh
@@ -1,19 +1,8 @@
 echo "Ensure xe.enable_psr=0 is set in CMDLINE for XPS Panther Lake systems"
 
 if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl && [[ -f /etc/default/limine ]]; then
-  UPDATED=false
-
-  if grep -Fq 'xe.enable_psr=' /etc/default/limine; then
-    if grep -qE 'xe\.enable_psr=[^0[:space:]"]|xe\.enable_psr=0[^[:space:]"]+' /etc/default/limine; then
-      sudo sed -Ei 's/(^|[[:space:]])xe\.enable_psr=[^[:space:]"]+/\1xe.enable_psr=0/g' /etc/default/limine
-      UPDATED=true
-    fi
-  else
+  if ! grep -Fq 'xe.enable_psr=0' /etc/default/limine; then
     echo 'KERNEL_CMDLINE[default]+=" xe.enable_psr=0"' | sudo tee -a /etc/default/limine >/dev/null
-    UPDATED=true
-  fi
-
-  if $UPDATED; then
     sudo limine-mkinitcpio
   fi
 fi


### PR DESCRIPTION
PSR 1 on XPS IPS was experiencing flickering on the linux-ptl kernel and requires PSR2 with Panel Replay. 

This patch applies the limine kernel params to set xe.enable_psr=0. This ensures PSR2 is used with default xe.enable_psr2_sel_fetch=Y for both install and post-install migration.

Migration will replace any xe.enable_psr=X value to xe.enable_psr=0 inline if it previously was set to another value.

Tested on XPS 14 IPS.