### PR TITLE
Fix helix theme's word selection colors

### DIFF
--- a/default/themed/helix.toml.tpl
+++ b/default/themed/helix.toml.tpl
@@ -87,7 +87,7 @@
 "ui.virtual.jump-label" = { fg = "color1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "color8"
 
-"ui.selection" = { bg = "color0" }
+"ui.selection" = { bg = "selection_background", fg = "selection_foreground" }
 
 "ui.cursor" = { fg = "background", bg = "cursor" }
 "ui.cursor.primary" = { fg = "background", bg = "cursor" }

--- a/themes/matte-black/colors.toml
+++ b/themes/matte-black/colors.toml
@@ -3,7 +3,7 @@ cursor = "#eaeaea"
 foreground = "#bebebe"
 background = "#121212"
 selection_foreground = "#bebebe"
-selection_background = "#333333"
+selection_background = "#515151"
 
 color0 = "#333333"
 color1 = "#D35F5F"

--- a/themes/retro-82/colors.toml
+++ b/themes/retro-82/colors.toml
@@ -15,7 +15,7 @@ selection_foreground = "#00172e"
 selection_background = "#faa968"
 
 # Normal colors (ANSI 0-7)
-color0 = "#00172e"
+color0 = "#303442"
 color1 = "#f85525"
 color2 = "#028391"
 color3 = "#e97b3c"


### PR DESCRIPTION
Without this fix, if users enabled `editor.cursorline`, the word selection would not be visually distinct from the cursorline selection.

Closes: https://github.com/basecamp/omarchy/issues/5580

## Before fix
The word `cursorline` is being selected, but is not visually differentiated.

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/5080997a-c54f-4cc6-9eff-12d8b79a203b" />


## After fix
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/eb8f57e0-f3e2-49f7-b7a8-159a5fb4b026" />

## Looks reasonable across themes

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/4bd8d47b-3d79-4cd4-9eb5-03f758890b43" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/eb7af6be-9699-4844-a201-b8a6d170fc33" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/86455451-82a9-4ee4-ae49-5eea2f757535" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/940cb3f5-f3ec-41cf-8b0c-31351b95afad" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/bbb5e78f-e581-4017-84f4-bcc0465ca510" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/118e8a69-412e-4522-9b4e-f9a158c96cd4" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/5746b69d-d7bd-4595-af67-cc42111e538c" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/7d5cc993-3b91-485c-a4c3-1f067fdaa5f5" />
<img width="2952" height="1610" alt="image" src="https://github.com/user-attachments/assets/a86c61ba-efd5-44dd-b83f-cb7e2296af0f" />

matte-black matches color0 with the selection background, so this is more subtle, but the foreground still changes to make it visually distinct.
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/bddc5407-42e3-4d46-9079-027e222c1dcd" />
With the tweak in this PR:
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/83d6a2ae-7d91-44cb-b10f-0b0c7eac174e" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/4b33b18a-a022-4451-9c00-f16b5c6ed9b1" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/6b138055-b90c-4659-a103-9a867dc3fb9d" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/7673f6da-574c-432f-b9ef-9e209336b617" />
Retro-82's color0 is too close to the background color, but the fix would be to tweak retro-82.
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/fd4aa1e2-73a7-47cc-84f0-7148410e2b82" />
Tweaked in this PR:
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/a40d634b-bad3-4b05-adf0-73b7fd2d9ee2" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/c575563a-ed2b-4f80-a89b-63b10354229c" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/a73c2c2a-1876-4db0-9955-c12889b4f8b9" />

<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/5e540663-441d-46c9-947a-df61bb730f4e" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/d6181776-c22a-4312-9b88-b61a412c2495" />
<img width="2970" height="1628" alt="image" src="https://github.com/user-attachments/assets/d6493c28-07d6-4a38-adb8-65011bc2be9c" />

