### PR TITLE
Use flat pointer acceleration by default

### DIFF
--- a/config/hypr/input.conf
+++ b/config/hypr/input.conf
@@ -19,8 +19,8 @@ input {
   # Increase sensitivity for mouse/trackpad (default: 0)
   # sensitivity = 0.35
 
-  # Turn off mouse acceleration (default: adaptive)
-  # accel_profile = flat
+  # Use a constant pointer response instead of libinput's adaptive acceleration curve
+  accel_profile = flat
 
   touchpad {
     # Use natural (inverse) scrolling


### PR DESCRIPTION
## Summary

- set Hyprland's default `input:accel_profile` to `flat`
- replace libinput's adaptive pointer acceleration curve with a constant pointer response by default

This makes trackpad and mouse movement feel less laggy and less speed-dependent out of the box, while users can still override the setting in `~/.config/hypr/input.conf`.

## Testing

- `git diff --check dev..flat-pointer-acceleration`
