### PR TITLE
Add support for Studio Display XDR brightness

### DIFF
--- a/bin/omarchy-hyprland-monitor-focused-apple
+++ b/bin/omarchy-hyprland-monitor-focused-apple
@@ -2,4 +2,4 @@
 
 # omarchy:summary=Return success if the focused Hyprland monitor is an Apple display.
 
-hyprctl monitors -j | jq -e '.[] | select(.focused == true) | select(.make == "Apple Computer Inc" and (.model | test("StudioDisplay|ProDisplayXDR")))' >/dev/null
+hyprctl monitors -j | jq -e '.[] | select(.focused == true) | select(.make == "Apple Computer Inc" and (.model | test("StudioDisplay|ProDisplayXDR|Studio XDR")))' >/dev/null


### PR DESCRIPTION
Resolves #5596 

Since ddb8081eaae1570960fc63458428d036b366cdb8 unified all brightness control in one command it now depends on `omarchy-hyprland-monitor-focused-apple` detecting Apple displays correctly.

The underlying package has been updated to support XDR in https://github.com/omacom-io/omarchy-pkgs/pull/85 bringing in the patch from https://github.com/omakasui/asdcontrol/pull/1.

This now adds detection so omarchy brighntess and keyboard commands work correctly with Studio Display XDR.

```
~/Personal ❯ hyprctl monitors -j | jq '.[] | {name,description,make,model,serial,focused}'
{
  "name": "DP-4",
  "description": "Apple Computer Inc Studio XDR 0x1234",
  "make": "Apple Computer Inc",
  "model": "Studio XDR",
  "serial": "0x1234",
  "focused": true
}
```