### PR TITLE
Persist Bluetooth power state across reboots

### DIFF
--- a/install/config/hardware/bluetooth.sh
+++ b/install/config/hardware/bluetooth.sh
@@ -1,5 +1,8 @@
 # Turn on bluetooth by default
 chrootable_systemctl_enable bluetooth.service
 
+# Persist last power state across reboots (default AutoEnable=true overrides it)
+sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
+
 mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
 cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/bluetooth-a2dp-autoconnect.conf" ~/.config/wireplumber/wireplumber.conf.d/

--- a/migrations/1778291336.sh
+++ b/migrations/1778291336.sh
@@ -1,0 +1,3 @@
+echo "Persist Bluetooth power state across reboots"
+
+sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf

--- a/migrations/1778291336.sh
+++ b/migrations/1778291336.sh
@@ -1,3 +1,5 @@
 echo "Persist Bluetooth power state across reboots"
 
 sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
+
+omarchy-state set reboot-required

--- a/migrations/1778291336.sh
+++ b/migrations/1778291336.sh
@@ -1,5 +1,3 @@
 echo "Persist Bluetooth power state across reboots"
 
 sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
-
-omarchy-state set reboot-required


### PR DESCRIPTION
Closes #5684.

## Summary

BlueZ defaults to `AutoEnable=true` in `/etc/bluetooth/main.conf`, which forces controllers on at boot regardless of the last user-set state. With `AutoEnable=false` (BlueZ 5.66+), `bluetoothd` respects the persisted `Powered` state in `/var/lib/bluetooth/<MAC>/settings`, so toggling off in `bluetui` (or any D-Bus client) survives a reboot.

Today users who turn Bluetooth off in `bluetui` find it back on after every reboot. This makes the off state stick.

Applied in two places:
- `install/config/hardware/bluetooth.sh` (fresh installs)
- `migrations/1778291336.sh` (existing setups via `omarchy-update`)

The change takes effect on the next reboot (or `systemctl restart bluetooth`); the migration intentionally does not restart the service mid-update to avoid disconnecting active audio/input devices.

A drop-in at `/etc/bluetooth/main.conf.d/` would probably be cleaner, but BlueZ 5.86's `load_config()` only opens a single file, so no drop-in support that I'm aware of.