### PR TITLE
Color man pages with bat

### DIFF
--- a/default/bash/envs
+++ b/default/bash/envs
@@ -5,3 +5,7 @@ export BAT_THEME=ansi
 # Duplicated from .config/uwsm/env so SSH works too
 export OMARCHY_PATH=$HOME/.local/share/omarchy
 export PATH=$OMARCHY_PATH/bin:$PATH:$HOME/.local/bin
+
+# Color man pages with bat
+export MANROFFOPT="-c"
+export MANPAGER="sh -c 'col -bx | bat -l man -p'"


### PR DESCRIPTION
This makes the man pages being syntax-highlighted with current Omarchy theme, thus improving on the overall consistency of the themes across the system.

Got the idea from CachyOS default fish config: https://github.com/CachyOS/cachyos-fish-config/blob/main/cachyos-config.fish

Example using Catppuccin theme:

<img width="2536" height="1390" alt="screenshot-2026-04-29_20-54-43" src="https://github.com/user-attachments/assets/d0f8337f-da86-48b8-94af-a79c18ed2c39" />
