### PR TITLE
fix: resolve relative wallpaper paths before creating symlink

### DIFF
--- a/bin/omarchy-theme-bg-set
+++ b/bin/omarchy-theme-bg-set
@@ -9,8 +9,13 @@ if [[ -z $1 ]]; then
   exit 1
 fi
 
-BACKGROUND="$1"
+BACKGROUND="$(realpath "$1")"
 CURRENT_BACKGROUND_LINK="$HOME/.config/omarchy/current/background"
+
+if [[ ! -f "$BACKGROUND" ]]; then
+  echo "File does not exist: $BACKGROUND" >&2
+  exit 1
+fi
 
 # Create symlink to the new background
 ln -nsf "$BACKGROUND" "$CURRENT_BACKGROUND_LINK"


### PR DESCRIPTION
Fixes an issue where relative wallpaper paths produced broken symlinks.

The script was passing the user-provided path directly to `ln -s`, which caused relative paths to be resolved relative to the symlink location instead of the caller's current working directory.

This change resolves the provided path with `realpath` before creating the symlink.

Before:
```bash
omarchy-theme-bg-set wallpapers/bg.jpg
```
Would create a broken symlink inside: ~/.config/omarchy/current/background

After: The symlink correctly points to the absolute resolved image path.