### PR TITLE
Fix power profile udev rule race condition when AC connected at boot

### DIFF
--- a/install/config/powerprofilesctl-rules.sh
+++ b/install/config/powerprofilesctl-rules.sh
@@ -1,7 +1,7 @@
 if omarchy-battery-present; then
   cat <<EOF | sudo tee "/etc/udev/rules.d/99-power-profile.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
-SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=Requires=power-profiles-daemon.service --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
+SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=Requires=power-profiles-daemon.service --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
 EOF
 
   sudo systemctl enable power-profiles-daemon

--- a/migrations/1778346851.sh
+++ b/migrations/1778346851.sh
@@ -1,0 +1,7 @@
+echo "Add Requires=power-profiles-daemon.service to power profile udev rule"
+
+RULES_FILE="/etc/udev/rules.d/99-power-profile.rules"
+if [[ -f $RULES_FILE ]]; then
+  sudo sed -i 's/--property=After=power-profiles-daemon.service/--property=Requires=power-profiles-daemon.service --property=After=power-profiles-daemon.service/g' "$RULES_FILE"
+  sudo udevadm control --reload 2>/dev/null
+fi


### PR DESCRIPTION
## Summary

- Add `Requires=power-profiles-daemon.service` to the `systemd-run` invocation in the power profile udev rule
- Add migration to fix existing user udev rules

## Why

Issue #5688 reports that the power profile script fails when AC power is connected before boot, but works fine on manual run or post-boot hotplug.

The existing udev rule uses `--property=After=power-profiles-daemon.service` which only sets ordering between units that are already queued. It doesn't create a dependency, so when AC is connected at boot the transient `omarchy-power-profile` unit can execute before `power-profiles-daemon.service` has been started.

Adding `Requires=power-profiles-daemon.service` ensures the daemon is pulled in and fully started before `omarchy-powerprofiles-set` runs, fixing the race condition.

Fixes #5688