### PR TITLE
Fix omarchy-reinstall producing single-branch shallow clone

### DIFF
--- a/bin/omarchy-reinstall-git
+++ b/bin/omarchy-reinstall-git
@@ -6,6 +6,11 @@ set -e
 
 # Reinstall the Omarchy configuration directory from the git source.
 
-git clone --depth=1 "https://github.com/basecamp/omarchy.git" ~/.local/share/omarchy-new >/dev/null
-mv $OMARCHY_PATH ~/.local/share/omarchy-old
-mv ~/.local/share/omarchy-new $OMARCHY_PATH
+OMARCHY_REPO="${OMARCHY_REPO:-basecamp/omarchy}"
+CURRENT_BRANCH="$(git -C "$OMARCHY_PATH" branch --show-current 2>/dev/null || echo dev)"
+
+git clone "https://github.com/${OMARCHY_REPO}.git" ~/.local/share/omarchy-new >/dev/null
+git -C ~/.local/share/omarchy-new fetch origin "${CURRENT_BRANCH}" >/dev/null
+git -C ~/.local/share/omarchy-new checkout "${CURRENT_BRANCH}" >/dev/null
+mv "$OMARCHY_PATH" ~/.local/share/omarchy-old
+mv ~/.local/share/omarchy-new "$OMARCHY_PATH"


### PR DESCRIPTION
## Summary

- Remove `--depth=1` from `git clone` in `bin/omarchy-reinstall-git`, which implicitly enables `--single-branch` and prevents `omarchy-channel-set` from switching channels after reinstall
- Detect the user's current branch and check it out in the new clone, preserving the channel they were on
- Respect `OMARCHY_REPO` env var like `boot.sh` does

## Why

Issue #5687 reports that after running `omarchy-reinstall`, `omarchy-channel-set` fails for any channel other than the upstream default branch. This is because `--depth=1` implies `--single-branch` per `git-clone(1)`, so only the default branch (`dev`) is fetched. Users on `master`, `rc`, or `edge` lose access to other channels after reinstall.

Fixes #5687