### PR TITLE
Fix internal monitor disable for systems where built-in display is not eDP-1

### DIFF
--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 TOGGLE="internal-monitor-disable"
+TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.conf"
 MIRROR_TOGGLE="internal-monitor-mirror"
+
+# Get internal monitor name dynamically
+INTERNAL=$(hyprctl monitors -j | jq -r '.[] | select(.name | contains("eDP")).name' | head -n 1)
 
 enable() {
   if omarchy-hyprland-toggle-enabled "$TOGGLE"; then
@@ -10,13 +14,14 @@ enable() {
 }
 
 disable() {
-  if omarchy-hw-external-monitors; then
-    if omarchy-hyprland-toggle-disabled "$TOGGLE" && omarchy-hyprland-toggle-disabled "$MIRROR_TOGGLE"; then
-      omarchy-hyprland-toggle --enabled-notification "󰍹    Laptop display disabled" "$TOGGLE"
-    fi
-  else
+  if ! omarchy-hw-external-monitors; then
     notify-send -u low "󰍹    Can't disable the only active display"
     exit 1
+  fi
+  if omarchy-hyprland-toggle-disabled "$TOGGLE" && omarchy-hyprland-toggle-disabled "$MIRROR_TOGGLE"; then
+    echo "monitor=$INTERNAL,disable" >"$TOGGLE_FLAG"
+    notify-send -u low "󰍹    Laptop display disabled"
+    hyprctl reload
   fi
 }
 

--- a/default/hypr/toggles/internal-monitor-disable.conf
+++ b/default/hypr/toggles/internal-monitor-disable.conf
@@ -1,2 +1,0 @@
-# Disable the internal laptop monitor
-monitor=eDP-1,disable


### PR DESCRIPTION
## Problem

`default/hypr/toggles/internal-monitor-disable.conf` hardcodes `monitor=eDP-1,disable`. On laptops with hybrid GPUs (e.g. Intel iGPU + NVIDIA dGPU), the iGPU claims `eDP-1` as a disconnected connector while the actual built-in panel is enumerated as `eDP-2` or higher. Hyprland silently accepts the config but does nothing, so the toggle fires the notification but the display stays on.

Fixes #5443.

## Solution

Detect the internal monitor name dynamically at runtime using `hyprctl monitors -j`, following the same pattern already used in `omarchy-hyprland-monitor-internal-mirror`. The `disable()` function now writes the toggle flag file directly with the detected name instead of copying the static conf.

The static `default/hypr/toggles/internal-monitor-disable.conf` is removed — it is no longer needed.

## Testing

Tested on a system where the built-in display is `eDP-2` (Intel + NVIDIA hybrid GPU). Both the lid switch and the keyboard shortcut correctly disable and re-enable the internal monitor.

## AI Disclosure
Claude assisted with identifying the pattern in the `omarchy-hyprland-monitor-internal-mirror` script. I wasn't 100% happy with it's attempt at fixing it so I refactored it to match the style in the mirror script.