### PR TITLE
fix: remove deprecated Hyprland options from looknfeel.conf

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -50,8 +50,8 @@ decoration {
 group {
     col.border_active = $activeBorderColor
     col.border_inactive = $inactiveBorderColor
-    col.border_locked_active = -1
-    col.border_locked_inactive = -1
+    col.border_locked_active = $activeBorderColor
+    col.border_locked_inactive = $inactiveBorderColor
 
     groupbar {
         font_size = 12
@@ -108,8 +108,7 @@ animations {
 
 # See https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/ for more
 dwindle {
-    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
-    preserve_split = true # You probably want this
+    preserve_split = true
     force_split = 2 # Always split on the right
 }
 


### PR DESCRIPTION
## Problem

Two config options in `default/hypr/looknfeel.conf` cause errors on modern Hyprland (0.55+):

```
Config error at line 53: Error parsing gradient -1: failed to parse -1 as a color
Config error at line 54: Error parsing gradient -1: failed to parse -1 as a color
Config error at line 111: config option <dwindle:pseudotile> does not exist.
```

Related: #5752, #5758

## Changes

- **`dwindle.pseudotile`** — removed. This option no longer exists in Hyprland and causes a config error on load.
- **`group.col.border_locked_active/inactive = -1`** — `-1` was previously accepted as "inherit", but is now an invalid gradient. Replaced with the existing `$activeBorderColor` / `$inactiveBorderColor` variables, preserving the original intent.

## Note

The `dev` branch already migrated to Lua and doesn't have these issues. This fix targets `master` only for users on the current stable release.

## Tested

Verified with `hyprctl configerrors` on Hyprland 0.55 (Arch) — clean after the patch.