### PR TITLE
feat(hyprlock): implement a shutdown button for hyprlock

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -41,3 +41,14 @@ input-field {
 auth {
     fingerprint:enabled = false
 }
+label {
+    monitor =
+    text =  Shutdown
+    color = $font_color
+    font_size = 22
+    font_family = JetBrainsMono Nerd Font
+    position = 0, 50
+    halign = center
+    valign = bottom
+    onclick = systemctl poweroff
+}


### PR DESCRIPTION
added a shutdown widget to hyprlock config to avoid writing the password to shutdown the devcie