### PR TITLE
launch browser: suppress stderr when probing browser type

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -6,7 +6,7 @@
 default_browser=$(xdg-settings get default-web-browser)
 browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
 
-if $browser_exec --help | grep -q MOZ_LOG; then
+if $browser_exec --help 2>/dev/null | grep -q MOZ_LOG; then
   private_flag="--private-window"
 elif [[ $browser_exec =~ edge ]]; then
   private_flag="--inprivate"


### PR DESCRIPTION
## Summary
- Suppress stderr when probing the configured browser with `--help` so Chromium wrappers that invoke `man` do not leak missing-manpage noise.
- Preserve stdout-based `MOZ_LOG` detection for Firefox-style private browsing flags.

## Testing
- `bash -n bin/omarchy-launch-browser`
- `bash test/omarchy-cli-test.sh`
- Mocked Helium wrapper fixture confirming `No manual entry for helium` stderr is suppressed and `--private` maps to `--incognito`