### PR TITLE
Add a toggle for touchscreen on supported devices

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -17,5 +17,8 @@ done
 # Set the actual brightness of the display device.
 brightnessctl -d "$device" set "$step" >/dev/null
 
+# Prevent brightness from dropping to 0 - on OLED displays this turns the screen completely off
+[[ $(brightnessctl -d "$device" get) -eq 0 ]] && brightnessctl -d "$device" set 1 >/dev/null
+
 # Use SwayOSD to display the new brightness setting.
 omarchy-swayosd-brightness "$(brightnessctl -d "$device" -m | cut -d',' -f4 | tr -d '%')"

--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -17,8 +17,5 @@ done
 # Set the actual brightness of the display device.
 brightnessctl -d "$device" set "$step" >/dev/null
 
-# Prevent brightness from dropping to 0 - on OLED displays this turns the screen completely off
-[[ $(brightnessctl -d "$device" get) -eq 0 ]] && brightnessctl -d "$device" set 1 >/dev/null
-
 # Use SwayOSD to display the new brightness setting.
 omarchy-swayosd-brightness "$(brightnessctl -d "$device" -m | cut -d',' -f4 | tr -d '%')"

--- a/bin/omarchy-hw-touchscreen
+++ b/bin/omarchy-hw-touchscreen
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+device=$(hyprctl devices -j | jq -r '[.touch[]?.name, .tablets[]?.name] | first // empty')
+[[ -n $device ]] && echo "$device"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -194,10 +194,15 @@ show_hardware_menu() {
     options="$options\n󰟸  Touchpad"
   fi
 
+  if omarchy-hw-touchscreen; then
+    options="$options\n  Touchscreen"
+  fi
+
   case $(menu "Toggle" "$options") in
   *Laptop*) omarchy-hyprland-monitor-internal toggle ;;
   *Mirror*) omarchy-hyprland-monitor-internal-mirror toggle;;
   *Touchpad*) omarchy-toggle-touchpad ;;
+  *Touchscreen*) omarchy-toggle-touchscreen ;;
   *"Hybrid GPU"*) present_terminal omarchy-toggle-hybrid-gpu ;;
   *) back_to show_trigger_menu ;;
   esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -195,7 +195,7 @@ show_hardware_menu() {
   fi
 
   if omarchy-hw-touchscreen; then
-    options="$options\n  Touchscreen"
+    options="$options\n󰆽  Touchscreen"
   fi
 
   case $(menu "Toggle" "$options") in

--- a/bin/omarchy-toggle-touchscreen
+++ b/bin/omarchy-toggle-touchscreen
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+STATE_CONF="$HOME/.local/state/omarchy/toggles/hypr/touchscreen-disabled.conf"
+
+device="$(omarchy-hw-touchscreen)"
+
+if [[ -z $device ]]; then
+  echo "No touchscreen device found" >&2
+  exit 1
+fi
+
+enable() {
+  hyprctl keyword "device[$device]:enabled" true >/dev/null
+  rm -f "$STATE_CONF"
+  omarchy-swayosd-client --custom-icon device-support-touch-symbolic --custom-message "Touchscreen enabled"
+}
+
+disable() {
+  hyprctl keyword "device[$device]:enabled" false >/dev/null
+  mkdir -p "$(dirname "$STATE_CONF")"
+  printf 'device {\n    name = %s\n    enabled = false\n}\n' "$device" > "$STATE_CONF"
+  omarchy-swayosd-client --custom-icon touch-disabled-symbolic --custom-message "Touchscreen disabled"
+}
+
+case "${1:-toggle}" in
+  on) enable ;;
+  off) disable ;;
+  toggle) if [[ -f $STATE_CONF ]]; then enable; else disable; fi ;;
+esac


### PR DESCRIPTION
## Summary
- Add `omarchy-hw-touchscreen` to detect touchscreen/tablet devices
- Add `omarchy-toggle-touchscreen` to enable/disable touchscreen with state persistence
- Add touchscreen toggle option to the hardware menu