### PR TITLE
fix: reliable mic mute fallback using wpctl

### DIFF
--- a/bin/omarchy-audio-input-mute
+++ b/bin/omarchy-audio-input-mute
@@ -7,5 +7,17 @@ if omarchy-hw-match "XPS"; then
 elif omarchy-hw-match "ThinkPad"; then
   omarchy-audio-input-mute-thinkpad
 else
-  omarchy-swayosd-client --input-volume mute-toggle
+  wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle >/dev/null
+
+  if pactl get-source-mute @DEFAULT_SOURCE@ | rg -q 'yes'; then
+    osd_message='Microphone muted'
+    osd_icon='microphone-sensitivity-muted-symbolic'
+  else
+    osd_message='Microphone on'
+    osd_icon='audio-input-microphone-symbolic'
+  fi
+
+  omarchy-swayosd-client \
+    --custom-message "$osd_message" \
+    --custom-icon "$osd_icon"
 fi


### PR DESCRIPTION
### Problem

On non-XPS/ThinkPad systems, `omarchy-audio-input-mute` still fell back to `swayosd-client --input-volume mute-toggle`. That command can exit successfully while leaving the microphone mute state unchanged on PipeWire/PulseAudio setups.

### Solution

Use `wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle` for the actual mute toggle, then query `pactl get-source-mute @DEFAULT_SOURCE@` for the resulting state and use `omarchy-swayosd-client` only for the OSD message/icon.

### Verification

- `bash -n bin/omarchy-audio-input-mute`
- Fake `wpctl`/`pactl` harness confirmed the generic branch toggles muted/unmuted state and shows the expected OSD message/icon.

### References

- basecamp/omarchy#4831
- basecamp/omarchy#5127
- basecamp/omarchy#4938
- basecamp/omarchy#5252
- basecamp/omarchy#5493
- basecamp/omarchy#5492