### PR TITLE
Restart Walker after removing web apps

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -41,3 +41,5 @@ for APP_NAME in "${APP_NAMES[@]}"; do
   rm -f "$ICON_DIR/$APP_NAME.png"
   echo "Removed $APP_NAME"
 done
+
+omarchy-restart-walker

--- a/bin/omarchy-webapp-remove-all
+++ b/bin/omarchy-webapp-remove-all
@@ -33,4 +33,6 @@ if command -v update-desktop-database &>/dev/null; then
   update-desktop-database "$APP_DIR" &>/dev/null || true
 fi
 
+omarchy-restart-walker
+
 echo "Web apps removed successfully."


### PR DESCRIPTION
## Summary

Fixes #5507 by restarting Walker after web apps are removed, so deleted apps disappear from the launcher immediately.

## Changes

- Restart Walker after `omarchy-webapp-remove`
- Restart Walker after `omarchy-webapp-remove-all`

## Validation

- `bash -n bin/omarchy-webapp-remove bin/omarchy-webapp-remove-all`
- Hermetic temp `HOME` test with a stubbed `omarchy-restart-walker` for single-app and bulk removal
- `git diff --check`
