### PR TITLE
Add local text-to-speech with Piper

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -368,8 +368,9 @@ show_install_ai_menu() {
       echo ollama
   )
 
-  case $(menu "Install" "  Dictation\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush") in
+  case $(menu "Install" "  Dictation\n󰔊  Text to Speech\n󱚤  LM Studio\n󱚤  Ollama\n󱚤  Crush") in
   *Dictation*) present_terminal omarchy-voxtype-install ;;
+  *Speech*) present_terminal omarchy-piper-install ;;
   *Studio*) install "LM Studio" "lmstudio-bin" ;;
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;
@@ -456,13 +457,14 @@ show_install_elixir_menu() {
 }
 
 show_remove_menu() {
-  case $(menu "Remove" "󰣇  Package\n  Web App\n  TUI\n󰵮  Development\n󰏓  Preinstalls\n  Dictation\n󰸌  Theme\n󰍲  Windows\n󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Remove" "󰣇  Package\n  Web App\n  TUI\n󰵮  Development\n󰏓  Preinstalls\n  Dictation\n󰔊  Text to Speech\n󰸌  Theme\n󰍲  Windows\n󰈷  Fingerprint\n  Fido2") in
   *Package*) terminal omarchy-pkg-remove ;;
   *Web*) present_terminal omarchy-webapp-remove ;;
   *TUI*) present_terminal omarchy-tui-remove ;;
   *Development*) show_remove_development_menu ;;
   *Preinstalls*) present_terminal omarchy-remove-preinstalls ;;
   *Dictation*) present_terminal omarchy-voxtype-remove ;;
+  *Speech*) present_terminal omarchy-piper-remove ;;
   *Theme*) present_terminal omarchy-theme-remove ;;
   *Windows*) present_terminal "omarchy-windows-vm remove" ;;
   *Fingerprint*) present_terminal "omarchy-setup-fingerprint --remove" ;;

--- a/bin/omarchy-piper-install
+++ b/bin/omarchy-piper-install
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Install Piper and configure it for local text to speech.
+
+if gum confirm "Install Piper + default voice (~70MB) to enable local text to speech?"; then
+  omarchy-pkg-add uv
+  uv tool install piper-tts
+  hash -r
+
+  mkdir -p ~/.config/piper
+  if [[ ! -f ~/.config/piper/config.toml ]]; then
+    cp "$OMARCHY_PATH/default/piper/config.toml" ~/.config/piper/
+  fi
+
+  mkdir -p ~/.local/share/piper/voices
+  curl -L --fail --progress-bar -o ~/.local/share/piper/voices/en_US-lessac-medium.onnx \
+    https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/lessac/medium/en_US-lessac-medium.onnx
+  curl -L --fail --progress-bar -o ~/.local/share/piper/voices/en_US-lessac-medium.onnx.json \
+    https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/lessac/medium/en_US-lessac-medium.onnx.json
+
+  omarchy-restart-waybar
+
+  echo
+  echo "Piper TTS installed."
+  echo
+  echo "Shortcut: Super + Ctrl + R"
+  echo "Config:   ~/.config/piper/config.toml"
+  echo "Voices:   ~/.local/share/piper/voices"
+  echo "Samples:  https://rhasspy.github.io/piper-samples"
+
+  notify-send "󰔊    Piper TTS Ready" "Press Super + Ctrl + R to read selected text.\nEdit ~/.config/piper/config.toml for options." -t 10000
+fi

--- a/bin/omarchy-piper-remove
+++ b/bin/omarchy-piper-remove
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Remove Piper and its Omarchy configuration.
+
+if omarchy-cmd-present piper; then
+  echo "Uninstall Piper to remove text to speech."
+
+  uv tool uninstall piper-tts 2>/dev/null || true
+  rm -rf ~/.config/piper
+  rm -rf ~/.local/share/piper
+  omarchy-restart-waybar
+else
+  echo "Piper was not installed."
+fi

--- a/bin/omarchy-piper-speak
+++ b/bin/omarchy-piper-speak
@@ -68,18 +68,38 @@ read_text() {
 
   case $source in
   selection)
-    text=$(wl-paste --primary --no-newline 2>/dev/null || true)
+    text=$(wl-paste --primary 2>/dev/null || true)
     ;;
   clipboard)
-    text=$(wl-paste --no-newline 2>/dev/null || true)
+    text=$(wl-paste 2>/dev/null || true)
     ;;
   *)
-    text=$(wl-paste --primary --no-newline 2>/dev/null || true)
-    [[ -n $text ]] || text=$(wl-paste --no-newline 2>/dev/null || true)
+    text=$(wl-paste --primary 2>/dev/null || true)
+    [[ -n $text ]] || text=$(wl-paste 2>/dev/null || true)
     ;;
   esac
 
   echo "$text"
+}
+
+normalize_text() {
+  python - <<'PY'
+import re, sys
+
+text = sys.stdin.read()
+text = re.sub(r"[ \t]+", " ", text).strip()
+
+lines = []
+for line in text.splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    if not re.search(r"[.!?:;]$", line):
+        line += "."
+    lines.append(line)
+
+print(" ".join(lines))
+PY
 }
 
 reader_running() {
@@ -135,7 +155,7 @@ print(1 / reading_speed)
 PY
 )
   extra_args=$(read_config output.extra_args "")
-  text=$(read_text "$source")
+  text=$(read_text "$source" | normalize_text)
 
   if [[ -z $text ]]; then
     notify error "󰔊    Nothing to Speak" "Select text first." 5000

--- a/bin/omarchy-piper-speak
+++ b/bin/omarchy-piper-speak
@@ -1,0 +1,180 @@
+#!/bin/bash
+set -e
+
+config=~/.config/piper/config.toml
+state_dir=${XDG_RUNTIME_DIR:-/tmp}/omarchy-piper
+pid_file=$state_dir/pid
+
+read_config() {
+  local path=$1
+  local fallback=$2
+
+  python - "$config" "$path" "$fallback" <<'PY'
+import sys, tomllib
+
+config_path, key_path, fallback = sys.argv[1:]
+try:
+    with open(config_path, "rb") as f:
+        data = tomllib.load(f)
+    value = data
+    for key in key_path.split("."):
+        value = value[key]
+except Exception:
+    value = fallback
+
+if isinstance(value, bool):
+    print("true" if value else "false")
+else:
+    print(value)
+PY
+}
+
+notify() {
+  local kind=$1
+  local title=$2
+  local body=$3
+  local timeout=$4
+
+  case $kind in
+  generating)
+    [[ $(read_config output.notification.on_generating false) == "true" ]] || return 0
+    ;;
+  start)
+    [[ $(read_config output.notification.on_start false) == "true" ]] || return 0
+    ;;
+  end)
+    [[ $(read_config output.notification.on_end false) == "true" ]] || return 0
+    ;;
+  error)
+    [[ $(read_config output.notification.on_error true) == "true" ]] || return 0
+    ;;
+  esac
+
+  notify-send "$title" "$body" -t "$timeout"
+}
+
+expand_path() {
+  local path=$1
+  echo "${path/#\~/$HOME}"
+}
+
+signal_waybar() {
+  pkill -RTMIN+11 waybar 2>/dev/null || true
+}
+
+read_text() {
+  local source=$1
+  local text=""
+
+  case $source in
+  selection)
+    text=$(wl-paste --primary --no-newline 2>/dev/null || true)
+    ;;
+  clipboard)
+    text=$(wl-paste --no-newline 2>/dev/null || true)
+    ;;
+  *)
+    text=$(wl-paste --primary --no-newline 2>/dev/null || true)
+    [[ -n $text ]] || text=$(wl-paste --no-newline 2>/dev/null || true)
+    ;;
+  esac
+
+  echo "$text"
+}
+
+reader_running() {
+  if [[ -s $pid_file ]]; then
+    local pid
+    pid=$(cat "$pid_file" 2>/dev/null || true)
+    [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null && return 0
+  fi
+
+  pgrep -f "$HOME/.local/share/omarchy/bin/omarchy-piper-speak --run" >/dev/null 2>&1 && return 0
+  pgrep -f "piper --model .* --output-raw" >/dev/null 2>&1 && return 0
+  pgrep -f "pw-play --raw" >/dev/null 2>&1 && return 0
+  return 1
+}
+
+stop_reading() {
+  if [[ -s $pid_file ]]; then
+    local pid
+    pid=$(cat "$pid_file" 2>/dev/null || true)
+    if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+    fi
+  fi
+
+  pkill -TERM -f "$HOME/.local/share/omarchy/bin/omarchy-piper-speak --run" 2>/dev/null || true
+  pkill -TERM -f "piper --model .* --output-raw" 2>/dev/null || true
+  pkill -TERM -f "pw-play --raw" 2>/dev/null || true
+  rm -f "$pid_file"
+  signal_waybar
+  notify end "󰔊    Reading Interrupted" "Piper stopped reading." 2000
+}
+
+run_reader() {
+  trap 'rm -f "$pid_file"; signal_waybar' EXIT INT TERM
+  echo $$ >"$pid_file"
+  signal_waybar
+
+  if omarchy-cmd-missing piper; then
+    exit 1
+  fi
+
+  local voice source player reading_speed length_scale extra_args text sample_rate
+  voice=$(expand_path "$(read_config voice.model "~/.local/share/piper/voices/en_US-lessac-medium.onnx")")
+  source=$(read_config input.source "selection")
+  player=$(read_config output.player "pw-play")
+  reading_speed=$(read_config output.reading_speed "1.0")
+  length_scale=$(python - "$reading_speed" <<'PY'
+import sys
+reading_speed = float(sys.argv[1])
+if reading_speed <= 0:
+    reading_speed = 1.0
+print(1 / reading_speed)
+PY
+)
+  extra_args=$(read_config output.extra_args "")
+  text=$(read_text "$source")
+
+  if [[ -z $text ]]; then
+    notify error "󰔊    Nothing to Speak" "Select text first." 5000
+    exit 1
+  fi
+
+  if [[ ! -f $voice || ! -f $voice.json ]]; then
+    notify error "󰔊    Piper Voice Missing" "Download a voice from https://rhasspy.github.io/piper-samples and update ~/.config/piper/config.toml." 7000
+    exit 1
+  fi
+
+  sample_rate=$(jq -r '.audio.sample_rate // 22050' "$voice.json")
+  notify generating "󰔊    Generating Speech" "Piper is preparing selected text." 2000
+  notify start "󰔊    Reading" "Piper is reading selected text." 2000
+
+  # shellcheck disable=SC2086
+  piper --model "$voice" --output-raw --length-scale "$length_scale" $extra_args <<<"$text" | $player --raw --rate "$sample_rate" --channels 1 --format s16 -
+
+  notify end "󰔊    Reading Complete" "Piper finished reading." 2000
+}
+
+mkdir -p "$state_dir"
+
+case ${1:-toggle} in
+--run)
+  run_reader
+  ;;
+stop)
+  stop_reading
+  ;;
+toggle|*)
+  if reader_running; then
+    stop_reading
+    exit 0
+  fi
+
+  rm -f "$pid_file"
+  setsid "$0" --run >/tmp/omarchy-piper.log 2>&1 &
+  echo "$!" >"$pid_file"
+  signal_waybar
+  ;;
+esac

--- a/bin/omarchy-piper-speak
+++ b/bin/omarchy-piper-speak
@@ -141,7 +141,7 @@ run_reader() {
     exit 1
   fi
 
-  local voice source player reading_speed length_scale extra_args text sample_rate
+  local voice source player reading_speed length_scale sentence_silence extra_args text sample_rate
   voice=$(expand_path "$(read_config voice.model "~/.local/share/piper/voices/en_US-lessac-medium.onnx")")
   source=$(read_config input.source "selection")
   player=$(read_config output.player "pw-play")
@@ -152,6 +152,13 @@ reading_speed = float(sys.argv[1])
 if reading_speed <= 0:
     reading_speed = 1.0
 print(1 / reading_speed)
+PY
+)
+  sentence_silence=$(python - "$length_scale" <<'PY'
+import sys
+v = 0.38 * float(sys.argv[1])
+v = min(0.55, max(0.25, v))
+print(f"{v:.2f}")
 PY
 )
   extra_args=$(read_config output.extra_args "")
@@ -172,7 +179,7 @@ PY
   notify start "󰔊    Reading" "Piper is reading selected text." 2000
 
   # shellcheck disable=SC2086
-  piper --model "$voice" --output-raw --length-scale "$length_scale" $extra_args <<<"$text" | $player --raw --rate "$sample_rate" --channels 1 --format s16 -
+  piper --model "$voice" --output-raw --length-scale "$length_scale" --sentence-silence "$sentence_silence" $extra_args <<<"$text" | $player --raw --rate "$sample_rate" --channels 1 --format s16 -
 
   notify end "󰔊    Reading Complete" "Piper finished reading." 2000
 }

--- a/bin/omarchy-piper-status
+++ b/bin/omarchy-piper-status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+state_dir=${XDG_RUNTIME_DIR:-/tmp}/omarchy-piper
+pid_file=$state_dir/pid
+
+if [[ -s $pid_file ]]; then
+  pid=$(cat "$pid_file" 2>/dev/null || true)
+  if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
+    echo '{"text": "󰗊", "tooltip": "Piper Text to Speech\n󰍉  Reading selected text", "class": "reading"}'
+    exit 0
+  fi
+fi
+
+echo '{"text": "", "tooltip": ""}'

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -5,7 +5,7 @@
   "spacing": 0,
   "height": 26,
   "modules-left": ["custom/omarchy", "hyprland/workspaces"],
-  "modules-center": ["clock", "custom/update", "custom/voxtype", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-center": ["clock", "custom/update", "custom/voxtype", "custom/piper", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
   "modules-right": [
     "group/tray-expander",
     "bluetooth",
@@ -167,6 +167,13 @@
     "tooltip": true,
     "on-click-right": "omarchy-voxtype-config",
     "on-click": "omarchy-voxtype-model"
+  },
+  "custom/piper": {
+    "exec": "omarchy-piper-status",
+    "return-type": "json",
+    "format": "{}",
+    "tooltip": true,
+    "signal": 11
   },
   "tray": {
     "icon-size": 12,

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -98,3 +98,17 @@ tooltip {
 #custom-voxtype.recording {
   color: #a55555;
 }
+
+#custom-piper.reading {
+  min-width: 12px;
+  margin: 0 0 0 7.5px;
+  color: #a55555;
+  opacity: 0.6;
+  animation: blink 1s steps(2) infinite;
+}
+
+@keyframes blink {
+  to {
+    opacity: 1;
+  }
+}

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -59,6 +59,9 @@ bindd = SUPER CTRL, T, Activity, exec, omarchy-launch-tui btop
 # Dictation
 bindd = SUPER CTRL, X, Toggle dictation, exec, voxtype record toggle
 
+# Text to speech
+bindd = SUPER CTRL, R, Read selection or clipboard, exec, omarchy-piper-speak
+
 # Zoom
 bindd = SUPER CTRL, Z, Zoom in, exec, hyprctl keyword cursor:zoom_factor $(hyprctl getoption cursor:zoom_factor -j | jq '.float + 1')
 bindd = SUPER CTRL ALT, Z, Reset zoom, exec, hyprctl keyword cursor:zoom_factor 1

--- a/default/piper/config.toml
+++ b/default/piper/config.toml
@@ -1,0 +1,36 @@
+# Piper Text to Speech Configuration
+#
+# Location: ~/.config/piper/config.toml
+
+[voice]
+# Browse and download other voices: https://rhasspy.github.io/piper-samples
+# Download a .onnx voice and matching .onnx.json file, then update this path.
+model = "~/.local/share/piper/voices/en_US-lessac-medium.onnx"
+
+[input]
+# Text source: "selection", "clipboard", or "selection_or_clipboard"
+source = "selection"
+
+[output]
+# Audio player command. pw-play reads raw 16-bit mono PCM from stdin.
+player = "pw-play"
+
+# Reading speed multiplier. 1.0 is normal, 1.25 is faster, 0.8 is slower.
+reading_speed = 1.0
+
+# Extra Piper CLI arguments, e.g. "--sentence-silence 0.2".
+# See: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/CLI.md
+extra_args = ""
+
+[output.notification]
+# Show notification when speech generation starts
+on_generating = false
+
+# Show notification when reading starts
+on_start = false
+
+# Show notification when reading ends
+on_end = false
+
+# Show notifications for missing text or missing voice
+on_error = true

--- a/migrations/1777208564.sh
+++ b/migrations/1777208564.sh
@@ -1,0 +1,37 @@
+echo "Add Piper TTS to Waybar"
+
+STYLE_FILE=~/.config/waybar/style.css
+CONFIG_FILE=~/.config/waybar/config.jsonc
+
+# Add Piper CSS if not present
+if ! grep -q "#custom-piper.reading" "$STYLE_FILE"; then
+  cat >>"$STYLE_FILE" <<'EOF'
+
+#custom-piper.reading {
+  min-width: 12px;
+  margin: 0 0 0 7.5px;
+  color: #a55555;
+  opacity: 0.6;
+  animation: blink 1s steps(2) infinite;
+}
+
+@keyframes blink {
+  to {
+    opacity: 1;
+  }
+}
+EOF
+fi
+
+# Add Piper to modules-center if not present
+if ! grep -q "custom/piper" "$CONFIG_FILE"; then
+  if grep -q '"custom/voxtype", ' "$CONFIG_FILE"; then
+    sed -i 's/"custom\/voxtype", /"custom\/voxtype", "custom\/piper", /' "$CONFIG_FILE"
+  else
+    sed -i '/"modules-center"/ s/"custom\/screenrecording-indicator"/"custom\/piper", "custom\/screenrecording-indicator"/' "$CONFIG_FILE"
+  fi
+
+  sed -i '/"tray": {/i\  "custom/piper": {\n    "exec": "omarchy-piper-status",\n    "return-type": "json",\n    "format": "{}",\n    "tooltip": true,\n    "signal": 11\n  },' "$CONFIG_FILE"
+fi
+
+omarchy-restart-waybar


### PR DESCRIPTION
## Summary

Adds optional local text-to-speech via Piper.

Demo (fresh Omarchy VM): 

https://github.com/user-attachments/assets/d738f216-443c-4070-a9eb-1593f8985d26

- Install from `Install > AI > Text to Speech`
- Read selected text with `Super + Ctrl + R`
- Press the shortcut again to stop playback
- Configure via `~/.config/piper/config.toml`
- Shows a Waybar indicator only while reading
- Remove from `Remove > Text to Speech`

Piper runs locally/offline, installs through `uv` without building from AUR source, and keeps voices as separate files. The default `en_US-lessac-medium` voice is about 63MB, and users can browse alternative voices at https://rhasspy.github.io/piper-samples.


## Notes

This follows the same general integration pattern as Dictation through Voxtype (I used `uv tool install piper-tts` because the current AUR `piper-tts` package failed to build on a fresh Omarchy VM, while `piper-tts-bin` points at the archived rhasspy/piper repo. Happy to switch this to an OPR package if that’s preferred.)

The config supports voice path, input source, reading speed, extra Piper CLI args, and notification toggles.