### PR TITLE
Skip browser policy refresh when browser is not running

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -14,11 +14,11 @@ if omarchy-cmd-present chromium || omarchy-cmd-present brave; then
 
   if omarchy-cmd-present chromium; then
     echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/chromium/policies/managed/color.json" >/dev/null
-    chromium --refresh-platform-policy --no-startup-window &>/dev/null
+    pgrep -x chromium >/dev/null && chromium --refresh-platform-policy --no-startup-window &>/dev/null
   fi
 
   if omarchy-cmd-present brave; then
     echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/brave/policies/managed/color.json" >/dev/null
-    brave --refresh-platform-policy --no-startup-window &>/dev/null
+    pgrep -x brave >/dev/null && brave --refresh-platform-policy --no-startup-window &>/dev/null
   fi
 fi


### PR DESCRIPTION
## Summary

`omarchy-theme-set-browser` launches Chromium/Brave with `--refresh-platform-policy` even when the browser isn't running. On older Chromium versions (145.x), this blocks forever and hangs `omarchy-update`. On current versions (146.x), it exits but throws GPU errors to stderr.

The policy JSON file is written to `/etc/chromium/policies/managed/color.json` before this call, so Chromium picks up the theme on next launch regardless. The `--refresh-platform-policy` flag only triggers a hot-reload in an already-running instance.

Guard both the Chromium and Brave calls with `pgrep` so the refresh is skipped when the browser isn't running. This matches the existing pattern used by `omarchy-theme-set`, `omarchy-restart-terminal`, `omarchy-toggle-waybar`, and others.

## Test Notes

-  Chromium not running: `omarchy-theme-set-browser` returns immediately, no errors
-  Chromium running: `omarchy-theme-set-browser` returns immediately, theme updates live
-  Policy file (`/etc/chromium/policies/managed/color.json`) is written in both cases

## Test Evidence 

### Before 
<img width="2118" height="830" alt="screenshot-2026-04-16_02-12-13" src="https://github.com/user-attachments/assets/33b047bc-9439-4f5e-b427-72a0d221d50a" />


### After 

<img width="1488" height="643" alt="screenshot-2026-04-16_02-19-45" src="https://github.com/user-attachments/assets/6731c572-8d8f-44c3-9b99-5646d50187c7" />



Fixes #4772