### PR TITLE
feat(hardware): sync ThinkBook mute LEDs with WirePlumber state

### DIFF
--- a/bin/omarchy-cmd-mic-mute
+++ b/bin/omarchy-cmd-mic-mute
@@ -6,6 +6,8 @@ if omarchy-hw-match "XPS"; then
   omarchy-cmd-mic-mute-xps
 elif omarchy-hw-match "ThinkPad"; then
   omarchy-cmd-mic-mute-thinkpad
+elif omarchy-hw-match "ThinkBook"; then
+  omarchy-cmd-mic-mute-thinkbook
 else
   omarchy-swayosd-client --input-volume mute-toggle
 fi

--- a/bin/omarchy-cmd-mic-mute-thinkbook
+++ b/bin/omarchy-cmd-mic-mute-thinkbook
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Toggle microphone mute on ThinkPad systems. Uses wpctl for reliable toggling
+# Toggle microphone mute on ThinkBook systems. Uses wpctl for reliable toggling
 # (swayosd-server on some systems does not propagate input-volume mute-toggle
 # to WirePlumber). Syncs the platform::micmute LED, then fires swayosd's native
 # input-volume OSD via +0 so the mic-level progress bar is preserved.

--- a/bin/omarchy-cmd-mute
+++ b/bin/omarchy-cmd-mute
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Toggle speaker mute with OSD. On ThinkBook systems, also syncs the
+# platform::mute hardware LED to match WirePlumber state.
+
+omarchy-swayosd-client --output-volume mute-toggle
+
+if omarchy-hw-match "ThinkBook"; then
+  if pactl get-sink-mute @DEFAULT_SINK@ | grep -q 'yes'; then
+    led_value=1
+  else
+    led_value=0
+  fi
+  brightnessctl --device="platform::mute" set "$led_value" >/dev/null 2>&1 || true
+fi

--- a/bin/omarchy-hw-thinkbook
+++ b/bin/omarchy-hw-thinkbook
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Detect Lenovo ThinkBook hardware via DMI product_family.
+# Usage: omarchy-hw-thinkbook (returns exit 0 if ThinkBook, non-zero otherwise)
+
+omarchy-hw-match "ThinkBook"

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -1,7 +1,7 @@
 # Laptop multimedia keys for volume and LCD brightness (with OSD)
 bindeld = ,XF86AudioRaiseVolume, Volume up, exec, omarchy-swayosd-client --output-volume raise
 bindeld = ,XF86AudioLowerVolume, Volume down, exec, omarchy-swayosd-client --output-volume lower
-bindeld = ,XF86AudioMute, Mute, exec, omarchy-swayosd-client --output-volume mute-toggle
+bindeld = ,XF86AudioMute, Mute, exec, omarchy-cmd-mute
 bindeld = ,XF86AudioMicMute, Mute microphone, exec, omarchy-cmd-mic-mute
 bindeld = ,XF86MonBrightnessUp, Brightness up, exec, omarchy-brightness-display +5%
 bindeld = ,XF86MonBrightnessDown, Brightness down, exec, omarchy-brightness-display 5%-

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -57,6 +57,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 
+run_logged $OMARCHY_INSTALL/config/hardware/lenovo/fix-thinkbook-led-permissions.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh

--- a/install/config/hardware/lenovo/fix-thinkbook-led-permissions.sh
+++ b/install/config/hardware/lenovo/fix-thinkbook-led-permissions.sh
@@ -1,0 +1,14 @@
+# Grant users in the video group write access to the ThinkBook platform mute LEDs.
+# Without this, only root can update platform::mute and platform::micmute,
+# so keybinding scripts cannot sync the hardware LED to WirePlumber state.
+
+if omarchy-hw-match "ThinkBook"; then
+  sudo tee /etc/udev/rules.d/99-lenovo-thinkbook-leds.rules << 'EOF'
+# Allow users in the video group to control ThinkBook platform mute LEDs
+SUBSYSTEM=="leds", KERNEL=="platform::mute",    ACTION=="add|change", RUN+="/usr/bin/chgrp video /sys%p/brightness", RUN+="/usr/bin/chmod 0664 /sys%p/brightness"
+SUBSYSTEM=="leds", KERNEL=="platform::micmute", ACTION=="add|change", RUN+="/usr/bin/chgrp video /sys%p/brightness", RUN+="/usr/bin/chmod 0664 /sys%p/brightness"
+EOF
+
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --subsystem-match=leds
+fi

--- a/migrations/1777020424.sh
+++ b/migrations/1777020424.sh
@@ -1,0 +1,14 @@
+echo "Sync ThinkBook hardware mute LEDs with WirePlumber state"
+
+# Install udev rule so users in the video group can write to the platform mute LED nodes.
+# On ThinkBook laptops, the kernel exposes platform::mute and platform::micmute
+# under /sys/class/leds/ with root-only write permissions by default.
+if omarchy-hw-match "ThinkBook"; then
+  sudo tee /etc/udev/rules.d/99-lenovo-thinkbook-leds.rules > /dev/null << 'EOF'
+# Allow users in the video group to control ThinkBook platform mute LEDs
+SUBSYSTEM=="leds", KERNEL=="platform::mute",    ACTION=="add|change", RUN+="/usr/bin/chgrp video /sys%p/brightness", RUN+="/usr/bin/chmod 0664 /sys%p/brightness"
+SUBSYSTEM=="leds", KERNEL=="platform::micmute", ACTION=="add|change", RUN+="/usr/bin/chgrp video /sys%p/brightness", RUN+="/usr/bin/chmod 0664 /sys%p/brightness"
+EOF
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --subsystem-match=leds
+fi


### PR DESCRIPTION
## Description

This PR bridges the gap between WirePlumber's software audio state and the physical hardware LEDs (`platform::mute` and `platform::micmute`) on Lenovo ThinkBook laptops, ensuring that pressing the hardware mute keys accurately toggles the built-in LED indicators. 

Previously, ThinkBook users fell through to the generic mute path, resulting in no LED feedback, and the generic swayosd implementation had some limitations regarding accurate visual feedback on mute states.

### What's Changed

* **ThinkBook Hardware LED Support**: 
  * Added a `udev` rule (`99-lenovo-thinkbook-leds.rules`) to grant users in the `video` group write permissions (`0664`) to the `/sys/class/leds/platform::mute` and `platform::micmute` brightness nodes.
  * Added `omarchy-hw-thinkbook` hardware detection script (matching via DMI `product_family`).
  * Created `omarchy-cmd-mic-mute-thinkbook` to intercept mic mute events and accurately sync the `platform::micmute` LED.
  * Wrapped the global speaker mute (`XF86AudioMute`) via `omarchy-cmd-mute` to sync the `platform::mute` LED for ThinkBooks (acts as a safe no-op on other hardware).
* **SwayOSD Mic Level Bar Fix (ThinkBook & ThinkPad)**: 
  * Fixed an issue where the native `swayosd` mic-level progress bar was lost during toggling.
  * Migrated the ThinkPad and ThinkBook mic mute scripts to use `wpctl` for reliable, synchronous muting, while triggering `omarchy-swayosd-client --input-volume +0`. This preserves the native OSD mic-level bar while accurately updating the LED and audio state.
* **Migration Script**: Added a migration script (`1777020424.sh`) so existing ThinkBook users receive the necessary `udev` rules without needing a clean install.

### Motivation and Context
Without this change, ThinkBook users receive no physical LED feedback when muting their microphone or speakers. Additionally, it resolves a visual regression in the OSD where custom icons were replacing the native SwayOSD volume progress bars for microphone muting on ThinkPads.

### Verification
- [x] Verified `udev` rule correctly applies `0664` permissions and `video` group ownership to `platform::mute` and `platform::micmute`.
- [x] Verified `omarchy-hw-match "ThinkBook"` correctly identifies hardware.
- [x] Tested mic mute (`Fn+F1`) successfully toggles WirePlumber state, syncs the LED, and triggers the SwayOSD native level bar.
- [x] Tested speaker mute (`Fn+F4`) successfully toggles WirePlumber state, syncs the LED, and triggers the SwayOSD popup.
- [x] Verified existing ThinkPad logic remains intact while gaining the SwayOSD native level bar fix.