### PR TITLE
Use color# naming in tmux config

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -82,13 +82,13 @@ set -gw automatic-rename-format '#{b:pane_current_path}'
 
 # Theme
 set -g status-style "bg=default,fg=default"
-set -g status-left "#[fg=black,bg=blue,bold] #S #[bg=default] "
-set -g status-right "#[fg=blue]#{?pane_in_mode,COPY ,}#{?client_prefix,PREFIX ,}#{?window_zoomed_flag,ZOOM ,}#[fg=brightblack]#h "
-set -g window-status-format "#[fg=brightblack] #I:#W "
-set -g window-status-current-format "#[fg=blue,bold] #I:#W "
-set -g pane-border-style "fg=brightblack"
-set -g pane-active-border-style "fg=blue"
-set -g message-style "bg=default,fg=blue"
-set -g message-command-style "bg=default,fg=blue"
-set -g mode-style "bg=blue,fg=black"
-setw -g clock-mode-colour blue
+set -g status-left "#[fg=color0,bg=color4,bold] #S #[bg=default] "
+set -g status-right "#[fg=color4]#{?pane_in_mode,COPY ,}#{?client_prefix,PREFIX ,}#{?window_zoomed_flag,ZOOM ,}#[fg=color8]#h "
+set -g window-status-format "#[fg=color8] #I:#W "
+set -g window-status-current-format "#[fg=color4,bold] #I:#W "
+set -g pane-border-style "fg=color8"
+set -g pane-active-border-style "fg=color4"
+set -g message-style "bg=default,fg=color4"
+set -g message-command-style "bg=default,fg=color4"
+set -g mode-style "bg=color4,fg=color0"
+setw -g clock-mode-colour color4


### PR DESCRIPTION
The older ASCII naming for the first 16 colors does not necessarily match with the visual reality of the color used in a theme. The default ASCII colors are: black, red,  green, yellow, blue, magenta, cyan, white; the second set of 8 are their "bright" variants.

The 3 colors used in the default tmux config are blue, black, and brightblack.

In the Tokyo Night theme (for example), these names are perfectly fine as they match visually with the words used. However, in the Retro 82 theme the "blue" color is actually orange. This could be confusing.

Fortunately, there is a newer color naming standard which is very consistent across many utilities and configurations; color#. This also happens to be the naming convention used in the theme's main colors.toml config file.

In this newer convention, the names are changed like this:
  blue -> color4
  black -> color0
  brightblack -> color8

To be clear, this is only a naming change. The behavior - and colors in the UI - are unchanged by this feature.

Note:
There is a great NeoVim plugin - called "norcalli/nvim-colorizer" - which will highlight the actual visual colors of #HEXCODE colors within your terminal.

You can enable it and see it in action with the following two commands.

$ cat << EOF > ~/.config/nvim/lua/plugins/additions.lua
return {
  -- nvim-colorizer displays the color represented by a #HEXCODE inline (as the text's bgcolor)
  {
    "norcalli/nvim-colorizer.lua",
    event = "BufReadPre",
    config = function()
      require("colorizer").setup()
    end,
  },
}
EOF

$ nvim ~/.config/omarchy/current/theme/colors.toml