### PR TITLE
Remove only preinstalled webapps during preinstall cleanup

### DIFF
--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -5,7 +5,15 @@
 if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI wrappers, and desktop applications?"; then
   echo -e "Removing preinstalled Omarchy applications...\n"
 
-  omarchy-webapp-remove-all
+  source "$OMARCHY_PATH/install/packaging/webapps-data.sh"
+
+  preinstalled_webapps=()
+  for webapp in "${OMARCHY_PREINSTALLED_WEBAPPS[@]}"; do
+    IFS="|" read -r app_name _ <<< "$webapp"
+    preinstalled_webapps+=("$app_name")
+  done
+
+  omarchy-webapp-remove "${preinstalled_webapps[@]}"
   omarchy-tui-remove-all
 
   cp ~/.config/hypr/bindings.conf ~/.config/hypr/bindings.conf.bak

--- a/install/packaging/webapps-data.sh
+++ b/install/packaging/webapps-data.sh
@@ -1,0 +1,17 @@
+OMARCHY_PREINSTALLED_WEBAPPS=(
+  "HEY|https://app.hey.com|HEY.png|omarchy-webapp-handler-hey %u|x-scheme-handler/mailto"
+  "Basecamp|https://launchpad.37signals.com|Basecamp.png"
+  "WhatsApp|https://web.whatsapp.com/|WhatsApp.png"
+  "Google Photos|https://photos.google.com/|Google Photos.png"
+  "Google Contacts|https://contacts.google.com/|Google Contacts.png"
+  "Google Messages|https://messages.google.com/web/conversations|Google Messages.png"
+  "Google Maps|https://maps.google.com|Google Maps.png"
+  "ChatGPT|https://chatgpt.com/|ChatGPT.png"
+  "YouTube|https://youtube.com/|YouTube.png"
+  "GitHub|https://github.com/|GitHub.png"
+  "X|https://x.com/|X.png"
+  "Figma|https://figma.com/|Figma.png"
+  "Discord|https://discord.com/channels/@me|Discord.png"
+  "Zoom|https://app.zoom.us/wc/home|Zoom.png|omarchy-webapp-handler-zoom %u|x-scheme-handler/zoommtg;x-scheme-handler/zoomus"
+  "Fizzy|https://app.fizzy.do/|Fizzy.png"
+)

--- a/install/packaging/webapps.sh
+++ b/install/packaging/webapps.sh
@@ -1,4 +1,13 @@
-source "$OMARCHY_PATH/install/packaging/webapps-data.sh"
+set -euo pipefail
+
+webapps_data_file="$OMARCHY_PATH/install/packaging/webapps-data.sh"
+
+if [[ ! -f "$webapps_data_file" ]]; then
+  echo "Missing webapps data file: $webapps_data_file" >&2
+  exit 1
+fi
+
+source "$webapps_data_file"
 
 for webapp in "${OMARCHY_PREINSTALLED_WEBAPPS[@]}"; do
   IFS="|" read -r app_name app_url icon_ref custom_exec mime_types <<< "$webapp"

--- a/install/packaging/webapps.sh
+++ b/install/packaging/webapps.sh
@@ -1,15 +1,17 @@
-omarchy-webapp-install "HEY" https://app.hey.com HEY.png "omarchy-webapp-handler-hey %u" "x-scheme-handler/mailto"
-omarchy-webapp-install "Basecamp" https://launchpad.37signals.com Basecamp.png
-omarchy-webapp-install "WhatsApp" https://web.whatsapp.com/ WhatsApp.png
-omarchy-webapp-install "Google Photos" https://photos.google.com/ "Google Photos.png"
-omarchy-webapp-install "Google Contacts" https://contacts.google.com/ "Google Contacts.png"
-omarchy-webapp-install "Google Messages" https://messages.google.com/web/conversations "Google Messages.png"
-omarchy-webapp-install "Google Maps" https://maps.google.com "Google Maps.png"
-omarchy-webapp-install "ChatGPT" https://chatgpt.com/ ChatGPT.png
-omarchy-webapp-install "YouTube" https://youtube.com/ YouTube.png
-omarchy-webapp-install "GitHub" https://github.com/ GitHub.png
-omarchy-webapp-install "X" https://x.com/ X.png
-omarchy-webapp-install "Figma" https://figma.com/ Figma.png
-omarchy-webapp-install "Discord" https://discord.com/channels/@me Discord.png
-omarchy-webapp-install "Zoom" https://app.zoom.us/wc/home Zoom.png "omarchy-webapp-handler-zoom %u" "x-scheme-handler/zoommtg;x-scheme-handler/zoomus"
-omarchy-webapp-install "Fizzy" https://app.fizzy.do/ Fizzy.png
+source "$OMARCHY_PATH/install/packaging/webapps-data.sh"
+
+for webapp in "${OMARCHY_PREINSTALLED_WEBAPPS[@]}"; do
+  IFS="|" read -r app_name app_url icon_ref custom_exec mime_types <<< "$webapp"
+
+  args=("$app_name" "$app_url" "$icon_ref")
+
+  if [[ -n $custom_exec || -n $mime_types ]]; then
+    args+=("$custom_exec")
+  fi
+
+  if [[ -n $mime_types ]]; then
+    args+=("$mime_types")
+  fi
+
+  omarchy-webapp-install "${args[@]}"
+done


### PR DESCRIPTION
## Summary

- Add a shared list of Omarchy’s preinstalled webapps
- Reuse that list for default webapp installation
- Make `omarchy-remove-preinstalls` remove only those default webapps instead of every launcher created with `omarchy-webapp-install`

Closes #4830

## Why

`omarchy-remove-preinstalls` previously called `omarchy-webapp-remove-all`, which deletes every desktop file using `omarchy-launch-webapp` or an `omarchy-webapp-handler`. That also removes user-created webapps, even though the menu action says it removes preinstalled applications.

## Validation

- `bash -n bin/omarchy-remove-preinstalls bin/omarchy-webapp-remove bin/omarchy-webapp-remove-all install/packaging/webapps.sh install/packaging/webapps-data.sh`
- `git diff --check`
- Hermetic removal test confirmed a preinstalled `HEY` launcher is removed while a user-created `Custom App.desktop` is preserved
