### PR TITLE
fix: remove deprecated Hyprland options from looknfeel.conf

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -50,8 +50,8 @@ decoration {
 group {
     col.border_active = $activeBorderColor
     col.border_inactive = $inactiveBorderColor
-    col.border_locked_active = -1
-    col.border_locked_inactive = -1
+    col.border_locked_active = $activeBorderColor
+    col.border_locked_inactive = $inactiveBorderColor
 
     groupbar {
         font_size = 12
@@ -108,8 +108,7 @@ animations {
 
 # See https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/ for more
 dwindle {
-    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
-    preserve_split = true # You probably want this
+    preserve_split = true
     force_split = 2 # Always split on the right
 }
 


### PR DESCRIPTION
## Problem

Two config options in `default/hypr/looknfeel.conf` cause errors on modern Hyprland:

```
Config error: Error parsing gradient -1: failed to parse -1 as a color
Config error: config option <dwindle:pseudotile> does not exist.
```

## Changes

- **`dwindle.pseudotile`** — removed. This option no longer exists in Hyprland and causes a config error on load.
- **`group.col.border_locked_active/inactive = -1`** — `-1` was previously accepted as a special "inherit" value, but is now an invalid gradient. Replaced with the already-defined `$activeBorderColor` / `$inactiveBorderColor` variables, which preserves the original intent (locked groups use the same border color as unlocked ones).

## Tested

Verified with `hyprctl configerrors` — no errors after the fix.