### PR TITLE
Scope branding image pickers to ~/Pictures, fix About transcode mode

### DIFF
--- a/bin/omarchy-branding-about
+++ b/bin/omarchy-branding-about
@@ -8,9 +8,11 @@
 
 set -euo pipefail
 
+SOURCE_DIR="${XDG_PICTURES_DIR:-$HOME/Pictures}"
+
 case "${1:-}" in
 image)
-  image=$(omarchy-menu-file "Logo image" "${XDG_PICTURES_DIR:-$HOME/Pictures}" "svg png")
+  image=$(omarchy-menu-file "Pick png/svg from $SOURCE_DIR" "${SOURCE_DIR}" "svg png")
   if [[ -n $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/about.txt --width 54 --height 26; then
     omarchy-launch-about >/dev/null 2>&1
   fi

--- a/bin/omarchy-branding-about
+++ b/bin/omarchy-branding-about
@@ -10,8 +10,8 @@ set -euo pipefail
 
 case "${1:-}" in
 image)
-  image=$(omarchy-menu-file "Logo image" "$HOME" "svg png")
-  if [[ -n $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/about.txt --width 54 --height 26 --mode block; then
+  image=$(omarchy-menu-file "Logo image" "${XDG_PICTURES_DIR:-$HOME/Pictures}" "svg png")
+  if [[ -n $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/about.txt --width 54 --height 26; then
     omarchy-launch-about >/dev/null 2>&1
   fi
   ;;

--- a/bin/omarchy-branding-screensaver
+++ b/bin/omarchy-branding-screensaver
@@ -8,9 +8,11 @@
 
 set -euo pipefail
 
+SOURCE_DIR="${XDG_PICTURES_DIR:-$HOME/Pictures}"
+
 case "${1:-}" in
 image)
-  image=$(omarchy-menu-file "Logo image" "${XDG_PICTURES_DIR:-$HOME/Pictures}" "svg png")
+  image=$(omarchy-menu-file "Pick png/svg from $SOURCE_DIR" "${SOURCE_DIR}" "svg png")
   if [[ -n $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/screensaver.txt; then
     omarchy-launch-screensaver force >/dev/null 2>&1
   fi

--- a/bin/omarchy-branding-screensaver
+++ b/bin/omarchy-branding-screensaver
@@ -10,7 +10,7 @@ set -euo pipefail
 
 case "${1:-}" in
 image)
-  image=$(omarchy-menu-file "Logo image" "$HOME" "svg png")
+  image=$(omarchy-menu-file "Logo image" "${XDG_PICTURES_DIR:-$HOME/Pictures}" "svg png")
   if [[ -n $image ]] && omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/screensaver.txt; then
     omarchy-launch-screensaver force >/dev/null 2>&1
   fi


### PR DESCRIPTION
## Summary

The Style → About → Set From Image and Style → Screensaver → Set From Image flows were almost unusable on populated home directories. Two unrelated nits in the same code path:

- **Picker scope too broad.** `omarchy-branding-about` and `omarchy-branding-screensaver` both call `omarchy-menu-file "Logo image" "$HOME" "svg png"`, which feeds Walker dmenu every PNG/SVG under `$HOME` recursively. On my system that's ~46k entries — Walker can't usefully render or fuzzy-match a list that size, so the picker appears broken.
- **Inconsistent transcode mode in About.** `omarchy-branding-about` hardcodes `--mode block`, while `omarchy-branding-screensaver` uses the default braille mode. Stock `about.txt` ships as a braille render, so anyone using "Set From Image" gets a chunky low-res result that doesn't match what Omarchy ships with. The reduced `--width 54` is correct (it fits the fastfetch logo column) but the mode change looks unintentional.

## Changes

- Scope both pickers to `\${XDG_PICTURES_DIR:-\$HOME/Pictures}` — the same pattern already used in `omarchy-capture-screenshot`.
- Drop `--mode block` from `omarchy-branding-about` so it falls back to braille like the screensaver and the shipped default.

Three line changes total.

## Test plan

- [x] `bash test/omarchy-cli-test.sh` passes
- [x] `shellcheck bin/omarchy-branding-about bin/omarchy-branding-screensaver` clean
- [x] `omarchy-branding-about image` opens picker scoped to ~/Pictures, transcodes selection, About splash shows new braille-style logo
- [x] `omarchy-branding-screensaver image` opens picker scoped to ~/Pictures, transcodes selection, screensaver shows new logo
- [x] `omarchy-branding-about reset` and `omarchy-branding-screensaver reset` still work