### PR TITLE
Fix fontconfig monospace binding overriding app-specific fonts

### DIFF
--- a/config/fontconfig/fonts.conf
+++ b/config/fontconfig/fonts.conf
@@ -23,7 +23,7 @@
     <test name="family" qual="any">
       <string>monospace</string>
     </test>
-    <edit name="family" mode="assign" binding="strong">
+    <edit name="family" mode="append" binding="same">
       <string>JetBrainsMono Nerd Font</string>
     </edit>
   </match>

--- a/migrations/1778346208.sh
+++ b/migrations/1778346208.sh
@@ -1,0 +1,11 @@
+echo "Fix fontconfig monospace binding so app-specific fonts are not overridden"
+
+if [[ -f ~/.config/fontconfig/fonts.conf ]] && command -v xmlstarlet >/dev/null 2>&1; then
+  xmlstarlet ed -L \
+    -u '//match[@target="pattern"][test/string="monospace"]/edit[@name="family"]/@mode' \
+    -v "append" \
+    -u '//match[@target="pattern"][test/string="monospace"]/edit[@name="family"]/@binding' \
+    -v "same" \
+    ~/.config/fontconfig/fonts.conf
+  fc-cache -f >/dev/null 2>&1
+fi


### PR DESCRIPTION
## Summary

- Change fontconfig monospace match from `mode="assign" binding="strong"` to `mode="append" binding="same"`
- Add migration to fix existing user configs

## Why

Issue #5675 reports that Omarchy's global fontconfig monospace font overrides explicit app font configurations like Ghostty's `font-family`. The `mode="assign" binding="strong"` setting replaces the font family entirely, preventing apps from using their own explicit font choices.

With `mode="append" binding="same"`, the system monospace font is appended as a fallback rather than replacing the app's explicit font. This means:

- `fc-match monospace` still returns the Omarchy-selected global font
- Apps with explicit font configs (like Ghostty) can override it as expected

Fixes #5675