### PR TITLE
fix: restore comprehensive JetBrains window rules

### DIFF
--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -1,4 +1,35 @@
-# Disable mouse focus (see https://github.com/basecamp/omarchy/pull/5183#issuecomment-4189299971)
+# JetBrains windows default size
+windowrule = size 50% 50%, class:(.*jetbrains.*)$, title:^$
+
+# Fix splash screen showing in weird places and prevent annoying focus takeovers
+windowrule = tag +jetbrains-splash, class:^(jetbrains-.*)$, title:^(splash)$, floating:1
+windowrule = center, tag:jetbrains-splash
+windowrule = nofocus, tag:jetbrains-splash
+windowrule = noborder, tag:jetbrains-splash
+
+# Fix tab dragging (tab titles are just one space)
+windowrule = noinitialfocus, class:^(.*jetbrains.*)$, title:^\\s$
+
+# Center popups/find windows
+windowrule = tag +jetbrains, class:^(jetbrains-.*), title:^()$, floating:1
+windowrule = center, tag:jetbrains
+
+# Allow dialogs (like "Send usage statistics") to be focusable and clickable
+windowrule = unset,nofocus,class:^(.*jetbrains.*)$,title:^$
+windowrule = unset,noinitialfocus,class:^(.*jetbrains.*)$,title:^$
+
+# Enabling this makes it possible to provide input in popup dialogs (search window, new file, etc.)
+windowrule = stayfocused, tag:jetbrains
+windowrule = noborder, tag:jetbrains
+
+# For some reason tag:jetbrains does not work for size rule
+windowrule = size >50% >50%, class:^(jetbrains-.*), title:^()$, floating:1
+
+# Disable window flicker when autocomplete or tooltips appear
+windowrule = noinitialfocus, class:^(jetbrains-.*)$, title:^(win.*)$, floating:1
+
+# Disable mouse focus - prevents focus loss when mouse hovers over JetBrains windows
+# See: https://github.com/basecamp/omarchy/pull/3336
 windowrule {
     name = jetbrains-focus
     no_follow_mouse = on


### PR DESCRIPTION
Resolves https://github.com/basecamp/omarchy/discussions/100

Restores comprehensive JetBrains window rules including fixes from:
- PR #3326: popup focus, splash screen, centering, size rules  
- PR #3336: nofollowmouse to prevent focus loss on hover

Fixes: popup dialogs not receiving focus, tab dragging issues, window flicker, scaling issues