### PR TITLE
Quiet lid-close display toggle when undocked

### DIFF
--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# omarchy:summary=Enable, disable, toggle, or recover the internal laptop display
-# omarchy:args=<on|off|toggle|recover>
+# omarchy:summary=Enable, disable, toggle, conditionally disable, or recover the internal laptop display
+# omarchy:args=<on|off|off-if-external|toggle|recover>
 
 TOGGLE="internal-monitor-disable"
 TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.conf"
@@ -16,16 +16,27 @@ enable() {
   fi
 }
 
-disable() {
-  if ! omarchy-hw-external-monitors; then
-    notify-send -u low "󰍹    Can't disable the only active display"
-    exit 1
-  fi
+disable_laptop_display() {
   if omarchy-hyprland-toggle-disabled "$TOGGLE" && omarchy-hyprland-toggle-disabled "$MIRROR_TOGGLE"; then
     echo "monitor=$INTERNAL,disable" >"$TOGGLE_FLAG"
     notify-send -u low "󰍹    Laptop display disabled"
     hyprctl reload
   fi
+}
+
+disable() {
+  if ! omarchy-hw-external-monitors; then
+    notify-send -u low "󰍹    Can't disable the only active display"
+    exit 1
+  fi
+
+  disable_laptop_display
+}
+
+disable_if_external() {
+  omarchy-hw-external-monitors || exit 0
+
+  disable_laptop_display
 }
 
 recover() {
@@ -37,10 +48,11 @@ recover() {
 case "$1" in
   on) enable ;;
   off) disable ;;
+  off-if-external) disable_if_external ;;
   toggle) if omarchy-hyprland-toggle-enabled "$TOGGLE"; then enable; else disable; fi ;;
   recover) recover ;;
   *)
-    echo "Usage: $(basename "$0") {on|off|toggle|recover}" >&2
+    echo "Usage: $(basename "$0") {on|off|off-if-external|toggle|recover}" >&2
     exit 1
     ;;
 esac

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -31,7 +31,7 @@ bindd = SUPER CTRL, I, Toggle locking on idle, exec, omarchy-toggle-idle
 bindd = SUPER CTRL, N, Toggle nightlight, exec, omarchy-toggle-nightlight
 bindd = SUPER CTRL, Delete, Toggle laptop display, exec, omarchy-hyprland-monitor-internal toggle
 bindd = SUPER CTRL ALT, Delete, Toggle laptop display mirroring, exec, omarchy-hyprland-monitor-internal-mirror toggle
-bindl = , switch:on:Lid Switch, exec, omarchy-hyprland-monitor-internal off
+bindl = , switch:on:Lid Switch, exec, omarchy-hyprland-monitor-internal off-if-external
 bindl = , switch:off:Lid Switch, exec, omarchy-hyprland-monitor-internal on
 
 # Control Apple Display brightness


### PR DESCRIPTION
## Summary

- Add an `off-if-external` mode to `omarchy-hyprland-monitor-internal`
- Use it for the lid-close Hyprland binding
- Preserve the existing warning for manual attempts to disable the only active display

Fixes #5532

## Why

The lid-close binding used the same `off` path as the manual laptop-display toggle. When no external monitor was connected, opening or closing the lid could trigger the “Can’t disable the only active display” notification even though the user did not manually request that toggle.

The new `off-if-external` path keeps lid-close behavior active for docked setups, but silently no-ops when no external monitor is connected.

## Validation

- `bash -n bin/omarchy-hyprland-monitor-internal`
- `git diff --check`
- Hermetic behavior harness covering:
  - undocked lid-close no-op
  - manual `off` still shows the warning
  - docked `off-if-external` still disables the laptop display
