### PR TITLE
Add time, date, and battery to the lock screen

### DIFF
--- a/bin/omarchy-battery-status-hyprlock
+++ b/bin/omarchy-battery-status-hyprlock
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# omarchy:summary=Print battery icon and percentage for the hyprlock screen, or nothing if no battery is present.
+
+bat_path=$(upower -e 2>/dev/null | grep BAT | head -1)
+[[ -z $bat_path ]] && exit 0
+
+bat_info=$(upower -i "$bat_path" 2>/dev/null)
+percentage=$(echo "$bat_info" | awk '/percentage/ { print int($2); exit }')
+state=$(echo "$bat_info" | awk '/state/ { print $2; exit }')
+
+[[ -z $percentage ]] && exit 0
+
+if [[ $state == "charging" || $state == "fully-charged" ]]; then
+  icon="󰂄"
+elif (( percentage > 80 )); then icon="󰁹"
+elif (( percentage > 60 )); then icon="󰂀"
+elif (( percentage > 40 )); then icon="󰁾"
+elif (( percentage > 20 )); then icon="󰁻"
+else icon="󰁺"
+fi
+
+echo "$icon  $percentage%"

--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -15,6 +15,30 @@ animations {
     enabled = false
 }
 
+label {
+    monitor =
+    text = cmd[update:1000] echo "$(date +"%H:%M")"
+    color = $font_color
+    font_size = 96
+    font_family = JetBrainsMono Nerd Font
+    position = 0, 220
+    halign = center
+    valign = center
+    shadow_passes = 0
+}
+
+label {
+    monitor =
+    text = cmd[update:60000] echo "$(date +"%A, %B %-d")"
+    color = $font_color
+    font_size = 28
+    font_family = JetBrainsMono Nerd Font
+    position = 0, 130
+    halign = center
+    valign = center
+    shadow_passes = 0
+}
+
 input-field {
     monitor =
     size = 650, 100
@@ -36,6 +60,19 @@ input-field {
     rounding = 0
     shadow_passes = 0
     fade_on_empty = false
+}
+
+# Battery — shown only when a battery is present
+label {
+    monitor =
+    text = cmd[update:30000] omarchy-battery-status-hyprlock
+    color = $font_color
+    font_size = 18
+    font_family = JetBrainsMono Nerd Font
+    position = 20, 36
+    halign = left
+    valign = bottom
+    shadow_passes = 0
 }
 
 auth {


### PR DESCRIPTION
Shows a large clock and date centered on the hyprlock screen, and a battery icon with percentage in the bottom-left corner for laptop users (hidde automatically on devices without battery).

Adds omarchy-battery-status-hyprlock to drive the battery label.