### PR TITLE
Fix: Catppuccin colorscheme name in neovim.lua

### DIFF
--- a/themes/catppuccin/neovim.lua
+++ b/themes/catppuccin/neovim.lua
@@ -7,7 +7,7 @@ return {
   {
     "LazyVim/LazyVim",
     opts = {
-      colorscheme = "catppuccin",
+      colorscheme = "catppuccin-nvim",
     },
   },
 }


### PR DESCRIPTION
Updated the colorscheme name from `catppuccin` to `catppuccin-nvim` to align with recent upstream changes.

This follows the changes introduced in [catppuccin#977](https://github.com/catppuccin/nvim/pull/977), where the colorscheme naming was updated.

This fixes a potential issue where the Catppuccin theme would not load in Neovim.