### PR TITLE
add omarchy-screen-magnifier with keybindings for zoom toggle/in/out

### DIFF
--- a/bin/omarchy-screen-magnifier
+++ b/bin/omarchy-screen-magnifier
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # omarchy:summary=Toggle / zoom in / zoom out for Hyprland (uses cursor:zoom_factor)
 
@@ -22,4 +23,4 @@ case "$1" in
     ;;
 esac
 
-hyprctl keyword cursor:zoom_factor "$NEW"
+[[ -n "$NEW" ]] && hyprctl keyword cursor:zoom_factor "$NEW"

--- a/bin/omarchy-screen-magnifier
+++ b/bin/omarchy-screen-magnifier
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle / zoom in / zoom out for Hyprland (uses cursor:zoom_factor)
+
+STEP=0.3
+MIN=1.0
+MAX=10.0
+
+case "$1" in
+  toggle)
+    NEW=$(hyprctl getoption cursor:zoom_factor -j | jq "if .float == 1.0 then 1.7 else 1.0 end")
+    ;;
+  in)
+    NEW=$(hyprctl getoption cursor:zoom_factor -j | jq "[.float + $STEP, $MAX] | min")
+    ;;
+  out)
+    NEW=$(hyprctl getoption cursor:zoom_factor -j | jq "[.float - $STEP, $MIN] | max")
+    ;;
+  *)
+    echo "Usage: $0 {toggle|in|out}"
+    exit 1
+    ;;
+esac
+
+hyprctl keyword cursor:zoom_factor "$NEW"

--- a/bin/omarchy-screen-magnifier
+++ b/bin/omarchy-screen-magnifier
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# omarchy:summary=Toggle / zoom in / zoom out for Hyprland (uses cursor:zoom_factor)
+# omarchy:group=hyprland
+# omarchy:summary=Magnify the screen by toggling, zooming in, or zooming out using Hyprland's cursor zoom.
 
 STEP=0.3
 MIN=1.0
@@ -12,7 +13,7 @@ case "$1" in
     NEW=$(hyprctl getoption cursor:zoom_factor -j | jq "if .float == 1.0 then 1.7 else 1.0 end")
     ;;
   in)
-    NEW=$(hyprctl getoption cursor:zoom_factor -j | jq "[.float + $STEP, $MAX] | min")
+    NEW=$(hyprctl getoption cursor:zoom_factor -j | jq "[.float, ([.float + $STEP, $MAX] | min)] | max")
     ;;
   out)
     NEW=$(hyprctl getoption cursor:zoom_factor -j | jq "[.float - $STEP, $MIN] | max")

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -63,11 +63,11 @@ bindd  = , F9, Start dictation (push-to-talk), exec, voxtype record start
 binddr = , F9, Stop dictation (push-to-talk),  exec, voxtype record stop
 
 # Zoom
-bindd = SUPER, Z, Toggle zoom, exec, omarchy-screen-magnifier toggle
-bindd = SUPER, equal, Zoom in, exec, omarchy-screen-magnifier in
-bindd = SUPER, minus, Zoom out, exec, omarchy-screen-magnifier out
-bindd = SUPER, Kp_Add, Zoom in, exec, omarchy-screen-magnifier in
-bindd = SUPER, Kp_Subtract, Zoom out, exec, omarchy-screen-magnifier out
+bindd = SUPER, Z, Toggle screen magnifier, exec, omarchy-screen-magnifier toggle
+bindd = SUPER, equal, Increase screen magnifier, exec, omarchy-screen-magnifier in
+bindd = SUPER, minus, Decrease screen magnifier, exec, omarchy-screen-magnifier out
+bindd = SUPER, Kp_Add, Increase screen magnifier, exec, omarchy-screen-magnifier in
+bindd = SUPER, Kp_Subtract, Decrease screen magnifier, exec, omarchy-screen-magnifier out
 
 # Lock system
 bindd = SUPER CTRL, L, Lock system, exec, omarchy-system-lock

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -68,3 +68,10 @@ bindd = SUPER CTRL ALT, Z, Reset zoom, exec, hyprctl keyword cursor:zoom_factor 
 
 # Lock system
 bindd = SUPER CTRL, L, Lock system, exec, omarchy-system-lock
+
+# Zoom toggle / in / out
+bind = SUPER, Z, exec, omarchy-screen-magnifier toggle
+bind = SUPER, Kp_Add, exec, omarchy-screen-magnifier in
+bind = SUPER, Kp_Subtract, exec, omarchy-screen-magnifier out
+bind = SUPER, equal, exec, omarchy-screen-magnifier in
+bind = SUPER, minus, exec, omarchy-screen-magnifier out

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -63,15 +63,11 @@ bindd  = , F9, Start dictation (push-to-talk), exec, voxtype record start
 binddr = , F9, Stop dictation (push-to-talk),  exec, voxtype record stop
 
 # Zoom
-bindd = SUPER CTRL, Z, Zoom in, exec, hyprctl keyword cursor:zoom_factor $(hyprctl getoption cursor:zoom_factor -j | jq '.float + 1')
-bindd = SUPER CTRL ALT, Z, Reset zoom, exec, hyprctl keyword cursor:zoom_factor 1
+bindd = SUPER, Z, Toggle zoom, exec, omarchy-screen-magnifier toggle
+bindd = SUPER, equal, Zoom in, exec, omarchy-screen-magnifier in
+bindd = SUPER, minus, Zoom out, exec, omarchy-screen-magnifier out
+bindd = SUPER, Kp_Add, Zoom in, exec, omarchy-screen-magnifier in
+bindd = SUPER, Kp_Subtract, Zoom out, exec, omarchy-screen-magnifier out
 
 # Lock system
 bindd = SUPER CTRL, L, Lock system, exec, omarchy-system-lock
-
-# Zoom toggle / in / out
-bind = SUPER, Z, exec, omarchy-screen-magnifier toggle
-bind = SUPER, Kp_Add, exec, omarchy-screen-magnifier in
-bind = SUPER, Kp_Subtract, exec, omarchy-screen-magnifier out
-bind = SUPER, equal, exec, omarchy-screen-magnifier in
-bind = SUPER, minus, exec, omarchy-screen-magnifier out


### PR DESCRIPTION
Introduce omarchy-screen-magnifier, a script that controls Hyprland's cursor:zoom_factor to toggle, zoom in, and zoom out the screen.

Binds SUPER+Z to toggle zoom, SUPER+= and SUPER+Numpad+ to zoom in, and SUPER+- and SUPER+Numpad- to zoom out.