### PR TITLE
Add date subdir format for captures

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -186,6 +186,11 @@ start_screenrecording() {
 
   [[ $WEBCAM == "true" ]] && start_webcam_overlay
 
+  if [[ -n $OMARCHY_SCREENRECORD_SUBDIR_FORMAT ]]; then
+    OUTPUT_DIR="$OUTPUT_DIR/$(date +"$OMARCHY_SCREENRECORD_SUBDIR_FORMAT")"
+    mkdir -p "$OUTPUT_DIR" || return 1
+  fi
+
   local filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
   local audio_devices=""
   local audio_args=()

--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -8,10 +8,15 @@
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}}"
+if [[ -n $OMARCHY_SCREENSHOT_SUBDIR_FORMAT ]]; then
+  OUTPUT_DIR="$OUTPUT_DIR/$(date +"$OMARCHY_SCREENSHOT_SUBDIR_FORMAT")"
+fi
 
 if [[ ! -d $OUTPUT_DIR ]]; then
   mkdir -p "$OUTPUT_DIR"
-  notify-send "Created screenshot directory: $OUTPUT_DIR" -u normal -t 2000
+  if [[ -z $OMARCHY_SCREENSHOT_SUBDIR_FORMAT ]]; then
+    notify-send "Created screenshot directory: $OUTPUT_DIR" -u normal -t 2000
+  fi
 fi
 
 pkill slurp && exit 0

--- a/config/uwsm/default
+++ b/config/uwsm/default
@@ -9,5 +9,13 @@ export EDITOR=nvim
 # Use a custom directory for screenshots (remember to make the directory!)
 # export OMARCHY_SCREENSHOT_DIR="$HOME/Pictures/Screenshots"
 
+# Sort screenshots into date-based subfolders. Format is passed to date.
+# Example: "%Y-%m" creates Screenshots/2026-05/screenshot-...png
+# export OMARCHY_SCREENSHOT_SUBDIR_FORMAT="%Y-%m"
+
 # Use a custom directory for screenrecordings (remember to make the directory!)
 # export OMARCHY_SCREENRECORD_DIR="$HOME/Videos/Screencasts"
+
+# Sort screenrecordings into date-based subfolders. Format is passed to date.
+# Example: "%Y-%m" creates Screencasts/2026-05/screenrecording-...mp4
+# export OMARCHY_SCREENRECORD_SUBDIR_FORMAT="%Y-%m"


### PR DESCRIPTION
## Summary

- Add opt-in `OMARCHY_SCREENSHOT_SUBDIR_FORMAT` support to place screenshots in date-based subdirectories.
- Add matching `OMARCHY_SCREENRECORD_SUBDIR_FORMAT` support for screen recordings.
- Document both variables in `config/uwsm/default`, commented out by default.

## Why

Users who take many screenshots or recordings can end up with hundreds of
files in one flat directory. A shell workaround like:

```bash
export OMARCHY_SCREENSHOT_DIR="$HOME/Pictures/Screenshots/$(date +%Y-%m)"
```

only evaluates when the UWSM environment starts, so a session that crosses a
month boundary keeps writing to the old folder. This keeps the existing default
behavior while making date rotation explicit and evaluated when captures start.

## Behavior

When unset, output paths are unchanged.

When set:

```bash
export OMARCHY_SCREENSHOT_SUBDIR_FORMAT="%Y-%m"
export OMARCHY_SCREENRECORD_SUBDIR_FORMAT="%Y-%m"
```

captures are written to:

```text
Screenshots/2026-05/screenshot-...
Screencasts/2026-05/screenrecording-...
```

Nested formats like `%Y/%m/%d` are supported via `mkdir -p`.

## Test Plan

- `bash -n bin/omarchy-capture-screenshot bin/omarchy-capture-screenrecording`
- `bash test/omarchy-cli-test.sh` currently fails on an existing unrelated
  `omarchy-pkg-add` route metadata assertion; this patch only changes the two
  capture scripts and `config/uwsm/default`.
