### PR TITLE
Add uvx wrapper installer mirroring npx for PyPI packages

### DIFF
--- a/bin/omarchy-uvx-install
+++ b/bin/omarchy-uvx-install
@@ -18,7 +18,7 @@ mkdir -p "$HOME/.local/bin"
 
 cat > "$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
-exec mise exec uv@latest -- uvx --from $package $command "\$@"
+exec mise exec uv@latest -- uvx --from $package@latest $command "\$@"
 EOF
 
 chmod +x "$HOME/.local/bin/$command"

--- a/bin/omarchy-uvx-install
+++ b/bin/omarchy-uvx-install
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Install a uvx wrapper for a given PyPI package.
+# Usage: omarchy-uvx-install <package> [command-name]
+#
+# If command-name is omitted, it defaults to the package name.
+# Example: omarchy-uvx-install mistral-vibe vibe
+
+if [[ -z $1 ]]; then
+  echo "Usage: omarchy-uvx-install <package> [command-name]"
+  exit 1
+fi
+
+package=$1
+command=${2:-$1}
+
+mkdir -p "$HOME/.local/bin"
+
+cat > "$HOME/.local/bin/$command" <<EOF
+#!/bin/bash
+exec mise exec uv@latest -- uvx --from $package $command "\$@"
+EOF
+
+chmod +x "$HOME/.local/bin/$command"

--- a/install/config/mise-work.sh
+++ b/install/config/mise-work.sh
@@ -24,4 +24,5 @@ if [[ -n ${OMARCHY_CHROOT_INSTALL:-} ]]; then
   mise use -g node@"$NODE_VERSION"
 else
   mise use -g node@latest
+  mise use -g uv@latest
 fi

--- a/install/packaging/all.sh
+++ b/install/packaging/all.sh
@@ -5,6 +5,7 @@ run_logged $OMARCHY_INSTALL/packaging/icons.sh
 run_logged $OMARCHY_INSTALL/packaging/webapps.sh
 run_logged $OMARCHY_INSTALL/packaging/tuis.sh
 run_logged $OMARCHY_INSTALL/packaging/npx.sh
+run_logged $OMARCHY_INSTALL/packaging/uvx.sh
 run_logged $OMARCHY_INSTALL/packaging/asus-rog.sh
 run_logged $OMARCHY_INSTALL/packaging/framework16.sh
 run_logged $OMARCHY_INSTALL/packaging/surface.sh

--- a/install/packaging/uvx.sh
+++ b/install/packaging/uvx.sh
@@ -1,0 +1,1 @@
+omarchy-uvx-install mistral-vibe vibe

--- a/migrations/1776496664.sh
+++ b/migrations/1776496664.sh
@@ -1,0 +1,3 @@
+echo "Install uvx wrappers for Python-based AI CLI tools"
+
+source "$OMARCHY_PATH/install/packaging/uvx.sh"

--- a/migrations/1776496664.sh
+++ b/migrations/1776496664.sh
@@ -1,3 +1,5 @@
-echo "Install uvx wrappers for Python-based AI CLI tools"
+echo "Install uv and uvx wrappers for Python-based AI CLI tools"
+
+mise use -g uv@latest
 
 source "$OMARCHY_PATH/install/packaging/uvx.sh"


### PR DESCRIPTION
## Summary

Mirrors the existing `omarchy-npx-install` mechanism for PyPI packages via `uvx`, enabling install-on-first-use for Python-based AI CLI tools that aren't distributed through npm.

The first wrapper registered is `mistral-vibe` (Mistral's terminal coding agent). Future Python agents can be added to `uvx.sh` the same way codex/gemini/copilot/pi are registered in `npx.sh`.

Since Omarchy already lazy-loads `@openai/codex` via npx, adopting `uvx` — now part of OpenAI's Codex team via the Astral acquisition — feels like a natural parallel.

## Design notes

- `uv` is managed through mise (`mise exec uv@latest`), consistent with the `node@latest` pattern used by npx wrappers and with Omarchy's general practice of managing language runtimes through mise rather than pacman. No change to `omarchy-base.packages`.
- Generated wrapper is symmetric with npx:
  - npx: \`exec mise exec node@latest -- npx --yes <pkg> "\$@"\`
  - uvx: \`exec mise exec uv@latest   -- uvx --from <pkg> <cmd> "\$@"\`
- Migration \`1776496664.sh\` creates the wrapper on existing installs.

## Test plan

- [x] \`omarchy-uvx-install mistral-vibe vibe\` produces a stub identical in structure to npx-generated stubs
- [x] Wrapper \`~/.local/bin/vibe\` launches Mistral vibe correctly on a live Omarchy install

---

**Update after review:** added `@latest` to uvx stubs for auto-update parity with npx. The npm registry sets `Cache-Control: max-age=300` on package metadata which gives npx a 5-minute TTL before re-checking for newer versions; uvx has no such behavior by default. Appending `@latest` in the package spec is uvx's native idiom for "always resolve latest at invocation time" (overhead ~240ms per call). Global `uv` install moved to `install/config/mise-work.sh` next to `node@latest` for architectural symmetry, and the migration runs `mise use -g uv@latest` explicitly for existing installs (mirrors `migrations/1761274806.sh` for `node@latest`).