### PR TITLE
fix(network): add default iwd config to prevent micro drops

### DIFF
--- a/default/iwd/main.conf
+++ b/default/iwd/main.conf
@@ -1,0 +1,5 @@
+[General]
+RoamThreshold=-85
+
+[Network]
+EnableNetworkConfiguration=false

--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -1,6 +1,12 @@
 # Ensure iwd service will be started
 sudo systemctl enable iwd.service
 
+# Set up default iwd configuration to prevent DNS conflicts and micro-drops
+sudo mkdir -p /etc/iwd
+if [[ ! -f /etc/iwd/main.conf ]]; then
+  sudo cp "$OMARCHY_PATH/default/iwd/main.conf" /etc/iwd/main.conf
+fi
+
 # Prevent systemd-networkd-wait-online timeout on boot
 sudo systemctl disable systemd-networkd-wait-online.service
 sudo systemctl mask systemd-networkd-wait-online.service


### PR DESCRIPTION
## Description
This PR introduces a default `main.conf` for `iwd` to resolve a critical networking conflict and aggressive background scanning behavior that causes micro-disconnects for users.

## The Problem
when attempting to use real time UDP applications (microsoft teams, zoom, multiplayer games or sustained SSH sessions) experience connection drops every 1-2 minutes.

Testing with `mtr` reveals the `wlan0` interface momentarily drops the connection. System logs show this is caused by two overlapping default behaviors:

1. **DNS turf war:** because `iwd` defaults to managing the network, it constantly fights `systemd-networkd` to assign DNS entries, resulting in constant link resets.
2. **aggressive roaming:** `iwd`'s default `RoamThreshold` of `-70 dBm` is too aggressive for standard home environments, causing it to pause traffic and scan for new access points even when the current connection is perfectly stable. 

**Log Evidence:**
`journalctl -u iwd.service` constantly throws these errors right before a drop:
> `resolve-systemd: Failed to modify the DNS entries. org.freedesktop.resolve1.LinkBusy: Link wlan0 is managed.`
> `event: roam-scan`

## The Solution
Added a default system configuration file at `default/iwd/main.conf` with two rules:

* `EnableNetworkConfiguration=false` (Under `[Network]`): forces `iwd` to yield DNS and IP routing to `systemd-networkd`, stopping the `LinkBusy` conflict.
* `RoamThreshold=-85` (Under `[General]`): lowers the roaming panic threshold to a more reasonable level, preventing aggressive background scanning from interrupting real-time traffic.

## Testing
- verified that `iwd` now correctly logs `station: Network configuration is disabled.` upon startup.
- verified `mtr` holds a stable, 0% loss connection past the 1-minute mark during heavy real time UDP loads.
- verified the `LinkBusy` errors no longer appear in `journalctl`.