### PR TITLE
Move Obsidian launch flags to user config

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -10,7 +10,7 @@ bindd = SUPER SHIFT, M, Music, exec, omarchy-launch-or-focus spotify
 bindd = SUPER SHIFT, N, Editor, exec, omarchy-launch-editor
 bindd = SUPER SHIFT, D, Docker, exec, omarchy-launch-tui lazydocker
 bindd = SUPER SHIFT, G, Signal, exec, omarchy-launch-or-focus ^signal$ "uwsm-app -- signal-desktop"
-bindd = SUPER SHIFT, O, Obsidian, exec, omarchy-launch-or-focus ^obsidian$ "uwsm-app -- obsidian -disable-gpu --enable-wayland-ime"
+bindd = SUPER SHIFT, O, Obsidian, exec, omarchy-launch-or-focus ^obsidian$ "uwsm-app -- obsidian"
 bindd = SUPER SHIFT, W, Typora, exec, uwsm-app -- typora --enable-wayland-ime
 bindd = SUPER SHIFT, SLASH, Passwords, exec, uwsm-app -- 1password
 

--- a/config/obsidian/user-flags.conf
+++ b/config/obsidian/user-flags.conf
@@ -1,6 +1,3 @@
 # Obsidian reads this file through the Arch package wrapper.
---ozone-platform=wayland
+-disable-gpu
 --enable-wayland-ime
-
-# If Obsidian crashes because of GPU acceleration, uncomment:
-# --disable-gpu

--- a/config/obsidian/user-flags.conf
+++ b/config/obsidian/user-flags.conf
@@ -1,0 +1,6 @@
+# Obsidian reads this file through the Arch package wrapper.
+--ozone-platform=wayland
+--enable-wayland-ime
+
+# If Obsidian crashes because of GPU acceleration, uncomment:
+# --disable-gpu

--- a/default/hypr/bindings.conf
+++ b/default/hypr/bindings.conf
@@ -8,7 +8,7 @@ bindd = SUPER, N, Neovim, exec, $terminal -e nvim
 bindd = SUPER, T, Top, exec, $terminal -e btop
 bindd = SUPER, D, Lazy Docker, exec, $terminal -e lazydocker
 bindd = SUPER, G, Messenger, exec, $messenger
-bindd = SUPER, O, Obsidian, exec, obsidian -disable-gpu
+bindd = SUPER, O, Obsidian, exec, obsidian
 bindd = SUPER, SLASH, Password manager, exec, $passwordManager
 
 source = ~/.local/share/omarchy/default/hypr/bindings/media.conf

--- a/migrations/1776434586.sh
+++ b/migrations/1776434586.sh
@@ -1,22 +1,22 @@
 echo "Move Obsidian flags from Hyprland binding to Obsidian user flags"
 
 OBSIDIAN_FLAGS_FILE="$HOME/.config/obsidian/user-flags.conf"
+OBSIDIAN_DEFAULT_FLAGS_FILE="$OMARCHY_PATH/config/obsidian/user-flags.conf"
 
 mkdir -p "$(dirname "$OBSIDIAN_FLAGS_FILE")"
 
 if [[ ! -f $OBSIDIAN_FLAGS_FILE ]]; then
-  cat >"$OBSIDIAN_FLAGS_FILE" <<'EOF'
-# Obsidian reads this file through the Arch package wrapper.
--disable-gpu
---enable-wayland-ime
-EOF
-elif ! grep -qxF -- "-disable-gpu" "$OBSIDIAN_FLAGS_FILE" || ! grep -qxF -- "--enable-wayland-ime" "$OBSIDIAN_FLAGS_FILE"; then
-  {
-    echo
-    echo "# Added by Omarchy migration 1776434586: Obsidian launch flags moved from Hyprland binding."
-    grep -qxF -- "-disable-gpu" "$OBSIDIAN_FLAGS_FILE" || echo "-disable-gpu"
-    grep -qxF -- "--enable-wayland-ime" "$OBSIDIAN_FLAGS_FILE" || echo "--enable-wayland-ime"
-  } >>"$OBSIDIAN_FLAGS_FILE"
+  cp "$OBSIDIAN_DEFAULT_FLAGS_FILE" "$OBSIDIAN_FLAGS_FILE"
+else
+  missing_flags=$(grep -vE '^(#|$)' "$OBSIDIAN_DEFAULT_FLAGS_FILE" | grep -vxFf "$OBSIDIAN_FLAGS_FILE" || true)
+
+  if [[ -n $missing_flags ]]; then
+    {
+      echo
+      echo "# Added by Omarchy migration 1776434586: Obsidian launch flags moved from Hyprland binding."
+      printf "%s\n" "$missing_flags"
+    } >>"$OBSIDIAN_FLAGS_FILE"
+  fi
 fi
 
 if [[ -f ~/.config/hypr/bindings.conf ]]; then

--- a/migrations/1776434586.sh
+++ b/migrations/1776434586.sh
@@ -1,0 +1,26 @@
+echo "Move Obsidian flags from Hyprland binding to Obsidian user flags"
+
+OBSIDIAN_FLAGS_FILE="$HOME/.config/obsidian/user-flags.conf"
+
+mkdir -p "$(dirname "$OBSIDIAN_FLAGS_FILE")"
+
+if [[ ! -f $OBSIDIAN_FLAGS_FILE ]]; then
+  cat >"$OBSIDIAN_FLAGS_FILE" <<'EOF'
+# Obsidian reads this file through the Arch package wrapper.
+--ozone-platform=wayland
+--enable-wayland-ime
+
+# If Obsidian crashes because of GPU acceleration, uncomment:
+# --disable-gpu
+EOF
+fi
+
+if [[ -f ~/.config/hypr/bindings.conf ]]; then
+  sed -i '/Obsidian, exec/ {
+    s/ -disable-gpu//g
+    s/ --disable-gpu//g
+    s/ --enable-wayland-ime//g
+    s/ --ozone-platform=wayland//g
+    s/"uwsm app -- obsidian/"uwsm-app -- obsidian/g
+  }' ~/.config/hypr/bindings.conf
+fi

--- a/migrations/1776434586.sh
+++ b/migrations/1776434586.sh
@@ -7,17 +7,14 @@ mkdir -p "$(dirname "$OBSIDIAN_FLAGS_FILE")"
 if [[ ! -f $OBSIDIAN_FLAGS_FILE ]]; then
   cat >"$OBSIDIAN_FLAGS_FILE" <<'EOF'
 # Obsidian reads this file through the Arch package wrapper.
---ozone-platform=wayland
+-disable-gpu
 --enable-wayland-ime
-
-# If Obsidian crashes because of GPU acceleration, uncomment:
-# --disable-gpu
 EOF
-elif ! grep -qxF -- "--ozone-platform=wayland" "$OBSIDIAN_FLAGS_FILE" || ! grep -qxF -- "--enable-wayland-ime" "$OBSIDIAN_FLAGS_FILE"; then
+elif ! grep -qxF -- "-disable-gpu" "$OBSIDIAN_FLAGS_FILE" || ! grep -qxF -- "--enable-wayland-ime" "$OBSIDIAN_FLAGS_FILE"; then
   {
     echo
     echo "# Added by Omarchy migration 1776434586: Obsidian launch flags moved from Hyprland binding."
-    grep -qxF -- "--ozone-platform=wayland" "$OBSIDIAN_FLAGS_FILE" || echo "--ozone-platform=wayland"
+    grep -qxF -- "-disable-gpu" "$OBSIDIAN_FLAGS_FILE" || echo "-disable-gpu"
     grep -qxF -- "--enable-wayland-ime" "$OBSIDIAN_FLAGS_FILE" || echo "--enable-wayland-ime"
   } >>"$OBSIDIAN_FLAGS_FILE"
 fi
@@ -27,7 +24,6 @@ if [[ -f ~/.config/hypr/bindings.conf ]]; then
     s/ -disable-gpu//g
     s/ --disable-gpu//g
     s/ --enable-wayland-ime//g
-    s/ --ozone-platform=wayland//g
     s/"uwsm app -- obsidian/"uwsm-app -- obsidian/g
   }' ~/.config/hypr/bindings.conf
 fi

--- a/migrations/1776434586.sh
+++ b/migrations/1776434586.sh
@@ -13,6 +13,13 @@ if [[ ! -f $OBSIDIAN_FLAGS_FILE ]]; then
 # If Obsidian crashes because of GPU acceleration, uncomment:
 # --disable-gpu
 EOF
+elif ! grep -qxF -- "--ozone-platform=wayland" "$OBSIDIAN_FLAGS_FILE" || ! grep -qxF -- "--enable-wayland-ime" "$OBSIDIAN_FLAGS_FILE"; then
+  {
+    echo
+    echo "# Added by Omarchy migration 1776434586: Obsidian launch flags moved from Hyprland binding."
+    grep -qxF -- "--ozone-platform=wayland" "$OBSIDIAN_FLAGS_FILE" || echo "--ozone-platform=wayland"
+    grep -qxF -- "--enable-wayland-ime" "$OBSIDIAN_FLAGS_FILE" || echo "--enable-wayland-ime"
+  } >>"$OBSIDIAN_FLAGS_FILE"
 fi
 
 if [[ -f ~/.config/hypr/bindings.conf ]]; then


### PR DESCRIPTION
## Summary

- Move the existing Obsidian launch flags from the Hyprland binding into `config/obsidian/user-flags.conf`, which is read by the Arch Obsidian wrapper.
- Keep the existing Obsidian defaults unchanged: `-disable-gpu` and `--enable-wayland-ime`.
- Add a migration for existing installs that copies the default flags file when missing, appends missing default flags when a user flags file already exists, and removes those flags from the Obsidian Hyprland binding.

## Why

The current hotkey launches Obsidian with flags directly in the Hyprland binding:

```text
uwsm-app -- obsidian -disable-gpu --enable-wayland-ime
```

The Arch package already supports per-user Obsidian flags via:

```text
~/.config/obsidian/user-flags.conf
```

Moving the flags there keeps behavior unchanged while making hotkey, Walker, and desktop launches use the same Obsidian wrapper configuration path.