### PR TITLE
Fix keyboard brightness at 0, 1, 25 and 100 percent.

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Adjust keyboard backlight brightness using available steps.
+# Adjust keyboard backlight brightness through fixed levels: 0, 1, 25, 100%.
 # Usage: omarchy-brightness-keyboard <up|down|cycle>
 
 direction="${1:-up}"
@@ -19,29 +19,43 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
-# Get current and max brightness to determine step size.
+# Get current and max brightness.
 max_brightness="$(brightnessctl -d "$device" max)"
 current_brightness="$(brightnessctl -d "$device" get)"
 
-# Calculate step as 10% of max brightness. Keyboards with many levels (e.g. 512)
-# need larger steps; keyboards with few levels (e.g. 3) fall back to step=1.
-step=$(( max_brightness / 10 ))
-(( step < 1 )) && step=1
+# Fixed brightness levels as percentages: 0, 1, 25, 100.
+level_percents=(0 1 25 100)
+levels=()
+for p in "${level_percents[@]}"; do
+  levels+=( $(( max_brightness * p / 100 )) )
+done
 
-if [[ $direction == "cycle" ]]; then
-  new_brightness=$(( current_brightness + step ))
-  (( new_brightness > max_brightness )) && new_brightness=0
-elif [[ $direction == "up" ]]; then
-  new_brightness=$(( current_brightness + step ))
-  (( new_brightness > max_brightness )) && new_brightness=$max_brightness
+# Find the index of the nearest level to current brightness.
+nearest_idx=0
+nearest_dist=$(( current_brightness < 0 ? -current_brightness : current_brightness ))
+for i in "${!levels[@]}"; do
+  dist=$(( current_brightness - levels[i] ))
+  (( dist < 0 )) && dist=$(( -dist ))
+  if (( dist < nearest_dist )); then
+    nearest_dist=$dist
+    nearest_idx=$i
+  fi
+done
+
+if [[ $direction == "cycle" ]] || [[ $direction == "up" ]]; then
+  next_idx=$(( nearest_idx + 1 ))
+  if (( next_idx >= ${#levels[@]} )); then
+    [[ $direction == "cycle" ]] && next_idx=0 || next_idx=$(( ${#levels[@]} - 1 ))
+  fi
 else
-  new_brightness=$(( current_brightness - step ))
-  (( new_brightness < 0 )) && new_brightness=0
+  next_idx=$(( nearest_idx - 1 ))
+  (( next_idx < 0 )) && next_idx=0
 fi
+
+new_brightness="${levels[$next_idx]}"
 
 # Set the new brightness.
 brightnessctl -d "$device" set "$new_brightness" >/dev/null
 
 # Use SwayOSD to display the new brightness setting.
-percent=$((new_brightness * 100 / max_brightness))
-omarchy-swayosd-kbd-brightness "$percent"
+omarchy-swayosd-kbd-brightness "${level_percents[$next_idx]}"

--- a/bin/omarchy-swayosd-kbd-brightness
+++ b/bin/omarchy-swayosd-kbd-brightness
@@ -5,10 +5,14 @@
 
 percent="$1"
 
-progress="$(awk -v p="$percent" 'BEGIN{printf "%.2f", p/100}')"
-[[ $progress == "0.00" ]] && progress="0.01"
+case "$percent" in
+  0)   label="OFF"    ;;
+  1)   label="LOW"    ;;
+  25)  label="MEDIUM" ;;
+  100) label="HIGH"   ;;
+  *)   label="${percent}%" ;;
+esac
 
 omarchy-swayosd-client \
   --custom-icon keyboard-brightness-symbolic \
-  --custom-progress "$progress" \
-  --custom-progress-text "${percent}%"
+  --custom-message "$label"


### PR DESCRIPTION
Fixes #5414 

This PR sets keyboard backlight keys to use the fixed values of 0, 1, 25, and 100 percent corresponding to **off**, **low**, **medium**, and **high**. 

Limiting the backlight settings to off, low, medium and high on my hardware provides a simplified and practical user experience to get an appropriate backlight level in fewer presses compared to steps of 10%. In addition, since the backlight strength is not linear, more discrete options do not add functionality (values of 50-100 are almost identical). 
I chose the values of 0, 1, 25 and 100 because these subjectively looked like equidistant levels of brightness across the range.

Because this PR only exposes keyboard backlight values of off, low, medium and high I replaced the 100% scale bar with a simple text display:

<img width="268" height="133" alt="image" src="https://github.com/user-attachments/assets/4a3c2d26-43c6-45aa-8e6b-5164efa44ea4" />

Tested on MacBook Air 2014. Testing on additional hardware is welcome (and desired).

```
┌──────────────────────Hardware──────────────────────┐
 PC: MacBook Air (11-inch, Mid 2013/Early 2014) (1.0)
│ ├: Intel(R) Core(TM) i5-4260U (4) @ 2.70 GHz
│ ├: Intel Haswell-ULT Integrated Graphics Controller @ 1.00 GHz [Integrated]
│ ├󱄄: 1366x768 in 12", 60 Hz [Built-in]
│ ├󰋊: 82.80 GiB / 231.74 GiB (36%) - btrfs
│ ├: 1.81 GiB / 3.76 GiB (48%)
└ └󰓡 : 424.20 MiB / 1.88 GiB (22%)
└────────────────────────────────────────────────────┘

┌──────────────────────Software──────────────────────┐
 OS: Omarchy 3.6.0
│ ├󰘬: master
│ ├󰔫: stable
│ ├: Linux 6.19.12-arch1-1
│ ├: Hyprland 0.54.3 (Wayland)
│ ├: ghostty 1.3.1-arch2
│ ├󰏖: 1188 (pacman)
│ ├󰸌: Kanagawa ●●●●●●●●
└ └: JetBrainsMono Nerd Font (9pt)
└────────────────────────────────────────────────────┘
```