### PR TITLE
Allow configuring OCR languages via OMARCHY_OCR_LANGS env

### DIFF
--- a/bin/omarchy-capture-text-extraction
+++ b/bin/omarchy-capture-text-extraction
@@ -18,7 +18,7 @@ SELECTION=$(slurp 2>/dev/null)
 
 [[ -z $SELECTION ]] && exit 0
 
-TEXT=$(grim -g "$SELECTION" - | tesseract stdin stdout --oem 1 --psm 6 -l eng --dpi 300 -c preserve_interword_spaces=1 2>/dev/null) || exit 1
+TEXT=$(grim -g "$SELECTION" - | tesseract stdin stdout --oem 1 --psm 6 -l "${OMARCHY_OCR_LANGS:-eng}" --dpi 300 -c preserve_interword_spaces=1 2>/dev/null) || exit 1
 
 [[ -z $TEXT ]] && exit 1
 


### PR DESCRIPTION
## What

`bin/omarchy-capture-text-extraction` hardcodes `-l eng`, so the SUPER+CTRL+PRINT shortcut produces garbage on anything that isn't plain ASCII English — Polish diacritics (`ł`, `ż`, `ę`), Cyrillic, accented Latin scripts, CJK. Tesseract already supports multi-language OCR; it's just a flag.

## Diff

```diff
-tesseract … -l eng …
+tesseract … -l "${OMARCHY_OCR_LANGS:-eng}" …
```

One value swap. No new files, no logic, no defaults changed.

## Before / after

OCR'd from the same screenshot, three lines of mixed-script text:

| Lang flag | Output |
|---|---|
| `-l eng` (current) | `NMpuBiTt, 9K cnpaBu?` / `Dzien dobry, witam!` / `Hello, world!` |
| `-l ukr+eng+pol` | `Привіт, як справи?` / `Dzień dobry, witam!` / `Hello, world!` |

Same Tesseract, same image — just the right `-l`.

## Usage

Users opt in by installing the matching tessdata packages (`tesseract-data-ukr`, `tesseract-data-pol`, …) and setting one line in `envs.conf`:

```
env = OMARCHY_OCR_LANGS,ukr+eng+pol
```

Tesseract weights ambiguous glyphs by language priority, so users put their primary language first. Putting `eng` first breaks Cyrillic recognition on otherwise unambiguous strings (e.g. `Привіт` → `NpuBiT`), which is why this isn't auto-detected from `tesseract --list-langs` (alphabetical — wrong for most non-English users).

## Backward compatibility

`${OMARCHY_OCR_LANGS:-eng}` falls back to the current literal default when the env is unset or empty. Existing installs see no behavior change.

## Out of scope

- No new tessdata packages added to defaults — users install what they need.
- No defensive checks; the script still relies on tesseract being present, in keeping with the style established in #5595.
