### PR TITLE
Install hardware video acceleration for non-X-series Panther Lake Chips

### DIFF
--- a/install/config/hardware/intel/video-acceleration.sh
+++ b/install/config/hardware/intel/video-acceleration.sh
@@ -1,7 +1,7 @@
 # This installs hardware video acceleration for Intel GPUs
 
 if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel'); then
-  # HD Graphics / Iris / Xe / Arc use intel-media-driver + VPL
+  # HD Graphics / Iris / Xe / Arc / Non-Arc Panther Lake use intel-media-driver + VPL
   if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
     omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt
   elif [[ ${INTEL_GPU,,} =~ "gma" ]]; then

--- a/install/config/hardware/intel/video-acceleration.sh
+++ b/install/config/hardware/intel/video-acceleration.sh
@@ -2,7 +2,7 @@
 
 if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel'); then
   # HD Graphics / Iris / Xe / Arc use intel-media-driver + VPL
-  if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc) ]]; then
+  if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
     omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt
   elif [[ ${INTEL_GPU,,} =~ "gma" ]]; then
     # Older generations from 2008 to ~2014-2017 use libva-intel-driver

--- a/migrations/1778165347.sh
+++ b/migrations/1778165347.sh
@@ -1,0 +1,7 @@
+echo "Install hardware video acceleration for Intel GPUs on non-X Panther Lake systems"
+
+if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel' | grep -i 'panther lake'); then
+  if [[ ${INTEL_GPU,,} =~ intel\ graphics ]]; then
+    bash "$OMARCHY_PATH/install/config/hardware/intel/video-acceleration.sh"
+  fi
+fi

--- a/migrations/1778165347.sh
+++ b/migrations/1778165347.sh
@@ -1,7 +1,5 @@
 echo "Install hardware video acceleration for Intel GPUs on non-X Panther Lake systems"
 
-if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel' | grep -i 'panther lake'); then
-  if [[ ${INTEL_GPU,,} =~ intel\ graphics ]]; then
-    bash "$OMARCHY_PATH/install/config/hardware/intel/video-acceleration.sh"
-  fi
+if lspci | grep -iE 'vga|3d|display' | grep -i 'intel' | grep -i 'panther lake' | grep -qi 'intel graphics'; then
+  bash "$OMARCHY_PATH/install/config/hardware/intel/video-acceleration.sh"
 fi


### PR DESCRIPTION
## Problem
Non-X-series Panther Lake chips (like Intel Core 9 386H) were missing Intel GPU acceleration packages.
Both X and non-X models use the same Xe3 cores, but they identify differently when calling `lspci`:
- X models introduce themselves as Arc B370/B390, e.g.
	`Intel Corporation Panther Lake [Arc B390]`
- Non-X models introduce themselves as Intel Graphics, e.g.
	`Intel Corporation Panther Lake [Intel Graphics]`
`Intel Graphics` is too generic to match by because it has been used before for other lower-tier devices. The only reliable part to match here is `Panther Lake`.

## Solution
Update Intel video acceleration detection to treat non-Arc Panther Lake GPUs like the existing matches.

## Migration
Added a migration for existing non-X-series Panther Lake installations so they receive the same GPU acceleration packages without needing a reinstall.