### PR TITLE
Turn displays off on system lock only in power-saving modes

### DIFF
--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -28,6 +28,8 @@ if [[ ${OMARCHY_LOCK_ONLY:-false} != "true" ]]; then
     sleep 3
     pidof hyprlock >/dev/null || exit 0
     omarchy-brightness-keyboard off
-    omarchy-brightness-display off
+    if [[ $(powerprofilesctl get) != "performance" ]]; then
+      omarchy-brightness-display off
+    fi
   ) &
 fi

--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -17,3 +17,9 @@ listener {
     on-timeout = omarchy-system-lock
     on-resume = omarchy-system-wake
 }
+
+listener {
+    timeout = 1800
+    on-timeout = omarchy-brightness-display off
+    on-resume = omarchy-system-wake
+  }


### PR DESCRIPTION
# Issue

Since Omarchy 3.8.0, displays are turned off immediately on system lock. This introduces friction when unlocking. This tradeoff is justified to extend battery time; however, it is unnecessarily aggressive when a machine is plugged in. In my particular case, I use a minipc with an eInk display, so I want to a way disable this new behavior.

# Description

In power-saving modes, we want to save power by turning off displays immediately after a system lock. However, when power consumption is not a concern (desktop or plugged-in laptop), turning off displays aggressively creates unnecessary friction when unlocking.

Changes in this commit:
* On system lock, turn off displays only in power modes other than "performance"
* Add hypridle listener with a long timeout to turn displays off eventually in all cases

# Alternative designs

## Option 1 Change behavior depending on whether the power source is battery or AC

Use `omarchy-battery-present` or, better, extract the more robust logic from `omarchy-powerprofiles-set`.

## Option 2 Add toggle

Add a toggle similarly to the existing screensaver toggle to control the behavior.