### PR TITLE
Use emacsclient when setting default editor to Emacs

### DIFF
--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -16,7 +16,7 @@ zed | zeditor) editor="zeditor"; name="Zed"; glyph="" ;;
 sublime_text) editor="sublime_text"; name="Sublime Text"; glyph="" ;;
 helix) editor="helix"; name="Helix"; glyph="" ;;
 vim) editor="vim"; name="Vim"; glyph="" ;;
-emacs) editor="emacs"; name="Emacs"; glyph="" ;;
+emacs) editor="emacsclient"; name="Emacs"; glyph="" ;;
 nvim) editor="nvim"; name="Neovim"; glyph="" ;;
 *)
   echo "Usage: omarchy-default-editor <code|cursor|zed|sublime_text|helix|vim|emacs|nvim>"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -404,7 +404,7 @@ show_setup_default_editor_menu() {
   sublime_text) current="  Sublime Text" ;;
   helix) current="  Helix" ;;
   vim) current="  Vim" ;;
-  emacs) current="  Emacs" ;;
+  emacs | emacsclient) current="  Emacs" ;;
   esac
 
   case $(menu "Default Editor" "$options" "" "$current") in


### PR DESCRIPTION
We're already running the Emacs server; so it makes sense to use it.

Follow-up for https://github.com/basecamp/omarchy/pull/5651