### PR TITLE
chore: update hyprland wiki links

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -1,4 +1,4 @@
-# Learn how to configure Hyprland: https://wiki.hyprland.org/Configuring/
+# Learn how to configure Hyprland: https://wiki.hypr.land/Configuring/
 
 # Use defaults Omarchy defaults (but don't edit these directly!)
 source = ~/.local/share/omarchy/default/hypr/autostart.conf

--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -1,5 +1,5 @@
 # Control your input devices
-# See https://wiki.hypr.land/Configuring/Variables/#input
+# See https://wiki.hypr.land/Configuring/Basics/Variables/#input
 input {
   # Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
   # kb_layout = us,dk,eu
@@ -45,7 +45,7 @@ windowrule = match:class (Alacritty|kitty), scroll_touchpad 1.5
 windowrule = match:class com.mitchellh.ghostty, scroll_touchpad 0.2
 
 # Enable touchpad gestures for changing workspaces
-# See https://wiki.hyprland.org/Configuring/Gestures/
+# See https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/
 # gesture = 3, horizontal, workspace
 
 # Enable touchpad gestures for moving focus (helpful on scrolling layout)

--- a/config/hypr/looknfeel.conf
+++ b/config/hypr/looknfeel.conf
@@ -1,6 +1,6 @@
 # Change the default Omarchy look'n'feel
 
-# https://wiki.hyprland.org/Configuring/Variables/#general
+# https://wiki.hypr.land/Configuring/Basics/Variables/#general
 general {
     # No gaps between windows or borders
     # gaps_in = 0
@@ -11,7 +11,7 @@ general {
     # layout = scrolling
 }
 
-# https://wiki.hyprland.org/Configuring/Variables/#decoration
+# https://wiki.hypr.land/Configuring/Basics/Variables/#decoration
 decoration {
     # Use round window corners
     # rounding = 8
@@ -21,13 +21,13 @@ decoration {
     # dim_strength = 0.15
 }
 
-# https://wiki.hyprland.org/Configuring/Variables/#animations
+# https://wiki.hypr.land/Configuring/Basics/Variables/#animations
 animations {
     # Disable all animations
     # enabled = no
 }
 
-# https://wiki.hypr.land/Configuring/Variables/#layout
+# https://wiki.hypr.land/Configuring/Basics/Variables/#layout
 layout {
     # Avoid overly wide single-window layouts on wide screens
     # single_window_aspect_ratio = 1 1

--- a/config/hypr/monitors.conf
+++ b/config/hypr/monitors.conf
@@ -1,4 +1,4 @@
-# See https://wiki.hyprland.org/Configuring/Monitors/
+# See https://wiki.hypr.land/Configuring/Basics/Monitors/
 # List current monitors and resolutions possible: hyprctl monitors
 # Format: monitor = [port], resolution, position, scale
 

--- a/default/hypr/input.conf
+++ b/default/hypr/input.conf
@@ -1,4 +1,4 @@
-# https://wiki.hyprland.org/Configuring/Variables/#input
+# https://wiki.hypr.land/Configuring/Basics/Variables/#input
 input {
     kb_layout = us
     kb_variant =

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -1,30 +1,30 @@
-# Refer to https://wiki.hyprland.org/Configuring/Variables/
+# Refer to https://wiki.hypr.land/Configuring/Basics/Variables/
 
 # Variables
 $activeBorderColor = rgba(33ccffee) rgba(00ff99ee) 45deg
 $inactiveBorderColor = rgba(595959aa)
 
-# https://wiki.hyprland.org/Configuring/Variables/#general
+# https://wiki.hypr.land/Configuring/Basics/Variables/#general
 general {
     gaps_in = 5
     gaps_out = 10
 
     border_size = 2
 
-    # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
+    # https://wiki.hypr.land/Configuring/Basics/Variables/#variable-types for info about colors
     col.active_border = $activeBorderColor
     col.inactive_border = $inactiveBorderColor
 
     # Set to true enable resizing windows by clicking and dragging on borders and gaps
     resize_on_border = false
 
-    # Please see https://wiki.hyprland.org/Configuring/Tearing/ before you turn this on
+    # Please see https://wiki.hypr.land/Configuring/Advanced-and-Cool/Tearing/ before you turn this on
     allow_tearing = false
 
     layout = dwindle
 }
 
-# https://wiki.hyprland.org/Configuring/Variables/#decoration
+# https://wiki.hypr.land/Configuring/Basics/Variables/#decoration
 decoration {
     rounding = 0
 
@@ -35,7 +35,7 @@ decoration {
         color = rgba(1a1a1aee)
     }
 
-    # https://wiki.hyprland.org/Configuring/Variables/#blur
+    # https://wiki.hypr.land/Configuring/Basics/Variables/#blur
     blur {
         enabled = true
         size = 2
@@ -46,7 +46,7 @@ decoration {
     }
 }
 
-# https://wiki.hypr.land/Configuring/Variables/#group
+# https://wiki.hypr.land/Configuring/Basics/Variables/#group
 group {
     col.border_active = $activeBorderColor
     col.border_inactive = $inactiveBorderColor
@@ -77,11 +77,11 @@ group {
 }
 
 
-# https://wiki.hyprland.org/Configuring/Variables/#animations
+# https://wiki.hypr.land/Configuring/Basics/Variables/#animations
 animations {
     enabled = yes, please :)
 
-    # Default animations, see https://wiki.hyprland.org/Configuring/Animations/ for more
+    # Default animations, see https://wiki.hypr.land/Configuring/Advanced-and-Cool/Animations/ for more
 
     bezier = easeOutQuint,0.23,1,0.32,1
     bezier = easeInOutCubic,0.65,0.05,0.36,1
@@ -106,19 +106,19 @@ animations {
     animation = specialWorkspace, 1, 3, easeOutQuint, slidevert
 }
 
-# See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
+# See https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/ for more
 dwindle {
     pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
     preserve_split = true # You probably want this
     force_split = 2 # Always split on the right
 }
 
-# See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
+# See https://wiki.hypr.land/Configuring/Layouts/Master-Layout/ for more
 master {
     new_status = master
 }
 
-# https://wiki.hyprland.org/Configuring/Variables/#misc
+# https://wiki.hypr.land/Configuring/Basics/Variables/#misc
 misc {
     disable_hyprland_logo = true
     disable_splash_rendering  = true
@@ -128,7 +128,7 @@ misc {
     on_focus_under_fullscreen = 1
 }
 
-# https://wiki.hypr.land/Configuring/Variables/#cursor
+# https://wiki.hypr.land/Configuring/Basics/Variables/#cursor
 cursor {
     hide_on_key_press = true
     warp_on_change_workspace = 1

--- a/default/hypr/windows.conf
+++ b/default/hypr/windows.conf
@@ -1,4 +1,4 @@
-# See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
+# See https://wiki.hypr.land/Configuring/Basics/Window-Rules/ for more
 # Hyprland 0.53+ syntax
 windowrule = suppress_event maximize, match:class .*
 


### PR DESCRIPTION
## Summary

Many / most of the hyprland wiki links were dead (`404`) due to apparent changes in the Wiki structure.

- Cleans up the links
- Standardizes on `wiki.hypr.land` instead of `wiki.hyprland.org` (there was a mixed bag in the current config)

Note: I did not update a migration script since I don't really understand how that would impact installs so in theory someone could end up with a dead wiki.hypr.land link after an update due to `migrations/1772293693.sh`