### PR TITLE
Run SwayOSD as a session service

### DIFF
--- a/bin/omarchy-first-run
+++ b/bin/omarchy-first-run
@@ -16,6 +16,7 @@ if [[ -f $FIRST_RUN_MODE ]]; then
   bash "$OMARCHY_PATH/install/first-run/firewall.sh"
   bash "$OMARCHY_PATH/install/first-run/dns-resolver.sh"
   bash "$OMARCHY_PATH/install/first-run/gnome-theme.sh"
+  bash "$OMARCHY_PATH/install/first-run/swayosd.sh"
   bash "$OMARCHY_PATH/install/first-run/gtk-primary-paste.sh"
   bash "$OMARCHY_PATH/install/first-run/elephant.sh"
   omarchy-hook-install post-update "$OMARCHY_PATH/install/first-run/install-voxtype.hook"

--- a/bin/omarchy-restart-swayosd
+++ b/bin/omarchy-restart-swayosd
@@ -2,4 +2,8 @@
 
 # omarchy:summary=Restart the SwayOSD server
 
-omarchy-restart-app swayosd-server
+if systemctl --user is-enabled --quiet swayosd-server.service; then
+  systemctl --user restart swayosd-server.service
+else
+  omarchy-restart-app swayosd-server
+fi

--- a/config/systemd/user/swayosd-server.service
+++ b/config/systemd/user/swayosd-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SwayOSD server
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/swayosd-server
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=graphical-session.target

--- a/config/systemd/user/swayosd-server.service
+++ b/config/systemd/user/swayosd-server.service
@@ -6,7 +6,7 @@ After=graphical-session.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/swayosd-server
-Restart=on-failure
+Restart=always
 RestartSec=2
 
 [Install]

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -3,7 +3,6 @@ exec-once = uwsm-app -- mako
 exec-once = ! omarchy-toggle-enabled waybar-off && uwsm-app -- waybar
 exec-once = uwsm-app -- fcitx5 --disable notificationitem
 exec-once = uwsm-app -- swaybg -i ~/.config/omarchy/current/background -m fill
-exec-once = uwsm-app -- swayosd-server
 exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 exec-once = omarchy-first-run
 exec-once = omarchy-powerprofiles-init

--- a/install/first-run/swayosd.sh
+++ b/install/first-run/swayosd.sh
@@ -1,0 +1,4 @@
+sudo systemctl enable --now swayosd-libinput-backend.service
+
+systemctl --user daemon-reload
+systemctl --user enable --now swayosd-server.service

--- a/install/first-run/swayosd.sh
+++ b/install/first-run/swayosd.sh
@@ -1,4 +1,5 @@
-sudo systemctl enable --now swayosd-libinput-backend.service
+mkdir -p ~/.config/systemd/user
+cp "$OMARCHY_PATH/config/systemd/user/swayosd-server.service" ~/.config/systemd/user/swayosd-server.service
 
 systemctl --user daemon-reload
 systemctl --user enable --now swayosd-server.service

--- a/install/first-run/swayosd.sh
+++ b/install/first-run/swayosd.sh
@@ -1,5 +1,2 @@
-mkdir -p ~/.config/systemd/user
-cp "$OMARCHY_PATH/config/systemd/user/swayosd-server.service" ~/.config/systemd/user/swayosd-server.service
-
 systemctl --user daemon-reload
 systemctl --user enable --now swayosd-server.service

--- a/migrations/1778171768.sh
+++ b/migrations/1778171768.sh
@@ -1,9 +1,7 @@
 echo "Run SwayOSD as a supervised session service"
 
-SERVICE=swayosd-server.service
-
 mkdir -p ~/.config/systemd/user
-cp "$OMARCHY_PATH/config/systemd/user/$SERVICE" ~/.config/systemd/user/$SERVICE
+cp "$OMARCHY_PATH/config/systemd/user/swayosd-server.service" ~/.config/systemd/user/swayosd-server.service
 
 if [[ -f ~/.config/hypr/autostart.conf ]]; then
   sed -i '/^exec-once = uwsm-app -- swayosd-server$/d' ~/.config/hypr/autostart.conf
@@ -11,5 +9,4 @@ fi
 
 pkill -x swayosd-server || true
 
-systemctl --user daemon-reload
-systemctl --user enable --now "$SERVICE"
+bash "$OMARCHY_PATH/install/first-run/swayosd.sh"

--- a/migrations/1778171768.sh
+++ b/migrations/1778171768.sh
@@ -2,10 +2,6 @@ echo "Run SwayOSD as a supervised session service"
 
 SERVICE=swayosd-server.service
 
-if omarchy-cmd-missing swayosd-server; then
-  omarchy-pkg-add swayosd
-fi
-
 mkdir -p ~/.config/systemd/user
 cp "$OMARCHY_PATH/config/systemd/user/$SERVICE" ~/.config/systemd/user/$SERVICE
 

--- a/migrations/1778171768.sh
+++ b/migrations/1778171768.sh
@@ -1,0 +1,17 @@
+echo "Run SwayOSD as a supervised session service"
+
+SERVICE=swayosd-server.service
+
+if omarchy-cmd-missing swayosd-server; then
+  omarchy-pkg-add swayosd
+fi
+
+sudo systemctl enable --now swayosd-libinput-backend.service
+
+mkdir -p ~/.config/systemd/user
+cp "$OMARCHY_PATH/config/systemd/user/$SERVICE" "$HOME/.config/systemd/user/$SERVICE"
+
+pkill -x swayosd-server || true
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$SERVICE"

--- a/migrations/1778171768.sh
+++ b/migrations/1778171768.sh
@@ -6,10 +6,12 @@ if omarchy-cmd-missing swayosd-server; then
   omarchy-pkg-add swayosd
 fi
 
-sudo systemctl enable --now swayosd-libinput-backend.service
-
 mkdir -p ~/.config/systemd/user
-cp "$OMARCHY_PATH/config/systemd/user/$SERVICE" "$HOME/.config/systemd/user/$SERVICE"
+cp "$OMARCHY_PATH/config/systemd/user/$SERVICE" ~/.config/systemd/user/$SERVICE
+
+if [[ -f ~/.config/hypr/autostart.conf ]]; then
+  sed -i '/^exec-once = uwsm-app -- swayosd-server$/d' ~/.config/hypr/autostart.conf
+fi
 
 pkill -x swayosd-server || true
 


### PR DESCRIPTION
SwayOSD is currently started from Hyprland autostart through `uwsm-app` with `swayosd-server`. When that process exits after lock or suspend, the media bindings still run, but `swayosd-client` fails with `org.freedesktop.DBus.Error.ServiceUnknown`.

This adds a user service for `swayosd-server`. `omarchy-restart-swayosd` now restarts that service when it is enabled, with the old `uwsm-app` path left as a fallback for older installs.

The migration copies the service into the user systemd config, removes the old custom Hyprland autostart line if present, kills any old unmanaged `swayosd-server`, then enables and starts the service.

Tested:
- `bash -n bin/omarchy-first-run bin/omarchy-restart-swayosd install/first-run/swayosd.sh migrations/1778171768.sh`
- `systemd-analyze --user verify config/systemd/user/swayosd-server.service`
- `git diff --check`

Fixes #2718
Fixes #4551