### PR TITLE
Enable Bluetooth A2DP auto-connect in WirePlumber

### DIFF
--- a/bin/omarchy-restart-pipewire
+++ b/bin/omarchy-restart-pipewire
@@ -2,5 +2,9 @@
 
 # Restart the PipeWire audio service to fix audio issues or apply new configuration.
 
-echo -e "Restarting pipewire audio service...\n"
-systemctl --user restart pipewire.service
+echo -e "Restarting PipeWire audio services...\n"
+systemctl --user restart wireplumber.service pipewire.service
+
+if systemctl --user --quiet is-active pipewire-pulse.service; then
+  systemctl --user restart pipewire-pulse.service
+fi

--- a/default/wireplumber/wireplumber.conf.d/bluetooth-a2dp-autoconnect.conf
+++ b/default/wireplumber/wireplumber.conf.d/bluetooth-a2dp-autoconnect.conf
@@ -1,0 +1,18 @@
+## Auto-connect A2DP playback/capture profiles on Bluetooth devices.
+## This helps speakers and receivers expose their audio profiles without
+## requiring manual PipeWire/WirePlumber recovery.
+
+monitor.bluez.rules = [
+  {
+    matches = [
+      {
+        device.name = "~bluez_card.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        bluez5.auto-connect = [ a2dp_sink a2dp_source ]
+      }
+    }
+  }
+]

--- a/migrations/1776346552.sh
+++ b/migrations/1776346552.sh
@@ -1,7 +1,14 @@
+set -e
+
 echo "Enable Bluetooth A2DP auto-connect in WirePlumber"
 
+destination=~/.config/wireplumber/wireplumber.conf.d/bluetooth-a2dp-autoconnect.conf
+
 mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
-cp $OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/bluetooth-a2dp-autoconnect.conf \
-  ~/.config/wireplumber/wireplumber.conf.d/
+
+if [[ ! -f "$destination" ]]; then
+  cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/bluetooth-a2dp-autoconnect.conf" \
+    "$destination"
+fi
 
 omarchy-restart-pipewire

--- a/migrations/1776346552.sh
+++ b/migrations/1776346552.sh
@@ -1,6 +1,7 @@
-# Turn on bluetooth by default
-chrootable_systemctl_enable bluetooth.service
+echo "Enable Bluetooth A2DP auto-connect in WirePlumber"
 
 mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
 cp $OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/bluetooth-a2dp-autoconnect.conf \
   ~/.config/wireplumber/wireplumber.conf.d/
+
+omarchy-restart-pipewire


### PR DESCRIPTION
## Summary
- add a default WirePlumber Bluetooth rule that auto-connects A2DP sink and source profiles
- install the rule for new systems from the existing Bluetooth hardware config step
- migrate existing installs and restart PipeWire so the rule applies immediately

## Why
Issue #1818 currently recommends a local workaround that sets `bluez5.auto-connect` in `monitor.bluez.properties`, forces `bluez5.roles = [ a2dp_source ]`, and disables `device.restore-profile` globally.

WirePlumber documents `bluez5.auto-connect` as a device property that should be applied through `monitor.bluez.rules`, and `device.restore-profile` as a global setting with default `true`.

This PR keeps the fix narrower: it only enables documented A2DP auto-connect on Bluetooth cards and avoids changing global profile restore behavior.

## Validation
- reproduced locally with a Bluetooth Echo Dot that connected but did not become an output device under stock Omarchy settings
- applied the same rule locally in `~/.config/wireplumber/wireplumber.conf.d/`
- confirmed the device started appearing and working as an output without manual audio recovery
- `bash -n install/config/hardware/bluetooth.sh`
- `bash -n migrations/1776346552.sh`

Fixes #1818