### PR TITLE
Stop package install flows after aborts or failures

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -21,9 +21,9 @@ pkg_names=$(yay -Slqa | fzf "${fzf_args[@]}")
 
 if [[ -n $pkg_names ]]; then
   # Add aur/ prefix to each package name and convert to space-separated for yay
-  source omarchy-sudo-keepalive
+  source omarchy-sudo-keepalive || exit 1
 
-  echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm
-  sudo updatedb
+  echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm || exit 1
+  sudo updatedb || exit 1
   omarchy-show-done
 fi

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -18,9 +18,9 @@ fzf_args=(
 pkg_names=$(pacman -Slq | fzf "${fzf_args[@]}")
 
 if [[ -n $pkg_names ]]; then
-  source omarchy-sudo-keepalive
+  source omarchy-sudo-keepalive || exit 1
 
   # Convert newline-separated selections to space-separated for pacman
-  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm
+  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm || exit 1
   omarchy-show-done
 fi

--- a/bin/omarchy-sudo-keepalive
+++ b/bin/omarchy-sudo-keepalive
@@ -3,7 +3,9 @@
 # omarchy:summary=Prompt for sudo once and keep the credential alive in the background.
 # omarchy:requires-sudo=true
 
-sudo -v
+if ! sudo -v; then
+  return 1 2>/dev/null || exit 1
+fi
 while true; do sudo -n true; sleep 60; done 2>/dev/null &
 SUDO_KEEPALIVE_PID=$!
 trap "kill $SUDO_KEEPALIVE_PID 2>/dev/null" EXIT

--- a/test/omarchy-cli-test.sh
+++ b/test/omarchy-cli-test.sh
@@ -337,45 +337,45 @@ export PATH="$PKG_STUB_DIR:$ROOT/bin:$ORIGINAL_PATH"
 
 rm -f "$PKG_TEST_DIR"/*.log
 if SUDO_VALIDATE_STATUS=1 "$ROOT/bin/omarchy-pkg-install"; then
-  fail "pkg install exits when sudo validation fails"
+  fail "pkg install should exit non-zero when sudo validation fails"
 fi
-[[ ! -f $PKG_TEST_DIR/pacman-install.log ]] || fail "pkg install skips pacman after sudo validation failure"
-[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "pkg install skips done after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/pacman-install.log ]] || fail "pkg install should not run pacman after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "pkg install should not show done after sudo validation failure"
 pass "pkg install aborts cleanly when sudo validation fails"
 
 rm -f "$PKG_TEST_DIR"/*.log
 if PACMAN_INSTALL_STATUS=42 "$ROOT/bin/omarchy-pkg-install"; then
-  fail "pkg install exits when pacman fails"
+  fail "pkg install should exit non-zero when pacman fails"
 fi
-[[ -f $PKG_TEST_DIR/pacman-install.log ]] || fail "pkg install attempted pacman"
-[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "pkg install skips done after pacman failure"
+[[ -f $PKG_TEST_DIR/pacman-install.log ]] || fail "pkg install should attempt pacman before handling failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "pkg install should not show done after pacman failure"
 pass "pkg install skips done when pacman fails"
 
 rm -f "$PKG_TEST_DIR"/*.log
 if SUDO_VALIDATE_STATUS=1 "$ROOT/bin/omarchy-pkg-aur-install"; then
-  fail "aur install exits when sudo validation fails"
+  fail "aur install should exit non-zero when sudo validation fails"
 fi
-[[ ! -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install skips yay after sudo validation failure"
-[[ ! -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install skips updatedb after sudo validation failure"
-[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install skips done after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install should not run yay after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install should not run updatedb after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install should not show done after sudo validation failure"
 pass "aur install aborts cleanly when sudo validation fails"
 
 rm -f "$PKG_TEST_DIR"/*.log
 if YAY_INSTALL_STATUS=42 "$ROOT/bin/omarchy-pkg-aur-install"; then
-  fail "aur install exits when yay fails"
+  fail "aur install should exit non-zero when yay fails"
 fi
-[[ -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install attempted yay"
-[[ ! -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install skips updatedb after yay failure"
-[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install skips done after yay failure"
+[[ -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install should attempt yay before handling failure"
+[[ ! -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install should not run updatedb after yay failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install should not show done after yay failure"
 pass "aur install skips follow-up steps when yay fails"
 
 rm -f "$PKG_TEST_DIR"/*.log
 if UPDATEDB_STATUS=42 "$ROOT/bin/omarchy-pkg-aur-install"; then
-  fail "aur install exits when updatedb fails"
+  fail "aur install should exit non-zero when updatedb fails"
 fi
-[[ -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install attempted yay before updatedb"
-[[ -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install attempted updatedb"
-[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install skips done after updatedb failure"
+[[ -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install should attempt yay before updatedb"
+[[ -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install should attempt updatedb before handling failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install should not show done after updatedb failure"
 pass "aur install skips done when updatedb fails"
 
 export PATH="$ORIGINAL_PATH"

--- a/test/omarchy-cli-test.sh
+++ b/test/omarchy-cli-test.sh
@@ -258,3 +258,124 @@ assert_output_contains "partial metadata command dispatches" "$output" "partial-
 
 output=$("$TMPDIR/omarchy" body metadata test)
 assert_output_contains "body metadata command dispatches by filename" "$output" "body-metadata-ok"
+
+PKG_TEST_DIR="$TMPDIR/package-install"
+PKG_STUB_DIR="$PKG_TEST_DIR/bin"
+mkdir -p "$PKG_STUB_DIR"
+
+cat >"$PKG_STUB_DIR/fzf" <<'SH'
+#!/bin/bash
+sed -n '1p'
+SH
+chmod +x "$PKG_STUB_DIR/fzf"
+
+cat >"$PKG_STUB_DIR/pacman" <<'SH'
+#!/bin/bash
+
+case "${1:-}" in
+  -Slq)
+    printf 'example\n'
+    ;;
+  -S)
+    printf '%s\n' "$*" >>"$PKG_TEST_DIR/pacman-install.log"
+    exit "${PACMAN_INSTALL_STATUS:-0}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$PKG_STUB_DIR/pacman"
+
+cat >"$PKG_STUB_DIR/yay" <<'SH'
+#!/bin/bash
+
+case "${1:-}" in
+  -Slqa)
+    printf 'example\n'
+    ;;
+  -S)
+    printf '%s\n' "$*" >>"$PKG_TEST_DIR/yay-install.log"
+    exit "${YAY_INSTALL_STATUS:-0}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$PKG_STUB_DIR/yay"
+
+cat >"$PKG_STUB_DIR/sudo" <<'SH'
+#!/bin/bash
+
+case "${1:-}" in
+  -v)
+    exit "${SUDO_VALIDATE_STATUS:-0}"
+    ;;
+  -n)
+    exit 0
+    ;;
+  updatedb)
+    printf 'updatedb\n' >>"$PKG_TEST_DIR/updatedb.log"
+    exit "${UPDATEDB_STATUS:-0}"
+    ;;
+esac
+
+exec "$@"
+SH
+chmod +x "$PKG_STUB_DIR/sudo"
+
+cat >"$PKG_STUB_DIR/omarchy-show-done" <<'SH'
+#!/bin/bash
+printf 'done\n' >>"$PKG_TEST_DIR/show-done.log"
+SH
+chmod +x "$PKG_STUB_DIR/omarchy-show-done"
+
+export PKG_TEST_DIR
+ORIGINAL_PATH="$PATH"
+export PATH="$PKG_STUB_DIR:$ROOT/bin:$ORIGINAL_PATH"
+
+rm -f "$PKG_TEST_DIR"/*.log
+if SUDO_VALIDATE_STATUS=1 "$ROOT/bin/omarchy-pkg-install"; then
+  fail "pkg install exits when sudo validation fails"
+fi
+[[ ! -f $PKG_TEST_DIR/pacman-install.log ]] || fail "pkg install skips pacman after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "pkg install skips done after sudo validation failure"
+pass "pkg install aborts cleanly when sudo validation fails"
+
+rm -f "$PKG_TEST_DIR"/*.log
+if PACMAN_INSTALL_STATUS=42 "$ROOT/bin/omarchy-pkg-install"; then
+  fail "pkg install exits when pacman fails"
+fi
+[[ -f $PKG_TEST_DIR/pacman-install.log ]] || fail "pkg install attempted pacman"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "pkg install skips done after pacman failure"
+pass "pkg install skips done when pacman fails"
+
+rm -f "$PKG_TEST_DIR"/*.log
+if SUDO_VALIDATE_STATUS=1 "$ROOT/bin/omarchy-pkg-aur-install"; then
+  fail "aur install exits when sudo validation fails"
+fi
+[[ ! -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install skips yay after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install skips updatedb after sudo validation failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install skips done after sudo validation failure"
+pass "aur install aborts cleanly when sudo validation fails"
+
+rm -f "$PKG_TEST_DIR"/*.log
+if YAY_INSTALL_STATUS=42 "$ROOT/bin/omarchy-pkg-aur-install"; then
+  fail "aur install exits when yay fails"
+fi
+[[ -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install attempted yay"
+[[ ! -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install skips updatedb after yay failure"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install skips done after yay failure"
+pass "aur install skips follow-up steps when yay fails"
+
+rm -f "$PKG_TEST_DIR"/*.log
+if UPDATEDB_STATUS=42 "$ROOT/bin/omarchy-pkg-aur-install"; then
+  fail "aur install exits when updatedb fails"
+fi
+[[ -f $PKG_TEST_DIR/yay-install.log ]] || fail "aur install attempted yay before updatedb"
+[[ -f $PKG_TEST_DIR/updatedb.log ]] || fail "aur install attempted updatedb"
+[[ ! -f $PKG_TEST_DIR/show-done.log ]] || fail "aur install skips done after updatedb failure"
+pass "aur install skips done when updatedb fails"
+
+export PATH="$ORIGINAL_PATH"


### PR DESCRIPTION
## Summary

Fixes #4869 by stopping package install flows when sudo validation is canceled or when the install command fails.

## Changes

- Make `omarchy-sudo-keepalive` return/exit non-zero when `sudo -v` fails.
- Stop `omarchy-pkg-install` before showing the done notification if sudo or `pacman` fails.
- Stop `omarchy-pkg-aur-install` before `updatedb`/done if sudo or `yay` fails, and before done if `updatedb` fails.
- Add hermetic tests with stubs for the abort/failure paths.

## Validation

- `bash -n bin/omarchy-sudo-keepalive bin/omarchy-pkg-install bin/omarchy-pkg-aur-install test/omarchy-cli-test.sh`
- `git diff --check`
- Focused package-install test section passed
