### PR TITLE
Add subtle selected-row highlight to Walker

### DIFF
--- a/default/walker/themes/omarchy-default/style.css
+++ b/default/walker/themes/omarchy-default/style.css
@@ -116,5 +116,5 @@ child:selected .item-box * {
 }
 
 child:selected {
-  background: alpha(@text, .3);
+  background: alpha(@text, 0.3);
 }

--- a/default/walker/themes/omarchy-default/style.css
+++ b/default/walker/themes/omarchy-default/style.css
@@ -114,3 +114,7 @@ child:selected .item-box * {
 
 .preview {
 }
+
+child:selected {
+  background: alpha(@text, .3);
+}


### PR DESCRIPTION
## Summary
Adds a subtle, theme-aware background to the selected Walker result in the default Omarchy theme.

This makes the active item easier to pick out while keeping the highlight tied to the existing text color token and transparency.

<img width="1318" height="830" alt="image" src="https://github.com/user-attachments/assets/c34a815d-a7d2-42e7-a859-498bd24c1297" />

<img width="690" height="1310" alt="image" src="https://github.com/user-attachments/assets/559ac75b-b257-4ff8-b288-0270a992b020" />

<img width="1388" height="858" alt="image" src="https://github.com/user-attachments/assets/fad31019-ebb3-4c4d-b6cc-ea2e616186bc" />

<img width="2462" height="902" alt="image" src="https://github.com/user-attachments/assets/b5ae7c44-1db2-4c3c-a20b-be99dee813a4" />
