### PR TITLE
Persist workspace layout toggles

### DIFF
--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -2,6 +2,7 @@
 
 # Toggle the layout on the current active workspace between dwindle and scrolling
 
+LAYOUTS_CONF="$HOME/.local/state/omarchy/toggles/hypr/workspace-layouts.conf"
 ACTIVE_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
 CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
 
@@ -10,5 +11,11 @@ case "$CURRENT_LAYOUT" in
   *) NEW_LAYOUT=dwindle ;;
 esac
 
-hyprctl keyword workspace $ACTIVE_WORKSPACE, layout:$NEW_LAYOUT
+if [[ -f $LAYOUTS_CONF ]] && grep -q "^workspace = $ACTIVE_WORKSPACE," "$LAYOUTS_CONF"; then
+  sed -i "s/^workspace = $ACTIVE_WORKSPACE,.*/workspace = $ACTIVE_WORKSPACE, layout:$NEW_LAYOUT/" "$LAYOUTS_CONF"
+else
+  echo "workspace = $ACTIVE_WORKSPACE, layout:$NEW_LAYOUT" >> "$LAYOUTS_CONF"
+fi
+
+hyprctl reload
 notify-send -u low "󱂬    Workspace layout set to $NEW_LAYOUT"


### PR DESCRIPTION
## Summary
Persists the Hyprland workspace layout toggle through Omarchy's existing toggle config mechanism.

The previous implementation changed the active workspace layout with `hyprctl keyword`, which is runtime-only and gets reset by config reloads. The toggle now writes an explicit workspace layout rule to `~/.local/state/omarchy/toggles/hypr/workspace-layouts.conf` and reloads Hyprland, matching the persistent toggle pattern already used for window gaps and single-window aspect ratio.

This relies on the existing Omarchy toggle setup to create the toggle directory. The workspace layout file itself is created by the append path the first time a workspace layout is persisted, so the command does not need to run `mkdir -p` or `touch` on every layout change.

## Testing
- `bash -n bin/omarchy-hyprland-workspace-layout-toggle`
- `git diff --check origin/dev...HEAD`
- Verified toggling with no existing `workspace-layouts.conf` creates `workspace = <id>, layout:scrolling`
- Verified the persisted `scrolling` layout survives `hyprctl reload`
- Verified the persisted `scrolling` layout survives `omarchy-theme-set <current-theme>`
- Verified toggling the same workspace back updates the entry to `workspace = <id>, layout:dwindle`