### PR TITLE
Remove defunct libretro-vice-git from RetroArch install

### DIFF
--- a/bin/omarchy-install-gaming-retroarch
+++ b/bin/omarchy-install-gaming-retroarch
@@ -21,7 +21,7 @@ omarchy-pkg-add \
   libretro-parallel-n64 libretro-picodrive libretro-play libretro-ppsspp \
   libretro-sameboy libretro-scummvm libretro-shaders-slang libretro-snes9x \
   libretro-yabause \
-  libretro-cap32-git libretro-fbneo-git libretro-uae-git libretro-vice-git \
+  libretro-cap32-git libretro-fbneo-git libretro-uae-git \
   libretro-database-git \
   retroarch-joypad-autoconfig-git
 


### PR DESCRIPTION
## Summary

- Remove `libretro-vice-git` from the RetroArch install script package list
- The package no longer exists on AUR (returns 404), causing `omarchy-install-gaming-retroarch` to fail entirely

## Why

Issue #5697 reports that RetroArch installation fails because `libretro-vice-git` cannot be found. The package has been removed from AUR, so removing it from the install script allows the rest of the RetroArch core set to install successfully.

Fixes #5697