### PR TITLE
Add TLP support for power profile management

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -297,12 +297,12 @@ show_setup_menu() {
 }
 
 show_setup_power_menu() {
-  profile=$(menu "Power Profile" "$(omarchy-powerprofiles-list)" "" "$(powerprofilesctl get)")
+  profile=$(menu "Power Profile" "$(omarchy-powerprofiles-list)" "" "$("$(omarchy-power-cmd)" get)")
 
   if [[ $profile == "CNCLD" || -z $profile ]]; then
     back_to show_setup_menu
   else
-    powerprofilesctl set "$profile"
+    "$(omarchy-power-cmd)" set "$profile"
   fi
 }
 

--- a/bin/omarchy-power-cmd
+++ b/bin/omarchy-power-cmd
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Returns a appropriate power daemon command
+
+ if command -v powerprofilesctl &>/dev/null; then
+    echo "powerprofilesctl"
+  elif command -v tlpctl &>/dev/null; then
+    echo "tlpctl"
+  else
+    return
+  fi

--- a/bin/omarchy-powerprofiles-list
+++ b/bin/omarchy-powerprofiles-list
@@ -2,6 +2,6 @@
 
 # omarchy:summary=Returns a list of all the available power profiles on the system.
 
-powerprofilesctl list |
+"$(omarchy-power-cmd)" list |
   awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }' |
   tac


### PR DESCRIPTION
Adds runtime detection of the active power daemon, supporting both `powerprofilesctl` and `tlp` interchangeably.
<img width="299" height="249" alt="image" src="https://github.com/user-attachments/assets/f2c8d21f-9328-4ad2-a6ee-f2fba9d9800d" />


Since both daemons share the same interface (`get`, `set`, `list`), the implementation resolves the available binary at runtime with no duplication, existing menu behaviour is unchanged.

TLP is a great Linux tool for laptop battery management, offering fine-grained control over CPU power profiles, clock speeds, and battery charge thresholds

If this looks good, I can follow up with a PR to add TLP installation to the omarchy services menu (which handles removing `power-profiles-daemon`, stopping its service, and installing + enabling TLP).