### PR TITLE
Add libnm dependency for chromium DRM compatibility

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -68,6 +68,7 @@ kvantum-qt5
 lazydocker
 lazygit
 less
+libnm
 libsecret
 libyaml
 libqalculate


### PR DESCRIPTION
_Include libnm to resolve issues with Widevine/DRM playback in Chromium-based browsers. This ensures that media streaming services function correctly regardless of the system's actual network manager._

This PR adds libnm to the default package list. While many minimalist installations might opt for alternative network managers (such as iwd or systemd-networkd), the chromium package and its derivatives on Arch Linux are compiled with a hard dependency on libnm for specific functionalities.

Most notably, the Widevine Content Decryption Module (CDM)—used by platforms like Netflix, Spotify, and Disney+—requires the presence of libnm to correctly initialize the network stack and verify device integrity. Without this library, users encounter playback errors on encrypted streams, despite having a functional internet connection. Including libnm ensures seamless multimedia compatibility without requiring the full NetworkManager daemon to be active.