### PR TITLE
Add foot terminal support for screensaver

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -31,6 +31,12 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
       --config-file ~/.local/share/omarchy/default/alacritty/screensaver.toml \
       -e omarchy-screensaver
     ;;
+  *foot*)
+    hyprctl dispatch exec -- \
+      foot -a org.omarchy.screensaver \
+      -c ~/.local/share/omarchy/default/foot/screensaver.ini \
+      -e omarchy-screensaver
+    ;;
   *ghostty*)
     hyprctl dispatch exec -- \
       ghostty --class=org.omarchy.screensaver \
@@ -46,7 +52,7 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
       -e omarchy-screensaver
     ;;
   *)
-    notify-send -u low "✋  Screensaver only runs in Alacritty, Ghostty, or Kitty"
+    notify-send -u low "✋  Screensaver only runs in Alacritty, Foot, Ghostty, or Kitty"
     ;;
   esac
 done

--- a/default/foot/screensaver.ini
+++ b/default/foot/screensaver.ini
@@ -1,0 +1,14 @@
+[main]
+font=monospace:size=18
+
+[colors-dark]
+alpha=1
+foreground=000000
+background=000000
+cursor=000000 000000
+
+[colors-light]
+alpha=1
+foreground=000000
+background=000000
+cursor=000000 000000


### PR DESCRIPTION
Adds foot as a supported terminal in omarchy-launch-screensaver, following the same pattern as the existing Alacritty, Ghostty, and Kitty cases.

Includes the foot screensaver config at default/foot/screensaver.ini with font and color settings matching the Alacritty terminal config.

Tested on Hyprland with foot as the default terminal via xdg-terminal-exec.