### PR TITLE
Change weather location for the waybar

### DIFF
--- a/bin/omarchy-weather-city-select
+++ b/bin/omarchy-weather-city-select
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Input and set weather city
+# omarchy:requires-sudo=true
+
+city=$(gum input --header "Input a city for the weather") || exit 1
+echo ${city} >$HOME/.config/omarchy/current/weather_city.name
+echo "The city for the weather is ${city} now."

--- a/bin/omarchy-weather-icon
+++ b/bin/omarchy-weather-icon
@@ -2,7 +2,8 @@
 
 # omarchy:summary=Returns a weather condition icon, adjusted for live sunrise and sunset.
 
-weather_data=$(curl -fsS --max-time 3 "https://wttr.in?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
+city=$(<$HOME/.config/omarchy/current/weather_city.name)
+weather_data=$(curl -fsS --max-time 3 "https://wttr.in/${city}?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
 
 IFS=$'\t' read -r weather_code sunrise sunset <<< "$weather_data"
 if [[ ! $weather_code =~ ^[0-9]+$ || ! $sunrise =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ || ! $sunset =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ ]]; then

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -3,7 +3,7 @@
 # omarchy:summary=Returns a formatted weather status string with temperature and wind speed.
 
 city=$(<$HOME/.config/omarchy/current/weather_city.name)
-weather=$(curl -fsS --max-time 4 "https://wttr.in/${city}/?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+weather=$(curl -fsS --max-time 4 "https://wttr.in/${city}?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -2,14 +2,15 @@
 
 # omarchy:summary=Returns a formatted weather status string with temperature and wind speed.
 
-weather=$(curl -fsS --max-time 4 "https://wttr.in?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+city=$(<$HOME/.config/omarchy/current/weather_city.name)
+weather=$(curl -fsS --max-time 4 "https://wttr.in/${city}/?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"
   exit 1
 fi
 
-IFS='|' read -r place temperature wind <<< "$weather"
+IFS='|' read -r place temperature wind <<<"$weather"
 place=${place%%,*}
 place=${place^}
 temperature=${temperature#+}

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -72,7 +72,8 @@
     "return-type": "json",
     "interval": 60,
     "tooltip": false,
-    "on-click": "notify-send -u low \"$(omarchy-weather-status)\""
+    "on-click": "notify-send -u low \"$(omarchy-weather-status)\"",
+    "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-weather-city-select"
   },
   "network": {
     "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],


### PR DESCRIPTION
With this PR you can input the city for which you want to see the weather.

## The problem
I always use VPN, so with the current configuration I see the weather for any city but not mine. Now I can select my city, so I will see the correct weather.

## How it works
1. Right-click on the weather-widget
2. Enter the city, then the city saves to a file in $HOME/.config/omarchy/current/weather_city.name
3. The weather scripts reads the name and curls the weather status for the correct city.