### PR TITLE
fix: Refactor ThinkPad mic mute to use omarchy-swayosd-client

### DIFF
--- a/bin/omarchy-audio-input-mute-thinkpad
+++ b/bin/omarchy-audio-input-mute-thinkpad
@@ -17,7 +17,6 @@ fi
 
 brightnessctl --device="platform::micmute" set "$led_value" >/dev/null 2>&1 || true
 
-swayosd-client \
-  --monitor "$(omarchy-hyprland-monitor-focused)" \
+omarchy-swayosd-client \
   --custom-message "$osd_message" \
   --custom-icon "$osd_icon"


### PR DESCRIPTION
Following the pattern used in the XPS mic mute script, this refactors the ThinkPad version to use the `omarchy-swayosd-client` wrapper instead of calling `swayosd-client` directly with the monitor flag.