### PR TITLE
Harden Resume Boost

### DIFF
--- a/default/systemd/system-sleep/resume-boost
+++ b/default/systemd/system-sleep/resume-boost
@@ -1,16 +1,52 @@
 #!/bin/bash
 
-# Temporarily switch to performance power profile on resume
-# to avoid sluggishness while the system catches up, then
-# restore the previous profile after 10 seconds.
+# Temporarily hold the performance power profile on resume
+# when waking from balanced mode to avoid sluggishness while
+# the system catches up without clobbering other user choices.
 
-if [[ $1 == "pre" ]]; then
-  mkdir -p /run/omarchy
-  powerprofilesctl get > /run/omarchy/power-profile-before-sleep
-fi
+log_warning() {
+  command -v logger &>/dev/null || return 0
+  logger -t resume-boost "$1"
+}
+
+profile_available() {
+  powerprofilesctl list 2>/dev/null | grep -Eq "^[*[:space:]]*${1}:"
+}
+
+start_resume_boost() {
+  local current_profile
+
+  command -v powerprofilesctl &>/dev/null || return 0
+  command -v systemd-run &>/dev/null || return 0
+
+  current_profile=$(powerprofilesctl get 2>/dev/null) || return 0
+
+  # power-profiles-daemon restores a released performance hold back to
+  # balanced, so only boost from the default balanced profile.
+  [[ $current_profile == "balanced" ]] || return 0
+
+  if ! powerprofilesctl launch --help &>/dev/null; then
+    log_warning "powerprofilesctl launch unavailable; skipping resume boost"
+    return 0
+  fi
+
+  if ! profile_available performance; then
+    log_warning "performance profile unavailable; skipping resume boost"
+    return 0
+  fi
+
+  systemd-run --quiet --collect --service-type=exec \
+    --description="Omarchy resume boost" \
+    powerprofilesctl launch \
+      --profile performance \
+      --reason "Temporary performance hold after resume" \
+      --appid "omarchy-resume-boost" \
+      /usr/bin/sleep 10
+}
 
 if [[ $1 == "post" ]]; then
-  previous=$(cat /run/omarchy/power-profile-before-sleep 2>/dev/null || echo "balanced")
-  powerprofilesctl set performance
-  systemd-run --on-active=10 --timer-property=AccuracySec=1 powerprofilesctl set "$previous"
+  start_resume_boost || {
+    log_warning "failed to start resume boost"
+    exit 1
+  }
 fi

--- a/default/systemd/system-sleep/resume-boost
+++ b/default/systemd/system-sleep/resume-boost
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Temporarily hold the performance power profile on resume
-# when waking from balanced mode to avoid sluggishness while
-# the system catches up without clobbering other user choices.
+# to avoid sluggishness while the system catches up.
 
 log_warning() {
   command -v logger &>/dev/null || return 0
@@ -21,9 +20,8 @@ start_resume_boost() {
 
   current_profile=$(powerprofilesctl get 2>/dev/null) || return 0
 
-  # power-profiles-daemon restores a released performance hold back to
-  # balanced, so only boost from the default balanced profile.
-  [[ $current_profile == "balanced" ]] || return 0
+  # No boost is needed when the system is already in performance mode.
+  [[ $current_profile == "performance" ]] && return 0
 
   if ! powerprofilesctl launch --help &>/dev/null; then
     log_warning "powerprofilesctl launch unavailable; skipping resume boost"

--- a/migrations/1776652728.sh
+++ b/migrations/1776652728.sh
@@ -1,0 +1,3 @@
+echo "Refresh the resume boost hook to use profile holds"
+
+source "$OMARCHY_PATH/install/config/hardware/intel/resume-boost.sh"


### PR DESCRIPTION
## Summary
- replace the resume hook's save-and-restore flow with a temporary `powerprofilesctl` performance hold after resume
- apply the resume boost for any non-`performance` profile so wake-up stays responsive without doing extra work when the system is already in `performance`
- add a migration that reinstalls the updated Intel resume hook on upgrade so existing systems pick up the new behavior
## Why
The previous resume hook saved the active power profile before suspend, switched to `performance` on wake, and restored the saved profile 10 seconds later. That approach was fragile across repeated suspend/resume cycles and could restore the wrong profile or leave the system in `performance` if the delayed restore path failed.
This change lets `power-profiles-daemon` manage the temporary resume override directly through a short-lived performance hold instead of Omarchy snapshotting and replaying profile state itself.
## Testing
- ran `bash -n default/systemd/system-sleep/resume-boost`
- ran the migration locally to reinstall the hook
- tested the installed hook directly from `balanced`, `power-saver`, and `performance`
- verified the D-Bus hold state through `net.hadess.PowerProfiles`
- tested overlapping resume-style invocations to confirm the system no longer gets stuck in `performance`
- tested a real suspend/resume cycle and verified the resume boost transient unit started and completed successfully