### PR TITLE
Fix screenshot cancel cleaning stale hyprpicker

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -12,7 +12,10 @@ if [[ ! -d $OUTPUT_DIR ]]; then
   notify-send "Created screenshot directory: $OUTPUT_DIR" -u normal -t 2000
 fi
 
-pkill slurp && exit 0
+killed=0
+pkill -x slurp && killed=1
+pkill -x hyprpicker && killed=1
+(( killed )) && exit 0
 
 SCREENSHOT_EDITOR="${OMARCHY_SCREENSHOT_EDITOR:-satty}"
 

--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -14,7 +14,7 @@ fi
 
 killed=0
 pkill -x slurp && killed=1
-pkill -x hyprpicker && killed=1
+pkill -f '(^|/)hyprpicker -r -z$' && killed=1
 (( killed )) && exit 0
 
 SCREENSHOT_EDITOR="${OMARCHY_SCREENSHOT_EDITOR:-satty}"


### PR DESCRIPTION
## Summary
- Exact-match screenshot helper process cleanup.
- Kill both `slurp` and `hyprpicker` when cancelling an in-progress or stale screenshot capture.

## Why
Fixes #5506.

If a screenshot run is force-killed before its EXIT trap runs, `hyprpicker` can keep the frozen overlay alive. Pressing the screenshot key again only killed `slurp`, so the stale overlay remained.

## Validation
- `bash -n bin/omarchy-capture-screenshot`
- Mocked early-cancel run
- `git diff --check`
