### PR TITLE
Add Transcode entry to Nautilus context menu

### DIFF
--- a/default/nautilus-python/extensions/transcode.py
+++ b/default/nautilus-python/extensions/transcode.py
@@ -1,0 +1,94 @@
+import shutil
+
+from gi import require_version
+
+require_version("Nautilus", "4.1")
+
+from gi.repository import GObject, Gio, Nautilus
+
+
+SUPPORTED_MIME_PREFIXES = ("image/", "video/")
+SUPPORTED_EXTENSIONS = {
+    ".jpg", ".jpeg", ".png", ".webp", ".gif", ".heic", ".avif",
+    ".mp4", ".mov", ".m4v", ".mkv", ".webm", ".avi",
+}
+
+
+class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
+    def _launch_transcode(self, paths):
+        wrapper = shutil.which("omarchy-launch-floating-terminal-with-presentation")
+        binary = shutil.which("omarchy-transcode")
+        if not wrapper or not binary:
+            return
+
+        quoted = " ".join(self._shell_quote(p) for p in paths)
+        if len(paths) == 1:
+            cmd = f"{binary} {quoted}"
+        else:
+            cmd = (
+                "for f in " + quoted + "; do "
+                f'echo "Transcoding $f"; {binary} "$f" || true; '
+                "done"
+            )
+
+        Gio.Subprocess.new([wrapper, cmd], Gio.SubprocessFlags.NONE)
+
+    def _shell_quote(self, value):
+        return "'" + value.replace("'", "'\\''") + "'"
+
+    def _is_supported(self, file):
+        mime = file.get_mime_type() or ""
+        if mime.startswith(SUPPORTED_MIME_PREFIXES):
+            return True
+
+        location = file.get_location()
+        if not location:
+            return False
+        path = location.get_path() or ""
+        lower = path.lower()
+        return any(lower.endswith(ext) for ext in SUPPORTED_EXTENSIONS)
+
+    def _selected_paths(self, files):
+        paths = []
+        for file in files:
+            if file.is_directory():
+                continue
+            if not self._is_supported(file):
+                continue
+            location = file.get_location()
+            if not location:
+                continue
+            path = location.get_path()
+            if path and path not in paths:
+                paths.append(path)
+        return paths
+
+    def _make_item(self, paths):
+        label = "Transcode" if len(paths) == 1 else f"Transcode {len(paths)} items"
+        item = Nautilus.MenuItem(
+            name="OmarchyTranscodeNautilus::transcode",
+            label=label,
+            icon="media-playback-start",
+        )
+        item.connect("activate", self._on_activate, paths)
+        return item
+
+    def _on_activate(self, _menu, paths):
+        self._launch_transcode(paths)
+
+    def _tools_available(self):
+        return bool(
+            shutil.which("omarchy-launch-floating-terminal-with-presentation")
+            and shutil.which("omarchy-transcode")
+        )
+
+    def get_file_items(self, *args):
+        files = args[0] if len(args) == 1 else args[1]
+        if not self._tools_available():
+            return []
+
+        paths = self._selected_paths(files)
+        if not paths:
+            return []
+
+        return [self._make_item(paths)]

--- a/default/nautilus-python/extensions/transcode.py
+++ b/default/nautilus-python/extensions/transcode.py
@@ -1,3 +1,4 @@
+import shlex
 import shutil
 
 from gi import require_version
@@ -21,20 +22,18 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
         if not wrapper or not binary:
             return
 
-        quoted = " ".join(self._shell_quote(p) for p in paths)
+        binary_q = shlex.quote(binary)
+        quoted = " ".join(shlex.quote(p) for p in paths)
         if len(paths) == 1:
-            cmd = f"{binary} {quoted}"
+            cmd = f"{binary_q} {quoted}"
         else:
             cmd = (
                 "for f in " + quoted + "; do "
-                f'echo "Transcoding $f"; {binary} "$f" || true; '
+                f'echo "Transcoding $f"; {binary_q} "$f" || true; '
                 "done"
             )
 
         Gio.Subprocess.new([wrapper, cmd], Gio.SubprocessFlags.NONE)
-
-    def _shell_quote(self, value):
-        return "'" + value.replace("'", "'\\''") + "'"
 
     def _is_supported(self, file):
         mime = file.get_mime_type() or ""

--- a/default/nautilus-python/extensions/transcode.py
+++ b/default/nautilus-python/extensions/transcode.py
@@ -22,15 +22,13 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
         if not wrapper or not binary:
             return
 
-        binary_q = shlex.quote(binary)
-        quoted = " ".join(shlex.quote(p) for p in paths)
         if len(paths) == 1:
-            cmd = f"{binary_q} {quoted}"
+            cmd = shlex.join([binary, paths[0]])
         else:
-            cmd = (
-                "for f in " + quoted + "; do "
-                f'echo "Transcoding $f"; {binary_q} "$f" || true; '
-                "done"
+            cmd = "; ".join(
+                f"echo {shlex.quote(f'Transcoding {path}')} && "
+                f"{shlex.join([binary, path])} || true"
+                for path in paths
             )
 
         Gio.Subprocess.new([wrapper, cmd], Gio.SubprocessFlags.NONE)
@@ -49,6 +47,8 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
 
     def _selected_paths(self, files):
         paths = []
+        seen = set()
+
         for file in files:
             if file.is_directory():
                 continue
@@ -58,7 +58,8 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
             if not location:
                 continue
             path = location.get_path()
-            if path and path not in paths:
+            if path and path not in seen:
+                seen.add(path)
                 paths.append(path)
         return paths
 

--- a/install/config/nautilus-python.sh
+++ b/install/config/nautilus-python.sh
@@ -2,3 +2,4 @@ EXTENSIONS_DIR="$HOME/.local/share/nautilus-python/extensions"
 
 mkdir -p "$EXTENSIONS_DIR"
 cp "$OMARCHY_PATH/default/nautilus-python/extensions/localsend.py" "$EXTENSIONS_DIR/"
+cp "$OMARCHY_PATH/default/nautilus-python/extensions/transcode.py" "$EXTENSIONS_DIR/"

--- a/migrations/1778099894.sh
+++ b/migrations/1778099894.sh
@@ -1,0 +1,3 @@
+echo "Add Transcode entry to Nautilus context menu"
+
+source $OMARCHY_PATH/install/config/nautilus-python.sh


### PR DESCRIPTION
## Summary

Right-click on image or video files in Nautilus to send them to `omarchy-transcode` in a presentation terminal — same pattern as the existing LocalSend extension.

The selected file is passed as a positional arg, so the user skips the fzf picker and goes straight to the `gum` format / resolution prompts. Multi-select loops files sequentially in one floating terminal.

## Files

- `default/nautilus-python/extensions/transcode.py` — new Nautilus.MenuProvider, modeled on `localsend.py`. Filters by MIME prefix (`image/`, `video/`) with an extension fallback matching what `omarchy-transcode` accepts. Hides itself if `omarchy-transcode` or `omarchy-launch-floating-terminal-with-presentation` aren't on PATH.
- `install/config/nautilus-python.sh` — copy `transcode.py` alongside `localsend.py`.
- `migrations/1778099894.sh` — re-sources the installer so existing 3.8 installs pick up the new extension on `omarchy update`.

## Notes

- Depends on `omarchy-transcode` (3.8+), so this can only land alongside or after the transcode CLI itself — both are already on `dev`.
- Label is just **"Transcode"** (or **"Transcode N items"** for multi-select), no provider name in the menu since the action originates from Omarchy's own file manager UX.

## Test plan

- [ ] Right-click a single `.jpg` / `.png` / `.mp4` / `.mov` in Nautilus → "Transcode" appears, opens floating terminal with `omarchy-transcode <path>`.
- [ ] Right-click a non-media file (e.g. `.txt`, `.pdf`) → entry does NOT appear.
- [ ] Right-click a directory → entry does NOT appear.
- [ ] Multi-select a mix of media + non-media → entry appears with media count, processes them sequentially.
- [ ] Filenames containing spaces and apostrophes pass through correctly to the wrapper.
- [ ] Migration script runs cleanly on an existing install (`omarchy update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)