### PR TITLE
Add decoration section with rounding = 0 to no-gaps mode

### DIFF
--- a/default/hypr/toggles/window-no-gaps.conf
+++ b/default/hypr/toggles/window-no-gaps.conf
@@ -4,3 +4,7 @@ general {
     gaps_in = 0
     border_size = 0
 }
+
+decoration {
+    rounding = 0
+}


### PR DESCRIPTION
When the user has custom rounding, the no-gaps toggle needs to set that value to zero.