### PR TITLE
feat: gracefully swap ALSA hardware profiles on single-sink unified chips systems

### DIFF
--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -7,6 +7,39 @@ focused_monitor="$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).n
 sinks=$(pactl -f json list sinks | jq '[.[] | select((.ports | length == 0) or ([.ports[]? | .availability != "not available"] | any))]')
 sinks_count=$(echo "$sinks" | jq '. | length')
 
+if (( sinks_count <= 1 )); then
+  first_card=$(pactl -f json list cards | jq -r '[.[] | select(.name | startswith("alsa_card"))][0].name')
+  
+  if [[ -n $first_card ]] && [[ $first_card != "null" ]]; then
+    active_profile=$(pactl -f json list cards | jq -r ".[] | select(.name == \"$first_card\") | .active_profile")
+    
+    was_playing=false
+    if command -v playerctl >/dev/null 2>&1 && [[ $(playerctl status 2>/dev/null) == "Playing" ]]; then
+      was_playing=true
+    fi
+
+    if [[ $active_profile == *"analog-stereo"* ]]; then
+      if pactl set-card-profile "$first_card" "output:hdmi-stereo" 2>/dev/null; then
+        swayosd-client \
+          --monitor "$focused_monitor" \
+          --custom-message "Digital Output (HDMI)" \
+          --custom-icon "video-display"
+        [[ $was_playing == true ]] && sleep 0.5 && playerctl play >/dev/null 2>&1
+        exit 0
+      fi
+    elif [[ $active_profile == *"hdmi-stereo"* ]]; then
+      if pactl set-card-profile "$first_card" "output:analog-stereo" 2>/dev/null; then
+        swayosd-client \
+          --monitor "$focused_monitor" \
+          --custom-message "Analog Output (Headphones)" \
+          --custom-icon "audio-headphones"
+        [[ $was_playing == true ]] && sleep 0.5 && playerctl play >/dev/null 2>&1
+        exit 0
+      fi
+    fi
+  fi
+fi
+
 if (( sinks_count == 0 )); then
   swayosd-client \
     --monitor "$focused_monitor" \


### PR DESCRIPTION
## Description

On systems with unified audio cards (like the HDA Intel PCH), the HDMI output and the Analog (Headphones) output are mutually exclusive ALSA profiles. Because of this, only a single sink is ever exposed to PipeWire/PulseAudio at any given time. As a result, the default `omarchy-cmd-audio-switch` script incorrectly fails with "No audio devices found" instead of allowing the user to switch to the unplugged/inactive profile port.

Changes:

1. Modified omarchy-cmd-audio-switch to add fallback ALSA card profile logic:
If only 1 sink is available and it belongs to a card currently in `analog-stereo` or `hdmi-stereo` mode, gracefully command `pactl set-card-profile` to forcefully switch to the other one.
2. Added an intelligent media auto-resume via `playerctl` (`play` / `status`):
Changing ALSA profiles destroys and recreates the audio nodes in PipeWire/WirePlumber behind the scenes. This drop-off causes apps (like Media players and Browsers) to hard-pause playback as a safety measure. The script now records playback state before switching profiles, sleeps briefly to let the soundcard re-initialize, and re-triggers `playerctl play` to unpause the stream seamlessly.