### PR TITLE
ASUS ExpertBook B9406 fingerprint reader (FocalTech FT9349) support

### DIFF
--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -100,6 +100,21 @@ else
 
   # Install required packages
   print_info "Installing required packages..."
+
+  # ASUS ExpertBook B9406CAA ships a FocalTech FT9349 ESS reader (USB
+  # 2808:a97a). Mainline libfprint at 1.94.x lacks the focaltech_moc
+  # driver (and its 0xa97a id_table entry); OPR ships libfprint-git
+  # which carries both. Once upstream catches up, this branch is a
+  # no-op and `libfprint-git` provides=libfprint anyway. Detect via
+  # /sys to avoid depending on usbutils being installed first.
+  for v in /sys/bus/usb/devices/*/idVendor; do
+    [[ "$(cat "$v" 2>/dev/null)" == "2808" ]] || continue
+    [[ "$(cat "${v%idVendor}idProduct" 2>/dev/null)" == "a97a" ]] || continue
+    print_info "FocalTech FT9349 detected (B9406CAA) — using libfprint-git from OPR..."
+    omarchy-pkg-add libfprint-git
+    break
+  done
+
   omarchy-pkg-add fprintd usbutils
 
   if ! check_fingerprint_hardware; then


### PR DESCRIPTION
## Summary

Adds support for the FocalTech FT9349 ESS fingerprint reader (USB `2808:a97a`) shipped with the ASUS ExpertBook Ultra B9406CAA. Without this, fingerprint enrollment fails with "no devices available" because mainline libfprint (1.94.x) does not yet ship the open-source `focaltech_moc` driver.

AI disclaimer: investigation and patch produced with help from Claude Code (Opus 4.7).

## How it works

`bin/omarchy-hw-asus-fingerprint-ft9349` returns true only when `lsusb -d 2808:a97a` finds the device. The install hook then runs `pacman -S libfprint-git fprintd`. Machines without the FT9349 skip both.

`libfprint-git` is added to OPR in omacom-io/omarchy-pkgs#82. It builds libfprint master with the one-line PID patch applied and is `provides=libfprint conflicts=libfprint`, so it cleanly replaces the stock package. Depends on that PR landing and being available in the `[omarchy]` repo.

## Upstream

Working on getting the same one-line patch upstreamed to libfprint at `gitlab.freedesktop.org/libfprint/libfprint`. Once that lands and Arch's libfprint catches up to a release that includes both, OPR can drop `libfprint-git` and this hook becomes a no-op.

## Tested

- [x] `libfprint-git` builds clean locally with `makepkg -s`.
- [x] Built lib contains the `focaltech_moc` driver; `id_table[]` includes `0xA97A` after `prepare()` patch step.
- [x] Same patched build has been running on a B9406CAA since 2026-04-25 :)
- [x] `fprintd-enroll` completes; three fingers enrolled.
- [x] `fprintd-verify` matches enrolled fingers and rejects unenrolled ones.
- [x] Survives `systemctl suspend`/resume; sensor re-binds without re-enrollment.
- [x] PAM integration (hyprlock + system-local-login) verified.
