### PR TITLE
Restore keyboard layout after hyprland config refresh

### DIFF
--- a/bin/omarchy-detect-keyboard-layout
+++ b/bin/omarchy-detect-keyboard-layout
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Re-apply the system keyboard layout to Hyprland input config.
+
+bash "$OMARCHY_PATH/install/config/detect-keyboard-layout.sh"

--- a/bin/omarchy-refresh-hyprland
+++ b/bin/omarchy-refresh-hyprland
@@ -7,3 +7,4 @@ omarchy-refresh-config hypr/bindings.conf
 omarchy-refresh-config hypr/input.conf
 omarchy-refresh-config hypr/looknfeel.conf
 omarchy-refresh-config hypr/hyprland.conf
+omarchy-detect-keyboard-layout


### PR DESCRIPTION
## Summary

`omarchy-refresh-hyprland` overwrites `input.conf` with the default template, which has `kb_layout` and `kb_variant` commented out. Non-US keyboard users lose their layout with no obvious recovery path.

Re-runs `detect-keyboard-layout.sh` after the refresh to re-apply the system layout from `/etc/vconsole.conf`, matching what the initial install does.

- Keyboard layout is the only install-time customization applied to `input.conf`
- No-op for US layout users (`/etc/vconsole.conf` has no `XKBLAYOUT`)

## Approach

This PR wraps the call in a new `bin/omarchy-detect-keyboard-layout` command to follow the existing convention where `omarchy-refresh-hyprland` is a list of `omarchy-*` commands.

## Alternative

If a single-file change is preferred, see #5319 — same fix as a one-liner directly in `omarchy-refresh-hyprland`.

## Test Evidence

### BEFORE 

Note that `kb_layout` reverts to the template and disagrees with XKBLAYOUT after refresh. 

<img width="1280" height="800" alt="before-kb-layout-fix" src="https://github.com/user-attachments/assets/d3f4297d-4d34-4117-9453-a9bf1b2ab939" />

### AFTER

`kb_layout` persists after refresh 

<img width="1280" height="800" alt="after-kb-layout-fix" src="https://github.com/user-attachments/assets/0fe7f504-66e7-45f8-95f2-80bfbc8eabd3" />

### VERIFICATION

<img width="1280" height="800" alt="verification" src="https://github.com/user-attachments/assets/34111e1d-aaa5-4b60-8df0-30abfb69de1f" />


Fixes #2507