### PR TITLE
Fix hibernation on new NVidia drivers

### DIFF
--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -26,6 +26,12 @@ if [[ -n $NVIDIA ]]; then
 options nvidia_drm modeset=1
 EOF
 
+  # Ensure NVreg_UseKernelSuspendNotifiers is used for hibernation
+  sudo tee -a /etc/modprobe.d/nvidia.conf <<EOF >/dev/null
+options nvidia NVreg_PreserveVideoMemoryAllocations=0
+options nvidia NVreg_UseKernelSuspendNotifiers=1
+EOF
+
   # Configure mkinitcpio for early loading
   sudo tee /etc/mkinitcpio.conf.d/nvidia.conf <<EOF >/dev/null
 MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)

--- a/migrations/1777018591.sh
+++ b/migrations/1777018591.sh
@@ -1,0 +1,9 @@
+echo "Ensure NVreg_UseKernelSuspendNotifiers is used for hibernation"
+
+if [[ -f /etc/modprobe.d/nvidia.conf ]] && ! grep -q "NVreg_PreserveVideoMemoryAllocations" /etc/modprobe.d/nvidia.conf; then
+  sudo tee -a /etc/modprobe.d/nvidia.conf <<EOF >/dev/null
+options nvidia NVreg_PreserveVideoMemoryAllocations=0
+options nvidia NVreg_UseKernelSuspendNotifiers=1
+EOF
+  sudo limine-update
+fi


### PR DESCRIPTION
As explained on https://github.com/basecamp/omarchy/discussions/5500, new drivers don't seem to expose the necessary suspend interface to use `NVreg_PreserveVideoMemoryAllocations`.

While https://github.com/omacom-io/omarchy-pkgs/pull/84 fixed part of the issue, the default value of `NVreg_PreserveVideoMemoryAllocations` after the PR became `2` when it should be 0.

This PR fix the required values in `/etc/modprobe.d/nvidia.conf `.

See [Arch's wiki: Preserve video memory after suspend](https://wiki.archlinux.org/title/NVIDIA/Tips_and_tricks#Preserve_video_memory_after_suspend).

Note that Arch set `NVreg_UseKernelSuspendNotifiers` to 1 by default, so setting it in nvidia.conf is not strictly needed, but I think it keeps the context together.
