### PR TITLE
Add Default Apps setup menu

### DIFF
--- a/applications/hidden/hx.desktop
+++ b/applications/hidden/hx.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Helix
+Exec=xdg-terminal-exec --app-id=org.omarchy.hx -e hx %F
+TryExec=hx
+Type=Application
+Terminal=false
+NoDisplay=true
+Categories=Utility;TextEditor;Development;
+MimeType=text/plain;text/english;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;application/xml;text/xml;

--- a/applications/hidden/micro.desktop
+++ b/applications/hidden/micro.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Micro
+Exec=xdg-terminal-exec --app-id=org.omarchy.micro -e micro %F
+TryExec=micro
+Type=Application
+Terminal=false
+NoDisplay=true
+Categories=Utility;TextEditor;Development;
+MimeType=text/plain;text/english;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;application/xml;text/xml;

--- a/applications/hidden/nano.desktop
+++ b/applications/hidden/nano.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Nano
+Exec=xdg-terminal-exec --app-id=org.omarchy.nano -e nano %F
+TryExec=nano
+Type=Application
+Terminal=false
+NoDisplay=true
+Categories=Utility;TextEditor;Development;
+MimeType=text/plain;text/english;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;application/xml;text/xml;

--- a/applications/hidden/vim.desktop
+++ b/applications/hidden/vim.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Vim
+Exec=xdg-terminal-exec --app-id=org.omarchy.vim -e vim %F
+TryExec=vim
+Type=Application
+Terminal=false
+NoDisplay=true
+Categories=Utility;TextEditor;Development;
+MimeType=text/plain;text/english;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;application/xml;text/xml;

--- a/bin/omarchy-defaults
+++ b/bin/omarchy-defaults
@@ -1,0 +1,808 @@
+#!/bin/bash
+
+desktop_search_paths() {
+  echo "$HOME/.local/share/applications"
+  echo "$HOME/.nix-profile/share/applications"
+  echo "/usr/share/applications"
+}
+
+desktop_path() {
+  local desktop_id="$1"
+  local base
+
+  while IFS= read -r base; do
+    if [[ -f $base/$desktop_id ]]; then
+      echo "$base/$desktop_id"
+      return 0
+    fi
+  done < <(desktop_search_paths)
+
+  return 1
+}
+
+desktop_field() {
+  local desktop_id="$1"
+  local field="$2"
+  local path
+
+  path=$(desktop_path "$desktop_id") || return 1
+  sed -n "s/^$field=//p" "$path" | head -1
+}
+
+desktop_name() {
+  local desktop_id="$1"
+  local name
+
+  name=$(desktop_field "$desktop_id" "Name" 2>/dev/null) || true
+  echo "${name:-${desktop_id%.desktop}}"
+}
+
+desktop_has_mime() {
+  local desktop_id="$1"
+  local mime="$2"
+  local mimetypes
+
+  mimetypes=$(desktop_field "$desktop_id" "MimeType" 2>/dev/null) || return 1
+  [[ $mimetypes == *"$mime"* ]]
+}
+
+desktop_is_browser() {
+  local desktop_id="$1"
+  local categories mimetypes
+
+  categories=$(desktop_field "$desktop_id" "Categories" 2>/dev/null) || categories=""
+  mimetypes=$(desktop_field "$desktop_id" "MimeType" 2>/dev/null) || mimetypes=""
+
+  [[ $categories == *WebBrowser* || $mimetypes == *"x-scheme-handler/http"* ]]
+}
+
+desktop_ids() {
+  local base file
+  declare -A seen=()
+
+  while IFS= read -r base; do
+    [[ -d $base ]] || continue
+
+    for file in "$base"/*.desktop; do
+      [[ -f $file ]] || continue
+
+      if [[ -z ${seen[$(basename "$file")]:-} ]]; then
+        seen[$(basename "$file")]=1
+        echo "$(basename "$file")"
+      fi
+    done
+  done < <(desktop_search_paths)
+}
+
+role_primary_mime() {
+  case "$1" in
+  browser) echo "x-scheme-handler/http" ;;
+  filemanager) echo "inode/directory" ;;
+  mail) echo "x-scheme-handler/mailto" ;;
+  image) echo "image/png" ;;
+  pdf) echo "application/pdf" ;;
+  video) echo "video/mp4" ;;
+  audio) echo "audio/mpeg" ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+mime_registered_desktop_ids() {
+  local mime="$1"
+
+  command -v gio >/dev/null 2>&1 || return 1
+
+  gio mime "$mime" 2>/dev/null | awk '
+    /^Registered applications:/ { in_registered = 1; next }
+    /^Recommended applications:/ { in_registered = 0 }
+    in_registered {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+      sub(/;$/, "", $0)
+      if ($0 != "") {
+        print $0
+      }
+    }
+  '
+}
+
+role_default_value() {
+  case "$1" in
+  terminal) echo "Alacritty.desktop" ;;
+  shell) echo "/bin/bash" ;;
+  browser) echo "chromium.desktop" ;;
+  editor) echo "nvim" ;;
+  filemanager) echo "org.gnome.Nautilus.desktop" ;;
+  mail) echo "HEY.desktop" ;;
+  image) echo "imv.desktop" ;;
+  pdf) echo "org.gnome.Evince.desktop" ;;
+  video) echo "mpv.desktop" ;;
+  audio) echo "mpv.desktop" ;;
+  *)
+    echo "Unknown role: $1" >&2
+    return 1
+    ;;
+  esac
+}
+
+role_note_text() {
+  case "$1" in
+  shell) echo "requires relogin" ;;
+  *)
+    echo ""
+    ;;
+  esac
+}
+
+editor_specs() {
+  cat <<'EOF'
+nvim|Neovim|nvim.desktop|nvim
+code|VSCode|code.desktop|code
+cursor|Cursor|cursor.desktop,Cursor.desktop|cursor
+zed|Zed|dev.zed.Zed.desktop,zed.desktop|zed
+subl|Sublime Text|sublime_text.desktop|subl,sublime_text
+emacs|Emacs|emacsclient.desktop,emacs.desktop|emacsclient,emacs
+hx|Helix|hx.desktop|hx
+vim|Vim|vim.desktop|vim
+nano|Nano|nano.desktop|nano
+micro|Micro|micro.desktop|micro
+EOF
+}
+
+editor_spec_field() {
+  local key="$1"
+  local field_index="$2"
+  local line
+
+  line=$(editor_specs | awk -F'|' -v key="$key" '$1 == key { print $0 }') || true
+  [[ -n $line ]] || return 1
+  echo "$line" | cut -d'|' -f"$field_index"
+}
+
+editor_key_from_value() {
+  local value="$1"
+  local normalized="${value##*/}"
+  local key desktop_ids commands desktop_id command
+
+  normalized="${normalized%\"}"
+  normalized="${normalized#\"}"
+  normalized="${normalized%\'}"
+  normalized="${normalized#\'}"
+
+  while IFS='|' read -r key _ desktop_ids commands; do
+    if [[ $normalized == "$key" ]]; then
+      echo "$key"
+      return 0
+    fi
+
+    IFS=',' read -r -a command_list <<<"$commands"
+    for command in "${command_list[@]}"; do
+      if [[ $normalized == "$command" ]]; then
+        echo "$key"
+        return 0
+      fi
+    done
+
+    IFS=',' read -r -a desktop_list <<<"$desktop_ids"
+    for desktop_id in "${desktop_list[@]}"; do
+      if [[ $normalized == "$desktop_id" || $normalized == "${desktop_id%.desktop}" ]]; then
+        echo "$key"
+        return 0
+      fi
+    done
+  done < <(editor_specs)
+
+  echo "$normalized"
+}
+
+editor_desktop_id() {
+  local key="$1"
+  local desktop_ids desktop_id
+
+  desktop_ids=$(editor_spec_field "$key" 3) || return 1
+  IFS=',' read -r -a desktop_list <<<"$desktop_ids"
+
+  for desktop_id in "${desktop_list[@]}"; do
+    if desktop_path "$desktop_id" >/dev/null 2>&1; then
+      echo "$desktop_id"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+editor_command() {
+  local key="$1"
+  local commands command
+
+  commands=$(editor_spec_field "$key" 4) || return 1
+  IFS=',' read -r -a command_list <<<"$commands"
+
+  for command in "${command_list[@]}"; do
+    if command -v "$command" >/dev/null 2>&1; then
+      echo "$command"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+editor_label() {
+  local key="$1"
+  local label
+
+  label=$(editor_spec_field "$key" 2) || true
+  echo "${label:-$key}"
+}
+
+editor_is_terminal() {
+  case "$1" in
+  nvim | vim | nano | micro | hx | fresh) return 0 ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+role_mode_value() {
+  local role="$1"
+  local value="${2:-}"
+
+  case "$role" in
+  terminal | shell) echo "tui" ;;
+  editor)
+    if editor_is_terminal "$(editor_key_from_value "$value")"; then
+      echo "tui"
+    else
+      echo "gui"
+    fi
+    ;;
+  browser | filemanager | mail | image | pdf | video | audio) echo "gui" ;;
+  *)
+    echo "Unknown role: $role" >&2
+    return 1
+    ;;
+  esac
+}
+
+ensure_uwsm_default_file() {
+  mkdir -p "$HOME/.config/uwsm"
+
+  if [[ ! -f $HOME/.config/uwsm/default ]]; then
+    cat >"$HOME/.config/uwsm/default" <<'EOF'
+# Changes require a restart to take effect.
+
+export TERMINAL=xdg-terminal-exec
+export EDITOR=nvim
+EOF
+  fi
+}
+
+replace_export() {
+  local variable="$1"
+  local value="$2"
+  local file="$3"
+  local tmp
+
+  tmp=$(mktemp)
+
+  if [[ -f $file ]]; then
+    awk -v variable="$variable" -v value="$value" '
+      BEGIN { replaced = 0 }
+      $0 ~ "^export " variable "=" {
+        print "export " variable "=" value
+        replaced = 1
+        next
+      }
+      { print }
+      END {
+        if (!replaced) {
+          print "export " variable "=" value
+        }
+      }
+    ' "$file" >"$tmp"
+  else
+    printf '# Changes require a restart to take effect.\n\nexport %s=%s\n' "$variable" "$value" >"$tmp"
+  fi
+
+  mv "$tmp" "$file"
+}
+
+current_editor_value() {
+  local editor
+
+  editor=$(sed -n 's/^export EDITOR=//p' "$HOME/.config/uwsm/default" 2>/dev/null | tail -1) || true
+  [[ -n $editor ]] || editor="${EDITOR:-nvim}"
+  echo "$editor"
+}
+
+current_shell_value() {
+  getent passwd "$USER" | cut -d: -f7
+}
+
+current_terminal_value() {
+  local terminal
+
+  terminal=$(xdg-terminal-exec --print-id 2>/dev/null) || true
+
+  if [[ -z $terminal ]]; then
+    terminal=$(awk 'NF && $1 !~ /^#/' "$HOME/.config/xdg-terminals.list" 2>/dev/null | head -1) || true
+  fi
+
+  echo "$terminal"
+}
+
+role_current_value() {
+  local role="$1"
+
+  case "$role" in
+  terminal) current_terminal_value ;;
+  shell) current_shell_value ;;
+  browser) xdg-settings get default-web-browser 2>/dev/null ;;
+  editor) editor_key_from_value "$(current_editor_value)" ;;
+  editor-desktop) editor_desktop_id "$(editor_key_from_value "$(current_editor_value)")" ;;
+  filemanager) xdg-mime query default inode/directory 2>/dev/null ;;
+  mail) xdg-mime query default x-scheme-handler/mailto 2>/dev/null ;;
+  image) xdg-mime query default image/png 2>/dev/null ;;
+  pdf) xdg-mime query default application/pdf 2>/dev/null ;;
+  video) xdg-mime query default video/mp4 2>/dev/null ;;
+  audio) xdg-mime query default audio/mpeg 2>/dev/null ;;
+  *)
+    echo "Unknown role: $role" >&2
+    return 1
+    ;;
+  esac
+}
+
+role_value_label() {
+  local role="$1"
+  local value="$2"
+
+  case "$role" in
+  terminal | browser | filemanager | mail | image | pdf | video | audio) desktop_name "$value" ;;
+  shell)
+    case "${value##*/}" in
+    zsh) echo "Zsh" ;;
+    bash) echo "Bash" ;;
+    fish) echo "Fish" ;;
+    sh) echo "Sh" ;;
+    *) echo "${value##*/}" ;;
+    esac
+    ;;
+  editor) editor_label "$(editor_key_from_value "$value")" ;;
+  *)
+    echo "$value"
+    ;;
+  esac
+}
+
+list_terminal_candidates() {
+  local desktop_id
+
+  for desktop_id in Alacritty.desktop com.mitchellh.ghostty.desktop kitty.desktop; do
+    if desktop_path "$desktop_id" >/dev/null 2>&1; then
+      printf '%s|%s\n' "$desktop_id" "$(desktop_name "$desktop_id")"
+    fi
+  done
+}
+
+list_shell_candidates() {
+  local shell
+  local name
+  declare -A seen=()
+
+  while IFS= read -r shell; do
+    [[ -n $shell ]] || continue
+    [[ $shell == \#* ]] && continue
+    [[ $shell == */sh || $shell == *rbash || $shell == *git-shell || $shell == *systemd-home-fallback-shell ]] && continue
+
+    name="${shell##*/}"
+    [[ -n ${seen[$name]:-} ]] && continue
+
+    seen[$name]=1
+    printf '%s|%s\n' "$shell" "$(role_value_label shell "$shell")"
+  done </etc/shells
+}
+
+list_desktop_candidates_scan() {
+  local role="$1"
+  local desktop_id
+  local label
+  local mime
+  declare -A seen=()
+
+  mime=$(role_primary_mime "$role") || return 1
+
+  while IFS= read -r desktop_id; do
+    [[ -n $desktop_id ]] || continue
+    [[ -n ${seen[$desktop_id]:-} ]] && continue
+
+    desktop_has_mime "$desktop_id" "$mime" || continue
+
+    if [[ $role != "browser" && $role != "pdf" ]]; then
+      desktop_is_browser "$desktop_id" && continue
+    fi
+
+    seen[$desktop_id]=1
+    label=$(desktop_name "$desktop_id")
+    printf '%s|%s\n' "$desktop_id" "$label"
+  done < <(desktop_ids)
+}
+
+list_desktop_candidates() {
+  local role="$1"
+  local mime
+  local desktop_id
+  local label
+  declare -A seen=()
+
+  mime=$(role_primary_mime "$role") || {
+    echo "Unknown desktop role: $role" >&2
+    return 1
+  }
+
+  while IFS= read -r desktop_id; do
+    [[ -n $desktop_id ]] || continue
+    [[ -n ${seen[$desktop_id]:-} ]] && continue
+
+    if [[ $role != "browser" && $role != "pdf" ]]; then
+      desktop_is_browser "$desktop_id" && continue
+    fi
+
+    seen[$desktop_id]=1
+    label=$(desktop_name "$desktop_id")
+    printf '%s|%s\n' "$desktop_id" "$label"
+  done < <(mime_registered_desktop_ids "$mime")
+
+  if ((${#seen[@]} == 0)); then
+    list_desktop_candidates_scan "$role"
+  fi
+}
+
+list_editor_candidates() {
+  local key label
+
+  while IFS='|' read -r key label _ _; do
+    if editor_desktop_id "$key" >/dev/null 2>&1 && editor_command "$key" >/dev/null 2>&1; then
+      printf '%s|%s\n' "$key" "$label"
+    fi
+  done < <(editor_specs)
+}
+
+role_candidates() {
+  local role="$1"
+
+  case "$role" in
+  terminal) list_terminal_candidates ;;
+  shell) list_shell_candidates ;;
+  browser | filemanager | mail | image | pdf | video | audio) list_desktop_candidates "$role" ;;
+  editor) list_editor_candidates ;;
+  *)
+    echo "Unknown role: $role" >&2
+    return 1
+    ;;
+  esac
+}
+
+set_terminal_default() {
+  local desktop_id="$1"
+
+  mkdir -p "$HOME/.config"
+  cat >"$HOME/.config/xdg-terminals.list" <<EOF
+# Terminal emulator preference order for xdg-terminal-exec
+# The first found and valid terminal will be used
+$desktop_id
+EOF
+}
+
+set_editor_default() {
+  local key="$1"
+  local command desktop_id
+
+  command=$(editor_command "$key") || {
+    echo "Editor '$key' is not installed" >&2
+    return 1
+  }
+  desktop_id=$(editor_desktop_id "$key") || {
+    echo "Editor desktop entry for '$key' is not available" >&2
+    return 1
+  }
+
+  ensure_uwsm_default_file
+  replace_export "EDITOR" "$command" "$HOME/.config/uwsm/default"
+
+  xdg-mime default "$desktop_id" \
+    text/plain \
+    text/english \
+    text/x-makefile \
+    text/x-c++hdr \
+    text/x-c++src \
+    text/x-chdr \
+    text/x-csrc \
+    text/x-java \
+    text/x-moc \
+    text/x-pascal \
+    text/x-tcl \
+    text/x-tex \
+    application/x-shellscript \
+    text/x-c \
+    text/x-c++ \
+    application/xml \
+    text/xml
+}
+
+set_browser_default() {
+  local desktop_id="$1"
+
+  xdg-settings set default-web-browser "$desktop_id"
+  xdg-mime default "$desktop_id" text/html x-scheme-handler/http x-scheme-handler/https
+}
+
+set_filemanager_default() {
+  xdg-mime default "$1" inode/directory
+}
+
+set_mail_default() {
+  xdg-mime default "$1" x-scheme-handler/mailto
+}
+
+set_image_default() {
+  xdg-mime default "$1" image/png image/jpeg image/gif image/webp image/bmp image/tiff
+}
+
+set_pdf_default() {
+  xdg-mime default "$1" application/pdf
+}
+
+set_video_default() {
+  xdg-mime default "$1" \
+    video/mp4 \
+    video/x-msvideo \
+    video/x-matroska \
+    video/x-flv \
+    video/x-ms-wmv \
+    video/mpeg \
+    video/ogg \
+    video/webm \
+    video/quicktime \
+    video/3gpp \
+    video/3gpp2 \
+    video/x-ms-asf \
+    video/x-ogm+ogg \
+    video/x-theora+ogg \
+    application/ogg
+}
+
+set_audio_default() {
+  xdg-mime default "$1" \
+    audio/mpeg \
+    audio/mp4 \
+    audio/x-m4a \
+    audio/flac \
+    audio/ogg \
+    audio/opus \
+    audio/wav \
+    audio/x-wav \
+    audio/webm \
+    audio/aac \
+    audio/x-aac \
+    audio/x-mpegurl \
+    audio/x-scpls \
+    audio/m3u
+}
+
+apply_role_value() {
+  local role="$1"
+  local value="$2"
+
+  case "$role" in
+  terminal)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "Terminal desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_terminal_default "$value"
+    ;;
+  shell)
+    grep -qxF "$value" /etc/shells || {
+      echo "Shell '$value' is not listed in /etc/shells" >&2
+      return 1
+    }
+    chsh -s "$value"
+    ;;
+  browser)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "Browser desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_browser_default "$value"
+    ;;
+  editor)
+    set_editor_default "$value"
+    ;;
+  filemanager)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "File manager desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_filemanager_default "$value"
+    ;;
+  mail)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "Mail desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_mail_default "$value"
+    ;;
+  image)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "Image viewer desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_image_default "$value"
+    ;;
+  pdf)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "PDF viewer desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_pdf_default "$value"
+    ;;
+  video)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "Video player desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_video_default "$value"
+    ;;
+  audio)
+    desktop_path "$value" >/dev/null 2>&1 || {
+      echo "Audio player desktop entry '$value' is not installed" >&2
+      return 1
+    }
+    set_audio_default "$value"
+    ;;
+  *)
+    echo "Unknown role: $role" >&2
+    return 1
+    ;;
+  esac
+}
+
+desktop_launch_id() {
+  echo "${1%.desktop}"
+}
+
+open_role_value() {
+  local role="$1"
+  local value="${2:-}"
+  local key command
+
+  [[ -n $value ]] || value=$(role_current_value "$role")
+
+  case "$role" in
+  terminal)
+    setsid gtk-launch "$(desktop_launch_id "$value")"
+    ;;
+  shell)
+    setsid xdg-terminal-exec -e "$value"
+    ;;
+  editor)
+    key=$(editor_key_from_value "$value")
+    command=$(editor_command "$key") || {
+      echo "Editor '$key' is not installed" >&2
+      return 1
+    }
+
+    if editor_is_terminal "$key"; then
+      omarchy-launch-tui "$command"
+    else
+      setsid uwsm-app -- "$command"
+    fi
+    ;;
+  browser | filemanager | mail | image | pdf | video | audio)
+    setsid gtk-launch "$(desktop_launch_id "$value")"
+    ;;
+  *)
+    echo "Unknown role: $role" >&2
+    return 1
+    ;;
+  esac
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  omarchy-defaults current <role>
+  omarchy-defaults list <role>
+  omarchy-defaults label <role> <value>
+  omarchy-defaults apply <role> <value>
+  omarchy-defaults open <role> [value]
+  omarchy-defaults note <role>
+  omarchy-defaults mode <role> <value>
+  omarchy-defaults summary
+  omarchy-defaults export
+  omarchy-defaults doctor
+EOF
+}
+
+summary() {
+  local role current label
+
+  for role in terminal shell browser editor filemanager mail image pdf video audio; do
+    current=$(role_current_value "$role" 2>/dev/null) || current=""
+    if [[ -n $current ]]; then
+      label=$(role_value_label "$role" "$current")
+    else
+      label="Not set"
+    fi
+
+    printf '%s|%s|%s\n' "$role" "$current" "$label"
+  done
+}
+
+export_values() {
+  local role current
+
+  for role in terminal shell browser editor filemanager mail image pdf video audio; do
+    current=$(role_current_value "$role" 2>/dev/null) || current=""
+    printf '%s=%s\n' "$role" "$current"
+  done
+}
+
+doctor() {
+  local role current label note
+
+  for role in terminal shell browser editor filemanager mail image pdf video audio; do
+    current=$(role_current_value "$role" 2>/dev/null) || current=""
+    label="Not set"
+    [[ -n $current ]] && label=$(role_value_label "$role" "$current")
+    note=$(role_note_text "$role")
+
+    if [[ -n $note ]]; then
+      printf '%s: %s (%s)\n' "$role" "$label" "$note"
+    else
+      printf '%s: %s\n' "$role" "$label"
+    fi
+  done
+}
+
+case "${1:-}" in
+current)
+  role_current_value "${2:-}" || exit 1
+  ;;
+list)
+  role_candidates "${2:-}" || exit 1
+  ;;
+label)
+  role_value_label "${2:-}" "${3:-}" || exit 1
+  ;;
+apply)
+  apply_role_value "${2:-}" "${3:-}" || exit 1
+  ;;
+open)
+  open_role_value "${2:-}" "${3:-}" || exit 1
+  ;;
+note)
+  role_note_text "${2:-}" || exit 1
+  ;;
+mode)
+  role_mode_value "${2:-}" "${3:-}" || exit 1
+  ;;
+summary)
+  summary
+  ;;
+export)
+  export_values
+  ;;
+doctor)
+  doctor
+  ;;
+*)
+  usage
+  exit 1
+  ;;
+esac

--- a/bin/omarchy-install-terminal
+++ b/bin/omarchy-install-terminal
@@ -28,12 +28,7 @@ if omarchy-pkg-add $package; then
     cp $OMARCHY_PATH/applications/Alacritty.desktop ~/.local/share/applications/
   fi
 
-  # Update xdg-terminals.list to prioritize the proper terminal
-  cat >~/.config/xdg-terminals.list <<EOF
-# Terminal emulator preference order for xdg-terminal-exec
-# The first found and valid terminal will be used
-$desktop_id
-EOF
+  omarchy-defaults apply terminal "$desktop_id"
 else
   echo "Failed to install $package"
 fi

--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Launch the default editor as determined by $EDITOR (set via ~/.config/uwsm/default) (or nvim if missing).
+# Launch the default editor as determined by ~/.config/uwsm/default (or nvim if missing).
 # Starts suitable editors in a terminal window and otherwise as a regular application.
+
+[[ -f $HOME/.config/uwsm/default ]] && source "$HOME/.config/uwsm/default"
 
 omarchy-cmd-present "$EDITOR" || EDITOR=nvim
 

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -220,25 +220,30 @@ show_font_menu() {
 }
 
 show_setup_menu() {
-  local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
-  [[ -f ~/.config/hypr/bindings.conf ]] && options="$options\n  Keybindings"
-  [[ -f ~/.config/hypr/input.conf ]] && options="$options\n  Input"
-  options="$options\n󰱔  DNS\n  Security\n  Config"
+  local options
 
-  case $(menu "Setup" "$options") in
-  *Audio*) omarchy-launch-audio ;;
-  *Wifi*) omarchy-launch-wifi ;;
-  *Bluetooth*) omarchy-launch-bluetooth ;;
-  *Power*) show_setup_power_menu ;;
-  *System*) show_setup_system_menu ;;
-  *Monitors*) open_in_editor ~/.config/hypr/monitors.conf ;;
-  *Keybindings*) open_in_editor ~/.config/hypr/bindings.conf ;;
-  *Input*) open_in_editor ~/.config/hypr/input.conf ;;
-  *DNS*) present_terminal omarchy-setup-dns ;;
-  *Security*) show_setup_security_menu ;;
-  *Config*) show_setup_config_menu ;;
-  *) show_main_menu ;;
-  esac
+  while true; do
+    options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
+    [[ -f ~/.config/hypr/bindings.conf ]] && options="$options\n  Keybindings"
+    [[ -f ~/.config/hypr/input.conf ]] && options="$options\n  Input"
+    options="$options\n  Default Apps\n󰱔  DNS\n  Security\n  Config"
+
+    case $(menu "Setup" "$options") in
+    *Audio*) omarchy-launch-audio; return ;;
+    *Wifi*) omarchy-launch-wifi; return ;;
+    *Bluetooth*) omarchy-launch-bluetooth; return ;;
+    *Power*) show_setup_power_menu; return ;;
+    *System*) show_setup_system_menu; return ;;
+    *Monitors*) open_in_editor ~/.config/hypr/monitors.conf; return ;;
+    *Keybindings*) open_in_editor ~/.config/hypr/bindings.conf; return ;;
+    *Input*) open_in_editor ~/.config/hypr/input.conf; return ;;
+    *Default*) omarchy-setup-defaults && return ;;
+    *DNS*) present_terminal omarchy-setup-dns; return ;;
+    *Security*) show_setup_security_menu; return ;;
+    *Config*) show_setup_config_menu; return ;;
+    *) show_main_menu; return ;;
+    esac
+  done
 }
 
 show_setup_power_menu() {
@@ -260,7 +265,7 @@ show_setup_security_menu() {
 }
 
 show_setup_config_menu() {
-  case $(menu "Setup" "  Defaults\n  Hyprland\n  Hypridle\n  Hyprlock\n  Hyprsunset\n  Swayosd\n󰌧  Walker\n󰍜  Waybar\n󰞅  XCompose") in
+  case $(menu "Setup" "  UWSM Defaults\n  Hyprland\n  Hypridle\n  Hyprlock\n  Hyprsunset\n  Swayosd\n󰌧  Walker\n󰍜  Waybar\n󰞅  XCompose") in
   *Defaults*) open_in_editor ~/.config/uwsm/default ;;
   *Hyprland*) open_in_editor ~/.config/hypr/hyprland.conf ;;
   *Hypridle*) open_in_editor ~/.config/hypr/hypridle.conf && omarchy-restart-hypridle ;;
@@ -608,6 +613,7 @@ go_to_menu() {
   *background*) show_background_menu ;;
   *capture*) show_capture_menu ;;
   *style*) show_style_menu ;;
+  *defaults*) omarchy-setup-defaults ;;
   *theme*) show_theme_menu ;;
   *screenrecord*) show_screenrecord_menu ;;
   *setup*) show_setup_menu ;;

--- a/bin/omarchy-setup-defaults
+++ b/bin/omarchy-setup-defaults
@@ -1,0 +1,277 @@
+#!/bin/bash
+
+# Select Omarchy and XDG default applications using the themed Walker dmenu UI.
+
+export PATH="$HOME/.local/share/omarchy/bin:$PATH"
+
+SUMMARY_CACHE=""
+declare -A CANDIDATE_CACHE=()
+
+menu() {
+  local prompt="$1"
+  local options="$2"
+  local extra="${3:-}"
+  local preselect="${4:-}"
+  local index
+  local width
+  local longest
+
+  read -r -a args <<<"$extra"
+
+  if [[ $extra != *"--width"* ]]; then
+    longest=$(printf '%s\n%s\n' "$prompt" "$(echo -e "$options")" | awk 'length > max { max = length } END { print max + 0 }')
+    width=$((180 + longest * 8))
+    ((width < 300)) && width=300
+    ((width > 640)) && width=640
+    args+=("--width" "$width")
+  fi
+
+  if [[ -n $preselect ]]; then
+    index=$(echo -e "$options" | grep -nxF "$preselect" | cut -d: -f1)
+    if [[ -n $index ]]; then
+      args+=("-c" "$index")
+    fi
+  fi
+
+  echo -e "$options" | omarchy-launch-walker --dmenu --minheight 1 --maxheight 560 -p "$prompt…" "${args[@]}" 2>/dev/null
+}
+
+role_label() {
+  case "$1" in
+  terminal) echo "Terminal" ;;
+  shell) echo "Shell" ;;
+  browser) echo "Browser" ;;
+  editor) echo "Editor" ;;
+  filemanager) echo "File Manager" ;;
+  mail) echo "Mail App" ;;
+  image) echo "Image Viewer" ;;
+  pdf) echo "PDF Viewer" ;;
+  video) echo "Video Player" ;;
+  audio) echo "Audio Player" ;;
+  *)
+    echo "$1"
+    ;;
+  esac
+}
+
+role_icon() {
+  case "$1" in
+  terminal) echo "" ;;
+  shell) echo "" ;;
+  browser) echo "" ;;
+  editor) echo "" ;;
+  filemanager) echo "" ;;
+  mail) echo "" ;;
+  image) echo "" ;;
+  pdf) echo "" ;;
+  video) echo "" ;;
+  audio) echo "" ;;
+  *)
+    echo "•"
+    ;;
+  esac
+}
+
+normalize_role() {
+  case "${1,,}" in
+  terminal | terminals) echo "terminal" ;;
+  shell | shells) echo "shell" ;;
+  browser | browsers) echo "browser" ;;
+  editor | editors) echo "editor" ;;
+  filemanager | file-manager | filemanagers | files | folders) echo "filemanager" ;;
+  mail | mailapp | mail-app | mailto) echo "mail" ;;
+  image | images) echo "image" ;;
+  pdf | pdfs | document | documents) echo "pdf" ;;
+  video | videos) echo "video" ;;
+  audio) echo "audio" ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+role_prompt() {
+  local role="$1"
+  local note
+
+  note=$(omarchy-defaults note "$role")
+
+  if [[ -n $note ]]; then
+    echo "$(role_label "$role") · $note"
+  else
+    echo "$(role_label "$role")"
+  fi
+}
+
+invalidate_cache() {
+  SUMMARY_CACHE=""
+
+  if [[ -n ${1:-} ]]; then
+    unset "CANDIDATE_CACHE[$1]"
+  else
+    CANDIDATE_CACHE=()
+  fi
+}
+
+summary_lines() {
+  if [[ -z $SUMMARY_CACHE ]]; then
+    SUMMARY_CACHE=$(omarchy-defaults summary)
+  fi
+
+  printf '%s\n' "$SUMMARY_CACHE"
+}
+
+candidate_lines() {
+  local role="$1"
+
+  if [[ -z ${CANDIDATE_CACHE[$role]+x} ]]; then
+    CANDIDATE_CACHE[$role]=$(omarchy-defaults list "$role")
+  fi
+
+  printf '%s\n' "${CANDIDATE_CACHE[$role]}"
+}
+
+display_candidate_label() {
+  local role="$1"
+  local value="$2"
+  local label="$3"
+
+  printf '%s' "$label"
+}
+
+role_values_match() {
+  local role="$1"
+  local left="$2"
+  local right="$3"
+
+  case "$role" in
+  shell)
+    [[ ${left##*/} == "${right##*/}" ]]
+    ;;
+  *)
+    [[ $left == "$right" ]]
+    ;;
+  esac
+}
+
+notify_update() {
+  local title="$1"
+  local body="$2"
+
+  notify-send -u low "$title" "$body"
+}
+
+run_shell_command() {
+  local command="$1"
+  local title="$2"
+  local body="$3"
+
+  omarchy-launch-floating-terminal-with-presentation "$command"
+  notify_update "$title" "$body"
+}
+
+confirm() {
+  local prompt="$1"
+
+  [[ $(menu "$prompt" "  Confirm\n↩  Cancel" "" "  Confirm") == *Confirm* ]]
+}
+
+apply_role_value() {
+  local role="$1"
+  local value="$2"
+  local label
+
+  label=$(omarchy-defaults label "$role" "$value")
+
+  if [[ $role == "shell" ]]; then
+    if ! confirm "Change login shell to $label?"; then
+      return 1
+    fi
+
+    run_shell_command "omarchy-defaults apply shell $(printf '%q' "$value")" "Default shell" "Requested $label as the login shell"
+  else
+    omarchy-defaults apply "$role" "$value" || return 1
+    notify_update "Default updated" "$label is now used for $(role_label "$role")"
+  fi
+
+  invalidate_cache "$role"
+}
+
+show_role_menu() {
+  local role="$1"
+  local options=""
+  local current_value current_label selection selected_value selected_label line marker is_current
+  declare -A values=()
+
+  options=""
+  values=()
+
+  current_value=$(omarchy-defaults current "$role" 2>/dev/null) || current_value=""
+  current_label="Not set"
+  [[ -n $current_value ]] && current_label=$(omarchy-defaults label "$role" "$current_value")
+
+  while IFS='|' read -r selected_value selected_label; do
+    [[ -n $selected_value ]] || continue
+
+    is_current="false"
+    marker="○"
+    if role_values_match "$role" "$selected_value" "$current_value"; then
+      marker="●"
+      is_current="true"
+    fi
+
+    selected_label=$(display_candidate_label "$role" "$selected_value" "$selected_label")
+    line="$marker  $selected_label"
+    values["$line"]="$selected_value"
+    options+="$line\n"
+  done < <(candidate_lines "$role")
+
+  if [[ -z $options ]]; then
+    notify_update "Default Apps" "No installed options found for $(role_label "$role")"
+    return 1
+  fi
+
+  selection=$(menu "$(role_prompt "$role")" "${options%\\n}")
+
+  if [[ -z $selection || $selection == "CNCLD" ]]; then
+    return 1
+  fi
+
+  if role_values_match "$role" "${values[$selection]}" "$current_value"; then
+    return 0
+  fi
+
+  apply_role_value "$role" "${values[$selection]}"
+}
+
+show_main_menu() {
+  local role current label options=""
+  local selection
+  declare -A roles=()
+
+  while IFS='|' read -r role current label; do
+    selection="$(role_icon "$role")  $(printf '%-12s' "$(role_label "$role")")  $label"
+    roles["$selection"]="$role"
+    options+="$selection\n"
+  done < <(summary_lines)
+
+  selection=$(menu "Default Apps" "${options%\\n}")
+
+  if [[ -z $selection || $selection == "CNCLD" ]]; then
+    return 1
+  fi
+
+  show_role_menu "${roles[$selection]}"
+}
+
+if [[ -n ${1:-} ]]; then
+  role=$(normalize_role "$1") || {
+    echo "Unknown defaults role: $1" >&2
+    exit 1
+  }
+  show_role_menu "$role"
+  exit $?
+else
+  show_main_menu
+  exit $?
+fi

--- a/install/config/mimetypes.sh
+++ b/install/config/mimetypes.sh
@@ -2,59 +2,23 @@ omarchy-refresh-applications
 update-desktop-database ~/.local/share/applications
 
 # Open directories in file manager
-xdg-mime default org.gnome.Nautilus.desktop inode/directory
+omarchy-defaults apply filemanager org.gnome.Nautilus.desktop
 
 # Open all images with imv
-xdg-mime default imv.desktop image/png
-xdg-mime default imv.desktop image/jpeg
-xdg-mime default imv.desktop image/gif
-xdg-mime default imv.desktop image/webp
-xdg-mime default imv.desktop image/bmp
-xdg-mime default imv.desktop image/tiff
+omarchy-defaults apply image imv.desktop
 
 # Open PDFs with the Document Viewer
-xdg-mime default org.gnome.Evince.desktop application/pdf
+omarchy-defaults apply pdf org.gnome.Evince.desktop
 
 # Use Chromium as the default browser
-xdg-settings set default-web-browser chromium.desktop
-xdg-mime default chromium.desktop x-scheme-handler/http
-xdg-mime default chromium.desktop x-scheme-handler/https
+omarchy-defaults apply browser chromium.desktop
 
-# Open video files with mpv
-xdg-mime default mpv.desktop video/mp4
-xdg-mime default mpv.desktop video/x-msvideo
-xdg-mime default mpv.desktop video/x-matroska
-xdg-mime default mpv.desktop video/x-flv
-xdg-mime default mpv.desktop video/x-ms-wmv
-xdg-mime default mpv.desktop video/mpeg
-xdg-mime default mpv.desktop video/ogg
-xdg-mime default mpv.desktop video/webm
-xdg-mime default mpv.desktop video/quicktime
-xdg-mime default mpv.desktop video/3gpp
-xdg-mime default mpv.desktop video/3gpp2
-xdg-mime default mpv.desktop video/x-ms-asf
-xdg-mime default mpv.desktop video/x-ogm+ogg
-xdg-mime default mpv.desktop video/x-theora+ogg
-xdg-mime default mpv.desktop application/ogg
+# Open video and audio files with mpv
+omarchy-defaults apply video mpv.desktop
+omarchy-defaults apply audio mpv.desktop
 
 # Use Hey for mailto: links
-xdg-mime default HEY.desktop x-scheme-handler/mailto
+omarchy-defaults apply mail HEY.desktop
 
 # Open text files with nvim
-xdg-mime default nvim.desktop text/plain
-xdg-mime default nvim.desktop text/english
-xdg-mime default nvim.desktop text/x-makefile
-xdg-mime default nvim.desktop text/x-c++hdr
-xdg-mime default nvim.desktop text/x-c++src
-xdg-mime default nvim.desktop text/x-chdr
-xdg-mime default nvim.desktop text/x-csrc
-xdg-mime default nvim.desktop text/x-java
-xdg-mime default nvim.desktop text/x-moc
-xdg-mime default nvim.desktop text/x-pascal
-xdg-mime default nvim.desktop text/x-tcl
-xdg-mime default nvim.desktop text/x-tex
-xdg-mime default nvim.desktop application/x-shellscript
-xdg-mime default nvim.desktop text/x-c
-xdg-mime default nvim.desktop text/x-c++
-xdg-mime default nvim.desktop application/xml
-xdg-mime default nvim.desktop text/xml
+omarchy-defaults apply editor nvim

--- a/tests/defaults_test.sh
+++ b/tests/defaults_test.sh
@@ -1,0 +1,361 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ $expected != "$actual" ]]; then
+    fail "$message (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+
+  grep -Fqx "$pattern" "$file" || fail "$message"
+}
+
+create_stub_commands() {
+  mkdir -p "$TEST_BIN" "$HOME/.config/uwsm" "$HOME/.config" "$HOME/.local/share/applications"
+
+  cat >"$TEST_BIN/xdg-terminal-exec" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "--print-id" ]]; then
+  awk 'NF && $1 !~ /^#/' "$HOME/.config/xdg-terminals.list" | head -1
+  exit 0
+fi
+
+exit 1
+EOF
+
+  cat >"$TEST_BIN/xdg-settings" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+state_file="$HOME/.config/browser.default"
+
+case "${1:-}" in
+get)
+  cat "$state_file"
+  ;;
+set)
+  printf '%s\n' "$3" >"$state_file"
+  ;;
+*)
+  exit 1
+  ;;
+esac
+EOF
+
+  cat >"$TEST_BIN/xdg-mime" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+state_file="$HOME/.config/mimeapps.test"
+mkdir -p "$(dirname "$state_file")"
+touch "$state_file"
+
+case "${1:-}" in
+query)
+  mime="${3:-}"
+  awk -F= -v mime="$mime" '$1 == mime { print $2 }' "$state_file" | tail -1
+  ;;
+default)
+  desktop_id="$2"
+  shift 2
+  for mime in "$@"; do
+    awk -F= -v mime="$mime" '$1 != mime { print $0 }' "$state_file" >"$state_file.tmp"
+    mv "$state_file.tmp" "$state_file"
+    printf '%s=%s\n' "$mime" "$desktop_id" >>"$state_file"
+  done
+  ;;
+*)
+  exit 1
+  ;;
+esac
+EOF
+
+  cat >"$TEST_BIN/gio" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} != "mime" ]]; then
+  exit 1
+fi
+
+mime="${2:-}"
+default=""
+if [[ -f $HOME/.config/mimeapps.test ]]; then
+  default=$(awk -F= -v mime="$mime" '$1 == mime { print $2 }' "$HOME/.config/mimeapps.test" | tail -1)
+fi
+
+registered=()
+for file in "$HOME/.local/share/applications"/*.desktop; do
+  [[ -f $file ]] || continue
+  if sed -n 's/^MimeType=//p' "$file" | grep -q "$mime"; then
+    registered+=("$(basename "$file")")
+  fi
+done
+
+printf 'Default application for “%s”: %s\n' "$mime" "${default:-}"
+printf 'Registered applications:\n'
+for app in "${registered[@]}"; do
+  printf '\t%s\n' "$app"
+done
+printf 'Recommended applications:\n'
+for app in "${registered[@]}"; do
+  printf '\t%s\n' "$app"
+done
+EOF
+
+  cat >"$TEST_BIN/getent" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "passwd" ]]; then
+  printf 'tester:x:1000:1000::/home/tester:%s\n' "$(cat "$HOME/.config/login.shell")"
+  exit 0
+fi
+
+exit 1
+EOF
+
+  cat >"$TEST_BIN/chsh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$2" >"$HOME/.config/login.shell"
+printf '%s\n' "$*" >"$HOME/.config/chsh.log"
+EOF
+
+  cat >"$TEST_BIN/omarchy-cmd-present" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+command -v "$1" >/dev/null 2>&1
+EOF
+
+  cat >"$TEST_BIN/omarchy-launch-tui" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >"$HOME/.config/launch-editor.log"
+EOF
+
+  cat >"$TEST_BIN/setsid" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >"$HOME/.config/setsid.log"
+EOF
+
+  cat >"$TEST_BIN/gtk-launch" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >"$HOME/.config/gtk-launch.log"
+EOF
+
+  cat >"$TEST_BIN/hx" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+  cat >"$TEST_BIN/nvim" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+  chmod +x "$TEST_BIN"/*
+}
+
+create_desktop_file() {
+  local id="$1"
+  local name="$2"
+  local categories="$3"
+  local mimetypes="$4"
+
+  cat >"$HOME/.local/share/applications/$id" <<EOF
+[Desktop Entry]
+Name=$name
+Exec=${id%.desktop}
+TryExec=${id%.desktop}
+Type=Application
+Categories=$categories
+MimeType=$mimetypes
+EOF
+}
+
+setup_test_env() {
+  TEST_ROOT=$(mktemp -d)
+  export HOME="$TEST_ROOT/home"
+  export TEST_BIN="$TEST_ROOT/bin"
+  export USER="tester"
+  export OMARCHY_PATH="$REPO_ROOT"
+  export PATH="$TEST_BIN:/usr/bin:/bin"
+
+  mkdir -p "$HOME"
+
+  create_stub_commands
+
+  cat >"$HOME/.config/uwsm/default" <<'EOF'
+# Changes require a restart to take effect.
+export TERMINAL=xdg-terminal-exec
+export EDITOR=nvim
+EOF
+
+  cat >"$HOME/.config/xdg-terminals.list" <<'EOF'
+# Terminal emulator preference order for xdg-terminal-exec
+# The first found and valid terminal will be used
+Alacritty.desktop
+EOF
+
+  printf '/usr/bin/zsh\n' >"$HOME/.config/login.shell"
+  printf 'chromium.desktop\n' >"$HOME/.config/browser.default"
+
+  create_desktop_file "Alacritty.desktop" "Alacritty" "System;TerminalEmulator;" ""
+  create_desktop_file "kitty.desktop" "Kitty" "System;TerminalEmulator;" ""
+  create_desktop_file "chromium.desktop" "Chromium" "Network;WebBrowser;" "text/html;x-scheme-handler/http;x-scheme-handler/https;image/png;"
+  create_desktop_file "brave-browser.desktop" "Brave" "Network;WebBrowser;" "text/html;x-scheme-handler/http;x-scheme-handler/https;"
+  create_desktop_file "imv.desktop" "Image Viewer" "Graphics;Viewer;" "image/png;image/jpeg;image/gif;image/webp;image/bmp;image/tiff;"
+  create_desktop_file "mpv.desktop" "Media Player" "AudioVideo;Player;" "video/mp4;audio/mpeg;audio/flac;audio/wav;audio/ogg;audio/opus;audio/webm;"
+  create_desktop_file "nvim.desktop" "Neovim" "Utility;TextEditor;Development;" "text/plain;text/x-c;application/xml;text/xml;"
+  create_desktop_file "hx.desktop" "Helix" "Utility;TextEditor;Development;" "text/plain;text/x-c;application/xml;text/xml;"
+  create_desktop_file "org.gnome.Evince.desktop" "Document Viewer" "Office;Viewer;" "application/pdf;"
+  create_desktop_file "org.gnome.Nautilus.desktop" "Files" "System;FileManager;" "inode/directory;"
+  create_desktop_file "HEY.desktop" "HEY" "Network;" "x-scheme-handler/mailto;"
+}
+
+test_terminal_apply_updates_terminal_preference() {
+  "$REPO_ROOT/bin/omarchy-defaults" apply terminal kitty.desktop
+
+  assert_file_contains "$HOME/.config/xdg-terminals.list" "kitty.desktop" "terminal default should be persisted"
+  assert_equals "kitty.desktop" "$("$REPO_ROOT/bin/omarchy-defaults" current terminal)" "current terminal should come from xdg-terminal-exec"
+}
+
+test_editor_apply_updates_uwsm_default_and_text_mimes() {
+  "$REPO_ROOT/bin/omarchy-defaults" apply editor hx
+
+  assert_file_contains "$HOME/.config/uwsm/default" "export EDITOR=hx" "editor should be written to uwsm defaults"
+  assert_equals "hx.desktop" "$("$REPO_ROOT/bin/omarchy-defaults" current editor-desktop)" "editor desktop should resolve from configured editor"
+  assert_equals "hx.desktop" "$(xdg-mime query default text/plain)" "text/plain should follow selected editor"
+}
+
+test_browser_apply_updates_xdg_state() {
+  "$REPO_ROOT/bin/omarchy-defaults" apply browser brave-browser.desktop
+
+  assert_equals "brave-browser.desktop" "$(xdg-settings get default-web-browser)" "browser should be stored via xdg-settings"
+  assert_equals "brave-browser.desktop" "$(xdg-mime query default x-scheme-handler/http)" "http handler should follow selected browser"
+}
+
+test_pdf_apply_updates_pdf_mime() {
+  "$REPO_ROOT/bin/omarchy-defaults" apply pdf org.gnome.Evince.desktop
+
+  assert_equals "org.gnome.Evince.desktop" "$(xdg-mime query default application/pdf)" "application/pdf should follow selected viewer"
+  assert_equals "org.gnome.Evince.desktop" "$("$REPO_ROOT/bin/omarchy-defaults" current pdf)" "current pdf viewer should read back through xdg-mime"
+}
+
+test_filemanager_apply_updates_directory_mime() {
+  "$REPO_ROOT/bin/omarchy-defaults" apply filemanager org.gnome.Nautilus.desktop
+
+  assert_equals "org.gnome.Nautilus.desktop" "$(xdg-mime query default inode/directory)" "inode/directory should follow selected file manager"
+}
+
+test_mail_apply_updates_mailto_handler() {
+  "$REPO_ROOT/bin/omarchy-defaults" apply mail HEY.desktop
+
+  assert_equals "HEY.desktop" "$(xdg-mime query default x-scheme-handler/mailto)" "mailto handler should follow selected mail app"
+}
+
+test_image_candidates_exclude_browsers() {
+  local candidates
+  candidates=$("$REPO_ROOT/bin/omarchy-defaults" list image)
+
+  [[ $candidates == *"imv.desktop|Image Viewer"* ]] || fail "image candidates should include image viewer"
+  [[ $candidates != *"chromium.desktop|Chromium"* ]] || fail "image candidates should exclude browsers"
+}
+
+test_shell_candidates_exclude_sh() {
+  local candidates
+  candidates=$("$REPO_ROOT/bin/omarchy-defaults" list shell)
+
+  [[ $candidates != *"/bin/sh|Sh"* ]] || fail "shell candidates should exclude sh"
+  [[ $candidates == *"/bin/bash|Bash"* ]] || fail "shell candidates should include bash"
+}
+
+test_shell_apply_invokes_chsh() {
+  "$REPO_ROOT/bin/omarchy-defaults" apply shell /bin/bash
+
+  assert_equals "/bin/bash" "$(cat "$HOME/.config/login.shell")" "shell change should flow through chsh"
+}
+
+test_reset_all_restores_defaults() {
+  if "$REPO_ROOT/bin/omarchy-defaults" reset-all >/dev/null 2>&1; then
+    fail "reset-all should no longer be exposed"
+  fi
+}
+
+test_open_uses_expected_launcher() {
+  "$REPO_ROOT/bin/omarchy-defaults" open editor hx
+  assert_equals "hx" "$(cat "$HOME/.config/launch-editor.log")" "opening a TUI editor should use omarchy-launch-tui"
+
+  "$REPO_ROOT/bin/omarchy-defaults" open browser chromium.desktop
+  assert_equals "gtk-launch chromium" "$(cat "$HOME/.config/setsid.log")" "opening a browser should use gtk-launch via setsid"
+
+  "$REPO_ROOT/bin/omarchy-defaults" open terminal Alacritty.desktop
+  assert_equals "gtk-launch Alacritty" "$(cat "$HOME/.config/setsid.log")" "opening a terminal should use gtk-launch via setsid"
+}
+
+test_editor_mode_and_notes() {
+  assert_equals "tui" "$("$REPO_ROOT/bin/omarchy-defaults" mode editor hx)" "terminal editors should be marked as tui"
+  assert_equals "gui" "$("$REPO_ROOT/bin/omarchy-defaults" mode browser chromium.desktop)" "desktop apps should be marked as gui"
+  assert_equals "requires relogin" "$("$REPO_ROOT/bin/omarchy-defaults" note shell)" "shell should expose relogin note"
+  assert_equals "" "$("$REPO_ROOT/bin/omarchy-defaults" note pdf)" "pdf should not expose an extra note"
+}
+
+test_launch_editor_reads_latest_uwsm_default() {
+  cat >"$HOME/.config/uwsm/default" <<'EOF'
+export TERMINAL=xdg-terminal-exec
+export EDITOR=hx
+EOF
+
+  "$REPO_ROOT/bin/omarchy-launch-editor" README.md
+
+  assert_equals "hx README.md" "$(cat "$HOME/.config/launch-editor.log")" "launch editor should source uwsm defaults on every run"
+}
+
+main() {
+  setup_test_env
+
+  test_terminal_apply_updates_terminal_preference
+  test_editor_apply_updates_uwsm_default_and_text_mimes
+  test_browser_apply_updates_xdg_state
+  test_pdf_apply_updates_pdf_mime
+  test_filemanager_apply_updates_directory_mime
+  test_mail_apply_updates_mailto_handler
+  test_image_candidates_exclude_browsers
+  test_shell_candidates_exclude_sh
+  test_shell_apply_invokes_chsh
+  test_reset_all_restores_defaults
+  test_open_uses_expected_launcher
+  test_editor_mode_and_notes
+  test_launch_editor_reads_latest_uwsm_default
+
+  echo "defaults_test.sh: ok"
+}
+
+main "$@"

--- a/tests/menu_defaults_test.sh
+++ b/tests/menu_defaults_test.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ $expected != "$actual" ]]; then
+    fail "$message (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+
+  [[ $haystack != *"$needle"* ]] || fail "$message"
+}
+
+setup_env() {
+  TEST_ROOT=$(mktemp -d)
+  export HOME="$TEST_ROOT/home"
+  export TEST_BIN="$TEST_ROOT/bin"
+  export USER="tester"
+  export PATH="$TEST_BIN:/usr/bin:/bin"
+
+  mkdir -p "$HOME/.config/hypr" "$HOME/.config/omarchy/extensions" "$TEST_BIN"
+  : >"$TEST_ROOT/walker.responses"
+  : >"$TEST_ROOT/walker.calls"
+
+  cat >"$TEST_BIN/pgrep" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+
+  cat >"$TEST_BIN/omarchy-launch-walker" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+responses_file="${TEST_ROOT}/walker.responses"
+calls_file="${TEST_ROOT}/walker.calls"
+response=$(head -n 1 "$responses_file")
+tail -n +2 "$responses_file" >"$responses_file.tmp" || true
+mv "$responses_file.tmp" "$responses_file"
+printf '%s\n' "$*" >>"$calls_file"
+printf '%s\n' "$response"
+EOF
+
+  cat >"$TEST_BIN/omarchy-setup-defaults" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf 'defaults\n' >>"${TEST_ROOT}/events.log"
+exit 1
+EOF
+
+  cat >"$TEST_BIN/omarchy-launch-wifi" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf 'wifi\n' >>"${TEST_ROOT}/events.log"
+EOF
+
+  cat >"$TEST_BIN/omarchy-launch-floating-terminal-with-presentation" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf 'terminal:%s\n' "$*" >>"${TEST_ROOT}/events.log"
+EOF
+
+  cat >"$TEST_BIN/omarchy-defaults" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+case "${1:-}" in
+summary)
+  printf 'shell|/usr/bin/zsh|Zsh\n'
+  ;;
+list)
+  printf '/bin/bash|Bash\n/usr/bin/zsh|Zsh\n'
+  ;;
+current)
+  printf '/usr/bin/zsh\n'
+  ;;
+label)
+  case "${3:-}" in
+  /bin/bash) printf 'Bash\n' ;;
+  /usr/bin/zsh) printf 'Zsh\n' ;;
+  *) printf '%s\n' "${3:-}" ;;
+  esac
+  ;;
+note)
+  printf 'requires relogin\n'
+  ;;
+*)
+  exit 0
+  ;;
+esac
+EOF
+
+  cat >"$TEST_BIN/notify-send" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+  chmod +x "$TEST_BIN"/*
+  export TEST_ROOT
+}
+
+test_setup_defaults_returns_to_setup_menu() {
+  printf '  Default Apps\n  Wifi\n' >"$TEST_ROOT/walker.responses"
+
+  bash "$REPO_ROOT/bin/omarchy-menu" setup >/dev/null 2>&1 || true
+
+  assert_equals $'defaults\nwifi' "$(cat "$TEST_ROOT/events.log")" "defaults should return to setup menu and allow choosing another setup entry"
+  assert_equals "2" "$(wc -l <"$TEST_ROOT/walker.calls" | tr -d ' ')" "setup walker should open twice"
+}
+
+test_setup_direct_action_closes_without_reopening() {
+  : >"$TEST_ROOT/events.log"
+  : >"$TEST_ROOT/walker.calls"
+  printf '  Wifi\n' >"$TEST_ROOT/walker.responses"
+
+  bash "$REPO_ROOT/bin/omarchy-menu" setup >/dev/null 2>&1 || true
+
+  assert_equals "wifi" "$(cat "$TEST_ROOT/events.log")" "setup direct actions should execute once"
+  assert_equals "1" "$(wc -l <"$TEST_ROOT/walker.calls" | tr -d ' ')" "setup should close after a final direct action"
+}
+
+test_defaults_width_is_not_hardcoded_large() {
+  : >"$TEST_ROOT/walker.calls"
+  printf 'CNCLD\n' >"$TEST_ROOT/walker.responses"
+
+  bash "$REPO_ROOT/bin/omarchy-setup-defaults" >/dev/null 2>&1 || true
+
+  call=$(cat "$TEST_ROOT/walker.calls")
+  assert_not_contains "$call" "--width 680" "defaults menu should not hardcode width 680"
+  assert_not_contains "$call" "--width 620" "defaults role menu should not hardcode width 620"
+  assert_not_contains "$call" "--width 560" "defaults menu should not hardcode width 560"
+}
+
+test_defaults_applies_selection_and_exits() {
+  : >"$TEST_ROOT/walker.calls"
+  : >"$TEST_ROOT/apply.log"
+  printf '○  Brave\n' >"$TEST_ROOT/walker.responses"
+
+  cat >"$TEST_BIN/omarchy-defaults" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+case "${1:-}" in
+summary)
+  printf 'browser|chromium.desktop|Chromium\n'
+  ;;
+list)
+  printf 'chromium.desktop|Chromium\nbrave-browser.desktop|Brave\n'
+  ;;
+current)
+  printf 'chromium.desktop\n'
+  ;;
+label)
+  case "${3:-}" in
+  chromium.desktop) printf 'Chromium\n' ;;
+  brave-browser.desktop) printf 'Brave\n' ;;
+  *) printf '%s\n' "${3:-}" ;;
+  esac
+  ;;
+note)
+  printf 'via XDG\n'
+  ;;
+apply)
+  printf '%s|%s\n' "$2" "$3" >>"${TEST_ROOT}/apply.log"
+  ;;
+*)
+  exit 0
+  ;;
+esac
+EOF
+  chmod +x "$TEST_BIN/omarchy-defaults"
+
+  bash "$REPO_ROOT/bin/omarchy-setup-defaults" browser >/dev/null 2>&1 || true
+
+  assert_equals "browser|brave-browser.desktop" "$(cat "$TEST_ROOT/apply.log")" "selecting a candidate should apply immediately"
+  assert_equals "1" "$(wc -l <"$TEST_ROOT/walker.calls" | tr -d ' ')" "direct role picker should close after applying"
+}
+
+test_defaults_main_menu_applies_and_closes() {
+  : >"$TEST_ROOT/walker.calls"
+  : >"$TEST_ROOT/apply.log"
+  printf '  Browser       Chromium\n○  Brave\n' >"$TEST_ROOT/walker.responses"
+
+  cat >"$TEST_BIN/omarchy-defaults" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+case "${1:-}" in
+summary)
+  printf 'browser|chromium.desktop|Chromium\n'
+  ;;
+list)
+  printf 'chromium.desktop|Chromium\nbrave-browser.desktop|Brave\n'
+  ;;
+current)
+  printf 'chromium.desktop\n'
+  ;;
+label)
+  case "${3:-}" in
+  chromium.desktop) printf 'Chromium\n' ;;
+  brave-browser.desktop) printf 'Brave\n' ;;
+  *) printf '%s\n' "${3:-}" ;;
+  esac
+  ;;
+note)
+  exit 0
+  ;;
+apply)
+  printf '%s|%s\n' "$2" "$3" >>"${TEST_ROOT}/apply.log"
+  ;;
+*)
+  exit 0
+  ;;
+esac
+EOF
+  chmod +x "$TEST_BIN/omarchy-defaults"
+
+  bash "$REPO_ROOT/bin/omarchy-setup-defaults" >/dev/null 2>&1 || true
+
+  assert_equals "browser|brave-browser.desktop" "$(cat "$TEST_ROOT/apply.log")" "selecting from the main defaults menu should apply immediately"
+  assert_equals "2" "$(wc -l <"$TEST_ROOT/walker.calls" | tr -d ' ')" "defaults should close after applying instead of reopening the main menu"
+}
+
+test_nested_install_action_closes_without_reopening() {
+  : >"$TEST_ROOT/events.log"
+  : >"$TEST_ROOT/walker.calls"
+  printf '  Service\n󰟵  Bitwarden\n' >"$TEST_ROOT/walker.responses"
+
+  bash "$REPO_ROOT/bin/omarchy-menu" install >/dev/null 2>&1 || true
+
+  assert_equals "terminal:echo 'Installing Bitwarden...'; omarchy-pkg-add bitwarden bitwarden-cli && setsid gtk-launch bitwarden" "$(cat "$TEST_ROOT/events.log")" "nested final actions should run once"
+  assert_equals "2" "$(wc -l <"$TEST_ROOT/walker.calls" | tr -d ' ')" "nested menus should close after a final action"
+}
+
+main() {
+  setup_env
+  test_setup_defaults_returns_to_setup_menu
+  test_setup_direct_action_closes_without_reopening
+  test_defaults_width_is_not_hardcoded_large
+  test_defaults_applies_selection_and_exits
+  test_defaults_main_menu_applies_and_closes
+  test_nested_install_action_closes_without_reopening
+  echo "menu_defaults_test.sh: ok"
+}
+
+main "$@"


### PR DESCRIPTION
Summary
- add a new Setup > Default Apps flow for changing Omarchy and XDG default applications
- support terminal, shell, browser, editor, file manager, mail, image, PDF, video, and audio defaults
- reuse shared default handlers from install scripts, add terminal-editor desktop wrappers, and cover the menu flow with tests

Testing
- bash tests/defaults_test.sh
- bash tests/menu_defaults_test.sh
- bash -n bin/omarchy-defaults bin/omarchy-setup-defaults bin/omarchy-menu bin/omarchy-launch-editor bin/omarchy-install-terminal install/config/mimetypes.sh tests/defaults_test.sh tests/menu_defaults_test.sh