### PR TITLE
Add bass speaker fix for Lenovo Yoga Pro 7 14IAH10

### DIFF
--- a/bin/omarchy-hw-lenovo-yoga-pro7-bass
+++ b/bin/omarchy-hw-lenovo-yoga-pro7-bass
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# omarchy:summary=Detect Lenovo Yoga Pro 7 14IAH10 with bass speaker fix needed.
+
+omarchy-hw-match "Yoga Pro 7 14IAH10"

--- a/bin/omarchy-hw-lenovo-yoga-pro7-bass
+++ b/bin/omarchy-hw-lenovo-yoga-pro7-bass
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# omarchy:summary=Detect Lenovo Yoga Pro 7 14IAH10 with bass speaker fix needed.
-
-omarchy-hw-match "Yoga Pro 7 14IAH10"

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -63,6 +63,8 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 
+run_logged $OMARCHY_INSTALL/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
+
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh

--- a/install/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
+++ b/install/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
@@ -1,0 +1,10 @@
+# Fix bass speakers on Lenovo Yoga Pro 7 14IAH10
+# The ALC287 codec needs a pin quirk to route audio to both AMP speakers.
+# Without this quirk, only one speaker works and bass output is missing.
+# Reference: https://wiki.archlinux.org/title/Lenovo_Yoga_9i_2022_(14AiPI7)
+
+if omarchy-hw-lenovo-yoga-pro7-bass; then
+  sudo tee /etc/modprobe.d/lenovo-yoga-pro7-bass.conf <<'EOF'
+options snd-sof-intel-hda-generic hda_model=alc287-yoga9-bass-spk-pin
+EOF
+fi

--- a/install/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
+++ b/install/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
@@ -3,7 +3,7 @@
 # Without this quirk, only one speaker works and bass output is missing.
 # Reference: https://wiki.archlinux.org/title/Lenovo_Yoga_9i_2022_(14AiPI7)
 
-if omarchy-hw-lenovo-yoga-pro7-bass; then
+if omarchy-hw-match "Yoga Pro 7 14IAH10"; then
   sudo tee /etc/modprobe.d/lenovo-yoga-pro7-bass.conf <<'EOF'
 options snd-sof-intel-hda-generic hda_model=alc287-yoga9-bass-spk-pin
 EOF

--- a/migrations/1778001804.sh
+++ b/migrations/1778001804.sh
@@ -1,0 +1,3 @@
+echo "Fix bass speakers on Lenovo Yoga Pro 7 14IAH10"
+
+source "$OMARCHY_PATH/install/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"


### PR DESCRIPTION
## Problem
The Lenovo Yoga Pro 7 14IAH10 has dual amplifier speakers (AMP1 + AMP2) that require a specific pin quirk for the ALC287 codec. Without this fix, only one speaker works and bass output is missing.

## Solution
This PR adds hardware detection and audio configuration for the Yoga Pro 7 14IAH10:

- **Hardware detection script**: `bin/omarchy-hw-lenovo-yoga-pro7-bass`
- **Audio fix**: `install/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh`

The fix creates `/etc/modprobe.d/lenovo-yoga-pro7-bass.conf` with:
```
options snd-sof-intel-hda-generic hda_model=alc287-yoga9-bass-spk-pin
```

## Testing
Tested on Lenovo Yoga Pro 7 14IAH10 with Intel Core Ultra 9 285H. Both speakers now work correctly with proper bass output.

## Reference
Based on the same fix used for Lenovo Yoga 9i 2022: https://wiki.archlinux.org/title/Lenovo_Yoga_9i_2022_(14AiPI7)#Audio