### PR TITLE
Harden browser managed policy permissions

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -4,6 +4,18 @@
 
 CHROMIUM_THEME=~/.config/omarchy/current/theme/chromium.theme
 
+write_browser_policy() {
+  local policy_dir="$1"
+  local policy_file="$policy_dir/color.json"
+
+  if [[ ! -w $policy_file ]]; then
+    echo "Cannot write $policy_file. Run omarchy-migrate to repair browser policy permissions." >&2
+    return 1
+  fi
+
+  printf '{"BrowserThemeColor": "%s", "BrowserColorScheme": "device"}\n' "$THEME_HEX_COLOR" >"$policy_file"
+}
+
 if omarchy-cmd-present chromium || omarchy-cmd-present brave || omarchy-cmd-present brave-origin-beta; then
   if [[ -f $CHROMIUM_THEME ]]; then
     THEME_RGB_COLOR=$(<$CHROMIUM_THEME)
@@ -15,13 +27,13 @@ if omarchy-cmd-present chromium || omarchy-cmd-present brave || omarchy-cmd-pres
   fi
 
   if omarchy-cmd-present chromium; then
-    echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/chromium/policies/managed/color.json" >/dev/null
+    write_browser_policy "/etc/chromium/policies/managed"
     pgrep -x chromium >/dev/null && chromium --refresh-platform-policy --no-startup-window &>/dev/null
   fi
 
   # Brave and Brave Origin Beta share /etc/brave/policies, so a single write covers both
   if omarchy-cmd-present brave || omarchy-cmd-present brave-origin-beta; then
-    echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "/etc/brave/policies/managed/color.json" >/dev/null
+    write_browser_policy "/etc/brave/policies/managed"
     if pgrep -x brave >/dev/null; then
       omarchy-cmd-present brave && brave --refresh-platform-policy --no-startup-window &>/dev/null
       omarchy-cmd-present brave-origin-beta && brave-origin-beta --refresh-platform-policy --no-startup-window &>/dev/null

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -2,16 +2,23 @@
 sudo ln -snf /usr/share/icons/Adwaita/symbolic/actions/go-previous-symbolic.svg /usr/share/icons/Yaru/scalable/actions/go-previous-symbolic.svg
 sudo ln -snf /usr/share/icons/Adwaita/symbolic/actions/go-next-symbolic.svg /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
 
+setup_browser_policy_file() {
+  local policy_dir="$1"
+  local policy_file="$policy_dir/color.json"
+
+  sudo install -d -m 755 -o root -g root "$policy_dir"
+  sudo rm -f "$policy_file"
+  sudo install -m 664 -o root -g wheel /dev/null "$policy_file"
+}
+
 # Setup user theme folder
 mkdir -p ~/.config/omarchy/themes
 
 # Add managed policy directories for Chromium and Brave for theme changes.
 # Must exist before the first omarchy-theme-set, which writes color.json into them.
-sudo mkdir -p /etc/chromium/policies/managed
-sudo chmod a+rw /etc/chromium/policies/managed
+setup_browser_policy_file /etc/chromium/policies/managed
 
-sudo mkdir -p /etc/brave/policies/managed
-sudo chmod a+rw /etc/brave/policies/managed
+setup_browser_policy_file /etc/brave/policies/managed
 
 # Set initial theme
 omarchy-theme-set "Tokyo Night"

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -7,7 +7,7 @@ setup_browser_policy_file() {
   local policy_file="$policy_dir/color.json"
 
   sudo install -d -m 755 -o root -g root "$policy_dir"
-  sudo rm -f "$policy_file"
+  sudo rm -rf -- "$policy_file"
   sudo install -m 664 -o root -g wheel /dev/null "$policy_file"
 }
 

--- a/migrations/1757147211.sh
+++ b/migrations/1757147211.sh
@@ -2,7 +2,7 @@ echo "Create managed policy directories for Chromium and Brave for theme switchi
 
 for policy_dir in /etc/chromium/policies/managed /etc/brave/policies/managed; do
   sudo install -d -m 755 -o root -g root "$policy_dir"
-  sudo rm -f "$policy_dir/color.json"
+  sudo rm -rf "$policy_dir/color.json"
   sudo install -m 664 -o root -g wheel /dev/null "$policy_dir/color.json"
 done
 

--- a/migrations/1757147211.sh
+++ b/migrations/1757147211.sh
@@ -2,7 +2,7 @@ echo "Create managed policy directories for Chromium and Brave for theme switchi
 
 for policy_dir in /etc/chromium/policies/managed /etc/brave/policies/managed; do
   sudo install -d -m 755 -o root -g root "$policy_dir"
-  sudo rm -rf "$policy_dir/color.json"
+  sudo rm -rf -- "$policy_dir/color.json"
   sudo install -m 664 -o root -g wheel /dev/null "$policy_dir/color.json"
 done
 

--- a/migrations/1777653181.sh
+++ b/migrations/1777653181.sh
@@ -2,7 +2,7 @@ echo "Restrict browser managed policy directories to administrators"
 
 for policy_dir in /etc/chromium/policies/managed /etc/brave/policies/managed; do
   sudo install -d -m 755 -o root -g root "$policy_dir"
-  sudo rm -f "$policy_dir/color.json"
+  sudo rm -rf -- "$policy_dir/color.json"
   sudo install -m 664 -o root -g wheel /dev/null "$policy_dir/color.json"
 done
 

--- a/migrations/1777653181.sh
+++ b/migrations/1777653181.sh
@@ -1,4 +1,4 @@
-echo "Create managed policy directories for Chromium and Brave for theme switching"
+echo "Restrict browser managed policy directories to administrators"
 
 for policy_dir in /etc/chromium/policies/managed /etc/brave/policies/managed; do
   sudo install -d -m 755 -o root -g root "$policy_dir"


### PR DESCRIPTION
## Summary

Fixes #5547.

This keeps Chromium and Brave managed policy directories from being writable by every local user, while preserving no-sudo theme switching.

## Changes

- Create `/etc/chromium/policies/managed` and `/etc/brave/policies/managed` as `root:root` mode `755`.
- Pre-create Omarchy’s managed `color.json` as `root:wheel` mode `664`.
- Keep `omarchy-theme-set-browser` sudo-free by only overwriting the existing `color.json`.
- Remove stale `color.json` paths during migration before recreating them, so old symlinks from the previous world-writable directory state are not followed.
- Update the older migration path to use the same hardened directory/file setup.

## Validation

- `bash -n bin/omarchy-theme-set-browser install/config/theme.sh migrations/1757147211.sh migrations/1777653181.sh`
- `git diff --check`
- Focused shell checks for:
  - sudo-free theme writer
  - stale `color.json` symlink removal
  - `root:root` policy directories
  - `root:wheel` mode `664` policy file setup
