### PR TITLE
Tmux two pane opt-in

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -56,6 +56,9 @@ bind N switch-client -n
 bind -n M-Up switch-client -p
 bind -n M-Down switch-client -n
 
+# on -> three panes; off -> two columns
+set -g @omarchy-tdl-bottom-pane on
+
 # General
 set -g default-terminal "tmux-256color"
 set -ag terminal-overrides ",*:RGB"

--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -49,8 +49,11 @@ alias d='docker'
 alias r='rails'
 alias t='tmux attach || tmux new -s Work'
 alias ic='tdl c'
+alias ic2='tdl2 c'
 alias ix='tdl cx'
+alias ix2='tdl2 cx'
 alias icx='tdl c cx'
+alias icx2='tdl2 c cx'
 n() { if [ "$#" -eq 0 ]; then command nvim . ; else command nvim "$@"; fi; }
 
 # Git

--- a/default/bash/fns/tmux
+++ b/default/bash/fns/tmux
@@ -1,13 +1,15 @@
-# Create a Tmux Dev Layout with editor, ai, and terminal
+# Create a Tmux Dev Layout with editor, ai, and optional terminal
 # Usage: tdl <c|cx|codex|other_ai> [<second_ai>]
 tdl() {
   [[ -z $1 ]] && { echo "Usage: tdl <c|cx|codex|other_ai> [<second_ai>]"; return 1; }
   [[ -z $TMUX ]] && { echo "You must start tmux to use tdl."; return 1; }
 
   local current_dir="${PWD}"
-  local editor_pane ai_pane ai2_pane
+  local editor_pane ai_pane ai2_pane bottom_pane
   local ai="$1"
   local ai2="$2"
+  bottom_pane="${OMARCHY_TDL_BOTTOM_PANE:-}"
+  [[ -z $bottom_pane ]] && bottom_pane=$(tmux show-option -gqv @omarchy-tdl-bottom-pane || true)
 
   # Use TMUX_PANE for the pane we're running in (stable even if active window changes)
   editor_pane="$TMUX_PANE"
@@ -15,8 +17,10 @@ tdl() {
   # Name the current window after the base directory name
   tmux rename-window -t "$editor_pane" "$(basename "$current_dir")"
 
-  # Split window vertically - top 85%, bottom 15% (target editor pane explicitly)
-  tmux split-window -v -p 15 -t "$editor_pane" -c "$current_dir"
+  # Split out a shell unless the layout is configured for two columns
+  if [[ $bottom_pane != "off" && $bottom_pane != "false" && $bottom_pane != "0" ]]; then
+    tmux split-window -v -p 15 -t "$editor_pane" -c "$current_dir"
+  fi
 
   # Split editor pane horizontally - AI on right 30% (capture new pane ID directly)
   ai_pane=$(tmux split-window -h -p 30 -t "$editor_pane" -c "$current_dir" -P -F '#{pane_id}')
@@ -35,6 +39,10 @@ tdl() {
 
   # Select the nvim pane for focus
   tmux select-pane -t "$editor_pane"
+}
+
+tdl2() {
+  OMARCHY_TDL_BOTTOM_PANE=off tdl "$@"
 }
 
 # Create multiple tdl windows with one per subdirectory in the current directory

--- a/migrations/1778025414.sh
+++ b/migrations/1778025414.sh
@@ -1,0 +1,13 @@
+echo "Add two-column tdl option to tmux configuration"
+
+TMUX_CONF=~/.config/tmux/tmux.conf
+
+if [[ -f $TMUX_CONF ]]; then
+  if ! grep -q "@omarchy-tdl-bottom-pane" "$TMUX_CONF"; then
+    sed -i '/bind -n M-Down switch-client -n/a\
+\
+# on -> three panes; off -> two columns\
+set -g @omarchy-tdl-bottom-pane on' "$TMUX_CONF"
+    omarchy-restart-tmux
+  fi
+fi


### PR DESCRIPTION
Some small screen laptop workflows are more comfortable with a two-column `tdl` layout especially when you can use the nvim bottom terminal via `ctrl+/`.

The PR keeps the current three-pane layout as the default , while adding `tdl2`, `ic2`, `ix2`, and `icx2` as opt-in two-column variants

The default can be changed in tmux config via `@omarchy-tdl-bottom-pane`.  Existing `tdl`, `ic`, `ix`, `icx` stay unchanged.

When changed to bottom nvim terminal, looks like so 

<img width="1916" height="1050" alt="image" src="https://github.com/user-attachments/assets/2f6b0613-348a-4583-837f-2aa8c32f85ea" />
