### PR TITLE
Better system idle

### DIFF
--- a/bin/omarchy-system-idle
+++ b/bin/omarchy-system-idle
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# omarchy:summary=Lock the screen from idle and turn the display off after a delay
+# omarchy:group=system
+# omarchy:name=idle
+# omarchy:examples=omarchy system idle
+
+if ! loginctl lock-session; then
+  omarchy-system-lock
+fi
+
+(
+  sleep 10
+  pidof hyprlock >/dev/null || exit 0
+  brightnessctl -sd '*::kbd_backlight' set 0 >/dev/null 2>&1
+  hyprctl dispatch dpms off >/dev/null 2>&1
+) &

--- a/bin/omarchy-system-idle-resume
+++ b/bin/omarchy-system-idle-resume
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# omarchy:summary=Resume displays and brightness after idle
+# omarchy:group=system
+# omarchy:name=idle resume
+# omarchy:examples=omarchy system idle resume
+
+hyprctl dispatch dpms on >/dev/null 2>&1
+brightnessctl -r >/dev/null 2>&1
+brightnessctl -rd '*::kbd_backlight' >/dev/null 2>&1

--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -5,24 +5,15 @@ general {
     inhibit_sleep = 3                                      # wait until screen is locked
 }
 
+# Start screensaver after 2.5 minutes
 listener {
-    timeout = 150                                             # 2.5min
-    on-timeout = pidof hyprlock || omarchy-launch-screensaver # start screensaver (if we haven't locked already)
+    timeout = 150
+    on-timeout = pidof hyprlock || omarchy-launch-screensaver
 }
 
+# Idle system after 5 minutes
 listener {
-    timeout = 151                      # 5min
-    on-timeout = loginctl lock-session # lock screen when timeout has passed
-}
-
-listener {
-    timeout = 330                                            # 5.5min
-    on-timeout = brightnessctl -sd '*::kbd_backlight' set 0  # save state and turn off keyboard backlight
-    on-resume = brightnessctl -rd '*::kbd_backlight'         # restore keyboard backlight
-}
-
-listener {
-    timeout = 330                                            # 5.5min
-    on-timeout = hyprctl dispatch dpms off                   # screen off when timeout has passed
-    on-resume = hyprctl dispatch dpms on && brightnessctl -r # screen on when activity is detected
+    timeout = 152
+    on-timeout = omarchy-system-idle
+    on-resume = omarchy-system-idle-resume
 }

--- a/migrations/1778054328.sh
+++ b/migrations/1778054328.sh
@@ -1,4 +1,3 @@
 echo "Use omarchy-system-idle and omarchy-system-idle-resume in hypridle"
 
-omarchy-refresh-config hypr/hypridle.conf
-omarchy-restart-hypridle
+omarchy-refresh-hypridle

--- a/migrations/1778054328.sh
+++ b/migrations/1778054328.sh
@@ -1,0 +1,4 @@
+echo "Use omarchy-system-idle and omarchy-system-idle-resume in hypridle"
+
+omarchy-refresh-config hypr/hypridle.conf
+omarchy-restart-hypridle


### PR DESCRIPTION
System idle suffered from a timing problem because due to idle resets in hypridle from the screensaver. Now we do the idle step as a single unit, so the lock screen itself only appears for 10 seconds before the screen is turned off. Simplify the hypridle by moving the logic into `omarchy-system-idle` and `omarchy-system-idle-resume`.

This does mean resetting the user's hypridle.conf, but a backup is made for anyone with specializations to retain.