### PR TITLE
Add Theme marketplace browser

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -264,7 +264,8 @@ show_hardware_touchpad_haptics_menu() {
 }
 
 show_style_menu() {
-  case $(menu "Style" "󰸌  Theme\n󰟵  Unlock\n  Font\n  Background\n  Hyprland\n󱄄  Screensaver\n  About") in
+  case $(menu "Style" "󰸌  Theme\n󰣇  Theme Marketplace\n󰟵  Unlock\n  Font\n  Background\n  Hyprland\n󱄄  Screensaver\n  About") in
+  *"Theme Marketplace"*) show_theme_marketplace_menu ;;
   *Theme*) show_theme_menu ;;
   *Unlock*) omarchy-launch-walker -m menus:omarchyunlocks --width 800 --minheight 400 ;;
   *Font*) show_font_menu ;;
@@ -296,6 +297,10 @@ show_screensaver_menu() {
 
 show_theme_menu() {
   omarchy-launch-walker -m menus:omarchythemes --width 800 --minheight 400
+}
+
+show_theme_marketplace_menu() {
+  omarchy-theme-marketplace
 }
 
 show_background_menu() {

--- a/bin/omarchy-theme-marketplace
+++ b/bin/omarchy-theme-marketplace
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# omarchy:summary=Browse installable Omarchy themes from the marketplace
+# omarchy:group=theme
+# omarchy:name=marketplace
+# omarchy:examples=omarchy theme marketplace
+
+set -euo pipefail
+
+CACHE_FILE="$HOME/.cache/omarchy/theme-marketplace/themes.tsv"
+PREVIEW_DIR="$HOME/.cache/omarchy/theme-marketplace/previews"
+READY_TIMEOUT_TENTHS="300"
+
+notify_marketplace() {
+  local urgency="$1"
+  local title="$2"
+  local message="$3"
+
+  if omarchy-cmd-present notify-send; then
+    notify-send -u "$urgency" "$title" "$message"
+  fi
+}
+
+omarchy-theme-marketplace-refresh >/dev/null 2>&1 &
+refresh_pid=$!
+
+preview_count=0
+theme_count=0
+[[ -f $CACHE_FILE ]] && theme_count=$(wc -l <"$CACHE_FILE")
+[[ -d $PREVIEW_DIR ]] && preview_count=$(find "$PREVIEW_DIR" -maxdepth 1 -type f -name '*.jpg' -printf '.' 2>/dev/null | wc -c)
+
+if ((theme_count == 0 || preview_count < theme_count)); then
+  notify_marketplace low "Fetching themes" "Preparing marketplace previews..."
+fi
+
+for _ in $(seq 1 "$READY_TIMEOUT_TENTHS"); do
+  if [[ -f $CACHE_FILE ]]; then
+    theme_count=$(wc -l <"$CACHE_FILE")
+    preview_count=$(find "$PREVIEW_DIR" -maxdepth 1 -type f -name '*.jpg' -printf '.' 2>/dev/null | wc -c)
+    if ((theme_count > 0 && preview_count >= theme_count)); then
+      break
+    fi
+  fi
+
+  if ! kill -0 "$refresh_pid" 2>/dev/null && ((theme_count == 0)); then
+    notify_marketplace critical "Theme marketplace" "Could not fetch marketplace themes."
+    exit 1
+  fi
+
+  sleep 0.1
+done
+
+if ((theme_count > 0 && preview_count < theme_count)); then
+  notify_marketplace normal "Theme marketplace" "Opening with $preview_count of $theme_count previews ready."
+fi
+
+exec omarchy-launch-walker -m menus:omarchyThemeMarketplace --width 800 --minheight 400 --maxheight 400

--- a/bin/omarchy-theme-marketplace-install
+++ b/bin/omarchy-theme-marketplace-install
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# omarchy:summary=Install a marketplace theme through the existing theme installer
+# omarchy:group=theme
+# omarchy:name=marketplace install
+# omarchy:args=<git-repo-url> [theme-name]
+# omarchy:examples=omarchy theme marketplace install https://github.com/example/omarchy-example-theme
+
+set -euo pipefail
+
+if [[ -z ${1:-} ]]; then
+  echo "Usage: omarchy-theme-marketplace-install <git-repo-url> [theme-name]"
+  exit 1
+fi
+
+repo_url="$1"
+display_name="${2:-}"
+
+if [[ $repo_url != https://github.com/* ]]; then
+  echo "Usage: omarchy-theme-marketplace-install <git-repo-url> [theme-name]" >&2
+  exit 1
+fi
+
+if [[ -z $display_name ]]; then
+  repo_path="${repo_url%/}"
+  display_name=$(basename "$repo_path" .git | sed -E 's/^omarchy-//; s/-theme$//; s/-/ /g')
+fi
+
+shell_escape() {
+  printf "'%s'" "${1//\'/\'\\\'\'}"
+}
+
+if omarchy-cmd-present notify-send; then
+  notify-send -u low "Installing theme" "$display_name" || true
+fi
+
+cmd="omarchy-theme-install $(shell_escape "$repo_url")"
+exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c \
+  "omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"

--- a/bin/omarchy-theme-marketplace-refresh
+++ b/bin/omarchy-theme-marketplace-refresh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# omarchy:summary=Refresh cached Omarchy theme marketplace data
+# omarchy:group=theme
+# omarchy:name=marketplace refresh
+# omarchy:examples=omarchy theme marketplace refresh
+
+set -euo pipefail
+
+if omarchy-cmd-missing curl; then
+  echo "curl is required to refresh the theme marketplace" >&2
+  exit 1
+fi
+
+if omarchy-cmd-missing magick; then
+  echo "ImageMagick is required to prepare marketplace previews" >&2
+  exit 1
+fi
+
+SOURCE_URL="https://learn.omacom.io/2/the-omarchy-manual/90/extra-themes.md"
+CACHE_DIR="$HOME/.cache/omarchy/theme-marketplace"
+PREVIEW_DIR="$CACHE_DIR/previews"
+CACHE_FILE="$CACHE_DIR/themes.tsv"
+SOURCE_FILE="$CACHE_DIR/source.md"
+SOURCE_HASH_FILE="$CACHE_DIR/source.sha256"
+PLACEHOLDER_PREVIEW="$CACHE_DIR/fetching-preview.jpg"
+PREVIEW_MAX_SIZE="1000x1000>"
+PREVIEW_QUALITY="82"
+FIRST_PREVIEW_COUNT="10"
+FIRST_PREVIEW_JOBS="4"
+PREVIEW_JOBS="8"
+
+notify_marketplace_error() {
+  local message="$1"
+
+  if omarchy-cmd-present notify-send; then
+    notify-send -u critical "Theme marketplace" "$message"
+  fi
+
+  echo "Theme marketplace: $message" >&2
+}
+
+if [[ ${1:-} == "--preview-worker" ]]; then
+  image_url="${2:-}"
+  preview_path="${3:-}"
+
+  if [[ -z $image_url || -z $preview_path || -f $preview_path ]]; then
+    exit 0
+  fi
+
+  tmp_image=$(mktemp)
+  cleanup_preview_worker() {
+    rm -f "$tmp_image"
+  }
+  trap cleanup_preview_worker EXIT
+
+  curl --fail --silent --show-error --location --output "$tmp_image" "$image_url" || exit 0
+  magick "$tmp_image" -auto-orient -resize "$PREVIEW_MAX_SIZE" -strip -quality "$PREVIEW_QUALITY" "$preview_path"
+  exit 0
+fi
+
+mkdir -p "$PREVIEW_DIR"
+
+if [[ ! -f $PLACEHOLDER_PREVIEW ]]; then
+  magick -size 1000x563 xc:'#111318' \
+    -fill '#39dce8' -gravity center -pointsize 44 \
+    -annotate 0 'Fetching themes...' \
+    "$PLACEHOLDER_PREVIEW"
+fi
+
+tmp_md=$(mktemp)
+tmp_cache=$(mktemp)
+tmp_first_jobs=$(mktemp)
+tmp_rest_jobs=$(mktemp)
+
+cleanup() {
+  rm -rf "$tmp_md" "$tmp_cache" "$tmp_first_jobs" "$tmp_rest_jobs"
+}
+trap cleanup EXIT
+
+run_preview_jobs() {
+  local job_file="$1"
+  local jobs="$2"
+
+  if [[ ! -s $job_file ]]; then
+    return
+  fi
+
+  xargs -r -0 -n 2 -P "$jobs" bash "$0" --preview-worker <"$job_file"
+}
+
+queue_preview_jobs() {
+  local cache_file="$1"
+  local first_jobs_file="$2"
+  local rest_jobs_file="$3"
+  local index=0
+  local theme_name name repo_url image_url preview_path
+
+  while IFS=$'\t' read -r theme_name name repo_url image_url preview_path; do
+    index=$((index + 1))
+
+    if [[ -z $image_url || -z $preview_path || -f $preview_path ]]; then
+      continue
+    fi
+
+    if ((index <= FIRST_PREVIEW_COUNT)); then
+      printf '%s\0%s\0' "$image_url" "$preview_path" >>"$first_jobs_file"
+    else
+      printf '%s\0%s\0' "$image_url" "$preview_path" >>"$rest_jobs_file"
+    fi
+  done <"$cache_file"
+}
+
+if ! curl -fsSL "$SOURCE_URL" -o "$tmp_md"; then
+  notify_marketplace_error "Could not fetch the marketplace source."
+  exit 1
+fi
+
+new_hash=$(sha256sum "$tmp_md" | cut -d' ' -f1)
+old_hash=$(cat "$SOURCE_HASH_FILE" 2>/dev/null || true)
+
+if [[ $new_hash == "$old_hash" && -f $CACHE_FILE ]]; then
+  queue_preview_jobs "$CACHE_FILE" "$tmp_first_jobs" "$tmp_rest_jobs"
+  run_preview_jobs "$tmp_first_jobs" "$FIRST_PREVIEW_JOBS"
+  run_preview_jobs "$tmp_rest_jobs" "$PREVIEW_JOBS"
+  exit 0
+fi
+
+image_url=""
+image_re='!\[[^]]*\]\(([^)]+)\)'
+repo_re='^[[:space:]]*\[([^]]+)\]\((https://github.com/[^)]+)\)'
+
+while IFS= read -r line; do
+  if [[ $line =~ $image_re ]]; then
+    image_url="${BASH_REMATCH[1]}"
+
+    if [[ $image_url == /* ]]; then
+      image_url="https://learn.omacom.io$image_url"
+    fi
+  elif [[ -n $image_url && $line =~ $repo_re ]]; then
+    name="${BASH_REMATCH[1]}"
+    repo_url="${BASH_REMATCH[2]}"
+
+    if [[ -z $name || -z $repo_url ]]; then
+      image_url=""
+      continue
+    fi
+
+    repo_path="${repo_url%/}"
+    theme_name=$(basename "$repo_path" .git | sed -E 's/^omarchy-//; s/-theme$//' | tr '[:upper:]' '[:lower:]')
+
+    if [[ -z $theme_name ]]; then
+      image_url=""
+      continue
+    fi
+
+    preview_path="$PREVIEW_DIR/$theme_name.jpg"
+
+    printf '%s\t%s\t%s\t%s\t%s\n' "$theme_name" "$name" "$repo_url" "$image_url" "$preview_path" >>"$tmp_cache"
+
+    image_url=""
+  fi
+done <"$tmp_md"
+
+parsed_count=$(wc -l <"$tmp_cache")
+
+if ((parsed_count < 10)); then
+  notify_marketplace_error "Could not parse the marketplace source."
+  exit 1
+fi
+
+cp "$tmp_md" "$SOURCE_FILE"
+printf '%s\n' "$new_hash" >"$SOURCE_HASH_FILE"
+mv "$tmp_cache" "$CACHE_FILE"
+
+find "$PREVIEW_DIR" -maxdepth 1 -type f ! -name '*.jpg' -delete
+
+queue_preview_jobs "$CACHE_FILE" "$tmp_first_jobs" "$tmp_rest_jobs"
+run_preview_jobs "$tmp_first_jobs" "$FIRST_PREVIEW_JOBS"
+run_preview_jobs "$tmp_rest_jobs" "$PREVIEW_JOBS"

--- a/default/elephant/omarchy_theme_marketplace.lua
+++ b/default/elephant/omarchy_theme_marketplace.lua
@@ -1,0 +1,121 @@
+--
+-- Dynamic Omarchy Theme Marketplace Menu for Elephant/Walker
+--
+Name = "omarchyThemeMarketplace"
+NamePretty = "Omarchy Theme Marketplace"
+HideFromProviderlist = true
+Cache = false
+
+local function file_exists(path)
+  local f = io.open(path, "r")
+  if f then
+    f:close()
+    return true
+  end
+  return false
+end
+
+local function shell_escape(s)
+  return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+local function split_tsv(line)
+  local fields = {}
+  local start = 1
+
+  for _ = 1, 4 do
+    local tab = line:find("\t", start, true)
+    if not tab then
+      return fields
+    end
+
+    table.insert(fields, line:sub(start, tab - 1))
+    start = tab + 1
+  end
+
+  table.insert(fields, line:sub(start))
+  return fields
+end
+
+local function load_installed_themes()
+  local installed = {}
+  local home = os.getenv("HOME")
+  local omarchy_path = os.getenv("OMARCHY_PATH") or ""
+  local dirs = {
+    home .. "/.config/omarchy/themes",
+  }
+
+  if omarchy_path ~= "" then
+    table.insert(dirs, omarchy_path .. "/themes")
+  end
+
+  for _, dir in ipairs(dirs) do
+    local handle = io.popen("find -L " ..
+      shell_escape(dir) .. " -mindepth 1 -maxdepth 1 -type d -printf '%f\\n' 2>/dev/null")
+    if handle then
+      for theme_name in handle:lines() do
+        installed[theme_name] = true
+      end
+      handle:close()
+    end
+  end
+
+  return installed
+end
+
+function GetEntries()
+  local entries = {}
+  local home = os.getenv("HOME")
+  local cache_dir = home .. "/.cache/omarchy/theme-marketplace"
+  local cache_file = cache_dir .. "/themes.tsv"
+  local placeholder_preview = cache_dir .. "/fetching-preview.jpg"
+  local installed_themes = load_installed_themes()
+
+  local handle = io.open(cache_file, "r")
+  if not handle then
+    return {
+      {
+        Text = "Marketplace unavailable ",
+        Actions = {
+          activate = "omarchy-theme-marketplace-refresh",
+        },
+      },
+    }
+  end
+
+  for line in handle:lines() do
+    local fields = split_tsv(line)
+    local theme_name = fields[1]
+    local name = fields[2]
+    local repo_url = fields[3]
+    local preview_path = fields[5]
+
+    if theme_name ~= "" and name ~= "" and repo_url ~= "" and preview_path ~= "" then
+      local installed = installed_themes[theme_name] == true
+      local text = installed and (name .. "  [installed]") or (name .. "  ")
+      local action = installed
+          and ("omarchy-theme-set " .. shell_escape(theme_name))
+          or ("omarchy-theme-marketplace-install " .. shell_escape(repo_url) .. " " .. shell_escape(name))
+
+      local entry = {
+        Text = text,
+        Actions = {
+          activate = action,
+        },
+      }
+
+      if file_exists(preview_path) then
+        entry.Preview = preview_path
+        entry.PreviewType = "file"
+      elseif file_exists(placeholder_preview) then
+        entry.Preview = placeholder_preview
+        entry.PreviewType = "file"
+      end
+
+      table.insert(entries, entry)
+    end
+  end
+
+  handle:close()
+  return entries
+end

--- a/default/elephant/omarchy_theme_marketplace.lua
+++ b/default/elephant/omarchy_theme_marketplace.lua
@@ -85,34 +85,37 @@ function GetEntries()
 
   for line in handle:lines() do
     local fields = split_tsv(line)
-    local theme_name = fields[1]
-    local name = fields[2]
-    local repo_url = fields[3]
-    local preview_path = fields[5]
 
-    if theme_name ~= "" and name ~= "" and repo_url ~= "" and preview_path ~= "" then
-      local installed = installed_themes[theme_name] == true
-      local text = installed and (name .. "  [installed]") or (name .. "  ")
-      local action = installed
-          and ("omarchy-theme-set " .. shell_escape(theme_name))
-          or ("omarchy-theme-marketplace-install " .. shell_escape(repo_url) .. " " .. shell_escape(name))
+    if #fields == 5 then
+      local theme_name = fields[1]
+      local name = fields[2]
+      local repo_url = fields[3]
+      local preview_path = fields[5]
 
-      local entry = {
-        Text = text,
-        Actions = {
-          activate = action,
-        },
-      }
+      if theme_name ~= "" and name ~= "" and repo_url ~= "" and preview_path ~= "" then
+        local installed = installed_themes[theme_name] == true
+        local text = installed and (name .. "  [installed]") or (name .. "  ")
+        local action = installed
+            and ("omarchy-theme-set " .. shell_escape(theme_name))
+            or ("omarchy-theme-marketplace-install " .. shell_escape(repo_url) .. " " .. shell_escape(name))
 
-      if file_exists(preview_path) then
-        entry.Preview = preview_path
-        entry.PreviewType = "file"
-      elseif file_exists(placeholder_preview) then
-        entry.Preview = placeholder_preview
-        entry.PreviewType = "file"
+        local entry = {
+          Text = text,
+          Actions = {
+            activate = action,
+          },
+        }
+
+        if file_exists(preview_path) then
+          entry.Preview = preview_path
+          entry.PreviewType = "file"
+        elseif file_exists(placeholder_preview) then
+          entry.Preview = placeholder_preview
+          entry.PreviewType = "file"
+        end
+
+        table.insert(entries, entry)
       end
-
-      table.insert(entries, entry)
     end
   end
 

--- a/install/config/walker-elephant.sh
+++ b/install/config/walker-elephant.sh
@@ -26,6 +26,7 @@ EOF
 
 # Link the visual theme menu config
 mkdir -p ~/.config/elephant/menus
+ln -snf $OMARCHY_PATH/default/elephant/omarchy_theme_marketplace.lua ~/.config/elephant/menus/omarchy_theme_marketplace.lua
 ln -snf $OMARCHY_PATH/default/elephant/omarchy_themes.lua ~/.config/elephant/menus/omarchy_themes.lua
 ln -snf $OMARCHY_PATH/default/elephant/omarchy_background_selector.lua ~/.config/elephant/menus/omarchy_background_selector.lua
 ln -snf $OMARCHY_PATH/default/elephant/omarchy_unlocks.lua ~/.config/elephant/menus/omarchy_unlocks.lua

--- a/migrations/1778340048.sh
+++ b/migrations/1778340048.sh
@@ -1,0 +1,5 @@
+echo "Add Omarchy theme marketplace to Walker"
+
+mkdir -p ~/.config/elephant/menus
+ln -snf "$OMARCHY_PATH/default/elephant/omarchy_theme_marketplace.lua" ~/.config/elephant/menus/omarchy_theme_marketplace.lua
+omarchy-restart-walker


### PR DESCRIPTION
## What

  Adds a native Walker/Elephant browser for extra Omarchy themes listed in the Omarchy
  manual.

  The marketplace lets users browse preview images, see which themes are already installed,
  and install new themes through the existing `omarchy-theme-install` command.

## Why
  
  Omarchy already exposes extra community themes through the manual, but discovering,
  previewing, and installing them currently requires leaving the desktop workflow,
  opening the browser, manually browsing repositories, and running install commands.
  
  This adds a native Omarchy-first browsing flow directly inside Walker/Elephant while
  still using the existing theme installation pipeline.

  This upstream version also adds the marketplace to Omarchy’s Style menu as `Theme
  Marketplace`, so users can open it without knowing the command name.  

## Demo

  Standalone prototype demo:

  https://github.com/user-attachments/assets/bc1753f1-de0e-4551-8d4c-aa956868e009

 The demo is from the standalone prototype. This PR integrates the same flow directly into
  Omarchy and additionally adds a Style menu entry.

  Standalone prototype repo:

  https://github.com/prettyletto/omarchy-theme-marketplace

  ## Design

  This PR does not add a new theme installation mechanism. It delegates installation to the
  existing:

  ```bash
  omarchy-theme-install <git-repo-url>
  ``` 

  The marketplace command only discovers themes, caches metadata/previews, and opens the
  Walker UI.

  The current data source is the published Markdown version of the Omarchy manual extra-themes page:

  https://learn.omacom.io/2/the-omarchy-manual/90/extra-themes.md

  The meta-data fetching logic is isolated in omarchy-theme-marketplace-refresh, so it can be
  replaced by an official index later without changing the UI.

  ## Notes

  - Adds Theme Marketplace to the Omarchy Style menu
  - Caches marketplace data under ~/.cache/omarchy/theme-marketplace
  - Keeps old cache if fetching or parsing the source fails
  - Adds a migration to link the new Elephant provider and restart Walker
  - Adds fresh-install wiring through install/config/walker-elephant.sh

  ## Tested

  bash -n bin/omarchy-menu
  bash -n bin/omarchy-theme-marketplace
  bash -n bin/omarchy-theme-marketplace-refresh
  bash -n bin/omarchy-theme-marketplace-install
  PATH="$PWD/bin:$PATH" OMARCHY_PATH="$PWD" bash test/omarchy-cli-test.sh

  Also manually tested Walker marketplace launch and install action.

