### PR TITLE
Restore keyboard layout after hyprland config refresh - Alternative Implementation

### DIFF
--- a/bin/omarchy-refresh-hyprland
+++ b/bin/omarchy-refresh-hyprland
@@ -7,3 +7,4 @@ omarchy-refresh-config hypr/bindings.conf
 omarchy-refresh-config hypr/input.conf
 omarchy-refresh-config hypr/looknfeel.conf
 omarchy-refresh-config hypr/hyprland.conf
+bash "$OMARCHY_PATH/install/config/detect-keyboard-layout.sh"


### PR DESCRIPTION
## Summary

Simpler alternative to #5318 with one file changed instead of two.

`omarchy-refresh-hyprland` overwrites `input.conf` with the default template, which has `kb_layout` and `kb_variant` commented out. Non-US keyboard users lose their layout with no obvious recovery path.

This adds a single line to `omarchy-refresh-hyprland` that re-runs `detect-keyboard-layout.sh` after the refresh, re-applying the system layout from `/etc/vconsole.conf`.

## Tradeoff vs #5318

- **This PR:** One-line change, one file. Simpler, but calls directly into `install/config/` which is slightly inconsistent with the rest of the script.
- **#5318:** Wraps the call in a new `bin/omarchy-detect-keyboard-layout` command to match the convention. Two files, but consistent style.

## Test Evidence 

Tested on #5318 with screenshots. 

Fixes #2507