### PR TITLE
ghui autoreloads oma theme

### DIFF
--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -14,7 +14,8 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
 
   # Remove npx stubs
   rm -f ~/.local/bin/codex ~/.local/bin/gemini ~/.local/bin/copilot \
-       ~/.local/bin/opencode ~/.local/bin/playwright-cli ~/.local/bin/pi
+       ~/.local/bin/opencode ~/.local/bin/playwright-cli ~/.local/bin/pi \
+       ~/.local/bin/ghui
 
   omarchy-pkg-drop \
     aether \

--- a/bin/omarchy-restart-ghui
+++ b/bin/omarchy-restart-ghui
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# omarchy:summary=Reload ghui configuration (used by the Omarchy theme switching).
+
+if pgrep -x ghui >/dev/null; then
+  killall -SIGUSR2 ghui
+fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -58,6 +58,7 @@ omarchy-restart-terminal
 omarchy-restart-hyprctl
 omarchy-restart-btop
 omarchy-restart-opencode
+omarchy-restart-ghui
 omarchy-restart-mako
 omarchy-restart-helix
 

--- a/config/ghui/config.json
+++ b/config/ghui/config.json
@@ -1,0 +1,4 @@
+{
+  "theme": "system",
+  "systemThemeAutoReload": true
+}

--- a/migrations/1777978416.sh
+++ b/migrations/1777978416.sh
@@ -1,0 +1,6 @@
+echo "Configure ghui with system theming"
+
+if [[ ! -f ~/.config/ghui/config.json ]]; then
+  mkdir -p ~/.config/ghui
+  cp "$OMARCHY_PATH/config/ghui/config.json" ~/.config/ghui/config.json
+fi


### PR DESCRIPTION
Hi all,

thanks a lot for oma , I enjoy it a lot. also thanks for 3.7.0/1 great updates

would be cool if `ghui`, now that its part of oma, would get the cool theme switching whenever the main omarchy theme switches as well

this PR does that following the way `opencode` implements a similar feature in the older #4566 , #4582 PRs

**attention:** so `ghui` does yet not receive the `sigusr` signal on the other side, but I made a matching PR there to add this feature https://github.com/kitlangton/ghui/pull/28 

would be really nice to have the auto theme switch at some future point ! 