### PR TITLE
fix: add hyprlock PAM config to omarchy-setup-fingerprint

### DIFF
--- a/bin/omarchy-setup-fingerprint
+++ b/bin/omarchy-setup-fingerprint
@@ -53,6 +53,12 @@ password  required pam_unix.so
 session   required pam_unix.so
 EOF
   fi
+
+  # Configure hyprlock
+  if [[ -f /etc/pam.d/hyprlock ]] && ! grep -q 'pam_fprintd.so' /etc/pam.d/hyprlock; then
+    print_info "Configuring hyprlock for fingerprint authentication..."
+    sudo sed -i '1i auth        sufficient  pam_fprintd.so' /etc/pam.d/hyprlock
+  fi
 }
 
 add_hyprlock_fingerprint_icon() {
@@ -78,6 +84,12 @@ remove_pam_config() {
   if [[ -f /etc/pam.d/polkit-1 ]] && grep -Fq 'pam_fprintd.so' /etc/pam.d/polkit-1; then
     print_info "Removing fingerprint authentication from polkit..."
     sudo sed -i '/pam_fprintd\.so/d' /etc/pam.d/polkit-1
+  fi
+
+  # Remove from hyprlock
+  if [[ -f /etc/pam.d/hyprlock ]] && grep -q 'pam_fprintd.so' /etc/pam.d/hyprlock; then
+    print_info "Removing fingerprint authentication from hyprlock..."
+    sudo sed -i '/pam_fprintd\.so/d' /etc/pam.d/hyprlock
   fi
 }
 


### PR DESCRIPTION
## Problem

`omarchy-setup-fingerprint` adds `pam_fprintd.so` to `/etc/pam.d/sudo` and `/etc/pam.d/polkit-1`, but not to `/etc/pam.d/hyprlock`. The result is that the fingerprint icon appears on the lock screen (because `fingerprint:enabled = true` is set in `hyprlock.conf`) but touching the reader does nothing — hyprlock's PAM chain has no fingerprint entry.

The script even prints _"You can use your fingerprint for sudo, polkit, and lock screen"_, but the lock screen claim was never true.

Closes #5503
Related: #1819

## Solution

Add a hyprlock block to both `setup_pam_config` and `remove_pam_config`, matching the pattern already used for sudo and polkit. The block is guarded by a file-existence check (consistent with how the polkit block works) since `/etc/pam.d/hyprlock` was itself only added recently via #2955.

## Testing

Verified manually: after running `sudo sed -i '1i auth        sufficient  pam_fprintd.so' /etc/pam.d/hyprlock`, lock screen fingerprint auth works immediately on a system where `omarchy-setup-fingerprint` had already been run.