### PR TITLE
Round mako notification corners

### DIFF
--- a/default/mako/core.ini
+++ b/default/mako/core.ini
@@ -4,6 +4,7 @@ width=420
 outer-margin=20
 padding=10,15
 border-size=2
+border-radius=10
 max-icon-size=32
 font=sans-serif 14px
 


### PR DESCRIPTION
## Summary

Adds rounded corners to Omarchy's shared mako notification config.

This ports the previous Tokyo Night-specific `border-radius=10` tweak to the current config structure. Mako colors are now generated from theme templates, so the shared notification shape belongs in `default/mako/core.ini`.

## Changes

- Adds `border-radius=10` to the shared mako core config.

## Testing

- `git diff --check origin/dev..cp/rounded-mako-notifications`
