### PR TITLE
Fix: Use accel_profile=flat instead of force_no_accel for proper pointer behavior

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -20,7 +20,7 @@ input {
   # sensitivity = 0.35
 
   # Turn off mouse acceleration (default: false)
-  # force_no_accel = true
+  # accel_profile = flat
 
   touchpad {
     # Use natural (inverse) scrolling

--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -19,7 +19,7 @@ input {
   # Increase sensitivity for mouse/trackpad (default: 0)
   # sensitivity = 0.35
 
-  # Turn off mouse acceleration (default: false)
+  # Turn off mouse acceleration (default: adaptive)
   # accel_profile = flat
 
   touchpad {


### PR DESCRIPTION
## Summary

In hyprland, the variable `force_no_accel` is not recommended due to potential cursor desynchronization and sensitivity issues.

`accel_profile` should be used instead with the value `flat` which is the same as disabling acceleration.

[hyprland wiki](https://wiki.hypr.land/Configuring/Basics/Variables/)

[wayland pointer acceleration profiles](https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration-profiles)

**Changes:**
- `config/hypr/input.conf` - replace `force_no_accel` with `accel_profile`