### PR TITLE
Non-US keyboard cycle monitor scaling keybinding

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -128,6 +128,6 @@ bindd = SUPER ALT, code:12, Switch to group window 3, changegroupactive, 3
 bindd = SUPER ALT, code:13, Switch to group window 4, changegroupactive, 4
 bindd = SUPER ALT, code:14, Switch to group window 5, changegroupactive, 5
 
-# Cycle monitor scaling
-bindd = SUPER, Slash, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle
-bindd = SUPER ALT, Slash, Cycle monitor scaling backwards, exec, omarchy-hyprland-monitor-scaling-cycle --reverse
+# Cycle monitor scaling with SUPER + /
+bindd = SUPER, code:61, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle
+bindd = SUPER ALT, code:61, Cycle monitor scaling backwards, exec, omarchy-hyprland-monitor-scaling-cycle --reverse


### PR DESCRIPTION
Use the code instead so the cycle monitor scaling keybinding works with non US English keyboard as well.