### PR TITLE
add fallback for pasted file path in ASCII art generation

### DIFF
--- a/bin/omarchy-branding-about
+++ b/bin/omarchy-branding-about
@@ -14,7 +14,7 @@ image)
   if [[ -z $image ]]; then
     image=$(omarchy-menu-input "Paste image path")
   fi
-  if [[ -n $image && -f $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/about.txt --width 54 --height 26 --mode block; then
+  if [[ -n $image && -f $image && $image =~ \.(svg|png)$ ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/about.txt --width 54 --height 26 --mode block; then
     omarchy-launch-about >/dev/null 2>&1
   fi
   ;;

--- a/bin/omarchy-branding-about
+++ b/bin/omarchy-branding-about
@@ -11,7 +11,10 @@ set -euo pipefail
 case "${1:-}" in
 image)
   image=$(omarchy-menu-file "Logo image" "$HOME" "svg png")
-  if [[ -n $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/about.txt --width 54 --height 26 --mode block; then
+  if [[ -z $image ]]; then
+    image=$(omarchy-menu-input "Paste image path")
+  fi
+  if [[ -n $image && -f $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/about.txt --width 54 --height 26 --mode block; then
     omarchy-launch-about >/dev/null 2>&1
   fi
   ;;

--- a/bin/omarchy-branding-screensaver
+++ b/bin/omarchy-branding-screensaver
@@ -14,7 +14,7 @@ image)
   if [[ -z $image ]]; then
     image=$(omarchy-menu-input "Paste image path")
   fi
-  if [[ -n $image && -f $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/screensaver.txt; then
+  if [[ -n $image && -f $image && $image =~ \.(svg|png)$ ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/screensaver.txt; then
     omarchy-launch-screensaver force >/dev/null 2>&1
   fi
   ;;

--- a/bin/omarchy-branding-screensaver
+++ b/bin/omarchy-branding-screensaver
@@ -11,7 +11,10 @@ set -euo pipefail
 case "${1:-}" in
 image)
   image=$(omarchy-menu-file "Logo image" "$HOME" "svg png")
-  if [[ -n $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/screensaver.txt; then
+  if [[ -z $image ]]; then
+    image=$(omarchy-menu-input "Paste image path")
+  fi
+  if [[ -n $image && -f $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/screensaver.txt; then
     omarchy-launch-screensaver force >/dev/null 2>&1
   fi
   ;;


### PR DESCRIPTION
I added a fallback option when omarchy-menu-file returns empty (which would be the case if you paste a file path), it falls through to omarchy-menu-input to capture the pasted path.
I also added a transcode condition that checks -f $image so a nonexistent path fails explicitly rather than being passed silently.
Closes #5727 