### PR TITLE
fix(weather): Use local units for temperature and wind

### DIFF
--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -13,7 +13,5 @@ IFS='|' read -r place temperature wind <<< "$weather"
 place=${place%%,*}
 place=${place^}
 temperature=${temperature#+}
-# wttr.in returns locale-appropriate units already (e.g. °F/mph in the US),
-# so display the values as-is instead of forcing metric-to-imperial conversion.
 
 echo "$(omarchy-weather-icon)    $place  ·  Temp $temperature  ·  Wind $wind"

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Returns a formatted weather status string with temperature and wind speed.
 
-weather=$(curl -fsS --max-time 4 "https://wttr.in?m&format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+weather=$(curl -fsS --max-time 4 "https://wttr.in?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"
@@ -12,15 +12,8 @@ fi
 IFS='|' read -r place temperature wind <<< "$weather"
 place=${place%%,*}
 place=${place^}
-format_temperature() {
-  local celsius=${1#+}
-  celsius=${celsius//°/}
-  celsius=${celsius%C}
-
-  echo "${celsius}°c / $((celsius * 9 / 5 + 32))°f"
-}
-
-temperature=$(format_temperature "$temperature")
-wind=${wind//km\// km/}
+temperature=${temperature#+}
+# wttr.in returns locale-appropriate units already (e.g. °F/mph in the US),
+# so display the values as-is instead of forcing metric-to-imperial conversion.
 
 echo "$(omarchy-weather-icon)    $place  ·  Temp $temperature  ·  Wind $wind"


### PR DESCRIPTION
The waybar weather widget show metric units for wind for a USA location.  This change simplifies the script to use the default units for the locale as returned by wttr.in.

Remove the metric-to-imperial temperature conversion and display temperature and wind values as returned for the current locale.