### PR TITLE
Install sof-firmware on Intel Panther Lake for DSP audio

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -47,6 +47,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/intel/ipu7-camera.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/ptl-kernel.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/fred.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/fix-wifi7-eht.sh
+run_logged $OMARCHY_INSTALL/config/hardware/intel/sof-firmware.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/dell/fix-xps-haptic-touchpad.sh
 

--- a/install/config/hardware/intel/sof-firmware.sh
+++ b/install/config/hardware/intel/sof-firmware.sh
@@ -1,0 +1,8 @@
+# Install Sound Open Firmware for the audio DSP on non-XPS Intel Panther
+# Lake systems. XPS PTL stays on linux-ptl, which hard-deps sof-firmware.
+# Mainline `linux` only optdeps it, so without this the DSP fails to boot
+# and only auto_null shows up in PipeWire.
+
+if omarchy-hw-intel-ptl && ! omarchy-hw-match "XPS"; then
+  omarchy-pkg-add sof-firmware
+fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -41,6 +41,7 @@ pipewire-jack
 pipewire-pulse
 qt6-wayland
 snapper
+sof-firmware
 thermald
 webp-pixbuf-loader
 yay-debug

--- a/migrations/1778026496.sh
+++ b/migrations/1778026496.sh
@@ -1,0 +1,11 @@
+echo "Install sof-firmware on Intel Panther Lake to restore DSP audio"
+
+# linux-ptl hard-depped sof-firmware, mainline linux only optdeps it, so the
+# orphan sweep after migration 1777572869 removed it. Force explicit so a
+# subsequent orphan sweep in the same update cycle cannot take it again.
+
+if omarchy-hw-intel-ptl && ! omarchy-hw-match "XPS"; then
+  omarchy-pkg-add sof-firmware
+  sudo pacman -D --asexplicit sof-firmware >/dev/null
+  omarchy-state set reboot-required
+fi


### PR DESCRIPTION
## Summary

After migration `1777572869.sh` swaps non-XPS Panther Lake systems like ASUS Expertbook PTL off `linux-ptl` to mainline `linux`, audio dies. The DSP fails to boot:

```
sof-audio-pci-intel-ptl 0000:00:1f.3: SOF firmware and/or topology file not found.
sof-audio-pci-intel-ptl 0000:00:1f.3: Firmware file: intel/sof-ipc4/ptl/sof-ptl.ri
sof-audio-pci-intel-ptl 0000:00:1f.3: Check if you have 'sof-firmware' package installed.
```

Only `auto_null` shows up in PipeWire, no Speaker, no Mic, no HDMI sinks.

### Cause

`linux-ptl`'s PKGBUILD declares `sof-firmware` as a hard dependency. Mainline `linux` only treats it as `Optional Deps`. So when `1777572869.sh` runs `pacman -Rdd linux-ptl`, `sof-firmware` is left installed but no longer required by anything. The next `omarchy-update-orphan-pkgs` run in the same update cycle then sweeps it:

```
[ALPM] removed linux-ptl (7.0.3.arch1-1)
...
[PACMAN] Running 'pacman -Rs --noconfirm sof-firmware'
[ALPM] removed sof-firmware (2025.12.2-1)
```

Confirmed reproducer on ASUS ExpertBook B9406 (Panther Lake), should hit every non-XPS PTL OEM following the same kernel-swap path.

###  What this does

- **Install hook** `install/config/hardware/intel/sof-firmware.sh`, wired into `install/config/all.sh` next to the other `intel/` hooks — installs `sof-firmware` on every non-XPS PTL system. Idempotent via `omarchy-pkg-add`.

- **Migration** `migrations/1778026496.sh` — recovery for systems already migrated off `linux-ptl` and missing audio. Also pins the install reason to explicit, because `pacman -S --needed` is a no-op when the package is still present-as-dep mid-update — the orphan sweep would otherwise re-take it.

Gated on `omarchy-hw-intel-ptl && ! omarchy-hw-match "XPS"`, mirroring `1777572869.sh`. XPS PTL stays on `linux-ptl` and gets `sof-firmware` via dependency as before.

### Verification on ASUS ExpertBook B9406 (Panther Lake),

1. **Fresh-install path:** removed `sof-firmware`, ran the install hook directly: package installed as `Explicitly installed`, `intel/sof-ipc4/ptl/sof-ptl.ri` and the `sof-ptl-cs42l43-agg-l3-cs35l56-l2.tplg` topology back on disk.

2. **Recovery-migration path:** same start state, ran the migration: audio sinks reappear after `modprobe -r snd_sof_pci_intel_ptl && modprobe snd_sof_pci_intel_ptl` + PipeWire restart:
   ```
   alsa_output.pci-0000_00_1f.3-platform-sof_sdw.HiFi__Speaker__sink
   alsa_output.pci-0000_00_1f.3-platform-sof_sdw.HiFi__HDMI{1,2,3}__sink
   alsa_input.pci-0000_00_1f.3-platform-sof_sdw.HiFi__Mic__source
   ```

3. **Orphan-sweep race:** forced `sof-firmware` back to `--asdeps` (simulating mid-cycle state), confirmed `pacman -Qtdq` lists it as orphan. Ran the migration: `Install Reason: Explicitly installed` afterward, no longer in orphan list.

### Related

Issue #5557 reports a separate audio bug on ASUS Zenbook S14 UX5406AA: kernel↔topology ABI mismatch (3:23 vs 3:29) on `linux-ptl` with both `linux-ptl` and `sof-firmware` installed. Different root cause, different fix path. 

### Tested

- [x] Install hook registered in `install/config/all.sh`
- [x] Install hook produces correct end state on non-XPS PTL hardware
- [x] Migration recovers a broken `linux-ptl → linux` system
- [x] Migration is robust to mid-update orphan-sweep race
- [x] Both gated on non-XPS PTL (XPS unaffected)
- [ ] Other non-XPS PTL hardware confirms recovery ?