### PR TITLE
Add dosfstools for /boot recovery

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -24,6 +24,7 @@ cups-pdf
 docker
 docker-buildx
 docker-compose
+dosfstools
 dotnet-runtime-9.0
 dust
 evince

--- a/migrations/1777145626.sh
+++ b/migrations/1777145626.sh
@@ -1,0 +1,3 @@
+echo "Install dosfstools for FAT filesystem utilities like fsck.fat and mkfs.fat"
+
+omarchy-pkg-add dosfstools


### PR DESCRIPTION
- Adds `dosfstools` to default installs and migrates existing systems so `fsck.fat` and `mkfs.fat` are available for Omarchy’s FAT32 `/boot` partition. This also helps with recovery from dirty or corrupt FAT filesystems after unclean shutdowns or power loss.

Related: #4192, #4284, and similar reports on Discord.