### PR TITLE
Set PATH in omarchy-battery-monitor.service unit

### DIFF
--- a/config/systemd/user/omarchy-battery-monitor.service
+++ b/config/systemd/user/omarchy-battery-monitor.service
@@ -6,4 +6,5 @@ After=graphical-session.target
 Type=oneshot
 ExecStart=%h/.local/share/omarchy/bin/omarchy-battery-monitor
 Environment=DISPLAY=:0
+Environment=PATH=%h/.local/share/omarchy/bin:/usr/local/bin:/usr/bin:/bin
 LogLevelMax=warning


### PR DESCRIPTION
## Summary
Add `Environment=PATH=` to the battery-monitor service unit so `omarchy-battery-remaining` resolves on the first timer-driven run after boot.

## Problem
`omarchy-battery-monitor` calls `omarchy-battery-remaining` (line 7) without an absolute path. But `config/systemd/user/omarchy-battery-monitor.service` does not set `Environment=PATH=`, so the timer-driven first invocation after boot can run before the systemd user manager's PATH includes `~/.local/share/omarchy/bin`. The journal at every boot shows:

> omarchy-battery-monitor: line 7: omarchy-battery-remaining: command not found

`omarchy-battery-monitor` doesn't `set -e`, so the script continues past the failed command substitution: `BATTERY_LEVEL` ends up empty, the numeric guard fails silently, and the unit reports success — but the low-battery check is effectively skipped on that first run. Subsequent runs (every 30s via the timer) work fine once the user-manager PATH catches up, which masks the issue.

## Fix
```diff
 [Service]
 Type=oneshot
 ExecStart=%h/.local/share/omarchy/bin/omarchy-battery-monitor
 Environment=DISPLAY=:0
+Environment=PATH=%h/.local/share/omarchy/bin:/usr/local/bin:/usr/bin:/bin
 LogLevelMax=warning
```

This guarantees the script's `omarchy-battery-remaining` lookup resolves regardless of when (or whether) the user-manager environment is updated.

## Test plan
- Apply this branch and reboot
- `journalctl --user -u omarchy-battery-monitor.service -b 0 | grep 'command not found'` is empty
- `systemctl --user show omarchy-battery-monitor.service -p Environment` includes the new `PATH=`
