### PR TITLE
Add support for updating the RGB color of Razer devices

### DIFF
--- a/bin/omarchy-theme-set-keyboard
+++ b/bin/omarchy-theme-set-keyboard
@@ -2,3 +2,4 @@
 
 omarchy-theme-set-keyboard-asus-rog
 omarchy-theme-set-keyboard-f16
+omarchy-theme-set-keyboard-razer

--- a/bin/omarchy-theme-set-keyboard-razer
+++ b/bin/omarchy-theme-set-keyboard-razer
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+RAZER_THEME=~/.config/omarchy/current/theme/keyboard.rgb
+
+if omarchy-cmd-present razer-cli && [[ -f $RAZER_THEME ]]; then
+  color=$(cat "$RAZER_THEME" | tr -d '#')
+  razer-cli --effect static --brightness 100 --color $color
+fi


### PR DESCRIPTION
At the moment the user needs to install the following packages:
  * `razer-cli`
  * `openrazer-driver-dkms`
  * `openrazer-daemon`

And the following needs to be configured:
```
$ systemctl --user enable openrazer-daemon.service
$ systemctl --user start openrazer-daemon.service
```

Detecting razer device:
```
$ lsusb -d 0x1532:
```

Tested on a **Razer Huntsman V3 Pro** keyboard