### PR TITLE
Trash imv deletes; add Ctrl+E to edit in Satty

### DIFF
--- a/config/imv/config
+++ b/config/imv/config
@@ -3,11 +3,14 @@
 # Print the current image file
 <Ctrl+p> = exec lp "$imv_current_file"
 
-# Delete the current image and quit the viewer
-<Ctrl+x> = exec rm "$imv_current_file"; quit
+# Trash the current image and quit the viewer (recoverable from Trash)
+<Ctrl+x> = exec gio trash "$imv_current_file"; quit
 
-# Delete the current image and move to the next one
-<Ctrl+Shift+X> = exec rm "$imv_current_file"; close
+# Trash the current image and move to the next one
+<Ctrl+Shift+X> = exec gio trash "$imv_current_file"; close
 
 # Rotate the currently open image by 90 degrees
 <Ctrl+r> = exec mogrify -rotate 90 "$imv_current_file"
+
+# Edit the current image in Satty and quit the viewer
+<Ctrl+e> = exec satty --filename "$imv_current_file" & ; quit

--- a/config/imv/config
+++ b/config/imv/config
@@ -4,10 +4,10 @@
 <Ctrl+p> = exec lp "$imv_current_file"
 
 # Trash the current image and quit the viewer (recoverable from Trash)
-<Ctrl+x> = exec gio trash "$imv_current_file"; quit
+<Ctrl+x> = exec gio trash -- "$imv_current_file"; quit
 
 # Trash the current image and move to the next one
-<Ctrl+Shift+X> = exec gio trash "$imv_current_file"; close
+<Ctrl+Shift+X> = exec gio trash -- "$imv_current_file"; close
 
 # Rotate the currently open image by 90 degrees
 <Ctrl+r> = exec mogrify -rotate 90 "$imv_current_file"


### PR DESCRIPTION
## Summary
- `Ctrl+X` and `Ctrl+Shift+X` now use `gio trash` instead of `rm`, so accidentally hitting them sends the image to the freedesktop Trash (recoverable from any file manager) instead of permanently deleting it.
- Adds `Ctrl+E` to open the current image in Satty for annotation, then quit imv. Mirrors the usual screenshot → annotate flow without forcing a separate launcher invocation.

Both `imv` and `satty` are already in `install/omarchy-base.packages`, and `gio` ships via `glib2` (transitive dep of GTK / Hyprland), so no new dependencies.

## Test plan
- [ ] Open an image with imv, press `Ctrl+X` — image moves to `~/.local/share/Trash/files/`, imv quits.
- [ ] Open multiple images, press `Ctrl+Shift+X` — current image trashed, imv advances to the next.
- [ ] Press `Ctrl+E` — Satty opens with the current image loaded; imv quits.
- [ ] Pre-existing bindings (`Ctrl+P` print, `Ctrl+R` rotate) still work.