### PR TITLE
Fix monitor scaling shortcut conflict on alternative keyboard layouts

### DIFF
--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -128,6 +128,6 @@ bindd = SUPER ALT, code:12, Switch to group window 3, changegroupactive, 3
 bindd = SUPER ALT, code:13, Switch to group window 4, changegroupactive, 4
 bindd = SUPER ALT, code:14, Switch to group window 5, changegroupactive, 5
 
-# Cycle monitor scaling with SUPER + /
-bindd = SUPER, code:61, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle
-bindd = SUPER ALT, code:61, Cycle monitor scaling backwards, exec, omarchy-hyprland-monitor-scaling-cycle --reverse
+# Cycle monitor scaling with SUPER + .
+bindd = SUPER, code:60, Cycle monitor scaling, exec, omarchy-hyprland-monitor-scaling-cycle
+bindd = SUPER ALT, code:60, Cycle monitor scaling backwards, exec, omarchy-hyprland-monitor-scaling-cycle --reverse

--- a/migrations/1778346570.sh
+++ b/migrations/1778346570.sh
@@ -1,0 +1,10 @@
+echo "Fix monitor scaling shortcut conflict on alternative keyboard layouts"
+
+MONITOR_CONF="$HOME/.config/hypr/monitors.conf"
+TILING_CONF="$HOME/.config/hypr/tiling-v2.conf"
+
+# Update monitors.conf if it has the old code:61 bindings
+if [[ -f $TILING_CONF ]]; then
+  sed -i 's/SUPER, code:61, Cycle monitor scaling/SUPER, code:60, Cycle monitor scaling/' "$TILING_CONF"
+  sed -i 's/SUPER ALT, code:61, Cycle monitor scaling backwards/SUPER ALT, code:60, Cycle monitor scaling backwards/' "$TILING_CONF"
+fi


### PR DESCRIPTION
## Summary

- Change monitor scaling shortcuts from `code:61` (/) to `code:60` (.) in `default/hypr/bindings/tiling-v2.conf`
- Add migration to update existing user configs

## Why

Issue #5665 reports that on the bépo (French ergonomic) keyboard layout, the monitor scaling shortcuts (`SUPER + code:61` and `SUPER + ALT + code:61`) conflict with `SUPER + F` (fullscreen) and `SUPER + ALT + F` (full width). This is because `code:61` maps to the F key position on bépo, whereas it maps to `/` on QWERTY.

Changing to `code:60` (the `.` key on QWERTY, `,` on bépo) avoids letter key conflicts on alternative layouts while keeping the shortcut in the same physical area near the right shift key.

Fixes #5665