### PR TITLE
Fix: read files from symlink directory in background selector menu

### DIFF
--- a/default/elephant/omarchy_background_selector.lua
+++ b/default/elephant/omarchy_background_selector.lua
@@ -22,26 +22,6 @@ function FormatName(filename)
   return name
 end
 
-local function ResolvePathOrSymlink(path)
-  if not path or path == "" then
-    return nil
-  end
-  -- Safely escape the path for shell usage
-  local escaped_path = ShellEscape(path)
-  -- Use `--` to prevent option injection
-  local cmd = "realpath -- " .. escaped_path .. " 2>/dev/null"
-
-  local handle = io.popen(cmd)
-  if not handle then
-    return nil
-  end
-
-  local result = handle:read("*l")
-  handle:close()
-
-  return result
-end
-
 function GetEntries()
   local entries = {}
   local home = os.getenv("HOME")
@@ -58,9 +38,7 @@ function GetEntries()
     home .. "/.config/omarchy/current/theme/backgrounds",
   }
   if theme_name then
-    local theme_dir = home .. "/.config/omarchy/backgrounds/" .. theme_name
-    local resolved_dir = ResolvePathOrSymlink(theme_dir)
-    table.insert(dirs, resolved_dir or theme_dir)
+    table.insert(dirs, home .. "/.config/omarchy/backgrounds/" .. theme_name)
   end
 
   -- Track added files to avoid duplicates
@@ -68,7 +46,7 @@ function GetEntries()
 
   for _, wallpaper_dir in ipairs(dirs) do
     local handle = io.popen(
-      "find " .. ShellEscape(wallpaper_dir)
+      "find -L " .. ShellEscape(wallpaper_dir)
         .. " -maxdepth 1 -type f \\( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' -o -name '*.gif' -o -name '*.bmp' -o -name '*.webp' \\) 2>/dev/null | sort"
     )
     if handle then

--- a/default/elephant/omarchy_background_selector.lua
+++ b/default/elephant/omarchy_background_selector.lua
@@ -23,16 +23,23 @@ function FormatName(filename)
 end
 
 local function ResolvePathOrSymlink(path)
-  -- Convert path into absolute path and resolve symbolic link(if any)
-  local handle = io.popen('realpath "' .. path .. '" 2>/dev/null')
-  -- If path exists then return the resolved path
-  if handle then
-    local result = handle:read("*l")
-    handle:close()
-    return result
+  if not path or path == "" then
+    return nil
   end
-  -- Return nil, if path does not exist
-  return nil
+  -- Safely escape the path for shell usage
+  local escaped_path = ShellEscape(path)
+  -- Use `--` to prevent option injection
+  local cmd = "realpath -- " .. escaped_path .. " 2>/dev/null"
+
+  local handle = io.popen(cmd)
+  if not handle then
+    return nil
+  end
+
+  local result = handle:read("*l")
+  handle:close()
+
+  return result
 end
 
 function GetEntries()

--- a/default/elephant/omarchy_background_selector.lua
+++ b/default/elephant/omarchy_background_selector.lua
@@ -22,6 +22,19 @@ function FormatName(filename)
   return name
 end
 
+local function ResolvePathOrSymlink(path)
+  -- Convert path into absolute path and resolve symbolic link(if any)
+  local handle = io.popen('realpath "' .. path .. '" 2>/dev/null')
+  -- If path exists then return the resolved path
+  if handle then
+    local result = handle:read("*l")
+    handle:close()
+    return result
+  end
+  -- Return nil, if path does not exist
+  return nil
+end
+
 function GetEntries()
   local entries = {}
   local home = os.getenv("HOME")
@@ -38,7 +51,9 @@ function GetEntries()
     home .. "/.config/omarchy/current/theme/backgrounds",
   }
   if theme_name then
-    table.insert(dirs, home .. "/.config/omarchy/backgrounds/" .. theme_name)
+    local theme_dir = home .. "/.config/omarchy/backgrounds/" .. theme_name
+    local resolved_dir = ResolvePathOrSymlink(theme_dir)
+    table.insert(dirs, resolved_dir or theme_dir)
   end
 
   -- Track added files to avoid duplicates


### PR DESCRIPTION
This PR adds support for listing images from a symlink directory, having same name as the theme name within the `~/.config/omarchy/backgrounds` directory.

**Scenario:**
If we have a common wallpapers directory at `~/Pictures/Wallpapers`.
And we create symlink for this directory in `~/.config/omarchy/backgrounds` with correct theme name convention like:

- `ln -s ~/Pictures/Wallpapers ~/.config/omarchy/backgrounds/lumon`, OR,
- `ln -s ~/Pictures/Wallpapers ~/.config/omarchy/backgrounds/tokyo-night`

The omarchy background selector menu does not show the images from the symlinked directory.
<img width="1911" height="1166" alt="before-symlink-fix" src="https://github.com/user-attachments/assets/473fbbca-83b8-4416-8e3a-7fb50f17c057" />

The update in this PR adds support for:
- Listing the default theme backgrounds, and
  -  <img width="1901" height="1143" alt="screenshot-2026-05-01_16-04-00" src="https://github.com/user-attachments/assets/2c7eeca7-7684-4cf9-855b-65404718ffc3" />

- Images from the symlink directory
  - <img width="1898" height="1147" alt="screenshot-2026-05-01_16-03-25" src="https://github.com/user-attachments/assets/23cb2d60-ae10-48f3-bfbb-5d6da0574fa2" />