### PR TITLE
feat: Add Touchpad toggle/on/off support

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -168,7 +168,13 @@ show_share_menu() {
 }
 
 show_toggle_menu() {
-  case $(menu "Toggle" "󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n󰛧  Laptop Display") in
+  local options="󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰍜  Top Bar\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n󰛧  Laptop Display"
+
+  if hyprctl devices -j 2>/dev/null | jq -e '[.mice[] | select(.name | test("touchpad|trackpad"; "i"))] | length > 0' >/dev/null; then
+    options="$options\n󰟸  Touchpad"
+  fi
+
+  case $(menu "Toggle" "$options") in
 
   *Screensaver*) omarchy-toggle-screensaver ;;
   *Nightlight*) omarchy-toggle-nightlight ;;
@@ -179,6 +185,7 @@ show_toggle_menu() {
   *Gaps*) omarchy-hyprland-window-gaps-toggle ;;
   *Scaling*) omarchy-hyprland-monitor-scaling-cycle ;;
   *Laptop*) omarchy-hyprland-monitor-internal-toggle ;;
+  *Touchpad*) omarchy-toggle-touchpad ;;
   *) back_to show_trigger_menu ;;
   esac
 }

--- a/bin/omarchy-toggle-touchpad
+++ b/bin/omarchy-toggle-touchpad
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-STATE_FILE="/tmp/omarchy-touchpad-disabled"
+STATE_CONF="$HOME/.local/state/omarchy/toggles/hypr/touchpad-disabled.conf"
 osdclient="swayosd-client --monitor $(omarchy-hyprland-monitor-focused)"
 
 device="$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')"
@@ -12,18 +12,19 @@ fi
 
 enable() {
   hyprctl keyword "device[$device]:enabled" true >/dev/null
-  rm -f "$STATE_FILE"
+  rm -f "$STATE_CONF"
   $osdclient --custom-icon input-touchpad-symbolic --custom-message "Enabled"
 }
 
 disable() {
   hyprctl keyword "device[$device]:enabled" false >/dev/null
-  touch "$STATE_FILE"
+  mkdir -p "$(dirname "$STATE_CONF")"
+  printf 'device {\n    name = %s\n    enabled = false\n}\n' "$device" > "$STATE_CONF"
   $osdclient --custom-icon touchpad-disabled-symbolic --custom-message "Disabled"
 }
 
 case "${1:-toggle}" in
   on)     enable ;;
   off)    disable ;;
-  toggle) [[ -f $STATE_FILE ]] && enable || disable ;;
+  toggle) [[ -f $STATE_CONF ]] && enable || disable ;;
 esac

--- a/bin/omarchy-toggle-touchpad
+++ b/bin/omarchy-toggle-touchpad
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+STATE_FILE="/tmp/omarchy-touchpad-disabled"
+osdclient="swayosd-client --monitor $(omarchy-hyprland-monitor-focused)"
+
+device="$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')"
+
+if [[ -z $device ]]; then
+  echo "No touchpad device found" >&2
+  exit 1
+fi
+
+if [[ -f $STATE_FILE ]]; then
+  hyprctl keyword "device[$device]:enabled" true >/dev/null
+  rm "$STATE_FILE"
+  $osdclient --custom-icon input-touchpad-symbolic --custom-message "Enabled"
+else
+  hyprctl keyword "device[$device]:enabled" false >/dev/null
+  touch "$STATE_FILE"
+  $osdclient --custom-icon touchpad-disabled-symbolic --custom-message "Disabled"
+fi

--- a/bin/omarchy-toggle-touchpad
+++ b/bin/omarchy-toggle-touchpad
@@ -10,12 +10,20 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
-if [[ -f $STATE_FILE ]]; then
+enable() {
   hyprctl keyword "device[$device]:enabled" true >/dev/null
-  rm "$STATE_FILE"
+  rm -f "$STATE_FILE"
   $osdclient --custom-icon input-touchpad-symbolic --custom-message "Enabled"
-else
+}
+
+disable() {
   hyprctl keyword "device[$device]:enabled" false >/dev/null
   touch "$STATE_FILE"
   $osdclient --custom-icon touchpad-disabled-symbolic --custom-message "Disabled"
-fi
+}
+
+case "${1:-toggle}" in
+  on)     enable ;;
+  off)    disable ;;
+  toggle) [[ -f $STATE_FILE ]] && enable || disable ;;
+esac

--- a/bin/omarchy-toggle-touchpad
+++ b/bin/omarchy-toggle-touchpad
@@ -26,5 +26,17 @@ disable() {
 case "${1:-toggle}" in
   on)     enable ;;
   off)    disable ;;
-  toggle) [[ -f $STATE_CONF ]] && enable || disable ;;
+  toggle)
+  if [[ -f $STATE_CONF ]]; then
+    enable || {
+      echo "enable failed" >&2
+      exit 1
+    }
+  else
+    disable || {
+      echo "disable failed" >&2
+      exit 1
+    }
+  fi
+  ;;
 esac

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -11,6 +11,9 @@ bindeld = ,XF86MonBrightnessDown, Brightness down, exec, omarchy-brightness-disp
 bindeld = ,XF86KbdBrightnessUp, Keyboard brightness up, exec, omarchy-brightness-keyboard up
 bindeld = ,XF86KbdBrightnessDown, Keyboard brightness down, exec, omarchy-brightness-keyboard down
 bindld = ,XF86KbdLightOnOff, Keyboard backlight cycle, exec, omarchy-brightness-keyboard cycle
+bindld = ,XF86TouchpadToggle, Toggle touchpad, exec, omarchy-toggle-touchpad
+bindld = ,XF86TouchpadOn, Enable touchpad, exec, omarchy-toggle-touchpad
+bindld = ,XF86TouchpadOff, Disable touchpad, exec, omarchy-toggle-touchpad
 
 # Precise 1% multimedia adjustments with Alt modifier
 bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -12,8 +12,8 @@ bindeld = ,XF86KbdBrightnessUp, Keyboard brightness up, exec, omarchy-brightness
 bindeld = ,XF86KbdBrightnessDown, Keyboard brightness down, exec, omarchy-brightness-keyboard down
 bindld = ,XF86KbdLightOnOff, Keyboard backlight cycle, exec, omarchy-brightness-keyboard cycle
 bindld = ,XF86TouchpadToggle, Toggle touchpad, exec, omarchy-toggle-touchpad
-bindld = ,XF86TouchpadOn, Enable touchpad, exec, omarchy-toggle-touchpad
-bindld = ,XF86TouchpadOff, Disable touchpad, exec, omarchy-toggle-touchpad
+bindld = ,XF86TouchpadOn, Enable touchpad, exec, omarchy-toggle-touchpad on
+bindld = ,XF86TouchpadOff, Disable touchpad, exec, omarchy-toggle-touchpad off
 
 # Precise 1% multimedia adjustments with Alt modifier
 bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, $osdclient --output-volume +1


### PR DESCRIPTION
Adds a omarchy-toggle-touchpad script and wires it up to hardware keys and the toggle menu.

changes:
- New bin/omarchy-toggle-touchpad script that enables/disables the touchpad via hyprctl, with OSD feedback via swayosd-client
- State is persisted as a Hyprland device config at `~/.local/state/omarchy/toggles/hypr/touchpad-disabled.conf`, so it survives reboots
- Hardware keys (XF86TouchpadToggle, XF86TouchpadOn, XF86TouchpadOff) are bound in media.conf, with On/Off enforce state rather than toggling, matching the key semantics
- Touchpad option is added to the toggle menu, but only shown when a touchpad/trackpad device is actually       
  detected