### PR TITLE
FIx for #5601: Fix JetBrains focus loss and Waybar freeze on side panel hover (restore missing no_initial_focus)

### DIFF
--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -4,3 +4,12 @@ windowrule {
     no_follow_mouse = on
     match:class = ^(jetbrains-.*)$
 }
+
+# Prevent floating popup windows (tooltips, panel previews) from stealing focus on hover (see https://github.com/basecamp/omarchy/issues/5601)
+windowrule {
+    name = jetbrains-tooltip
+    no_initial_focus = on
+    match:class = ^(jetbrains-.*)$
+    match:title = ^(win.*)$
+    match:float = 1
+}


### PR DESCRIPTION

PR https://github.com/basecamp/omarchy/pull/5239 partially reverted https://github.com/basecamp/omarchy/pull/5183 by restoring no_follow_mouse for JetBrains windows.
However, it omitted a second rule that was part of the original config: no_initial_focus for floating internal popup windows.

When hovering over IDE side panel buttons (Project, Run, Git, etc.), JetBrains creates floating popup windows with titles like win0, win1, etc.
Without no_initial_focus, Hyprland gives these popups keyboard focus the moment they appear.
This causes:

The IDE loses focus on hover
The popup closes immediately and focus cycles back
3.his repeats rapidly for every pixel of mouse movement → a flood of activewindow IPC events
Waybar receives the event flood and freezes
The original config (before https://github.com/basecamp/omarchy/pull/5183) had both rules. https://github.com/basecamp/omarchy/pull/5239 only restored one.

Confirmed on: JetBrains IDEs with native Wayland support (2026.1+), Hyprland 0.54.x

Fix
Add missing rule to File: default/hypr/apps/jetbrains.conf

windowrule {
name = jetbrains-tooltip
no_initial_focus = on +
match:class = ^(jetbrains-.)$
match:title = ^(win.)$
match:float = 1
}