### PR TITLE
Add pre-refresh-pacman.d hooks for custom repository support during channel switching (ie, CachyOS, Chaotic, etc..)

### DIFF
--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -19,5 +19,8 @@ echo
 sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$channel.conf" /etc/pacman.conf
 sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirrorlist
 
+# Allow user customization of /etc/pacman.conf before the upgrade runs
+omarchy-hook pre-refresh-pacman
+
 # Reset all package DBs and then update
 sudo pacman -Syyuu --noconfirm

--- a/config/omarchy/hooks/pre-refresh-pacman.d/add-custom-repo.sample
+++ b/config/omarchy/hooks/pre-refresh-pacman.d/add-custom-repo.sample
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This hook is called by `omarchy refresh pacman` AFTER the channel template
+# is copied to /etc/pacman.conf and BEFORE `pacman -Syyuu` runs. Use it to
+# layer customizations onto the freshly-written pacman.conf so they're
+# respected by the upgrade — common cases are adding a custom repository
+# (e.g. CachyOS, Chaotic-AUR, an internal company repo) or extra IgnorePkg
+# lines.
+#
+# The hook runs as the invoking user with a warm sudo cache.
+#
+# To put it into use, remove .sample from this file name.
+
+# Example: add an Include line above [core] for a custom repo.
+# Maintain the repo entries in /etc/pacman.d/custom-repos.conf yourself.
+
+CONF=/etc/pacman.conf
+SNIPPET=/etc/pacman.d/custom-repos.conf
+MARKER="Include = $SNIPPET"
+
+[[ -r $SNIPPET ]] || exit 0
+grep -qxF "$MARKER" "$CONF" && exit 0
+
+sudo sed -i "0,/^\[core\]/s||$MARKER\n\n[core]|" "$CONF"


### PR DESCRIPTION
## Summary

- Adds a `pre-refresh-pacman` hook that fires inside `omarchy-refresh-pacman` AFTER `/etc/pacman.conf` is replaced with the channel template and BEFORE `pacman -Syyuu` runs.
- Lets users layer customizations (custom repo Includes, IgnorePkg lines, etc.) onto the freshly-written config so the upgrade respects them — no post-hoc cleanup, no double-download, no transient install of unwanted package versions.
- Ships with `config/omarchy/hooks/pre-refresh-pacman.d/add-custom-repo.sample` demonstrating the pattern.

## Why

Users on overlay-style Arch distributions (CachyOS znver4, Chaotic-AUR, internal company repos) currently lose their custom `[repo]` entries every time `omarchy-refresh-pacman` runs — including via channel switches and the half-dozen migrations that invoke it. The existing `post-update` hook can recover after the fact, but only AFTER `pacman -Syyuu` has already pulled vanilla Arch versions. For packages where Arch and the overlay distro share the same version string, a recovery `-Syu` doesn't actually switch them back — only an explicit reinstall does, and that costs time and bandwidth on every refresh.

A pre-refresh hook lets users restore their Includes before the upgrade resolves packages, so the desired versions are pulled directly the first time.

This is pure mechanism — Omarchy stays opinion-free about what users put in the hook. It mirrors the contract of the existing `theme-set`, `font-set`, `post-update`, `post-boot`, and `battery-low` hooks: a `.d` directory of drop-in scripts dispatched via `omarchy-hook`, with a documented `.sample` showing intended use.

Related to #2815 and #3497 (provides a mechanism users can leverage; doesn't take an Omarchy stance on any specific repo).

## Test plan

- [x] `omarchy refresh pacman` with no hook installed → behaves identically to before (no observable change)
- [x] Drop a script in `~/.config/omarchy/hooks/pre-refresh-pacman.d/` that touches a sentinel file → confirm it runs after cp and before `pacman -Syyuu`
- [x] Hook script `exit 1` → `omarchy-refresh-pacman` continues (failures isolated by `omarchy-hook`'s existing per-script catch)
- [x] Sample file with `.sample` suffix is skipped by the hook runner (existing `omarchy-hook` behavior)
- [x] End-to-end: install the included sample as `add-custom-repo` (no `.sample`) with a stub `/etc/pacman.d/custom-repos.conf` containing an `[extra-test]` block; run `omarchy refresh pacman`; confirm the Include line lands above `[core]` and survives the cycle