### PR TITLE
feat: Add installer for official Obsidian CLI

### DIFF
--- a/bin/omarchy-install-obsidian-cli
+++ b/bin/omarchy-install-obsidian-cli
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# omarchy:summary=Install the official Obsidian CLI binary
+# omarchy:hidden=false
+
+echo "Fetching latest Obsidian release version..."
+LATEST_RELEASE=$(curl -sL "https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest" | jq -r '.tag_name')
+
+if [[ "$LATEST_RELEASE" == "null" || -z "$LATEST_RELEASE" ]]; then
+  echo "Error: Could not fetch latest release version from GitHub."
+  exit 1
+fi
+
+VERSION="${LATEST_RELEASE#v}"
+DOWNLOAD_URL="https://github.com/obsidianmd/obsidian-releases/releases/download/${LATEST_RELEASE}/obsidian-${VERSION}.tar.gz"
+TEMP_DIR=$(mktemp -d)
+
+echo "Downloading Obsidian CLI v${VERSION}..."
+curl -L "$DOWNLOAD_URL" -o "$TEMP_DIR/obsidian.tar.gz" --progress-bar
+
+if [[ ! -f "$TEMP_DIR/obsidian.tar.gz" ]]; then
+  echo "Error: Download failed."
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+echo "Extracting binary..."
+tar -xzf "$TEMP_DIR/obsidian.tar.gz" -C "$TEMP_DIR"
+
+if [[ ! -f "$TEMP_DIR/obsidian-${VERSION}/obsidian-cli" ]]; then
+  echo "Error: obsidian-cli binary not found in the downloaded archive."
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+echo "Installing to ~/.local/bin/obsidian..."
+mkdir -p ~/.local/bin
+cp "$TEMP_DIR/obsidian-${VERSION}/obsidian-cli" ~/.local/bin/obsidian
+chmod 755 ~/.local/bin/obsidian
+
+rm -rf "$TEMP_DIR"
+
+echo "✅ Obsidian CLI installed successfully!"
+echo "You can now use 'obsidian <command>' in your terminal."

--- a/bin/omarchy-install-obsidian-cli
+++ b/bin/omarchy-install-obsidian-cli
@@ -16,9 +16,7 @@ DOWNLOAD_URL="https://github.com/obsidianmd/obsidian-releases/releases/download/
 TEMP_DIR=$(mktemp -d)
 
 echo "Downloading Obsidian CLI v${VERSION}..."
-curl -L "$DOWNLOAD_URL" -o "$TEMP_DIR/obsidian.tar.gz" --progress-bar
-
-if [[ ! -f "$TEMP_DIR/obsidian.tar.gz" ]]; then
+if ! curl -fL "$DOWNLOAD_URL" -o "$TEMP_DIR/obsidian.tar.gz" --progress-bar; then
   echo "Error: Download failed."
   rm -rf "$TEMP_DIR"
   exit 1
@@ -33,12 +31,12 @@ if [[ ! -f "$TEMP_DIR/obsidian-${VERSION}/obsidian-cli" ]]; then
   exit 1
 fi
 
-echo "Installing to ~/.local/bin/obsidian..."
+echo "Installing to ~/.local/bin/obsidian-cli..."
 mkdir -p ~/.local/bin
-cp "$TEMP_DIR/obsidian-${VERSION}/obsidian-cli" ~/.local/bin/obsidian
-chmod 755 ~/.local/bin/obsidian
+cp "$TEMP_DIR/obsidian-${VERSION}/obsidian-cli" ~/.local/bin/obsidian-cli
+chmod 755 ~/.local/bin/obsidian-cli
 
 rm -rf "$TEMP_DIR"
 
 echo "✅ Obsidian CLI installed successfully!"
-echo "You can now use 'obsidian <command>' in your terminal."
+echo "You can now use 'obsidian-cli <command>' in your terminal."

--- a/bin/omarchy-install-obsidian-cli
+++ b/bin/omarchy-install-obsidian-cli
@@ -12,31 +12,38 @@ if [[ "$LATEST_RELEASE" == "null" || -z "$LATEST_RELEASE" ]]; then
 fi
 
 VERSION="${LATEST_RELEASE#v}"
-DOWNLOAD_URL="https://github.com/obsidianmd/obsidian-releases/releases/download/${LATEST_RELEASE}/obsidian-${VERSION}.tar.gz"
+
+# Architecture detection
+ARCH=$(uname -m)
+if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+  ARCH_SUFFIX="-arm64"
+else
+  ARCH_SUFFIX=""
+fi
+
+DOWNLOAD_URL="https://github.com/obsidianmd/obsidian-releases/releases/download/${LATEST_RELEASE}/obsidian-${VERSION}${ARCH_SUFFIX}.tar.gz"
 TEMP_DIR=$(mktemp -d)
+
+# Ensure temp dir is cleaned up on exit
+trap 'rm -rf "$TEMP_DIR"' EXIT
 
 echo "Downloading Obsidian CLI v${VERSION}..."
 if ! curl -fL "$DOWNLOAD_URL" -o "$TEMP_DIR/obsidian.tar.gz" --progress-bar; then
   echo "Error: Download failed."
-  rm -rf "$TEMP_DIR"
   exit 1
 fi
 
 echo "Extracting binary..."
 tar -xzf "$TEMP_DIR/obsidian.tar.gz" -C "$TEMP_DIR"
 
-if [[ ! -f "$TEMP_DIR/obsidian-${VERSION}/obsidian-cli" ]]; then
+if [[ ! -f "$TEMP_DIR/obsidian-${VERSION}${ARCH_SUFFIX}/obsidian-cli" ]]; then
   echo "Error: obsidian-cli binary not found in the downloaded archive."
-  rm -rf "$TEMP_DIR"
   exit 1
 fi
 
 echo "Installing to ~/.local/bin/obsidian-cli..."
 mkdir -p ~/.local/bin
-cp "$TEMP_DIR/obsidian-${VERSION}/obsidian-cli" ~/.local/bin/obsidian-cli
-chmod 755 ~/.local/bin/obsidian-cli
-
-rm -rf "$TEMP_DIR"
+install -m 755 "$TEMP_DIR/obsidian-${VERSION}${ARCH_SUFFIX}/obsidian-cli" ~/.local/bin/obsidian-cli
 
 echo "✅ Obsidian CLI installed successfully!"
 echo "You can now use 'obsidian-cli <command>' in your terminal."


### PR DESCRIPTION
Fixes #5743

### Summary
The official Arch Linux `obsidian` package (and the AUR `obsidian-bin` package) does not include the official Obsidian CLI binary (`obsidian-cli`). It only includes the Electron wrapper script.

This PR introduces `omarchy install obsidian-cli`, which downloads the latest official release, extracts the standalone `obsidian-cli` binary, and places it in `~/.local/bin/obsidian-cli`.

### How to test
1. Run `omarchy install obsidian-cli`
2. Verify with `obsidian-cli --help` (ensure the Obsidian GUI is running first).