### PR TITLE
feat: add Firefox and Zen browser support for WebApps

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -6,8 +6,17 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
-*) browser="chromium.desktop" ;;
+google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*)
+  exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+  ;;
+firefox* | firefox-esr*)
+  exec setsid uwsm-app -- firefox --no-remote --new-window --class WebApp "$1" "${@:2}"
+  ;;
+zen*)
+  exec setsid uwsm-app -- zen-browser --no-remote --new-window --class WebApp "$1" "${@:2}"
+  ;;
+*)
+  browser="chromium.desktop"
+  exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+  ;;
 esac
-
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"

--- a/default/hypr/apps/jetbrains.conf
+++ b/default/hypr/apps/jetbrains.conf
@@ -1,4 +1,35 @@
-# Disable mouse focus (see https://github.com/basecamp/omarchy/pull/5183#issuecomment-4189299971)
+# JetBrains windows default size
+windowrule = size 50% 50%, class:(.*jetbrains.*)$, title:^$
+
+# Fix splash screen showing in weird places and prevent annoying focus takeovers
+windowrule = tag +jetbrains-splash, class:^(jetbrains-.*)$, title:^(splash)$, floating:1
+windowrule = center, tag:jetbrains-splash
+windowrule = nofocus, tag:jetbrains-splash
+windowrule = noborder, tag:jetbrains-splash
+
+# Fix tab dragging (tab titles are just one space)
+windowrule = noinitialfocus, class:^(.*jetbrains.*)$, title:^\\s$
+
+# Center popups/find windows
+windowrule = tag +jetbrains, class:^(jetbrains-.*), title:^()$, floating:1
+windowrule = center, tag:jetbrains
+
+# Allow dialogs (like "Send usage statistics") to be focusable and clickable
+windowrule = unset,nofocus,class:^(.*jetbrains.*)$,title:^$
+windowrule = unset,noinitialfocus,class:^(.*jetbrains.*)$,title:^$
+
+# Enabling this makes it possible to provide input in popup dialogs (search window, new file, etc.)
+windowrule = stayfocused, tag:jetbrains
+windowrule = noborder, tag:jetbrains
+
+# For some reason tag:jetbrains does not work for size rule
+windowrule = size >50% >50%, class:^(jetbrains-.*), title:^()$, floating:1
+
+# Disable window flicker when autocomplete or tooltips appear
+windowrule = noinitialfocus, class:^(jetbrains-.*)$, title:^(win.*)$, floating:1
+
+# Disable mouse focus - prevents focus loss when mouse hovers over JetBrains windows
+# See: https://github.com/basecamp/omarchy/pull/3336
 windowrule {
     name = jetbrains-focus
     no_follow_mouse = on


### PR DESCRIPTION
Resolves https://github.com/basecamp/omarchy/discussions/2468

Adds support for Firefox and Zen Browser in WebApps launcher with proper window rules.