### PR TITLE
Add minimum brightness cap to prevent OLED displays turning off

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -17,5 +17,8 @@ done
 # Set the actual brightness of the display device.
 brightnessctl -d "$device" set "$step" >/dev/null
 
+# Prevent brightness from dropping to 0 - on OLED displays this turns the screen completely off
+[[ $(brightnessctl -d "$device" get) -eq 0 ]] && brightnessctl -d "$device" set 1 >/dev/null
+
 # Use SwayOSD to display the new brightness setting.
 omarchy-swayosd-brightness "$(brightnessctl -d "$device" -m | cut -d',' -f4 | tr -d '%')"


### PR DESCRIPTION
On OLED panels, setting brightness to 0 produces a true, deep black (pixels fully off), whereas LCDs still show faint content even at the lowest brightness

This PR adds:
- Add minimum brightness cap of 1 to prevent OLED displays from turning completely off
