### PR TITLE
Preserve Waybar config when changing position

### DIFF
--- a/bin/omarchy-style-waybar-position
+++ b/bin/omarchy-style-waybar-position
@@ -15,9 +15,9 @@ if [[ ! $position =~ ^(top|bottom|left|right)$ ]]; then
   exit 1
 fi
 
-# Reset config and styles before making adjustments
-omarchy-refresh-config waybar/config.jsonc
-omarchy-refresh-config waybar/style.css
+if [[ ! -f $WAYBAR_CONFIG ]]; then
+  omarchy-refresh-config waybar/config.jsonc
+fi
 
 if [[ $position == "left" || $position == "right" ]]; then
   height=0
@@ -35,11 +35,12 @@ sed -i -E "s/(\"position\"[[:space:]]*:[[:space:]]*\")[a-z]+(\")/\\1${position}\
 # Change height/width
 sed -i -E "s/(\"height\"[[:space:]]*:[[:space:]]*)[0-9]+/\\1${height}/; s/(\"width\"[[:space:]]*:[[:space:]]*)[0-9]+/\\1${width}/" "$WAYBAR_CONFIG"
 
-# Change the clock format
+# Change the clock format only when it still matches one of Omarchy's defaults.
+# Custom clock formats should survive a position change.
 if [[ $horizontal == true ]]; then
-  sed -i -E '/"clock"[[:space:]]*:[[:space:]]*\{/,/\}/ s/"format"[[:space:]]*:[[:space:]]*"[^"]*"/"format": "{:L%A %H:%M}"/' "$WAYBAR_CONFIG"
+  sed -i -E '/"clock"[[:space:]]*:[[:space:]]*\{/,/\}/ s/"format"[[:space:]]*:[[:space:]]*"\{:%H\\n  —\\n%M\}"/"format": "{:L%A %H:%M}"/' "$WAYBAR_CONFIG"
 else
-  sed -i -E '/"clock"[[:space:]]*:[[:space:]]*\{/,/\}/ s/"format"[[:space:]]*:[[:space:]]*"[^"]*"/"format": "{:%H\\n  —\\n%M}"/' "$WAYBAR_CONFIG"
+  sed -i -E '/"clock"[[:space:]]*:[[:space:]]*\{/,/\}/ s/"format"[[:space:]]*:[[:space:]]*"\{:L%A %H:%M\}"/"format": "{:%H\\n  —\\n%M}"/' "$WAYBAR_CONFIG"
 fi
 
 omarchy-restart-waybar


### PR DESCRIPTION
Closes #5764.

## Summary
- stop refreshing Waybar config/style when only changing Waybar position
- keep the missing-config fallback so first-use still gets the default config
- only switch the clock format when it still matches one of Omarchy's built-in horizontal/vertical defaults

## Testing
- `bash -n bin/omarchy-style-waybar-position`
- `git diff --check`
- ran a temp-home smoke test with stubbed `omarchy-refresh-config`/`omarchy-restart-waybar` verifying:
  - existing custom config fields survive
  - custom `style.css` is untouched
  - left/right updates position, height, width, and default clock format
  - custom clock format survives switching back to top

Note: `shellcheck` is not installed in this environment, so that check was skipped.
