### PR TITLE
Disable screenshot freeze overlay by default (#5468)

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -14,7 +14,14 @@ if [[ ! -d $OUTPUT_DIR ]]; then
   notify-send "Created screenshot directory: $OUTPUT_DIR" -u normal -t 2000
 fi
 
-pkill slurp && exit 0
+# Re-pressing the binding cancels an in-progress selection. Kill hyprpicker
+# too: its frozen overlay can outlive a stale slurp and hold keyboard focus,
+# leaving the session feeling locked (#5468).
+if pgrep -x slurp >/dev/null || pgrep -x hyprpicker >/dev/null; then
+  pkill -x slurp 2>/dev/null
+  pkill -x hyprpicker 2>/dev/null
+  exit 0
+fi
 
 SCREENSHOT_EDITOR="${OMARCHY_SCREENSHOT_EDITOR:-satty}"
 
@@ -65,6 +72,19 @@ get_rectangles() {
   hyprctl clients -j | jq -r --arg ws "$active_workspace" '.[] | select(.workspace.id == ($ws | tonumber)) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
 }
 
+# Hyprpicker freezes the screen during selection, but its overlay registers at
+# layer level 3 above slurp's level 2 and can grab keyboard focus, leaving Esc
+# unable to dismiss slurp (#5468). Off by default; opt in with
+# OMARCHY_SCREENSHOT_FREEZE=1.
+FREEZE="${OMARCHY_SCREENSHOT_FREEZE:-0}"
+
+start_freeze() {
+  [[ $FREEZE == 1 ]] || return 0
+  hyprpicker -r -z >/dev/null 2>&1 &
+  PID=$!
+  sleep .1
+}
+
 # Keep hyprpicker alive until after grim captures so the screenshot sees the
 # frozen overlay rather than live content shifting during teardown.
 cleanup_freeze() {
@@ -75,15 +95,11 @@ trap cleanup_freeze EXIT
 # Select based on mode
 case "$MODE" in
 region)
-  hyprpicker -r -z >/dev/null 2>&1 &
-  PID=$!
-  sleep .1
+  start_freeze
   SELECTION=$(slurp 2>/dev/null)
   ;;
 windows)
-  hyprpicker -r -z >/dev/null 2>&1 &
-  PID=$!
-  sleep .1
+  start_freeze
   SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
   ;;
 fullscreen)
@@ -91,9 +107,7 @@ fullscreen)
   ;;
 smart | *)
   RECTS=$(get_rectangles)
-  hyprpicker -r -z >/dev/null 2>&1 &
-  PID=$!
-  sleep .1
+  start_freeze
   SELECTION=$(echo "$RECTS" | slurp 2>/dev/null)
 
   # If the selection area is L * W < 20, we'll assume you were trying to select whichever


### PR DESCRIPTION
## Summary

Closes the deadlock path in #5468 by making the `hyprpicker -r -z` freeze overlay opt-in instead of default.

- **Default flipped:** screenshot capture no longer launches the freeze overlay. Region/window/smart selection still works — the screen just "lives" during the brief slurp window.
- **Opt in:** set `OMARCHY_SCREENSHOT_FREEZE=1` to restore the old behavior.
- **Toggle hardened:** re-pressing the binding now also kills any lingering `hyprpicker` alongside `slurp`, so a stuck overlay clears on next press instead of needing a TTY escape.

## Why

`hyprpicker -r -z` registers its frozen overlay at layer **level 3** (overlay), while `slurp` paints its selection on **level 2** (top). Intermittently — most reliably under load such as Zoom or Teams calls — the overlay grabs keyboard focus, leaving `Esc` unable to dismiss `slurp`. The session looks frozen: cursor moves, audio plays, but clicks register nowhere and the script blocks on `slurp` forever. Only escape today is `Ctrl+Alt+F2` → `pkill slurp hyprpicker` → `Ctrl+Alt+F1`.

Verified locally on Hyprland 0.54.3 with hyprpicker 0.4.6:

```
$ hyprctl layers -j | jq '.[] | .levels."3"[] | select(.namespace=="hyprpicker")'
{ "level": "3", "namespace": "hyprpicker", ... }
```

The polling-init approach in #5483 hardens against an init-timing race but doesn't change the layer-priority relationship, so it doesn't close this failure mode (verified in #5468). The class of bug also matches what motivated removing `--freeze` from hyprshot in v3.0.0.

## Trade-off

Users currently relying on the freeze visual will lose it on upgrade. They can restore it with one env var:

```
export OMARCHY_SCREENSHOT_FREEZE=1
```

I think that's the right trade — a session-killing deadlock should not be the default just to keep a visual nicety. Happy to discuss.

## Test plan

- [x] `bash -n` syntax check
- [x] Fullscreen mode end-to-end (produces a PNG)
- [x] Toggle path: pre-spawned `slurp` is killed and script exits cleanly
- [x] `FREEZE=0` (default) skips `hyprpicker`; `FREEZE=1` launches it
- [x] Soaked the equivalent no-freeze logic locally for ~3 weeks (no recurrence) per #5468
- [ ] Maintainer to spot-check region / windows / smart on a non-affected setup

Refs: #5468, #5483