### PR TITLE
Ensure /home is indexed by plocate on Btrfs

### DIFF
--- a/install/config/localdb.sh
+++ b/install/config/localdb.sh
@@ -1,2 +1,3 @@
-# Update localdb so that locate will find everything installed
+# Ensure /home is indexed on Btrfs (subvolumes look like bind mounts)
+sudo sed -i 's/PRUNE_BIND_MOUNTS.*=.*/PRUNE_BIND_MOUNTS = "no"/' /etc/updatedb.conf
 sudo updatedb

--- a/migrations/1776317254.sh
+++ b/migrations/1776317254.sh
@@ -1,0 +1,5 @@
+echo "Allow plocate to index Btrfs subvolumes (including home)"
+
+if grep -q '^PRUNE_BIND_MOUNTS.*=.*"yes"' /etc/updatedb.conf; then
+  sudo sed -i 's/^PRUNE_BIND_MOUNTS.*=.*"yes"/PRUNE_BIND_MOUNTS = "no"/' /etc/updatedb.conf
+fi


### PR DESCRIPTION
## Summary

Btrfs subvolumes appear as bind mounts to plocate. The default `PRUNE_BIND_MOUNTS="yes"` in `/etc/updatedb.conf` causes plocate to skip `$HOME` entirely, so `locate` returns no results for any file in the user's home directory.

Sets `PRUNE_BIND_MOUNTS` to `"no"` during install (in `localdb.sh`) and adds a migration for existing installs.

This is the same fix merged in 9f561e0 and reverted in 262fadd5 because the migration file was missing the `.sh` extension, which prevented the migration system from executing it. Re-applies the fix with a correctly named migration.

If this approach is no longer the right direction, then #3744 may not be fixable another way.

## Note on `updatedb`

The original commit (9f561e0) ran `sudo updatedb` inside the migration. We intentionally omit that here — `plocate-updatedb.timer` handles scheduled reindexing, so the next timer run picks up the config change without slowing down the update.

## Test  Notes

- Verified `locate ~/.bashrc` returns nothing on fresh Omarchy 3.5.0 VM (Btrfs)
- After applying `sed`, `sudo updatedb`, `locate ~/.bashrc` returns the correct path
- Migration is idempotent (guarded with `grep` before `sed`)

## Test Evidence 

### BEFORE 

<img width="1280" height="800" alt="locate-bug-example" src="https://github.com/user-attachments/assets/5e12cc26-c045-4334-913f-e44cf732ea6e" />

### AFTER 

<img width="1280" height="800" alt="locate-bug-fixed" src="https://github.com/user-attachments/assets/c31f0d8e-2bca-4afb-a227-af8374431741" />

Fixes #3744

Co-authored-by: David Heinemeier Hansson <david@hey.com>
Co-authored-by: Jorge Campo <jorge-campo@users.noreply.github.com>