### PR TITLE
Fix jumping cursor / disable-while-typing on ASUS ROG Flow Z13 detachable keyboard

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -49,6 +49,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/dell/fix-xps-haptic-touchpad.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-audio-mixer.sh
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-mic.sh
+run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-z13-touchpad.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/framework/fix-f13-amd-audio-input.sh
 run_logged $OMARCHY_INSTALL/config/hardware/framework/qmk-hid.sh

--- a/install/config/hardware/asus/fix-z13-touchpad.sh
+++ b/install/config/hardware/asus/fix-z13-touchpad.sh
@@ -9,11 +9,12 @@
 # (AttrKeyboardIntegration=internal), but touchpad integration is controlled
 # via udev, not libinput quirks. This udev rule marks the touchpad as internal
 # so dwt can properly pair it with the keyboard.
-#
-# This should be upstreamed to the libinput project:
-# https://gitlab.freedesktop.org/libinput/libinput
 
-if omarchy-hw-asus-rog && lsusb | grep -q "0b05:1a30"; then
+z13_present() {
+  [[ $(cat /sys/class/dmi/id/product_name 2>/dev/null) == *GZ302* ]]
+}
+
+if omarchy-hw-asus-rog && z13_present; then
   sudo tee /etc/udev/rules.d/99-omarchy-asus-z13-touchpad.rules > /dev/null <<'EOF'
 ACTION=="add|change", KERNEL=="event*", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1a30", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
 EOF

--- a/install/config/hardware/asus/fix-z13-touchpad.sh
+++ b/install/config/hardware/asus/fix-z13-touchpad.sh
@@ -10,11 +10,7 @@
 # via udev, not libinput quirks. This udev rule marks the touchpad as internal
 # so dwt can properly pair it with the keyboard.
 
-z13_present() {
-  [[ $(cat /sys/class/dmi/id/product_name 2>/dev/null) == *GZ302* ]]
-}
-
-if omarchy-hw-asus-rog && z13_present; then
+if omarchy-hw-asus-rog && omarchy-hw-match "GZ302"; then
   sudo tee /etc/udev/rules.d/99-omarchy-asus-z13-touchpad.rules > /dev/null <<'EOF'
 ACTION=="add|change", KERNEL=="event*", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1a30", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
 EOF

--- a/install/config/hardware/asus/fix-z13-touchpad.sh
+++ b/install/config/hardware/asus/fix-z13-touchpad.sh
@@ -1,0 +1,21 @@
+# Fix disable-while-typing on ASUS ROG Flow Z13 detachable keyboard.
+#
+# The Z13's detachable keyboard touchpad is detected as external by udev,
+# which prevents libinput's disable-while-typing (dwt) from pairing it
+# with the keyboard. This causes ghost touchpad taps from keyboard
+# flex/vibration while typing quickly, jumping the cursor to random positions.
+#
+# Upstream libinput (50-system-asus.quirks) marks the keyboard as internal
+# (AttrKeyboardIntegration=internal), but touchpad integration is controlled
+# via udev, not libinput quirks. This udev rule marks the touchpad as internal
+# so dwt can properly pair it with the keyboard.
+#
+# This should be upstreamed to the libinput project:
+# https://gitlab.freedesktop.org/libinput/libinput
+
+if omarchy-hw-asus-rog && lsusb | grep -q "0b05:1a30"; then
+  sudo tee /etc/udev/rules.d/99-omarchy-asus-z13-touchpad.rules > /dev/null <<'EOF'
+ACTION=="add|change", KERNEL=="event*", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1a30", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
+EOF
+  sudo udevadm control --reload-rules
+fi

--- a/migrations/1777072987.sh
+++ b/migrations/1777072987.sh
@@ -1,9 +1,7 @@
 echo "Fix disable-while-typing on ASUS ROG Flow Z13 detachable keyboard"
 
-if omarchy-hw-asus-rog && lsusb | grep -q "0b05:1a30"; then
-  sudo tee /etc/udev/rules.d/99-omarchy-asus-z13-touchpad.rules > /dev/null <<'EOF'
-ACTION=="add|change", KERNEL=="event*", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1a30", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
-EOF
-  sudo udevadm control --reload-rules
+source $OMARCHY_PATH/install/config/hardware/asus/fix-z13-touchpad.sh
+
+if [[ -f /etc/udev/rules.d/99-omarchy-asus-z13-touchpad.rules ]]; then
   omarchy-state set reboot-required
 fi

--- a/migrations/1777072987.sh
+++ b/migrations/1777072987.sh
@@ -1,0 +1,9 @@
+echo "Fix disable-while-typing on ASUS ROG Flow Z13 detachable keyboard"
+
+if omarchy-hw-asus-rog && lsusb | grep -q "0b05:1a30"; then
+  sudo tee /etc/udev/rules.d/99-omarchy-asus-z13-touchpad.rules > /dev/null <<'EOF'
+ACTION=="add|change", KERNEL=="event*", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1a30", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
+EOF
+  sudo udevadm control --reload-rules
+  omarchy-state set reboot-required
+fi


### PR DESCRIPTION
## Fix jumping cursor / disable-while-typing on ASUS ROG Flow Z13 detachable keyboard
The Z13's detachable keyboard causes ghost touchpad taps from keyboard flex/vibration while typing quickly, jumping the text cursor to random positions. This happens across all applications.
### Root cause
The Z13's keyboard and touchpad are separate USB HID interfaces. Upstream libinput (`50-system-asus.quirks`) marks the keyboard as `AttrKeyboardIntegration=internal`, but the touchpad's integration is controlled via udev (not libinput quirks) and defaults to `external`. Since `disable_while_typing` requires both devices to be internal to pair them, it is effectively inactive — allowing vibration-induced ghost touches on the touchpad to register as taps between keystrokes.

Confirmed via `evtest` — the touchpad emits touch events when typing quickly on middle-row keys without any physical contact.
### Fix
Adds a udev rule (`/etc/udev/rules.d/99-omarchy-asus-z13-touchpad.rules`) that sets `ID_INPUT_TOUCHPAD_INTEGRATION=internal` for the Z13 touchpad (USB vendor `0x0B05`, product `0x1A30`), enabling `disable_while_typing` to properly pair it with the keyboard.

Z13 detection uses DMI product name (`GZ302*`) so the fix applies regardless of whether the detachable keyboard is attached during install/update.
### Changes
- `install/config/hardware/asus/fix-z13-touchpad.sh` — new hardware fix script with udev rule
- `install/config/all.sh` — wire in the new script
- `migrations/1777072987.sh` — sources the install script and sets reboot-required for existing Z13 users