### PR TITLE
feat: add touchpad toggle keybinding and script

### DIFF
--- a/bin/omarchy-toggle-touchpad
+++ b/bin/omarchy-toggle-touchpad
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+STATE_FILE="/tmp/omarchy-touchpad-disabled"
+osdclient="swayosd-client --monitor $(omarchy-hyprland-monitor-focused)"
+
+device="$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')"
+
+if [[ -z $device ]]; then
+  echo "No touchpad device found" >&2
+  exit 1
+fi
+
+if [[ -f $STATE_FILE ]]; then
+  hyprctl keyword "device[$device]:enabled" true >/dev/null
+  rm "$STATE_FILE"
+  $osdclient --custom-icon input-touchpad-symbolic --custom-message "Enabled"
+else
+  hyprctl keyword "device[$device]:enabled" false >/dev/null
+  touch "$STATE_FILE"
+  $osdclient --custom-icon touchpad-disabled-symbolic --custom-message "Disabled"
+fi

--- a/bin/omarchy-toggle-touchpad
+++ b/bin/omarchy-toggle-touchpad
@@ -10,12 +10,20 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
-if [[ -f $STATE_FILE ]]; then
+enable() {
   hyprctl keyword "device[$device]:enabled" true >/dev/null
-  rm "$STATE_FILE"
+  rm -f "$STATE_FILE"
   $osdclient --custom-icon input-touchpad-symbolic --custom-message "Enabled"
-else
+}
+
+disable() {
   hyprctl keyword "device[$device]:enabled" false >/dev/null
   touch "$STATE_FILE"
   $osdclient --custom-icon touchpad-disabled-symbolic --custom-message "Disabled"
-fi
+}
+
+case "${1:-toggle}" in
+  on)     enable ;;
+  off)    disable ;;
+  toggle) [[ -f $STATE_FILE ]] && enable || disable ;;
+esac

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -11,6 +11,9 @@ bindeld = ,XF86MonBrightnessDown, Brightness down, exec, omarchy-brightness-disp
 bindeld = ,XF86KbdBrightnessUp, Keyboard brightness up, exec, omarchy-brightness-keyboard up
 bindeld = ,XF86KbdBrightnessDown, Keyboard brightness down, exec, omarchy-brightness-keyboard down
 bindld = ,XF86KbdLightOnOff, Keyboard backlight cycle, exec, omarchy-brightness-keyboard cycle
+bindld = ,XF86TouchpadToggle, Toggle touchpad, exec, omarchy-toggle-touchpad
+bindld = ,XF86TouchpadOn, Enable touchpad, exec, omarchy-toggle-touchpad
+bindld = ,XF86TouchpadOff, Disable touchpad, exec, omarchy-toggle-touchpad
 
 # Precise 1% multimedia adjustments with Alt modifier
 bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -12,8 +12,8 @@ bindeld = ,XF86KbdBrightnessUp, Keyboard brightness up, exec, omarchy-brightness
 bindeld = ,XF86KbdBrightnessDown, Keyboard brightness down, exec, omarchy-brightness-keyboard down
 bindld = ,XF86KbdLightOnOff, Keyboard backlight cycle, exec, omarchy-brightness-keyboard cycle
 bindld = ,XF86TouchpadToggle, Toggle touchpad, exec, omarchy-toggle-touchpad
-bindld = ,XF86TouchpadOn, Enable touchpad, exec, omarchy-toggle-touchpad
-bindld = ,XF86TouchpadOff, Disable touchpad, exec, omarchy-toggle-touchpad
+bindld = ,XF86TouchpadOn, Enable touchpad, exec, omarchy-toggle-touchpad on
+bindld = ,XF86TouchpadOff, Disable touchpad, exec, omarchy-toggle-touchpad off
 
 # Precise 1% multimedia adjustments with Alt modifier
 bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1


### PR DESCRIPTION
Adds support for the touchpad toggle function key found on most laptops, matching the existing pattern for volume, display brightness, and keyboard backlight.                             
                                                                                                                    
  ## Changes                                                                                                        
  - New `omarchy-toggle-touchpad` script that auto-detects the touchpad device                                      
    via `hyprctl devices`, toggles it with `hyprctl keyword device[...]:enabled`,                                   
    and shows OSD feedback through SwayOSD                                                                          
  - Binds `XF86TouchpadToggle`, `XF86TouchpadOn`, and `XF86TouchpadOff` in                                          
    `default/hypr/bindings/media.conf` to cover laptops that send any of the three key symbols 