### PR TITLE
Fix bluetui navigation keys in Ghostty

### DIFF
--- a/bin/omarchy-launch-bluetooth
+++ b/bin/omarchy-launch-bluetooth
@@ -3,4 +3,9 @@
 # omarchy:summary=Launch the Omarchy bluetooth controls TUI (provided by bluetui).
 
 rfkill unblock bluetooth
-exec omarchy-launch-or-focus-tui bluetui
+
+# bluetui/crossterm does not reliably handle navigation keys when Ghostty
+# advertises TERM=xterm-ghostty. Use a widely-supported terminfo entry for
+# this TUI while preserving the usual Omarchy app id for focus/floating rules.
+exec omarchy-launch-or-focus "org.omarchy.bluetui" \
+  "uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.bluetui -e env TERM=xterm-256color bluetui"


### PR DESCRIPTION
## Summary
- Launch the Bluetooth TUI with `TERM=xterm-256color` to work around bluetui/crossterm navigation key issues under Ghostty
- Preserve the `org.omarchy.bluetui` app id so existing focus/floating window rules continue to apply

## Context
On Omarchy with Ghostty as the default terminal, Ghostty advertises `TERM=xterm-ghostty`. With `bluetui` 0.8.1, navigation keys (`j`/`k` and arrow keys) did not move through the device lists. Running the same TUI with `TERM=xterm-256color` fixes keyboard navigation.

## Testing
- Verified `bash -n bin/omarchy-launch-bluetooth`
- Verified locally that bluetui navigation works when launched with `TERM=xterm-256color` in Ghostty
