### PR TITLE
Avoid Chromium VAAPI flags on NVIDIA

### DIFF
--- a/bin/omarchy-config-chromium-flags
+++ b/bin/omarchy-config-chromium-flags
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# omarchy:summary=Strip unsupported VAAPI flags from Chromium-family browser configs on NVIDIA
+# omarchy:hidden=true
+
+has_nvidia() {
+  lspci | grep -qi 'nvidia'
+}
+
+sanitize_chromium_flags() {
+  local file="$1"
+  local tmp_file
+
+  [[ -f $file ]] || return
+
+  tmp_file=$(mktemp)
+
+  while IFS= read -r line || [[ -n $line ]]; do
+    if [[ $line == --enable-features=* ]]; then
+      local features=${line#--enable-features=}
+      local keep_features=()
+      local feature
+
+      IFS=, read -ra feature_list <<< "$features"
+      for feature in "${feature_list[@]}"; do
+        case $feature in
+          VaapiVideoDecodeLinuxGL|VaapiVideoEncoder)
+            ;;
+          *)
+            keep_features+=("$feature")
+            ;;
+        esac
+      done
+
+      if ((${#keep_features[@]})); then
+        printf '%s\n' "--enable-features=$(IFS=,; echo "${keep_features[*]}")" >> "$tmp_file"
+      fi
+    else
+      printf '%s\n' "$line" >> "$tmp_file"
+    fi
+  done < "$file"
+
+  mv "$tmp_file" "$file"
+}
+
+if (($# == 0)); then
+  echo "Usage: omarchy-config-chromium-flags <path> [path...]"
+  exit 1
+fi
+
+has_nvidia || exit 0
+
+for file in "$@"; do
+  sanitize_chromium_flags "$file"
+done

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -24,6 +24,7 @@ announce_default_browser() {
 copy_chromium_flags() {
   mkdir -p ~/.config
   cp -f "${OMARCHY_PATH:-$HOME/.local/share/omarchy}/config/chromium-flags.conf" "$1"
+  "${OMARCHY_PATH:-$HOME/.local/share/omarchy}/bin/omarchy-config-chromium-flags" "$1"
 }
 
 setup_firefox_preferences() {

--- a/bin/omarchy-refresh-chromium
+++ b/bin/omarchy-refresh-chromium
@@ -14,6 +14,7 @@ fi
 
 # Refresh the Chromium configuration
 omarchy-refresh-config chromium-flags.conf
+"${OMARCHY_PATH:-$HOME/.local/share/omarchy}/bin/omarchy-config-chromium-flags" "$CONFIG_FILE"
 
 # Re-install Google accounts if previously configured
 if [[ $INSTALL_GOOGLE_ACCOUNTS == "true" ]]; then

--- a/migrations/1778151386.sh
+++ b/migrations/1778151386.sh
@@ -1,0 +1,7 @@
+echo "Disable Chromium VAAPI decode/encode flags on NVIDIA systems"
+
+"$OMARCHY_PATH/bin/omarchy-config-chromium-flags" \
+  ~/.config/chromium-flags.conf \
+  ~/.config/brave-flags.conf \
+  ~/.config/chrome-flags.conf \
+  ~/.config/microsoft-edge-stable-flags.conf


### PR DESCRIPTION
## Summary
- add a helper that strips Chromium VAAPI decode/encode flags on NVIDIA systems
- run it during browser install and Chromium refresh so the flags are not reintroduced
- add a migration to clean up existing Chromium-family browser configs on NVIDIA
