### PR TITLE
Clean up orphaned voxtype status processes on exit

### DIFF
--- a/bin/omarchy-voxtype-status
+++ b/bin/omarchy-voxtype-status
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap 'kill 0' EXIT
+
 if omarchy-cmd-present voxtype; then
   voxtype status --follow --extended --format json | while read -r line; do
     echo "$line" | jq -c '. + {alt: .class}'

--- a/bin/omarchy-voxtype-status
+++ b/bin/omarchy-voxtype-status
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Clean up the voxtype --follow child when Waybar reloads
 trap 'kill 0' EXIT
 
 if omarchy-cmd-present voxtype; then


### PR DESCRIPTION
## Summary

Waybar's `custom/voxtype` module runs `omarchy-voxtype-status`, which spawns a long-lived `voxtype status --follow` child. When Waybar reloads (config change, display hotplug, Hyprland reload), it kills the wrapper but the child survives as an orphan. Over time dozens accumulate.

Adds `trap 'kill 0' EXIT` to signal the entire process group when the wrapper exits, ensuring the voxtype status client is cleaned up. This matches the existing pattern in `omarchy-sudo-keepalive`.

Note: `kill 0` only signals the wrapper's own process group — the voxtype daemon runs in a separate process group and is not affected.

## Testing

- [x] Verified orphaned `voxtype status --follow` processes accumulate without the fix (4+ observed)
- [x] Applied fix, restarted Waybar — new processes cleaned up on subsequent restart
- [x] Old orphans (pre-fix) persisted as expected, killed manually, clean state confirmed
- [x] Voxtype daemon unaffected by the trap
- [x] Waybar voxtype widget continues to function after restart

## Evidence 

From my dual monitor config, where two followers are expected: 

<img width="1646" height="1660" alt="image" src="https://github.com/user-attachments/assets/6ce4fcd6-935d-4ebc-a86b-8409d8d613ff" />

