### PR TITLE
Fix headphone jack hotplug on MSI X370 ALC892 boards

### DIFF
--- a/bin/omarchy-hw-msi-x370-alc892
+++ b/bin/omarchy-hw-msi-x370-alc892
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Detect MSI X370 GAMING PLUS with the ALC892 codec that needs the jack-hotplug fix.
+
+[[ $(cat /sys/class/dmi/id/board_vendor 2>/dev/null) == "MSI" ]] || exit 1
+[[ $(cat /sys/class/dmi/id/board_name 2>/dev/null) == "X370 GAMING PLUS (MS-7A33)" ]] || exit 1
+
+for codec_file in /proc/asound/card*/codec*; do
+  [[ -f $codec_file ]] || continue
+  grep -q "Codec: Realtek ALC892" "$codec_file" 2>/dev/null &&
+    grep -q "Subsystem Id: 0x1462fa33" "$codec_file" 2>/dev/null && exit 0
+done
+
+exit 1

--- a/bin/omarchy-hw-msi-x370-gaming-plus
+++ b/bin/omarchy-hw-msi-x370-gaming-plus
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Detect the MSI X370 GAMING PLUS motherboard.
-
-[[ $(cat /sys/class/dmi/id/board_vendor 2>/dev/null) == "MSI" ]] &&
-  [[ $(cat /sys/class/dmi/id/board_name 2>/dev/null) == "X370 GAMING PLUS (MS-7A33)" ]]

--- a/bin/omarchy-hw-msi-x370-gaming-plus
+++ b/bin/omarchy-hw-msi-x370-gaming-plus
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Detect the MSI X370 GAMING PLUS motherboard.
+
+[[ $(cat /sys/class/dmi/id/board_vendor 2>/dev/null) == "MSI" ]] &&
+  [[ $(cat /sys/class/dmi/id/board_name 2>/dev/null) == "X370 GAMING PLUS (MS-7A33)" ]]

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -59,6 +59,8 @@ run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-audio-mixer.sh
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-mic.sh
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-z13-touchpad.sh
 
+run_logged $OMARCHY_INSTALL/config/hardware/msi/fix-alc892-jack-hotplug.sh
+
 run_logged $OMARCHY_INSTALL/config/hardware/framework/fix-f13-amd-audio-input.sh
 run_logged $OMARCHY_INSTALL/config/hardware/framework/qmk-hid.sh
 

--- a/install/config/hardware/msi/fix-alc892-jack-hotplug.sh
+++ b/install/config/hardware/msi/fix-alc892-jack-hotplug.sh
@@ -1,34 +1,18 @@
 # Fix flaky 3.5 mm jack hotplug on the MSI X370 GAMING PLUS with ALC892.
 # This hardware needs HDA powersave disabled for reliable jack detection.
 
-MATCHING_ALC892_CODEC=0
-for codec_file in /proc/asound/card*/codec*; do
-  [[ -f "$codec_file" ]] || continue
-
-  if grep -q "Codec: Realtek ALC892" "$codec_file" 2>/dev/null &&
-    grep -q "Subsystem Id: 0x1462fa33" "$codec_file" 2>/dev/null; then
-    MATCHING_ALC892_CODEC=1
-    break
-  fi
-done
-
-if omarchy-hw-msi-x370-gaming-plus && [[ "$MATCHING_ALC892_CODEC" -eq 1 ]]; then
+if omarchy-hw-msi-x370-alc892; then
   MODPROBE_FIX_PATH="/etc/modprobe.d/90-snd-hda-intel-jackfix.conf"
   MODPROBE_FIX_CONTENT="options snd_hda_intel power_save=0 power_save_controller=N"
 
   sudo mkdir -p /etc/modprobe.d
 
-  if [[ $(sudo cat "$MODPROBE_FIX_PATH" 2>/dev/null || true) != "$MODPROBE_FIX_CONTENT" ]]; then
+  if [[ $(cat "$MODPROBE_FIX_PATH" 2>/dev/null) != "$MODPROBE_FIX_CONTENT" ]]; then
     echo "$MODPROBE_FIX_CONTENT" | sudo tee "$MODPROBE_FIX_PATH" >/dev/null
   fi
 
-  if [[ -e /sys/module/snd_hda_intel/parameters/power_save ]] &&
-    [[ -e /sys/module/snd_hda_intel/parameters/power_save_controller ]]; then
-    sudo sh -c 'echo 0 > /sys/module/snd_hda_intel/parameters/power_save' || {
-      echo "Warning: could not update snd_hda_intel power_save at runtime; persistent config was written to $MODPROBE_FIX_PATH and a reboot may be required." >&2
-    }
-    sudo sh -c 'echo N > /sys/module/snd_hda_intel/parameters/power_save_controller' || {
-      echo "Warning: could not update snd_hda_intel power_save_controller at runtime; persistent config was written to $MODPROBE_FIX_PATH and a reboot may be required." >&2
-    }
+  if [[ -e /sys/module/snd_hda_intel/parameters/power_save ]]; then
+    sudo sh -c 'echo 0 > /sys/module/snd_hda_intel/parameters/power_save' 2>/dev/null || true
+    sudo sh -c 'echo N > /sys/module/snd_hda_intel/parameters/power_save_controller' 2>/dev/null || true
   fi
 fi

--- a/install/config/hardware/msi/fix-alc892-jack-hotplug.sh
+++ b/install/config/hardware/msi/fix-alc892-jack-hotplug.sh
@@ -1,0 +1,21 @@
+# Fix flaky 3.5 mm jack hotplug on the MSI X370 GAMING PLUS with ALC892.
+# This hardware needs HDA powersave disabled for reliable jack detection.
+
+if omarchy-hw-msi-x370-gaming-plus &&
+  grep -q "Codec: Realtek ALC892" /proc/asound/card*/codec* 2>/dev/null &&
+  grep -q "Subsystem Id: 0x1462fa33" /proc/asound/card*/codec* 2>/dev/null; then
+  MODPROBE_FIX_PATH="/etc/modprobe.d/90-snd-hda-intel-jackfix.conf"
+  MODPROBE_FIX_CONTENT="options snd_hda_intel power_save=0 power_save_controller=N"
+
+  sudo mkdir -p /etc/modprobe.d
+
+  if [[ $(sudo cat "$MODPROBE_FIX_PATH" 2>/dev/null || true) != "$MODPROBE_FIX_CONTENT" ]]; then
+    echo "$MODPROBE_FIX_CONTENT" | sudo tee "$MODPROBE_FIX_PATH" >/dev/null
+  fi
+
+  if [[ -e /sys/module/snd_hda_intel/parameters/power_save ]] &&
+    [[ -e /sys/module/snd_hda_intel/parameters/power_save_controller ]]; then
+    sudo sh -c 'echo 0 > /sys/module/snd_hda_intel/parameters/power_save'
+    sudo sh -c 'echo N > /sys/module/snd_hda_intel/parameters/power_save_controller'
+  fi
+fi

--- a/install/config/hardware/msi/fix-alc892-jack-hotplug.sh
+++ b/install/config/hardware/msi/fix-alc892-jack-hotplug.sh
@@ -1,9 +1,18 @@
 # Fix flaky 3.5 mm jack hotplug on the MSI X370 GAMING PLUS with ALC892.
 # This hardware needs HDA powersave disabled for reliable jack detection.
 
-if omarchy-hw-msi-x370-gaming-plus &&
-  grep -q "Codec: Realtek ALC892" /proc/asound/card*/codec* 2>/dev/null &&
-  grep -q "Subsystem Id: 0x1462fa33" /proc/asound/card*/codec* 2>/dev/null; then
+MATCHING_ALC892_CODEC=0
+for codec_file in /proc/asound/card*/codec*; do
+  [[ -f "$codec_file" ]] || continue
+
+  if grep -q "Codec: Realtek ALC892" "$codec_file" 2>/dev/null &&
+    grep -q "Subsystem Id: 0x1462fa33" "$codec_file" 2>/dev/null; then
+    MATCHING_ALC892_CODEC=1
+    break
+  fi
+done
+
+if omarchy-hw-msi-x370-gaming-plus && [[ "$MATCHING_ALC892_CODEC" -eq 1 ]]; then
   MODPROBE_FIX_PATH="/etc/modprobe.d/90-snd-hda-intel-jackfix.conf"
   MODPROBE_FIX_CONTENT="options snd_hda_intel power_save=0 power_save_controller=N"
 
@@ -15,7 +24,11 @@ if omarchy-hw-msi-x370-gaming-plus &&
 
   if [[ -e /sys/module/snd_hda_intel/parameters/power_save ]] &&
     [[ -e /sys/module/snd_hda_intel/parameters/power_save_controller ]]; then
-    sudo sh -c 'echo 0 > /sys/module/snd_hda_intel/parameters/power_save'
-    sudo sh -c 'echo N > /sys/module/snd_hda_intel/parameters/power_save_controller'
+    sudo sh -c 'echo 0 > /sys/module/snd_hda_intel/parameters/power_save' || {
+      echo "Warning: could not update snd_hda_intel power_save at runtime; persistent config was written to $MODPROBE_FIX_PATH and a reboot may be required." >&2
+    }
+    sudo sh -c 'echo N > /sys/module/snd_hda_intel/parameters/power_save_controller' || {
+      echo "Warning: could not update snd_hda_intel power_save_controller at runtime; persistent config was written to $MODPROBE_FIX_PATH and a reboot may be required." >&2
+    }
   fi
 fi

--- a/migrations/1778263200.sh
+++ b/migrations/1778263200.sh
@@ -1,0 +1,3 @@
+echo "Disable HDA powersave for MSI X370 GAMING PLUS boards with ALC892"
+
+source "$OMARCHY_PATH/install/config/hardware/msi/fix-alc892-jack-hotplug.sh"

--- a/migrations/1778263200.sh
+++ b/migrations/1778263200.sh
@@ -3,3 +3,7 @@ set -e
 echo "Disable HDA powersave for MSI X370 GAMING PLUS boards with ALC892"
 
 source "$OMARCHY_PATH/install/config/hardware/msi/fix-alc892-jack-hotplug.sh"
+
+if [[ -f /etc/modprobe.d/90-snd-hda-intel-jackfix.conf ]]; then
+  omarchy-state set reboot-required
+fi

--- a/migrations/1778263200.sh
+++ b/migrations/1778263200.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Disable HDA powersave for MSI X370 GAMING PLUS boards with ALC892"
 
 source "$OMARCHY_PATH/install/config/hardware/msi/fix-alc892-jack-hotplug.sh"


### PR DESCRIPTION
Closes #5334

## Summary
- add an exact-hardware detector for the MSI X370 GAMING PLUS with Realtek ALC892 subsystem id `0x1462fa33`
- apply an HDA powersave workaround only on that hardware
- ship a migration so existing installations receive the same fix and are prompted to reboot when the modprobe config is present

## Why
On this hardware, `snd_hda_intel` powersave makes 3.5 mm jack hotplug unreliable. Headphones only become available after restarting PipeWire/WirePlumber. Disabling `power_save` and `power_save_controller` restores stable jack detection on this exact board.

## Testing
- `bash -n bin/omarchy-hw-msi-x370-alc892`
- `bash -n install/config/hardware/msi/fix-alc892-jack-hotplug.sh`
- `bash -n migrations/1778263200.sh`
- `PATH=$PWD/bin:$PATH omarchy-hw-msi-x370-alc892`
- verified the fix is wired into `install/config/all.sh` and the migration sources the new hardware script
- retested after reboot on the affected machine and confirmed jack plug/unplug is detected without restarting PipeWire
