### PR TITLE
Fix hibernation setup --force to always rebuild UKI

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -30,8 +30,8 @@ MKINITCPIO_CONF="/etc/mkinitcpio.conf.d/omarchy_resume.conf"
 SWAP_FILE="/swap/swapfile"
 RESUME_DROP_IN="/etc/limine-entry-tool.d/resume.conf"
 
-# Check if hibernation is already configured
-if [[ -f $MKINITCPIO_CONF ]] && grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; then
+# Check if hibernation is already configured (skip when --force to ensure UKI rebuild)
+if ! $FORCE && [[ -f $MKINITCPIO_CONF ]] && grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; then
   # Fix empty resume_offset if btrfs map-swapfile failed during initial setup
   if [[ -f $RESUME_DROP_IN ]] && grep -q 'resume_offset="$' "$RESUME_DROP_IN" && [[ -f $SWAP_FILE ]]; then
     RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE" 2>/dev/null)


### PR DESCRIPTION
## Summary

- Skip the early-exit check in `omarchy-hibernation-setup` when `--force` is passed, ensuring the UKI is always rebuilt

## Why

Issue #5693 reports that after a snapper rollback, the on-ESP UKI can end up older than the mkinitcpio drop-in that enables the resume hook. Re-running `omarchy hibernation setup --force` doesn't fix it because it sees `HOOKS+=(resume)` already in the config, prints "Hibernation is already set up", and exits without invoking `limine-mkinitcpio`. The running initramfs has no resume hook, so hibernate writes the swap image but the next boot ignores it.

With this change, `--force` actually forces a rebuild, which is what users would expect and matches the flag's semantics.

Fixes #5693