### PR TITLE
Make power profile source defaults configurable

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -287,12 +287,49 @@ show_setup_menu() {
 }
 
 show_setup_power_menu() {
+  local ac_profile
+  local battery_profile
+  local options
+
+  ac_profile=$(omarchy-powerprofiles-config get ac)
+  battery_profile=$(omarchy-powerprofiles-config get battery)
+  options="󱐋  Temporary Profile\n󰚥  On AC: $ac_profile\n󰁹  On Battery: $battery_profile"
+
+  case $(menu "Power Profile" "$options") in
+  *Temporary*) show_power_profile_menu show_setup_power_menu ;;
+  *"On AC"*) show_power_profile_default_menu ac "On AC" ;;
+  *"On Battery"*) show_power_profile_default_menu battery "On Battery" ;;
+  *) back_to show_setup_menu ;;
+  esac
+}
+
+show_power_profile_menu() {
+  local parent_menu="${1:-show_main_menu}"
+  local profile
+
   profile=$(menu "Power Profile" "$(omarchy-powerprofiles-list)" "" "$(powerprofilesctl get)")
 
   if [[ $profile == "CNCLD" || -z $profile ]]; then
-    back_to show_setup_menu
+    back_to "$parent_menu"
   else
     powerprofilesctl set "$profile"
+    back_to "$parent_menu"
+  fi
+}
+
+show_power_profile_default_menu() {
+  local source="$1"
+  local label="$2"
+  local profile
+
+  profile=$(menu "$label Power Profile" "$(omarchy-powerprofiles-list)" "" "$(omarchy-powerprofiles-config get "$source")")
+
+  if [[ $profile == "CNCLD" || -z $profile ]]; then
+    back_to show_setup_power_menu
+  else
+    omarchy-powerprofiles-config set "$source" "$profile"
+    omarchy-powerprofiles-set
+    back_to show_setup_power_menu
   fi
 }
 
@@ -678,7 +715,7 @@ go_to_menu() {
   *theme*) show_theme_menu ;;
   *screenrecord*) show_screenrecord_menu ;;
   *setup*) show_setup_menu ;;
-  *power*) show_setup_power_menu ;;
+  *power*) show_power_profile_menu ;;
   *install*) show_install_menu ;;
   *remove*) show_remove_menu ;;
   *update*) show_update_menu ;;

--- a/bin/omarchy-powerprofiles-config
+++ b/bin/omarchy-powerprofiles-config
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# omarchy:summary=Get or set persistent AC/battery power profile defaults.
+# omarchy:args=<get|set> <ac|battery> [profile]
+
+set -e
+
+CONFIG_DIR="$HOME/.config/omarchy"
+CONFIG_PATH="$CONFIG_DIR/powerprofiles.conf"
+
+available_profiles() {
+  powerprofilesctl list |
+    awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }'
+}
+
+profile_available() {
+  local profile="$1"
+
+  while read -r available_profile; do
+    [[ $available_profile == $profile ]] && return 0
+  done < <(available_profiles)
+
+  return 1
+}
+
+fallback_profile() {
+  local source="$1"
+  local first_profile=""
+  local balanced_present=false
+  local performance_present=false
+
+  while read -r profile; do
+    [[ -z $first_profile ]] && first_profile="$profile"
+    [[ $profile == "balanced" ]] && balanced_present=true
+    [[ $profile == "performance" ]] && performance_present=true
+  done < <(available_profiles)
+
+  if [[ $source == "ac" && $performance_present == "true" ]]; then
+    echo "performance"
+  elif [[ $balanced_present == "true" ]]; then
+    echo "balanced"
+  else
+    echo "$first_profile"
+  fi
+}
+
+configured_profile() {
+  local source="$1"
+
+  if [[ -f $CONFIG_PATH ]]; then
+    awk -F= -v source="$source" '$1 == source { print $2; exit }' "$CONFIG_PATH"
+  fi
+}
+
+get_profile() {
+  local source="$1"
+  local profile
+
+  profile="$(configured_profile "$source")"
+
+  if [[ -n $profile ]] && profile_available "$profile"; then
+    echo "$profile"
+  else
+    fallback_profile "$source"
+  fi
+}
+
+set_profile() {
+  local source="$1"
+  local profile="$2"
+  local ac_profile
+  local battery_profile
+
+  if ! profile_available "$profile"; then
+    echo "Power profile '$profile' is not available on this system" >&2
+    exit 1
+  fi
+
+  ac_profile="$(get_profile ac)"
+  battery_profile="$(get_profile battery)"
+
+  case "$source" in
+  ac) ac_profile="$profile" ;;
+  battery) battery_profile="$profile" ;;
+  *)
+    echo "Usage: omarchy-powerprofiles-config <get|set> <ac|battery> [profile]" >&2
+    exit 1
+    ;;
+  esac
+
+  mkdir -p "$CONFIG_DIR"
+  {
+    echo "ac=$ac_profile"
+    echo "battery=$battery_profile"
+  } >"$CONFIG_PATH"
+}
+
+command="$1"
+source="$2"
+profile="$3"
+
+case "$command" in
+get)
+  [[ $source == "ac" || $source == "battery" ]] || {
+    echo "Usage: omarchy-powerprofiles-config get <ac|battery>" >&2
+    exit 1
+  }
+
+  get_profile "$source"
+  ;;
+set)
+  [[ $source == "ac" || $source == "battery" ]] && [[ -n $profile ]] || {
+    echo "Usage: omarchy-powerprofiles-config set <ac|battery> <profile>" >&2
+    exit 1
+  }
+
+  set_profile "$source" "$profile"
+  ;;
+*)
+  echo "Usage: omarchy-powerprofiles-config <get|set> <ac|battery> [profile]" >&2
+  exit 1
+  ;;
+esac

--- a/bin/omarchy-powerprofiles-config
+++ b/bin/omarchy-powerprofiles-config
@@ -5,7 +5,18 @@
 
 set -e
 
-CONFIG_DIR="$HOME/.config/omarchy"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config_home="${OMARCHY_CONFIG_HOME:-}"
+
+if [[ -z $config_home ]]; then
+  if [[ $script_dir == */.local/share/omarchy/bin ]]; then
+    config_home="${script_dir%/.local/share/omarchy/bin}"
+  else
+    config_home="$HOME"
+  fi
+fi
+
+CONFIG_DIR="$config_home/.config/omarchy"
 CONFIG_PATH="$CONFIG_DIR/powerprofiles.conf"
 
 available_profiles() {

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -4,6 +4,7 @@
 # omarchy:args=[autodetect|ac|battery]
 
 action="${1-}"
+omarchy_bin="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Auto-detect when called with no argument: treat any Mains or USB
 # power-supply device reporting online=1 as "on AC". This handles
@@ -23,18 +24,11 @@ if [[ -z $action || $action == "autodetect" ]]; then
   done
 fi
 
-mapfile -t profiles < <(powerprofilesctl list | awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }')
-
 case "$action" in
   ac)
-    # Prefer performance, fall back to balanced
-    if [[ " ${profiles[*]} " == *" performance "* ]]; then
-      powerprofilesctl set performance
-    else
-      powerprofilesctl set balanced
-    fi
+    powerprofilesctl set "$("$omarchy_bin/omarchy-powerprofiles-config" get ac)"
     ;;
   battery)
-    powerprofilesctl set balanced
+    powerprofilesctl set "$("$omarchy_bin/omarchy-powerprofiles-config" get battery)"
     ;;
 esac

--- a/config/omarchy/powerprofiles.conf
+++ b/config/omarchy/powerprofiles.conf
@@ -1,0 +1,4 @@
+# Persistent power profile defaults used by Omarchy's AC/battery udev rules.
+# Values must match profiles listed by powerprofilesctl.
+ac=performance
+battery=balanced

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -6,7 +6,6 @@ exec-once = uwsm-app -- swaybg -i ~/.config/omarchy/current/background -m fill
 exec-once = uwsm-app -- swayosd-server
 exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 exec-once = omarchy-first-run
-exec-once = omarchy-powerprofiles-init
 exec-once = uwsm-app -- omarchy-hyprland-monitor-watch
 
 # Slow app launch fix -- set systemd vars

--- a/migrations/1777938520.sh
+++ b/migrations/1777938520.sh
@@ -1,0 +1,3 @@
+echo "Apply configurable power profile source switching"
+
+source "$OMARCHY_PATH/install/config/powerprofilesctl-rules.sh"


### PR DESCRIPTION
## Motivation

The current default switches laptops to `performance` whenever AC power is connected. On my machine, that immediately drives the fans to 100%, so I prefer to stay on `balanced` even when plugged in.

The bigger issue is that this is currently managed through Omarchy's generated udev rule. Any manual change to that rule can be overwritten by updates or migrations, so keeping a different AC/battery policy requires repeatedly editing root-owned udev config by hand.

This patch keeps Omarchy's automatic AC/battery switching, but moves the policy into a user-facing configuration flow. Users can choose persistent AC and battery defaults from `Setup > Power Profile`, while the Waybar battery click remains a temporary one-off profile switch.

## Summary

- add persistent AC/battery power profile defaults in `~/.config/omarchy/powerprofiles.conf`
- extend `Setup > Power Profile` with separate persistent choices for AC and battery
- keep `omarchy-menu power` as the temporary profile picker used by the Waybar battery click
- route udev-triggered profile switching through the configured defaults
- remove the Hyprland autostart power profile setter so source switching stays in the udev path

This keeps the current defaults (`performance` on AC when available, `balanced` on battery), but lets users choose something else without editing `/etc/udev/rules.d/99-power-profile.rules`.

## Testing

- `bash -n bin/omarchy-powerprofiles-config bin/omarchy-powerprofiles-set bin/omarchy-menu migrations/1777938520.sh`
- `git diff --check dev..power-profile-defaults`
