### PR TITLE
Fix Waybar clock showing incorrect time offset from system timezone

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -63,6 +63,7 @@
   "clock": {
     "format": "{:L%A %H:%M}",
     "format-alt": "{:L%d %B W%V %Y}",
+    "timezone": "",
     "tooltip": false,
     "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
   },

--- a/migrations/1778347123.sh
+++ b/migrations/1778347123.sh
@@ -1,0 +1,6 @@
+echo "Fix Waybar clock timezone by explicitly setting system timezone"
+
+WAYBAR_CONF="$HOME/.config/waybar/config.jsonc"
+if [[ -f $WAYBAR_CONF ]] && ! grep -q '"timezone"' "$WAYBAR_CONF"; then
+  sed -i 's/"format": "{:L%A %H:%M}"/"format": "{:L%A %H:%M}",\n    "timezone": ""/' "$WAYBAR_CONF"
+fi


### PR DESCRIPTION
## Summary

- Add explicit `timezone` property to Waybar clock module to ensure it uses the system timezone
- Add migration to fix existing user configs

## Why

Issue #5696 reports that the Waybar clock shows a time offset of 1 hour from the system time reported by `timedatectl`. The user's timezone is correctly configured.

Some Waybar versions may default to UTC when the `TZ` environment variable is not set in the session environment (e.g., when Waybar is started by Hyprland without inheriting the full user environment). Explicitly setting `"timezone": ""` tells Waybar to use the system timezone, ensuring consistent behavior across different session setups.

Fixes #5696