### PR TITLE
Fix headphone audio on ASUS ROG Strix G16 (ALC285)

### DIFF
--- a/install/config/hardware/asus/fix-audio-mixer.sh
+++ b/install/config/hardware/asus/fix-audio-mixer.sh
@@ -1,13 +1,38 @@
-# Fix audio volume on Asus ROG laptops by using a soft mixer.
+# Fix audio volume on Asus ROG laptops.
+#
+# Soft-mixer is required on Asus G14, but breaks on Asus ROG Strix G16 (2025)
+# with Realtek ALC285 codec, subsystem id 0x10433f20: the kernel HDA fixup
+# re-mutes the Headphone switch after PipeWire opens the device, and
+# api.alsa.soft-mixer = true prevents PipeWire from clearing it via the
+# standard alsa-card-profile mixer paths (analog-output-headphones.conf).
+# See https://github.com/basecamp/omarchy/issues/4821
 
 if omarchy-hw-asus-rog; then
-  mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
-  cp $OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/alsa-soft-mixer.conf ~/.config/wireplumber/wireplumber.conf.d/
+  card=$(aplay -l 2>/dev/null | grep -i "ALC285" | head -1 | sed 's/card \([0-9]*\).*/\1/')
+
+  ssid=""
+  if [[ -n $card && -f /proc/asound/card${card}/codec#0 ]]; then
+    ssid=$(grep -oE 'Subsystem Id: 0x[0-9a-f]+' /proc/asound/card${card}/codec#0 | awk '{print $3}')
+  fi
+
+  case "$ssid" in
+    # ASUS ROG Strix G16 (2025) — soft-mixer breaks headphone output here
+    0x10433f20)
+      rm -f ~/.config/wireplumber/wireplumber.conf.d/alsa-soft-mixer.conf
+      ;;
+    *)
+      mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+      cp $OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/alsa-soft-mixer.conf ~/.config/wireplumber/wireplumber.conf.d/
+      ;;
+  esac
+
   rm -rf ~/.local/state/wireplumber/default-routes
 
-  # Unmute the Master control on the ALC285 card (often muted by default)
-  card=$(aplay -l 2>/dev/null | grep -i "ALC285" | head -1 | sed 's/card \([0-9]*\).*/\1/')
+  # Unmute Master and Line Out on the ALC285 card (kernel default is muted/zero).
+  # Line Out is the DAC stage feeding the headphone amp on this codec; if it
+  # stays at 0 the Headphone jack plays at near-silent levels even when unmuted.
   if [[ -n $card ]]; then
     amixer -c "$card" set Master 80% unmute 2>/dev/null
+    amixer -c "$card" set 'Line Out' 80% unmute 2>/dev/null
   fi
 fi


### PR DESCRIPTION
Fixes #4821.

## Problem
On Omarchy 3.6.0, ASUS ROG Strix G16 (2025) with Realtek ALC285 codec
(subsystem id `0x10433f20`), headphone audio is silent or extremely
quiet after a fresh install. The current `fix-audio-mixer.sh` installs
an `api.alsa.soft-mixer = true` WirePlumber override which prevents
PipeWire from managing the hardware Headphone switch through the
standard ALSA card-profile mixer paths (`analog-output-headphones.conf`
etc.). The kernel HDA fixup for this SSID re-mutes the Headphone switch
every time PipeWire opens the device, and nothing ever clears it.
Independently, `Line Out Playback Volume` (the DAC stage feeding the
headphone amp on this codec) is left at 0% by the kernel and never
bumped.

Full diagnosis in #4821.

## Why not just remove soft-mixer for all ROG?
Commit 21514dc made soft-mixer opt-in because it is required on the
Asus G14. Removing it unconditionally would regress G14 users. This PR
gates by ALC285 subsystem id so existing ROG behavior is preserved
everywhere except the G16 SSID `0x10433f20`. Other ROG variants that
hit the same bug can be added to the `case` as reports come in.

## Change
- Detect ALC285 subsystem id via `/proc/asound/card<N>/codec#0`.
- On `0x10433f20`: skip the soft-mixer copy; remove any previously
  installed copy; rely on PipeWire's default hardware-mixer management.
- For all ROG: also unmute `Line Out` (in addition to existing Master)
  so the headphone DAC stage is not stuck at 0%.

## Test
Verified on Omarchy 3.6.0, ASUS ROG Strix G16 2025 (ALC285,
SSID `0x10433f20`): before the fix `amixer -c 1 sget 'Line Out'`
reported 0% / -65dB and headphone output was inaudible at 100% PipeWire
volume; after the fix Line Out is at 80% / -12.75dB and headphone audio
plays at expected levels. `Speaker` correctly auto-mutes when headphones
are plugged in via PipeWire's mixer-path management (no soft-mixer).