### PR TITLE
typo themeing -> theming

### DIFF
--- a/migrations/1767478687.sh
+++ b/migrations/1767478687.sh
@@ -1,4 +1,4 @@
-echo "Add opencode with system themeing"
+echo "Add opencode with system theming"
 
 omarchy-pkg-add opencode
 

--- a/migrations/1769510847.sh
+++ b/migrations/1769510847.sh
@@ -1,4 +1,4 @@
-echo "Switch back to mainline chromium now that it supports full live themeing"
+echo "Switch back to mainline chromium now that it supports full live theming"
 
 if omarchy-pkg-present omarchy-chromium; then
   if gum confirm "Ready to switch to mainstream chromium? (Will close Chromium + reset settings)"; then


### PR DESCRIPTION
I noticed copilot complaining in #5589 about the word "themeing" so I checked its existence 

word counter in omarchy

themeing: twice vs theming : once

maybe innocous as printed during migrations only but agents tend to pick up words they find in code and reproduce that pattern 

though only lightly user facing , I'd change `themeing` -> `theming`  