### PR TITLE
Fix brightness indicator glitches caused by hardware-side key auto-repeat

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -6,6 +6,20 @@
 
 step="${1:-+5%}"
 
+if [[ $step == "off" ]]; then
+  hyprctl dispatch dpms off >/dev/null 2>&1
+  exit 0
+elif [[ $step == "on" ]]; then
+  hyprctl dispatch dpms on >/dev/null 2>&1
+  exit 0
+fi
+
+runtime_dir="${XDG_RUNTIME_DIR:-/tmp}"
+
+# Drop overlapping brightness key events before they race SwayOSD updates.
+exec 9>"$runtime_dir/omarchy-brightness-display.lock"
+flock -n 9 || exit 0
+
 # Start with the first possible output, then refine to the most likely given an order heuristic.
 device="$(ls -1 /sys/class/backlight 2>/dev/null | head -n1)"
 for candidate in amdgpu_bl* intel_backlight acpi_video*; do
@@ -14,14 +28,6 @@ for candidate in amdgpu_bl* intel_backlight acpi_video*; do
     break
   fi
 done
-
-if [[ $step == "off" ]]; then
-  hyprctl dispatch dpms off >/dev/null 2>&1
-  exit 0
-elif [[ $step == "on" ]]; then
-  hyprctl dispatch dpms on >/dev/null 2>&1
-  exit 0
-fi
 
 if omarchy-hyprland-monitor-focused-apple; then
   omarchy-brightness-display-apple "$step"

--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -16,7 +16,8 @@ fi
 
 runtime_dir="${XDG_RUNTIME_DIR:-/tmp}"
 
-# Drop overlapping brightness key events before they race SwayOSD updates.
+# Drop overlapping brightness key events so concurrent invocations do not race.
+# Hardware key repeat present on some devices can otherwise glitch SwayOSD rendering.
 exec 9>"$runtime_dir/omarchy-brightness-display.lock"
 flock -n 9 || exit 0
 


### PR DESCRIPTION
## Problem

When brightness is changed with the hardware keys on an Asus Zenbook UX5406AA (and possibly other devices), the SwayOSD indicator can randomly omit the icon, the percentage, or both. Running the same brightness command from a terminal works reliably.

<img width="1748" height="720" alt="screenrecording-2026-05-10_16-47-02-720p" src="https://github.com/user-attachments/assets/9154378e-887a-4caf-a20d-83398433094b" />

## Diagnosis

Asus Zenbook UX5406AA, and most likely some other devices too, keeps sending multiple key events while one of the brightness keys is held down. This in turn fires multiple `omarchy-brightness-display` commands at the same time (even after changing `bindeld` to `bindld` to avoid duplicated repeating on the Hyprland side). This causes some strange rendering issues.

Remapping brightness to another key that is not auto-repeated on the hardware side makes the issue disappear.

## Solution

Add a lock file around the brightness adjustment path so overlapping brightness key events are dropped instead of racing SwayOSD updates.

The lock uses `${XDG_RUNTIME_DIR:-/tmp}` and `flock -n`, so it never blocks or deadlocks. If another brightness update is already running, the newer event exits immediately. The kernel releases the lock automatically when the process exits.

Display power commands (`on`/`off`) are handled before acquiring the lock, so lock-screen sleep/wake behavior cannot be skipped by a concurrent brightness key event.

I think that would be the most universal and reliable solution, because we don't know exactly how different devices with auto-repeat behave. Trying to disable hardware auto-repeat would also probably require different fixes for different devices (if possible to fix at all).

## Testing help
In theory, this shouldn't affect devices that already behave correctly, but I would appreciate verification on another device.


