### PR TITLE
Enable voxtype pause_media by default

### DIFF
--- a/default/voxtype/config.toml
+++ b/default/voxtype/config.toml
@@ -25,6 +25,9 @@ sample_rate = 16000
 # Maximum recording duration in seconds (safety limit)
 max_duration_secs = 60
 
+# Pause MPRIS media players during recording
+pause_media = true
+
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)
 # enabled = true

--- a/migrations/1776617403.sh
+++ b/migrations/1776617403.sh
@@ -1,0 +1,14 @@
+echo "Enable pause_media in voxtype config"
+
+VOXTYPE_CONF=~/.config/voxtype/config.toml
+
+if [[ -f $VOXTYPE_CONF ]] && ! grep -q 'pause_media' "$VOXTYPE_CONF"; then
+  if grep -q '^\[audio\]' "$VOXTYPE_CONF"; then
+    sed -i '/^\[audio\]/a\
+\
+# Pause MPRIS media players during recording\
+pause_media = true' "$VOXTYPE_CONF"
+  else
+    printf '\n[audio]\n# Pause MPRIS media players during recording\npause_media = true\n' >> "$VOXTYPE_CONF"
+  fi
+fi


### PR DESCRIPTION
## Summary

- Adds `pause_media = true` to the default voxtype config for new installs
- Adds a migration to enable it for existing users who don't already have the setting

When you toggle voxtype into recording mode, voxtype will now pause any MPRIS compatible music players (cliamp, etc).

## Motivation

Several Omarchy users have requested this feature: it was one of the most upvoted enhancement requests on the voxtype repo.  Also, @abenz1267  built a wrapper script to introduce this functionality for omarchy users. It was was shared in the Discord community, which validated the demand. 

This pull request makes the behavior built-in and active by default so media doesn't bleed into dictation recordings, and has the benefit of not requiring a statefile to be written to disk to control unpause behavior. 

Requires voxtype 0.6.6

Co-authored-by: @crmne
Co-authored-by: @abenz1267 
