### PR TITLE
Q to Quit

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -1,5 +1,5 @@
 # Close windows
-bindd = SUPER, W, Close window, killactive,
+bindd = SUPER, Q, Close window, killactive,
 bindd = CTRL ALT, DELETE, Close all windows, exec, omarchy-hyprland-window-close-all
 
 # Control tiling


### PR DESCRIPTION
## Summary
Replaces the default close-window shortcut from Super+W to Super+Q in the Hyprland bindings.