### PR TITLE
Rebind hid-multitouch on resume to recover Razer Blade AMD trackpad click

### DIFF
--- a/default/systemd/system-sleep/fix-razer-amd-trackpad
+++ b/default/systemd/system-sleep/fix-razer-amd-trackpad
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Fix Razer Blade trackpad click after resume on AMD systems.
+#
+# The Cypress 06CB:CDA3 I2C HID touchpad on AMD's AMDI0010 controller
+# returns from S3/S4 with stale firmware state — motion still works but
+# click button events stop arriving. The kernel logs nothing because
+# nothing fails from its perspective. Unbinding and re-binding the
+# specific HID device under hid-multitouch forces the driver to re-run
+# the I2C HID protocol negotiation and recovers the click.
+#
+# Targeting the device (not the module) avoids disturbing any other
+# multitouch device on the system and works regardless of module
+# refcount.
+
+if [[ $1 != "post" ]]; then
+  exit 0
+fi
+
+driver=/sys/bus/hid/drivers/hid-multitouch
+[[ -d "$driver" ]] || exit 0
+
+for dev in "$driver"/*06CB:CDA3*; do
+  [[ -e "$dev" ]] || continue
+  name="$(basename "$dev")"
+  echo "$name" > "$driver/unbind" 2>/dev/null
+  echo "$name" > "$driver/bind"   2>/dev/null
+done

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -62,3 +62,4 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-tuxedo-backlight.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-razer-amd-trackpad.sh

--- a/install/config/hardware/fix-razer-amd-trackpad.sh
+++ b/install/config/hardware/fix-razer-amd-trackpad.sh
@@ -1,0 +1,11 @@
+# Install resume sleep-hook for Razer Blade laptops with the Cypress
+# 06CB:CDA3 I2C HID touchpad on AMD's AMDI0010 controller. After S3/S4
+# the touchpad returns with stale state and click stops working; the
+# hook reloads hid_multitouch on every resume to recover it.
+
+if grep -qi "Razer" /sys/class/dmi/id/sys_vendor 2>/dev/null \
+   && compgen -G "/sys/bus/platform/devices/AMDI0010*" >/dev/null \
+   && compgen -G "/sys/bus/hid/devices/*06CB:CDA3*" >/dev/null; then
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  sudo install -m 0755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/fix-razer-amd-trackpad" /usr/lib/systemd/system-sleep/
+fi


### PR DESCRIPTION
## Summary

On Razer Blade laptops with AMD chipsets, the trackpad click stops responding after resume from suspend or hibernate. Motion still works; only the click button events drop. The kernel logs nothing on resume — the driver doesn't notice anything is wrong, so users typically don't realize it's recoverable without a reboot.

The affected hardware is the Cypress 06CB:CDA3 I2C HID touchpad on AMD's `AMDI0010` I2C controller. After S3/S4 the device returns with stale firmware state and the I2C HID driver doesn't re-initialize it. Reloading `hid_multitouch` forces a clean detach + re-bind, which re-runs the protocol negotiation and recovers the click. There's no clean fix in 6.x kernels yet; this is a userspace workaround until that lands.

## Changes

- `default/systemd/system-sleep/fix-razer-amd-trackpad` — post-resume hook that reloads `hid_multitouch`. Guarded by `$1 == "post"` so it only fires on resume.
- `install/config/hardware/fix-razer-amd-trackpad.sh` — DMI-gated installer. Triple check (vendor `Razer` + `AMDI0010` platform device + `06CB:CDA3` HID device) so it's a no-op on Intel Razers and on Razer models with a different touchpad.
- `install/config/all.sh` — wired into the hardware-fix block next to `fix-tuxedo-backlight.sh`, matching the existing vendor-fix pattern.

Existing installs won't pick this up — there's no migration. Following the convention of the other `fix-*.sh` hardware scripts, which also only run on fresh install. Happy to add a migration if preferred.

## Test plan

- [x] On affected hardware (Razer Blade 14 RZ09-0370, AMD): sleep cycle without the hook → click broken on resume; with the hook → click works on every resume.
- [x] Detection guard verified: all three gates (DMI vendor, `AMDI0010` device, `06CB:CDA3` HID) present on the affected machine.
- [ ] Detection guard on non-affected hardware — script exits cleanly with no install (logically correct from the conditions, not separately reproduced).