### PR TITLE
feat: add omarchy-install-window-restore

### DIFF
--- a/bin/omarchy-install-window-restore
+++ b/bin/omarchy-install-window-restore
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Install Window Restore — save and restore closed windows with keybindings.
+# SUPER+W closes a window and saves it to history. SUPER+R restores the last closed window.
+# Supports both a relaunch mode (default) and a hide mode (preserves full window state).
+# Usually called via Install from the Omarchy Menu.
+
+echo "Installing Window Restore..."
+omarchy-pkg-aur-add omarchy-window-restore-git
+
+echo ""
+echo "Activating Window Restore..."
+/usr/bin/omarchy-install-window-restore


### PR DESCRIPTION
## What does this PR do?

Adds `omarchy-install-window-restore` — an installer script for **Window Restore**, a keybinding-based tool that saves closed windows to a history stack so they can be restored.

### How it works

- **`SUPER+W`** closes a window and saves it to history (instead of just `killactive`)
- **`SUPER+R`** restores the last closed window
- **`SUPER+SHIFT+R`** restores all closed windows at once
- **`SUPER+ALT+R`** opens a picker menu to choose which window to restore
- **`SUPER+CTRL+R`** opens a settings menu (mode, max windows, exclusions, etc.)
- **`SUPER+ALT+W`** closes permanently without saving (original killactive behavior)

### Two modes

| Mode | Description |
|---|---|
| **Relaunch** (default) | Kills the process, relaunches on restore — low memory usage |
| **Hide** | Moves window to invisible workspace, restores instantly with full state (YouTube keeps playing, tabs stay open) |

Switch between modes anytime via `SUPER+CTRL+R`.

### App support

Works for all app types: browsers, PWAs (Teams, ChatGPT, etc.), AppImages, editors, terminals. Excludes btop by default.

### Implementation

The feature is a separate AUR package to keep it opt-in:

- **GitHub:** https://github.com/TimHerb2005/omarchy-window-restore
- **AUR:** https://aur.archlinux.org/packages/omarchy-window-restore-git
- **Wiki / Docs:** https://github.com/TimHerb2005/omarchy-window-restore/wiki

The `omarchy-install-window-restore` script in this PR:
1. Installs the AUR package via `omarchy-pkg-aur-add`
2. Runs the package's activation step (adds keybindings to `bindings.conf`, installs scripts to `~/.local/bin/`, creates default config)

All keybindings are automatically visible in `SUPER+K` (keybinding menu) since they use `bindd` with descriptions.

## How to test

```bash
omarchy-install-window-restore
# then press SUPER+W to close a window, SUPER+R to restore it
```

## Checklist

- [x] Tested locally on Omarchy / Hyprland
- [x] Follows the same pattern as other `omarchy-install-*` scripts
- [x] Keybindings visible in SUPER+K
- [x] Fully reversible: `omarchy-uninstall-window-restore` removes everything