### PR TITLE
Add Install -> Editor -> Jetbrains menu

### DIFF
--- a/bin/omarchy-install-jetbrains
+++ b/bin/omarchy-install-jetbrains
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -e
+
+if (( $# != 2 )); then
+  echo "Usage: omarchy-install-jetbrains PRODUCT_CODE INSTALL_PATH"
+  exit 1
+fi
+
+PRODUCT_CODE="$1"
+INSTALL_PATH="${2%/}"
+PRODUCTS_URL="https://data.services.jetbrains.com/products?fields=code,name"
+RELEASES_URL="https://data.services.jetbrains.com/products/releases?code=$PRODUCT_CODE&type=release&latest=true"
+sudo_keepalive_pid=""
+install_path_tmp="$INSTALL_PATH-tmp"
+archive=""
+install_succeeded="false"
+
+cleanup() {
+  if [[ -n $archive && -f $archive ]]; then
+    rm -f "$archive" || true
+  fi
+
+  if [[ $install_succeeded != "true" && -d $install_path_tmp ]]; then
+    sudo -n rm -rf "$install_path_tmp" || true
+  fi
+
+  if [[ -n $sudo_keepalive_pid ]]; then
+    kill "$sudo_keepalive_pid" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+for command in curl gum jq sha256sum tar sudo; do
+  if omarchy-cmd-missing "$command"; then
+    echo "Missing required command: $command"
+    exit 1
+  fi
+done
+
+echo "Fetching JetBrains product information for $PRODUCT_CODE..."
+products_info=$(curl -fsSL "$PRODUCTS_URL")
+product_name=$(jq -r --arg code "$PRODUCT_CODE" '.[] | select(.code == $code).name // empty' <<<"$products_info")
+
+if [[ -z $product_name ]]; then
+  echo "Unable to find a JetBrains product for code: $PRODUCT_CODE"
+  exit 1
+fi
+
+echo "Fetching latest $product_name release..."
+release_info=$(curl -fsSL "$RELEASES_URL")
+version=$(jq -r --arg code "$PRODUCT_CODE" '.[$code][0].version // empty' <<<"$release_info")
+download_url=$(jq -r --arg code "$PRODUCT_CODE" '.[$code][0].downloads.linux.link // empty' <<<"$release_info")
+checksum_url=$(jq -r --arg code "$PRODUCT_CODE" '.[$code][0].downloads.linux.checksumLink // empty' <<<"$release_info")
+notes_link=$(jq -r --arg code "$PRODUCT_CODE" '.[$code][0].notesLink // empty' <<<"$release_info")
+
+if [[ -z $version || -z $download_url || -z $checksum_url ]]; then
+  echo "Unable to find a Linux release for $product_name."
+  exit 1
+fi
+
+if [[ $INSTALL_PATH != /* ]]; then
+  echo "INSTALL_PATH must be absolute."
+  exit 1
+fi
+
+if [[ -f $INSTALL_PATH/product-info.json ]]; then
+  installed_version=$(jq -r '.version // empty' "$INSTALL_PATH/product-info.json")
+
+  if [[ $installed_version == "$version" ]]; then
+    echo "$product_name $version is already installed at $INSTALL_PATH."
+    exit 0
+  fi
+elif [[ -e $INSTALL_PATH ]]; then
+  echo "$INSTALL_PATH already exists but is not a JetBrains installation."
+  exit 1
+fi
+
+style_lines=("Ready to install $product_name $version?")
+
+if [[ -n $notes_link ]]; then
+  style_lines+=("" "Release notes: $notes_link")
+fi
+
+gum style --border normal --border-foreground 6 --padding "1 2" "${style_lines[@]}"
+
+echo
+
+if ! gum confirm "Continue with installation?"; then
+  echo "Cancelled $product_name installation."
+  exit 0
+fi
+
+# Ask for user's sudo permission before the download so he can fire and forget.
+sudo -v
+while true; do
+  sudo -n -v
+  sleep 60
+done &
+sudo_keepalive_pid=$!
+
+sudo -n rm -rf "$install_path_tmp"
+sudo -n mkdir -p "$install_path_tmp"
+sudo -n chown "$USER:$USER" "$install_path_tmp"
+
+archive="$install_path_tmp/$PRODUCT_CODE-$version.tar.gz"
+
+echo "Downloading $product_name $version..."
+curl -fL -o "$archive" "$download_url"
+
+echo "Verifying the checksum..."
+read -r expected_checksum _ <<<"$(curl -fsSL "$checksum_url")"
+actual_checksum=$(sha256sum "$archive" | cut -d " " -f 1)
+
+if [[ -z $expected_checksum || $actual_checksum != "$expected_checksum" ]]; then
+  echo "Downloaded archive checksum mismatch."
+  exit 1
+fi
+
+echo "Extracting to $install_path_tmp..."
+tar -xzf "$archive" -C "$install_path_tmp" --strip-components=1
+
+rm -f "$archive"
+
+sudo -n chown -R "$USER:$USER" "$install_path_tmp"
+
+product_info="$install_path_tmp/product-info.json"
+if [[ ! -f $product_info ]]; then
+  echo "Missing product-info.json in $install_path_tmp"
+  exit 1
+fi
+
+product_name=$(jq -r '.name // empty' "$product_info")
+wmclass=$(jq -r '.launch[0].startupWmClass // empty' "$product_info")
+svg_path=$(jq -r '.svgIconPath // empty' "$product_info")
+bin_path=$(jq -r '.launch[0].launcherPath // empty' "$product_info")
+conf_path=$(jq -r '.launch[0].vmOptionsFilePath // empty' "$product_info")
+
+if [[ -z $product_name || -z $wmclass || -z $svg_path || -z $bin_path || -z $conf_path ]]; then
+  echo "Unable to read required launcher details from $product_info"
+  exit 1
+fi
+
+bin_name=$(basename "$bin_path")
+if [[ -z $bin_name ]]; then
+  echo "Unable to determine launcher symlink name from $bin_path"
+  exit 1
+fi
+
+conf_path="$install_path_tmp/$conf_path"
+if [[ ! -f $conf_path ]]; then
+  echo "Missing VM options file at $conf_path"
+  exit 1
+elif ! grep -qxF -- "-Dawt.toolkit.name=WLToolkit" "$conf_path"; then
+  printf '\n-Dawt.toolkit.name=WLToolkit\n' >>"$conf_path"
+fi
+
+echo "Moving $install_path_tmp to $INSTALL_PATH"
+sudo -n rm -rf "$INSTALL_PATH"
+sudo -n mv "$install_path_tmp" "$INSTALL_PATH"
+
+svg_path="$INSTALL_PATH/$svg_path"
+bin_path="$INSTALL_PATH/$bin_path"
+
+mkdir -p "$HOME/.local/share/applications"
+desktop_file="$HOME/.local/share/applications/$wmclass.desktop"
+echo "Installing desktop file to $desktop_file"
+cat >"$desktop_file" <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=$product_name
+Icon=$svg_path
+Exec="$bin_path" %f
+Categories=Development;IDE;
+Terminal=false
+StartupWMClass=$wmclass
+StartupNotify=true
+EOF
+
+chmod +x "$desktop_file"
+
+echo "Creating symlink to /usr/local/bin/$bin_name"
+sudo -n ln -sfn "$bin_path" "/usr/local/bin/$bin_name"
+
+if omarchy-cmd-present update-desktop-database; then
+  update-desktop-database "$HOME/.local/share/applications" >/dev/null 2>&1 || true
+fi
+
+install_succeeded="true"
+
+echo "$product_name $version is installed."

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -501,8 +501,9 @@ show_install_service_menu() {
 }
 
 show_install_editor_menu() {
-  case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Vim\n  Emacs") in
+  case $(menu "Install" "  VSCode\n  JetBrains\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Vim\n  Emacs") in
   *VSCode*) present_terminal omarchy-install-vscode ;;
+  *JetBrains*) show_install_jetbrains_menu ;;
   *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
   *Zed*) present_terminal omarchy-install-zed ;;
   *Sublime*) install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;
@@ -510,6 +511,24 @@ show_install_editor_menu() {
   *Vim*) install "Vim" "vim" ;;
   *Emacs*) install "Emacs" "emacs-wayland" && systemctl --user enable --now emacs.service ;;
   *) show_install_menu ;;
+  esac
+}
+
+show_install_jetbrains_menu() {
+  case $(menu "Install" "  IntelliJ IDEA\n  PyCharm\n  WebStorm\n  PhpStorm\n  GoLand\n  RubyMine\n  CLion\n  Rider\n  RustRover\n  DataGrip\n  DataSpell\n  MPS" "--width 360") in
+  *"IntelliJ IDEA"*) present_terminal "omarchy-install-jetbrains IIU /opt/jetbrains-idea" ;;
+  *PyCharm*) present_terminal "omarchy-install-jetbrains PCP /opt/jetbrains-pycharm" ;;
+  *WebStorm*) present_terminal "omarchy-install-jetbrains WS /opt/jetbrains-webstorm" ;;
+  *PhpStorm*) present_terminal "omarchy-install-jetbrains PS /opt/jetbrains-phpstorm" ;;
+  *GoLand*) present_terminal "omarchy-install-jetbrains GO /opt/jetbrains-goland" ;;
+  *RubyMine*) present_terminal "omarchy-install-jetbrains RM /opt/jetbrains-rubymine" ;;
+  *CLion*) present_terminal "omarchy-install-jetbrains CL /opt/jetbrains-clion" ;;
+  *Rider*) present_terminal "omarchy-install-jetbrains RD /opt/jetbrains-rider" ;;
+  *RustRover*) present_terminal "omarchy-install-jetbrains RR /opt/jetbrains-rustrover" ;;
+  *DataGrip*) present_terminal "omarchy-install-jetbrains DG /opt/jetbrains-datagrip" ;;
+  *DataSpell*) present_terminal "omarchy-install-jetbrains DS /opt/jetbrains-dataspell" ;;
+  *MPS*) present_terminal "omarchy-install-jetbrains MPS /opt/jetbrains-mps" ;;
+  *) show_install_editor_menu ;;
   esac
 }
 


### PR DESCRIPTION
## Motivation

The main motivation is to make it easy to install any of Jetbrain's product.

But additionally, ~JetBrains 2026.1~ Rider 2026.1 shipped with `-Dawt.toolkit.name=WLToolkit` enabled by default, but JetBrains [reverted that change in 2026.1.1](https://youtrack.jetbrains.com/issue/RIDER-137705/Force-disable-support-for-Wayland-in-Rider-2026.1). As a result, the latest ~JetBrains~ Rider IDEs have XWayland-related quirks out of the box. These can be fixed by adding `-Dawt.toolkit.name=WLToolkit` to the VM options.

Because this is no longer the default, users have opened issues and PRs such as https://github.com/basecamp/omarchy/pull/5640 caused by XWayland quirks.

This PR remedies the situation by allowing users to install popular JetBrains editors directly from Omarchy’s menu. The setup adds `-Dawt.toolkit.name=WLToolkit` by default, so users do not have to think about it. This was suggested by @dhh [here](https://github.com/basecamp/omarchy/pull/5640#issuecomment-4395998680).

EDIT: I've confirmed that this issue actually only impact pre-2026.1 AND [Rider 2026.1.1](https://youtrack.jetbrains.com/issue/RIDER-137705/Force-disable-support-for-Wayland-in-Rider-2026.1), **not all** Jetbrains product.

## What It Does
 
- Downloads and installs the latest version of the selected JetBrains product
- Installs each product into a stable path under `/opt`, such as `/opt/jetbrains-rider`
- Stages the new version in a temporary install folder, such as `/opt/jetbrains-rider-tmp`
- Verifies the downloaded archive checksum before extraction
- Extracts the archive with the top-level folder stripped, so the stable install path does not change between versions
- Adds `-Dawt.toolkit.name=WLToolkit` to the product’s VM options file
- Sets up a desktop entry from the product metadata in `product-info.json`
- Adds a symlink to the launcher in `/usr/local/bin`

For Rider, the resulting layout looks like this:
```text
/
├── opt/
│   └── jetbrains-rider/
│       ├── product-info.json
│       └── bin/
│           ├── rider
│           └── rider64.vmoptions
│               └── contains: -Dawt.toolkit.name=WLToolkit
├── usr/local/bin/
│   └── rider -> /opt/jetbrains-rider/bin/rider
└── home/<user>/.local/share/applications/
    └── jetbrains-rider.desktop
```

Sudo access is requested before the download starts, so the user can fire and forget while it downloads, and the installation can proceed without interruption.
If the same version is already installed at the selected install path, the installer exits early.

## Screenshots

<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/216f3ea3-b15f-47e3-964c-ff013c163299" />

<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/ba0ec6fb-7dcb-4155-b91c-0c4e6fef6c4e" />


