### PR TITLE
Remove multiple packages at once

### DIFF
--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -6,9 +6,10 @@
 fzf_args=(
   --multi
   --preview 'yay -Qi {1}'
-  --preview-label='alt-p: toggle description, alt-j/k: scroll, tab: multi-select'
+  --preview-label='space/tab: mark packages, enter: uninstall marked packages, alt-p: toggle description'
   --preview-label-pos='bottom'
   --preview-window 'down:65%:wrap'
+  --bind 'space:toggle'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'
@@ -18,7 +19,7 @@ fzf_args=(
 pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
 
 if [[ -n $pkg_names ]]; then
-  # Convert newline-separated selections to space-separated for yay
-  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
+  mapfile -t selected_packages <<<"$pkg_names"
+  sudo pacman -Rns --noconfirm "${selected_packages[@]}"
   omarchy-show-done
 fi


### PR DESCRIPTION
## Summary

- make the package removal picker easier to use for selecting multiple packages
- allow Space as an explicit multi-select toggle alongside Tab
- pass selected packages to pacman as array arguments
- fzf search continues to work, adds a mark beside packages selected for removal

<img width="1750" height="1200" alt="image" src="https://github.com/user-attachments/assets/d4b7f5ca-9da6-4512-be05-5de440fd7839" />
