### PR TITLE
Support tmux theme fragments in Omarchy themes

### DIFF
--- a/bin/omarchy-restart-tmux
+++ b/bin/omarchy-restart-tmux
@@ -2,6 +2,9 @@
 
 # omarchy:summary=Restart tmux if running with the latest configuration
 
-if pgrep -x tmux; then
+if tmux ls >/dev/null 2>&1; then
   tmux source-file ~/.config/tmux/tmux.conf
+  if [[ -f ~/.config/omarchy/current/theme/tmux.conf ]]; then
+    tmux source-file ~/.config/omarchy/current/theme/tmux.conf
+  fi
 fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -58,6 +58,7 @@ omarchy-restart-btop
 omarchy-restart-opencode
 omarchy-restart-mako
 omarchy-restart-helix
+omarchy-restart-tmux
 
 # Change app-specific themes
 omarchy-theme-set-gnome

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -92,3 +92,6 @@ set -g message-style "bg=default,fg=blue"
 set -g message-command-style "bg=default,fg=blue"
 set -g mode-style "bg=blue,fg=black"
 setw -g clock-mode-colour blue
+
+# Optional Omarchy theme fragment
+if-shell "[ -f ~/.config/omarchy/current/theme/tmux.conf ]" "source-file ~/.config/omarchy/current/theme/tmux.conf"


### PR DESCRIPTION
## Summary

Adds optional tmux theme fragments loaded from the active Omarchy theme.

This lets themes ship a `tmux.conf` fragment alongside existing app-specific
theme files, while keeping the default tmux colors intact for themes that do not
provide one.

## Changes

- Sources `~/.config/omarchy/current/theme/tmux.conf` from the default tmux config when present.
- Reloads tmux when changing Omarchy themes.
- Uses `tmux ls` instead of `pgrep` so tmux is only reloaded when a server is reachable.

## Testing

- `git diff --check origin/dev..cp/tmux-theme-fragments`
- `bash -n bin/omarchy-restart-tmux`
- `bash -n bin/omarchy-theme-set`
