### PR TITLE
Fix DefaultLimitNOFILE typo so fd-limit raise actually applies

### DIFF
--- a/install/config/increase-fd-limit.sh
+++ b/install/config/increase-fd-limit.sh
@@ -4,7 +4,7 @@ sudo mkdir -p /etc/systemd/system.conf.d /etc/systemd/user.conf.d
 
 sudo tee /etc/systemd/system.conf.d/99-omarchy-nofile.conf >/dev/null <<'EOF'
 [Manager]
-DefaultLimitNOFILESoft=65536
+DefaultLimitNOFILE=65536:524288
 EOF
 
 sudo cp /etc/systemd/system.conf.d/99-omarchy-nofile.conf \


### PR DESCRIPTION
## Summary
Replace the bogus `DefaultLimitNOFILESoft=65536` directive with the valid `DefaultLimitNOFILE=65536:524288` so the script's intended fd-limit raise actually takes effect.

## Problem
`install/config/increase-fd-limit.sh` writes `DefaultLimitNOFILESoft=65536` to both `/etc/systemd/system.conf.d/99-omarchy-nofile.conf` and `/etc/systemd/user.conf.d/99-omarchy-nofile.conf`. But `DefaultLimitNOFILESoft` is not a valid systemd configuration key — systemd silently ignores it and emits this warning on every boot, for both the system manager (PID 1) and the user manager:

> Unknown key 'DefaultLimitNOFILESoft' in section [Manager], ignoring.

The script's stated goal of raising the soft fd limit from 1024 to 65536 was never actually being achieved. Dev tools (VS Code, Docker, dev servers, databases) continued to run with systemd's default 1024 soft limit.

(The typo likely originated from someone reading `systemctl show` output, where `DefaultLimitNOFILESoft=` appears as a read-only display attribute for the soft component of the parsed limit. It looks like a config key, but it isn't.)

## Fix
```diff
-DefaultLimitNOFILESoft=65536
+DefaultLimitNOFILE=65536:524288
```

The SOFT:HARD form raises the soft limit to 65536 (matching the script's original intent) while preserving systemd's typical 524288 hard-limit default. Using the bare `DefaultLimitNOFILE=65536` form would lower the hard limit, which would be a regression.

## Test plan
- Apply this branch on a fresh Omarchy machine (or manually edit both `/etc/systemd/{system,user}.conf.d/99-omarchy-nofile.conf` files)
- `sudo systemctl daemon-reexec && systemctl --user daemon-reexec`
- `systemctl show | grep DefaultLimitNOFILE` reports `DefaultLimitNOFILE=524288` and `DefaultLimitNOFILESoft=65536`
- `systemctl --user show | grep DefaultLimitNOFILE` reports the same
- `journalctl -b 0 | grep NOFILESoft` is empty for events after the reexec — no more "Unknown key" warnings
