### PR TITLE
Create snapper configs during chroot install

### DIFF
--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -50,15 +50,13 @@ EOF
   # We overwrite the whole thing knowing the limine-update will add the entries for us
   sudo cp $OMARCHY_PATH/default/limine/limine.conf /boot/limine.conf
 
-  # Match Snapper configs if not installing from the ISO
-  if [[ -z ${OMARCHY_CHROOT_INSTALL:-} ]]; then
-    if ! sudo snapper list-configs 2>/dev/null | grep -q "root"; then
-      sudo snapper -c root create-config /
-    fi
+  # Ensure Snapper configs exist for both root and home
+  if ! sudo snapper list-configs 2>/dev/null | grep -q "root"; then
+    sudo snapper -c root create-config /
+  fi
 
-    if ! sudo snapper list-configs 2>/dev/null | grep -q "home"; then
-      sudo snapper -c home create-config /home
-    fi
+  if ! sudo snapper list-configs 2>/dev/null | grep -q "home"; then
+    sudo snapper -c home create-config /home
   fi
 
   # Enable quota to allow space-aware algorithms to work


### PR DESCRIPTION
The snapper config creation for root and home was guarded by a check
that skipped it during chroot installs. The sed commands that set
retention policy immediately after ran unconditionally and failed
silently when the configs didn't exist, leaving chroot installs with
no snapshot cleanup policy and unbounded snapshot growth.

Fixes #5344