### PR TITLE
Make color0 distinct from background/foreground and fix helix theme

### DIFF
--- a/default/themed/helix.toml.tpl
+++ b/default/themed/helix.toml.tpl
@@ -76,7 +76,7 @@
 "ui.bufferline.active" = { fg = "foreground", bg = "background", underline = { color = "color5", style = "line" } }
 
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "foreground", modifiers = ["bold"] }
+"ui.text.focus" = { fg = "foreground", bg = "color0", modifiers = ["bold"] }
 "ui.text.inactive" = { fg = "color8" }
 "ui.text.directory" = { fg = "color4" }
 
@@ -87,8 +87,7 @@
 "ui.virtual.jump-label" = { fg = "color1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "color8"
 
-"ui.selection" = { fg = "selection_foreground", bg = "selection_background" }
-"ui.selection.primary" = { fg = "selection_foreground", bg = "selection_background" }
+"ui.selection" = { bg = "color0" }
 
 "ui.cursor" = { fg = "background", bg = "cursor" }
 "ui.cursor.primary" = { fg = "background", bg = "cursor" }
@@ -99,7 +98,7 @@
 
 "ui.cursorline.primary" = { bg = "color0" }
 
-"ui.highlight" = { fg = "selection_foreground", bg = "selection_background", modifiers = ["bold"] }
+"ui.highlight" = { bg = "color0", modifiers = ["bold"] }
 
 "ui.menu" = { fg = "foreground", bg = "background" }
 "ui.menu.selected" = { fg = "background", bg = "foreground", modifiers = ["bold"] }

--- a/themes/ethereal/colors.toml
+++ b/themes/ethereal/colors.toml
@@ -5,7 +5,7 @@ background = "#060B1E"
 selection_foreground = "#060B1E"
 selection_background = "#ffcead"
 
-color0 = "#060B1E"
+color0 = "#3C486D"
 color1 = "#ED5B5A"
 color2 = "#92a593"
 color3 = "#E9BB4F"

--- a/themes/flexoki-light/colors.toml
+++ b/themes/flexoki-light/colors.toml
@@ -5,7 +5,7 @@ background = "#FFFCF0"
 selection_foreground = "#100F0F"
 selection_background = "#CECDC3"
 
-color0 = "#100F0F"
+color0 = "#DAD8CE"
 color1 = "#D14D41"
 color2 = "#879A39"
 color3 = "#D0A215"

--- a/themes/hackerman/colors.toml
+++ b/themes/hackerman/colors.toml
@@ -5,7 +5,7 @@ background = "#0B0C16"
 selection_foreground = "#0B0C16"
 selection_background = "#ddf7ff"
 
-color0 = "#0B0C16"
+color0 = "#3E4058"
 color1 = "#50f872"
 color2 = "#4fe88f"
 color3 = "#50f7d4"

--- a/themes/vantablack/colors.toml
+++ b/themes/vantablack/colors.toml
@@ -11,7 +11,7 @@ selection_foreground = "#000000"
 selection_background = "#ffffff"
 
 # Normal colors (ANSI 0-7)
-color0 = "#000000"
+color0 = "#404040"
 color1 = "#a4a4a4"
 color2 = "#b6b6b6"
 color3 = "#cecece"

--- a/themes/white/colors.toml
+++ b/themes/white/colors.toml
@@ -11,7 +11,7 @@ selection_foreground = "#ffffff"
 selection_background = "#1a1a1a"
 
 # Normal colors (ANSI 0-7)
-color0 = "#ffffff"
+color0 = "#c0c0c0"
 color1 = "#2a2a2a"
 color2 = "#3a3a3a"
 color3 = "#4a4a4a"


### PR DESCRIPTION
The majority of themes have color0 available as a subtle offset from
the background. For flexoki-light, because color0 matched foreground, it
wasn't subtle, and would cause invisible text when used as a background
color (e.g., in text editor rulers). For vantablack, ethereal,
hackerman, and white, color0 matched background and would cause
invisible text when a theme wanted text to be de-emphasized.

This patch makes it consistently a subtle offset from background.

This is in the same vein as https://github.com/basecamp/omarchy/pull/5467/changes/3fabdf73e1f1d7383151b447d531eadda13eb447

## After screenshots

With these tweaks applied, these are some example elements I've drawn arrows at where some programs want to apply a subtle color. In the case of flexoki-light, this color was too strong (matching foreground). In the others, this color matched background and was invisible.

<img width="2978" height="1628" alt="image" src="https://github.com/user-attachments/assets/73617968-12b5-4adf-b0b7-86c274dbadc9" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/74492e57-61a9-449b-8f7b-15e7c679bb87" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/11769ab4-9b3d-4037-ad4c-fec4b7d821e6" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/2b94ceb4-d061-454e-8f84-1fc9700a4105" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/6c64d6b0-6147-48eb-992a-e7042bdb203f" />


---

Make helix selection theme colors more subtle

Helix is more usable if the selection background is subtle. This is
primarily because of [[1]], which makes a bright selection like we had
before often make the foreground text unreadable in the picker preview.

[1]: https://github.com/helix-editor/helix/issues/12405

## Screenshots
### Before
<img width="2970" height="1628" alt="screenshot-2026-05-01_16-54-06" src="https://github.com/user-attachments/assets/093ccb93-25ad-4611-a956-2d243830b294" />


### After
<img width="2970" height="1628" alt="screenshot-2026-05-01_16-43-44" src="https://github.com/user-attachments/assets/75784d4c-9914-4485-8607-e274e3624372" />
