### PR TITLE
Remove '--noconfirm' from package removal command

### DIFF
--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -18,6 +18,6 @@ pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
 
 if [[ -n $pkg_names ]]; then
   # Convert newline-separated selections to space-separated for yay
-  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
+  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns
   omarchy-show-done
 fi


### PR DESCRIPTION
Removed the '--noconfirm' option from the pacman command to allow the user check before remove, as the removal list includes dependencies. ([discussion](https://github.com/basecamp/omarchy/discussions/5484))