### PR TITLE
Delay weather waybar startup to handle network initialization on boot

### DIFF
--- a/default/waybar/weather.sh
+++ b/default/waybar/weather.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Delay startup to allow network initialization after boot
+sleep 5
+
 icon=$(omarchy-weather-icon 2>/dev/null)
 
 if [[ -n $icon ]]; then


### PR DESCRIPTION
## Summary

- Add 5-second delay to `default/waybar/weather.sh` on script startup
- Fixes weather icon not appearing on first boot after restart

## Problem

When waybar starts on boot, `omarchy-weather-icon` uses curl to fetch weather data from wttr.in, but the network may not be ready yet. This causes the weather icon to not appear on first boot.

## Solution

Adding a 5-second delay at script startup ensures the network connection is established before the weather data is fetched.

Note: A similar workaround was already tested by the reporter using a custom wrapper script (`~/.config/waybar/weather-startup.sh`), which confirmed the 5-second delay fixes the issue.