### PR TITLE
Fix omarchy-theme-install not lowercasing theme name

### DIFF
--- a/bin/omarchy-theme-install
+++ b/bin/omarchy-theme-install
@@ -15,7 +15,7 @@ if [[ -z $REPO_URL ]]; then
 fi
 
 THEMES_DIR="$HOME/.config/omarchy/themes"
-THEME_NAME=$(basename "$REPO_URL" .git | sed -E 's/^omarchy-//; s/-theme$//')
+THEME_NAME=$(basename "$REPO_URL" .git | sed -E 's/^omarchy-//; s/-theme$//' | tr '[:upper:]' '[:lower:]')
 THEME_PATH="$THEMES_DIR/$THEME_NAME"
 
 # Remove existing theme if present


### PR DESCRIPTION
Fixes #5250.

`omarchy-theme-set` normalizes theme names to lowercase before looking them up:

```bash
THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
```

`omarchy-theme-install` didn't do the same when deriving the name from the repo URL, so it cloned into a mixed-case directory that `theme-set` then couldn't find.

One pipe added to match the behaviour.