### PR TITLE
Align Omarchy power profiles with intel-lpmd

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -247,7 +247,7 @@ show_setup_power_menu() {
   if [[ $profile == "CNCLD" || -z $profile ]]; then
     back_to show_setup_menu
   else
-    powerprofilesctl set "$profile"
+    omarchy-powerprofiles-set "$profile"
   fi
 }
 

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -5,8 +5,6 @@
 #
 # Usage: omarchy-powerprofiles-set <ac|battery|performance|balanced|power-saver>
 
-OMARCHY_BIN=$(cd -- "$(dirname "$0")" && pwd)
-
 mapfile -t profiles < <(powerprofilesctl list | awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }')
 
 profile_available() {
@@ -44,37 +42,5 @@ resolve_profile() {
   esac
 }
 
-sync_intel_lpmd() {
-  local method
-
-  "$OMARCHY_BIN/omarchy-pkg-present" intel-lpmd || return 0
-  "$OMARCHY_BIN/omarchy-cmd-present" busctl || return 0
-  systemctl is-active --quiet intel_lpmd.service || return 0
-
-  # Mirror Omarchy's effective power profile into intel_lpmd.
-  case $1 in
-    performance) method="LPM_FORCE_OFF" ;;
-    balanced) method="LPM_AUTO" ;;
-    power-saver) method="LPM_FORCE_ON" ;;
-    *) return 0 ;;
-  esac
-
-  if (( EUID == 0 )); then
-    busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
-  else
-    # install/config/hardware/intel/lpmd.sh grants passwordless access to these
-    # three method calls so menu-driven profile changes can sync intel_lpmd too.
-    sudo -n busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
-  fi
-}
-
 requested_profile=$(resolve_profile "$1") || exit 1
-
 powerprofilesctl set "$requested_profile"
-status=$?
-(( status == 0 )) || exit $status
-
-# Some systems advertise power-saver but coerce it back to balanced.
-applied_profile=$requested_profile
-current_profile=$(powerprofilesctl get 2>/dev/null) && applied_profile=$current_profile
-sync_intel_lpmd "$applied_profile"

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -62,6 +62,8 @@ sync_intel_lpmd() {
   if (( EUID == 0 )); then
     busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
   else
+    # install/config/hardware/intel/lpmd.sh grants passwordless access to these
+    # three method calls so menu-driven profile changes can sync intel_lpmd too.
     sudo -n busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
   fi
 }

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -51,7 +51,7 @@ sync_intel_lpmd() {
   "$OMARCHY_BIN/omarchy-cmd-present" busctl || return 0
   systemctl is-active --quiet intel_lpmd.service || return 0
 
-  # Mirror Omarchy's power profile choices into intel_lpmd when available.
+  # Mirror Omarchy's effective power profile into intel_lpmd.
   case $1 in
     performance) method="LPM_FORCE_OFF" ;;
     balanced) method="LPM_AUTO" ;;
@@ -66,7 +66,13 @@ sync_intel_lpmd() {
   fi
 }
 
-profile=$(resolve_profile "$1") || exit 1
+requested_profile=$(resolve_profile "$1") || exit 1
 
-powerprofilesctl set "$profile" || exit $?
-sync_intel_lpmd "$profile"
+powerprofilesctl set "$requested_profile"
+status=$?
+(( status == 0 )) || exit $status
+
+# Some systems advertise power-saver but coerce it back to balanced.
+applied_profile=$requested_profile
+current_profile=$(powerprofilesctl get 2>/dev/null) && applied_profile=$current_profile
+sync_intel_lpmd "$applied_profile"

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -1,22 +1,72 @@
 #!/bin/bash
 
-# Set the power profile to the requested level, falling back to balanced
-# if the requested profile isn't available on this machine.
+# Set the requested power profile, falling back to balanced if the
+# requested profile isn't available on this machine.
 #
-# Usage: omarchy-powerprofiles-set <ac|battery>
+# Usage: omarchy-powerprofiles-set <ac|battery|performance|balanced|power-saver>
+
+OMARCHY_BIN=$(cd -- "$(dirname "$0")" && pwd)
 
 mapfile -t profiles < <(powerprofilesctl list | awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }')
 
-case "$1" in
-  ac)
-    # Prefer performance, fall back to balanced
-    if [[ " ${profiles[*]} " == *" performance "* ]]; then
-      powerprofilesctl set performance
-    else
-      powerprofilesctl set balanced
-    fi
-    ;;
-  battery)
-    powerprofilesctl set balanced
-    ;;
-esac
+profile_available() {
+  local profile
+
+  for profile in "${profiles[@]}"; do
+    [[ $profile == "$1" ]] && return 0
+  done
+
+  return 1
+}
+
+resolve_profile() {
+  case $1 in
+    ac)
+      if profile_available performance; then
+        printf '%s\n' performance
+      else
+        printf '%s\n' balanced
+      fi
+      ;;
+    battery)
+      printf '%s\n' balanced
+      ;;
+    performance|balanced|power-saver)
+      if profile_available "$1"; then
+        printf '%s\n' "$1"
+      else
+        printf '%s\n' balanced
+      fi
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+sync_intel_lpmd() {
+  local method
+
+  "$OMARCHY_BIN/omarchy-pkg-present" intel-lpmd || return 0
+  "$OMARCHY_BIN/omarchy-cmd-present" busctl || return 0
+  systemctl is-active --quiet intel_lpmd.service || return 0
+
+  # Mirror Omarchy's power profile choices into intel_lpmd when available.
+  case $1 in
+    performance) method="LPM_FORCE_OFF" ;;
+    balanced) method="LPM_AUTO" ;;
+    power-saver) method="LPM_FORCE_ON" ;;
+    *) return 0 ;;
+  esac
+
+  if (( EUID == 0 )); then
+    busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
+  else
+    sudo -n busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
+  fi
+}
+
+profile=$(resolve_profile "$1") || exit 1
+
+powerprofilesctl set "$profile" || exit $?
+sync_intel_lpmd "$profile"

--- a/default/systemd/system-sleep/resume-boost
+++ b/default/systemd/system-sleep/resume-boost
@@ -4,13 +4,40 @@
 # to avoid sluggishness while the system catches up, then
 # restore the previous profile after 10 seconds.
 
+sync_intel_lpmd() {
+  local method
+
+  pacman -Q intel-lpmd &>/dev/null || return 0
+  command -v busctl &>/dev/null || return 0
+  systemctl is-active --quiet intel_lpmd.service || return 0
+
+  case $1 in
+    performance) method="LPM_FORCE_OFF" ;;
+    balanced) method="LPM_AUTO" ;;
+    power-saver) method="LPM_FORCE_ON" ;;
+    *) return 0 ;;
+  esac
+
+  busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
+}
+
+set_profile() {
+  powerprofilesctl set "$1"
+  sync_intel_lpmd "$1"
+}
+
 if [[ $1 == "pre" ]]; then
   mkdir -p /run/omarchy
   powerprofilesctl get > /run/omarchy/power-profile-before-sleep
 fi
 
+if [[ $1 == "restore" ]]; then
+  set_profile "${2:-balanced}"
+  exit 0
+fi
+
 if [[ $1 == "post" ]]; then
   previous=$(cat /run/omarchy/power-profile-before-sleep 2>/dev/null || echo "balanced")
-  powerprofilesctl set performance
-  systemd-run --on-active=10 --timer-property=AccuracySec=1 powerprofilesctl set "$previous"
+  set_profile performance
+  systemd-run --on-active=10 --timer-property=AccuracySec=1 "$0" restore "$previous"
 fi

--- a/default/systemd/system-sleep/resume-boost
+++ b/default/systemd/system-sleep/resume-boost
@@ -9,41 +9,14 @@ log_warning() {
   logger -t resume-boost "$1"
 }
 
-sync_intel_lpmd() {
-  local method
-
-  pacman -Q intel-lpmd &>/dev/null || return 0
-  command -v busctl &>/dev/null || return 0
-  systemctl is-active --quiet intel_lpmd.service || return 0
-
-  case $1 in
-    performance) method="LPM_FORCE_OFF" ;;
-    balanced) method="LPM_AUTO" ;;
-    power-saver) method="LPM_FORCE_ON" ;;
-    *) return 0 ;;
-  esac
-
-  busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd "$method" &>/dev/null || true
-}
-
 set_profile() {
-  local current requested actual status
+  local requested status
 
   requested=$1
 
   powerprofilesctl set "$requested"
   status=$?
   (( status == 0 )) || return $status
-
-  # Some systems advertise power-saver but coerce it back to balanced.
-  actual=$requested
-  if current=$(powerprofilesctl get 2>/dev/null); then
-    actual=$current
-  else
-    log_warning "powerprofilesctl get failed after setting '$requested'; syncing intel_lpmd to the requested profile"
-  fi
-
-  sync_intel_lpmd "$actual"
 }
 
 if [[ $1 == "pre" ]]; then

--- a/default/systemd/system-sleep/resume-boost
+++ b/default/systemd/system-sleep/resume-boost
@@ -4,6 +4,11 @@
 # to avoid sluggishness while the system catches up, then
 # restore the previous profile after 10 seconds.
 
+log_warning() {
+  command -v logger &>/dev/null || return 0
+  logger -t resume-boost "$1"
+}
+
 sync_intel_lpmd() {
   local method
 
@@ -22,22 +27,41 @@ sync_intel_lpmd() {
 }
 
 set_profile() {
-  powerprofilesctl set "$1"
-  sync_intel_lpmd "$1"
+  local current requested actual status
+
+  requested=$1
+
+  powerprofilesctl set "$requested"
+  status=$?
+  (( status == 0 )) || return $status
+
+  # Some systems advertise power-saver but coerce it back to balanced.
+  actual=$requested
+  if current=$(powerprofilesctl get 2>/dev/null); then
+    actual=$current
+  else
+    log_warning "powerprofilesctl get failed after setting '$requested'; syncing intel_lpmd to the requested profile"
+  fi
+
+  sync_intel_lpmd "$actual"
 }
 
 if [[ $1 == "pre" ]]; then
   mkdir -p /run/omarchy
-  powerprofilesctl get > /run/omarchy/power-profile-before-sleep
+  if ! powerprofilesctl get 2>/dev/null > /run/omarchy/power-profile-before-sleep; then
+    log_warning "powerprofilesctl get failed before sleep; saving balanced as the restore profile"
+    echo "balanced" > /run/omarchy/power-profile-before-sleep
+  fi
 fi
 
 if [[ $1 == "restore" ]]; then
-  set_profile "${2:-balanced}"
-  exit 0
+  requested=${2:-balanced}
+  set_profile "$requested"
+  exit $?
 fi
 
 if [[ $1 == "post" ]]; then
   previous=$(cat /run/omarchy/power-profile-before-sleep 2>/dev/null || echo "balanced")
-  set_profile performance
-  systemd-run --on-active=10 --timer-property=AccuracySec=1 "$0" restore "$previous"
+  set_profile performance || exit $?
+  systemd-run --on-active=10 --timer-property=AccuracySec=1 "$0" restore "$previous" || exit $?
 fi

--- a/install/config/hardware/intel/lpmd.sh
+++ b/install/config/hardware/intel/lpmd.sh
@@ -2,50 +2,10 @@
 # Supported models: Alder Lake (151/154), Raptor Lake (183/186/191),
 # Meteor Lake (170/172), Lunar Lake (189), Panther Lake (204)
 
-lpmd_config_path() {
-  local cpu_family cpu_model candidate config_path
-
-  cpu_family=$(grep -m1 "^cpu family" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ')
-  cpu_model=$(grep -m1 "^model\s*:" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ')
-
-  for candidate in /etc/intel_lpmd/intel_lpmd_config_F${cpu_family}_M${cpu_model}_T*.xml; do
-    [[ -f $candidate ]] || continue
-    config_path=$candidate
-    break
-  done
-
-  if [[ -z $config_path ]]; then
-    candidate="/etc/intel_lpmd/intel_lpmd_config_F${cpu_family}_M${cpu_model}.xml"
-    [[ -f $candidate ]] && config_path=$candidate
-  fi
-
-  if [[ -z $config_path ]]; then
-    candidate="/etc/intel_lpmd/intel_lpmd_config.xml"
-    [[ -f $candidate ]] && config_path=$candidate
-  fi
-
-  printf '%s\n' "$config_path"
-}
-
-configure_lpmd_defaults() {
-  local config_path
-
-  config_path=$(lpmd_config_path)
-  [[ -n $config_path ]] || return 0
-
-  # Let intel-lpmd follow power-profiles-daemon directly.
-  sudo xmlstarlet ed -L \
-    -u "/Configuration/PerformanceDef" -v "-1" \
-    -u "/Configuration/BalancedDef" -v "0" \
-    -u "/Configuration/PowersaverDef" -v "1" \
-    "$config_path"
-}
-
 if omarchy-hw-intel && omarchy-battery-present; then
   cpu_model=$(grep -m1 "^model\s*:" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ')
   if [[ $cpu_model =~ ^(151|154|170|172|183|186|189|191|204)$ ]]; then
     omarchy-pkg-add intel-lpmd
-    configure_lpmd_defaults
     sudo systemctl enable intel_lpmd.service
     sudo rm -f /etc/sudoers.d/omarchy-intel-lpmd
   fi

--- a/install/config/hardware/intel/lpmd.sh
+++ b/install/config/hardware/intel/lpmd.sh
@@ -7,5 +7,9 @@ if omarchy-hw-intel && omarchy-battery-present; then
   if [[ "$cpu_model" =~ ^(151|154|170|172|183|186|189|191|204)$ ]]; then
     omarchy-pkg-add intel-lpmd
     sudo systemctl enable intel_lpmd.service
+    sudo tee /etc/sudoers.d/omarchy-intel-lpmd >/dev/null <<EOF
+$USER ALL=(root) NOPASSWD: /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_AUTO, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_OFF, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_ON
+EOF
+    sudo chmod 440 /etc/sudoers.d/omarchy-intel-lpmd
   fi
 fi

--- a/install/config/hardware/intel/lpmd.sh
+++ b/install/config/hardware/intel/lpmd.sh
@@ -2,14 +2,51 @@
 # Supported models: Alder Lake (151/154), Raptor Lake (183/186/191),
 # Meteor Lake (170/172), Lunar Lake (189), Panther Lake (204)
 
+lpmd_config_path() {
+  local cpu_family cpu_model candidate config_path
+
+  cpu_family=$(grep -m1 "^cpu family" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ')
+  cpu_model=$(grep -m1 "^model\s*:" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ')
+
+  for candidate in /etc/intel_lpmd/intel_lpmd_config_F${cpu_family}_M${cpu_model}_T*.xml; do
+    [[ -f $candidate ]] || continue
+    config_path=$candidate
+    break
+  done
+
+  if [[ -z $config_path ]]; then
+    candidate="/etc/intel_lpmd/intel_lpmd_config_F${cpu_family}_M${cpu_model}.xml"
+    [[ -f $candidate ]] && config_path=$candidate
+  fi
+
+  if [[ -z $config_path ]]; then
+    candidate="/etc/intel_lpmd/intel_lpmd_config.xml"
+    [[ -f $candidate ]] && config_path=$candidate
+  fi
+
+  printf '%s\n' "$config_path"
+}
+
+configure_lpmd_defaults() {
+  local config_path
+
+  config_path=$(lpmd_config_path)
+  [[ -n $config_path ]] || return 0
+
+  # Let intel-lpmd follow power-profiles-daemon directly.
+  sudo xmlstarlet ed -L \
+    -u "/Configuration/PerformanceDef" -v "-1" \
+    -u "/Configuration/BalancedDef" -v "0" \
+    -u "/Configuration/PowersaverDef" -v "1" \
+    "$config_path"
+}
+
 if omarchy-hw-intel && omarchy-battery-present; then
   cpu_model=$(grep -m1 "^model\s*:" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ')
-  if [[ "$cpu_model" =~ ^(151|154|170|172|183|186|189|191|204)$ ]]; then
+  if [[ $cpu_model =~ ^(151|154|170|172|183|186|189|191|204)$ ]]; then
     omarchy-pkg-add intel-lpmd
+    configure_lpmd_defaults
     sudo systemctl enable intel_lpmd.service
-    sudo tee /etc/sudoers.d/omarchy-intel-lpmd >/dev/null <<EOF
-$USER ALL=(root) NOPASSWD: /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_AUTO, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_OFF, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_ON
-EOF
-    sudo chmod 440 /etc/sudoers.d/omarchy-intel-lpmd
+    sudo rm -f /etc/sudoers.d/omarchy-intel-lpmd
   fi
 fi

--- a/install/config/hardware/intel/lpmd.sh
+++ b/install/config/hardware/intel/lpmd.sh
@@ -4,9 +4,8 @@
 
 if omarchy-hw-intel && omarchy-battery-present; then
   cpu_model=$(grep -m1 "^model\s*:" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ')
-  if [[ $cpu_model =~ ^(151|154|170|172|183|186|189|191|204)$ ]]; then
+  if [[ "$cpu_model" =~ ^(151|154|170|172|183|186|189|191|204)$ ]]; then
     omarchy-pkg-add intel-lpmd
     sudo systemctl enable intel_lpmd.service
-    sudo rm -f /etc/sudoers.d/omarchy-intel-lpmd
   fi
 fi

--- a/install/first-run/battery-monitor.sh
+++ b/install/first-run/battery-monitor.sh
@@ -1,8 +1,8 @@
 if omarchy-battery-present; then
-  powerprofilesctl set balanced || true
+  omarchy-powerprofiles-set battery || true
 
   # Enable battery monitoring timer for low battery notifications
   systemctl --user enable --now omarchy-battery-monitor.timer
 else
-  powerprofilesctl set performance || true
+  omarchy-powerprofiles-set ac || true
 fi

--- a/migrations/1776348229.sh
+++ b/migrations/1776348229.sh
@@ -1,8 +1,12 @@
-echo "Allow passwordless intel-lpmd power profile sync"
+echo "Configure intel-lpmd to follow power profile defaults directly"
 
 if pacman -Q intel-lpmd &>/dev/null; then
-  sudo tee /etc/sudoers.d/omarchy-intel-lpmd >/dev/null <<EOF
-$USER ALL=(root) NOPASSWD: /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_AUTO, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_OFF, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_ON
-EOF
-  sudo chmod 440 /etc/sudoers.d/omarchy-intel-lpmd
+  source "$OMARCHY_PATH/install/config/hardware/intel/lpmd.sh"
+
+  if omarchy-hw-intel && omarchy-battery-present; then
+    sudo systemctl restart intel_lpmd.service || sudo systemctl start intel_lpmd.service
+  fi
 fi
+
+source "$OMARCHY_PATH/install/config/hardware/intel/resume-boost.sh"
+sudo rm -f /etc/sudoers.d/omarchy-intel-lpmd

--- a/migrations/1776348229.sh
+++ b/migrations/1776348229.sh
@@ -1,0 +1,8 @@
+echo "Allow passwordless intel-lpmd power profile sync"
+
+if pacman -Q intel-lpmd &>/dev/null; then
+  sudo tee /etc/sudoers.d/omarchy-intel-lpmd >/dev/null <<EOF
+$USER ALL=(root) NOPASSWD: /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_AUTO, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_OFF, /usr/bin/busctl call org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd LPM_FORCE_ON
+EOF
+  sudo chmod 440 /etc/sudoers.d/omarchy-intel-lpmd
+fi

--- a/migrations/1776348229.sh
+++ b/migrations/1776348229.sh
@@ -1,12 +1,7 @@
-echo "Refresh intel-lpmd integration to use packaged profile defaults"
-
-if pacman -Q intel-lpmd &>/dev/null; then
-  sudo systemctl enable intel_lpmd.service
-
-  if omarchy-hw-intel && omarchy-battery-present; then
-    sudo systemctl restart intel_lpmd.service || sudo systemctl start intel_lpmd.service
-  fi
-fi
+echo "Refresh resume boost and restart intel-lpmd for packaged defaults"
 
 source "$OMARCHY_PATH/install/config/hardware/intel/resume-boost.sh"
-sudo rm -f /etc/sudoers.d/omarchy-intel-lpmd
+
+if pacman -Q intel-lpmd &>/dev/null && omarchy-hw-intel && omarchy-battery-present; then
+  sudo systemctl restart intel_lpmd.service || sudo systemctl start intel_lpmd.service
+fi

--- a/migrations/1776348229.sh
+++ b/migrations/1776348229.sh
@@ -1,7 +1,7 @@
-echo "Configure intel-lpmd to follow power profile defaults directly"
+echo "Refresh intel-lpmd integration to use packaged profile defaults"
 
 if pacman -Q intel-lpmd &>/dev/null; then
-  source "$OMARCHY_PATH/install/config/hardware/intel/lpmd.sh"
+  sudo systemctl enable intel_lpmd.service
 
   if omarchy-hw-intel && omarchy-battery-present; then
     sudo systemctl restart intel_lpmd.service || sudo systemctl start intel_lpmd.service


### PR DESCRIPTION
## Summary
- Route Omarchy-managed power profile changes through `omarchy-powerprofiles-set` instead of calling `powerprofilesctl` directly.
- Keep `intel-lpmd` synchronized with Omarchy power profile changes when `intel-lpmd` is installed and active.
- Extend that same synchronization to resume boost behavior and first-run default profile setup.
## Why
Omarchy already manages power profiles at several points:
- from the setup menu
- during first-run battery/AC initialization
- during temporary resume performance boosting
With `intel-lpmd` installed, changing the `power-profiles-daemon` profile alone is not enough. Omarchy also needs to keep `intel-lpmd` aligned with those profile transitions so the expected CPU-set behavior matches the selected mode.
This makes the three profile modes behave distinctly on supported Intel systems:
- `performance`:
  - full CPU set
  - `intel-lpmd` forced off
- `balanced`:
  - opportunistic low power mode
  - `intel-lpmd` auto
- `power-saver`:
  - strongest battery-saving mode
  - `intel-lpmd` forced on
On systems without `intel-lpmd`, Omarchy should continue to behave exactly as before.
## What Changed
- Updated `omarchy-menu` to call `omarchy-powerprofiles-set` instead of `powerprofilesctl set`
- Expanded `omarchy-powerprofiles-set` so it can:
  - accept `ac` / `battery` defaults
  - accept direct profile names
  - no-op safely when `intel-lpmd` is not installed or not active
- Updated first-run battery/AC setup to use `omarchy-powerprofiles-set`
- Updated the Intel `resume-boost` hook so the temporary resume performance boost and the later restore also keep `intel-lpmd` in sync
## Behavior
### Systems without `intel-lpmd`
- no functional change
- Omarchy still sets the appropriate `power-profiles-daemon` profile
### Systems with `intel-lpmd`
- `performance` maps to `LPM_FORCE_OFF`
- `balanced` maps to `LPM_AUTO`
- `power-saver` maps to `LPM_FORCE_ON`
## Boot / First-Run Behavior
Omarchy’s current default behavior remains:
- on AC:
  - prefer `performance`
- on battery:
  - prefer `balanced`
This PR ensures that when Omarchy sets those defaults, `intel-lpmd` is updated to the matching policy as well.
## Validation
### Manual checks
- switched between `performance`, `balanced`, and `power-saver`
- confirmed `intel_lpmd.service` remained active
- confirmed expected `system.slice` cpuset behavior on Panther Lake:
  - `performance` -> `0-15`
  - `balanced` -> opportunistic low-power cpuset when lightly loaded
  - `power-saver` -> `12-15`
### Resume behavior
- resume boost still temporarily switches to `performance`
- after the delay, the previous profile is restored
- `intel-lpmd` is restored to the matching mode along with the power profile
## Notes
- This PR only changes Omarchy runtime/profile orchestration.
- The matching Panther Lake `intel-lpmd` packaged config is handled in the companion `omarchy-pkgs` https://github.com/omacom-io/omarchy-pkgs/pull/79 