### PR TITLE
Set Helix theme to terminal colors during install

### DIFF
--- a/bin/omarchy-install-helix
+++ b/bin/omarchy-install-helix
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Install Helix and configure it to use the current Omarchy theme.
+
+CONFIG_FILE="$HOME/.config/helix/config.toml"
+CONFIG_TEXT='theme = "base16_transparent" # Set by Omarchy install. Base16 theme makes Helix use terminal colors.'
+
+echo "Installing Helix..."
+omarchy-pkg-add helix
+
+mkdir -p $HOME/.config/helix
+
+if [[ -f $CONFIG_FILE ]]; then
+  sed -i -E "/^[[:space:]]*theme[[:space:]]*=[[:space:]]*\"/c\\
+  $CONFIG_TEXT" "$CONFIG_FILE"
+else
+  printf $CONFIG_TEXT > $CONFIG_FILE
+fi
+
+# Force reload config if any Helix instance is running
+pkill -USR1 helix

--- a/bin/omarchy-install-helix
+++ b/bin/omarchy-install-helix
@@ -3,7 +3,7 @@
 # Install Helix and configure it to use the current Omarchy theme.
 
 CONFIG_FILE="$HOME/.config/helix/config.toml"
-CONFIG_TEXT='theme = "base16_transparent" # Set by Omarchy install. Base16 theme makes Helix use terminal colors.'
+CONFIG_TEXT='theme = "term16_dark" # Set by Omarchy install. Base16 theme makes Helix use terminal colors.'
 
 echo "Installing Helix..."
 omarchy-pkg-add helix

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -347,7 +347,7 @@ show_install_editor_menu() {
   *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
   *Zed*) install_and_launch "Zed" "zed" "dev.zed.Zed" ;;
   *Sublime*) install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;
-  *Helix*) install "Helix" "helix" ;;
+  *Helix*) present_terminal omarchy-install-helix  ;;
   *Emacs*) install "Emacs" "emacs-wayland" && systemctl --user enable --now emacs.service ;;
   *) show_install_menu ;;
   esac

--- a/migrations/1777621525.sh
+++ b/migrations/1777621525.sh
@@ -1,4 +1,4 @@
-echo "Reinstalling Helix to set Omarchy theme"
+echo "Updating Helix configuration"
 
 if omarchy-pkg-present helix; then
   omarchy-install-helix

--- a/migrations/1777621525.sh
+++ b/migrations/1777621525.sh
@@ -1,0 +1,5 @@
+echo "Reinstalling Helix to set Omarchy theme"
+
+if omarchy-pkg-present helix; then
+  omarchy-install-helix
+fi


### PR DESCRIPTION
This PR adds some logic to Helix Editor install procedure, setting it's theme to "base16_transparent", which essentially makes it use terminal color palette and integrate nicely with Omarchy theme switcher kinda like nvim does (see attached screenshots).

**NOTE**: We *do* modify user config here, as Helix currently does not support any kind of config imports (at least not that I know of). Not sure if that is allowed practice in Omarchy..

~~**TODO**: It'd be nice to add migration for this along the lines of:~~

```bash
echo "Reinstalling Helix to set Omarchy theme"

if omarchy-pkg-present helix; then
  omarchy-install-helix
fi
```

~~.. but the migrations system is at this time beyond me (sorry I am new here).~~
edit: I think I figured it out :sweat_smile: 

## Before this PR:

<img width="2546" height="1400" alt="screenshot-2026-05-01_01-12-47" src="https://github.com/user-attachments/assets/22bcdcac-dd5c-4a7e-a6a6-5c5fe2ba9ec9" />

## After

<img width="2550" height="1406" alt="screenshot-2026-05-01_10-25-24" src="https://github.com/user-attachments/assets/2020985c-d66f-4b01-89de-257cfcf640df" />
<img width="2550" height="1401" alt="screenshot-2026-05-01_10-25-45" src="https://github.com/user-attachments/assets/60fe02d9-8d01-44eb-bb54-327967ff9b4b" />
<img width="2547" height="1402" alt="screenshot-2026-05-01_10-26-20" src="https://github.com/user-attachments/assets/2bc6d4a0-5033-4ef6-8a02-6ff27a5fefd9" />

