### PR TITLE
Use Opus audio for screen recordings

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -198,7 +198,7 @@ start_screenrecording() {
     audio_devices+="default_input"
   fi
 
-  [[ -n $audio_devices ]] && audio_args+=(-a "$audio_devices" -ac aac)
+  [[ -n $audio_devices ]] && audio_args+=(-a "$audio_devices" -ac opus)
 
   echo "===== $(date '+%F %T') args: $* target: $target =====" >>"$LOG_FILE"
   gpu-screen-recorder "${capture_args[@]}" -k auto -f 60 -fm cfr -fallback-cpu-encoding yes -o "$filename" "${audio_args[@]}" 2>>"$LOG_FILE" &


### PR DESCRIPTION
## Summary

Switches gpu-screen-recorder audio encoding from AAC to Opus for Omarchy screen recordings with audio.

The reason for this is Linux import compatibility with DaVinci Resolve. In
Blackmagic's DaVinci Resolve 20 supported codec list, AAC/aac-m4a has no decode or encode support on Rocky Linux, while OPUS in mov/mp4 is listed as decodable.
Using Opus makes Omarchy screen recordings easier to import into Resolve on Linux without an audio transcode step.

## Changes

- Changes the `-ac` value passed to `gpu-screen-recorder` from `aac` to `opus`.

## Reference

- Blackmagic Design: [DaVinci Resolve 20 Supported Codec List](https://documents.blackmagicdesign.com/SupportNotes/DaVinci_Resolve_20_Supported_Codec_List.pdf)

## Testing

- `git diff --check origin/dev..cp/screenrecord-opus-audio`
- `bash -n bin/omarchy-capture-screenrecording`
