### PR TITLE
fix silent text capture failure when tesseract is missing

### DIFF
--- a/bin/omarchy-capture-text-extraction
+++ b/bin/omarchy-capture-text-extraction
@@ -4,6 +4,14 @@
 # omarchy:group=capture
 # omarchy:examples=omarchy capture ocr
 
+if omarchy-cmd-missing tesseract || ! tesseract --list-langs 2>/dev/null | grep -qx "eng"; then
+  notify-send -u critical -t 20000 \
+    "Text extraction unavailable" \
+    "OCR support is missing. Install it with:\nomarchy-pkg-add tesseract tesseract-data-eng"
+  echo "Error: OCR requires tesseract and tesseract-data-eng" >&2
+  exit 1
+fi
+
 # Keep hyprpicker alive until after grim captures so the screenshot sees the
 # frozen overlay rather than live content shifting during teardown.
 cleanup_freeze() {


### PR DESCRIPTION
Per discussion #5594 it seems that the 3.7 text capture can fail when `tesseract` is not available.

Could happen, if a migration fails during omarchy update, or if the sb later just uninstalls it.

In any case it fails silently which is not so nice.

This PR fixes that.

One can quickly uninstall `tesseract` and reproduce the silent fail. Then get the couple of lines, and see that when `tesseract` is uninstalled, and the text capture is fired up, the popup emerges notifying the user that the text capture is unavailable.