### PR TITLE
Allow Docker DNS from 192.168 networks

### DIFF
--- a/install/first-run/firewall.sh
+++ b/install/first-run/firewall.sh
@@ -8,6 +8,7 @@ sudo ufw allow 53317/tcp
 
 # Allow Docker containers to use DNS on host
 sudo ufw allow in proto udp from 172.16.0.0/12 to 172.17.0.1 port 53 comment 'allow-docker-dns'
+sudo ufw allow in proto udp from 192.168.0.0/16 to 172.17.0.1 port 53 comment 'allow-docker-dns'
 
 # Turn on the firewall
 sudo ufw --force enable

--- a/migrations/1777282771.sh
+++ b/migrations/1777282771.sh
@@ -1,0 +1,5 @@
+echo "Allow Docker DNS from Docker's 192.168 address pool"
+
+if omarchy-cmd-present ufw; then
+  sudo ufw allow in proto udp from 192.168.0.0/16 to 172.17.0.1 port 53 comment 'allow-docker-dns'
+fi

--- a/migrations/1777282771.sh
+++ b/migrations/1777282771.sh
@@ -1,5 +1,5 @@
 echo "Allow Docker DNS from Docker's 192.168 address pool"
 
-if omarchy-cmd-present ufw; then
+if omarchy-cmd-present ufw && sudo ufw status | grep -q "Status: active"; then
   sudo ufw allow in proto udp from 192.168.0.0/16 to 172.17.0.1 port 53 comment 'allow-docker-dns'
 fi


### PR DESCRIPTION
## Summary
- Allow Docker DNS requests from Docker's documented 192.168.0.0/16 default address pool.
- Add a migration so existing UFW-enabled installs receive the same rule.

Fixes #5464