### PR TITLE
omarchy-setup-fingerprint: fix noninteractive libfprint-git install on FocalTech FT9349 hardware

### DIFF
--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -111,6 +111,14 @@ else
     [[ "$(cat "$v" 2>/dev/null)" == "2808" ]] || continue
     [[ "$(cat "${v%idVendor}idProduct" 2>/dev/null)" == "a97a" ]] || continue
     print_info "FocalTech FT9349 detected (B9406CAA) — using libfprint-git from OPR..."
+    # libfprint-git provides+conflicts libfprint; pacman -S --noconfirm
+    # defaults the conflict prompt to N and aborts. Pre-remove libfprint
+    # with -Rdd so the install goes silent. -Rdd (not omarchy-pkg-drop's
+    # -Rns) is required because fprintd requires libfprint; the dep is
+    # re-satisfied immediately by libfprint-git's provides=libfprint.
+    if omarchy-pkg-present libfprint; then
+      sudo pacman -Rdd --noconfirm libfprint
+    fi
     omarchy-pkg-add libfprint-git
     break
   done


### PR DESCRIPTION
Follow-up to #5454. The libfprint-git install in `omarchy-setup-fingerprint` aborts under `--noconfirm` because pacman emits a conflict prompt that defaults to N, aborting the install.

Pre-remove libfprint with `-Rdd` first. The dep is re-satisfied immediately by libfprint-git's `provides=libfprint`.

Uses `omarchy-pkg-present` and `omarchy-pkg-add` helpers. The removal step can't use `omarchy-pkg-drop` (which wraps `-Rns` and refuses to remove a package with reverse deps, and fprintd requires libfprint), so raw `pacman -Rdd` is used to skip the dep check.

Verified on B9406CAA: `pacman -Rdd --noconfirm libfprint` followed by `omarchy-pkg-add libfprint-git` succeeds non-interactively. fprintd-list and fprintd-verify continue to work against possible existing enrollments.

AI disclaimer: fix found and PR done with help from Claude Code (Opus 4.7).
