### PR TITLE
Add Vivaldi browser support (fixed)

### DIFF
--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default browser for Omarchy and XDG handlers
-# omarchy:args=[chromium|chrome|brave|brave-origin|edge|firefox|zen]
+# omarchy:args=[chromium|chrome|brave|brave-origin|edge|firefox|vivaldi|zen]
 # omarchy:examples=omarchy default browser firefox | omarchy default browser brave
 
 if (($# == 0)); then
@@ -12,6 +12,7 @@ if (($# == 0)); then
   brave-origin-beta.desktop) echo "brave-origin" ;;
   microsoft-edge.desktop) echo "edge" ;;
   firefox.desktop) echo "firefox" ;;
+  vivaldi-stable.desktop) echo "vivaldi" ;;
   zen.desktop) echo "zen" ;;
   *) xdg-settings get default-web-browser ;;
   esac
@@ -25,9 +26,10 @@ brave) desktop_id="brave-browser.desktop"; name="Brave"; glyph="󰖟" ;;
 brave-origin) desktop_id="brave-origin-beta.desktop"; name="Brave Origin"; glyph="󰖟" ;;
 edge) desktop_id="microsoft-edge.desktop"; name="Edge"; glyph="󰇩" ;;
 firefox) desktop_id="firefox.desktop"; name="Firefox"; glyph="󰈹" ;;
+vivaldi) desktop_id="vivaldi-stable.desktop"; name="Vivaldi"; glyph="󰰫" ;;
 zen) desktop_id="zen.desktop"; name="Zen"; glyph="󰖟" ;;
 *)
-  echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|vivaldi|zen>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Install a supported browser
-# omarchy:args=<chrome|brave|brave-origin|edge|firefox|zen>
+# omarchy:args=<chrome|brave|brave-origin|edge|firefox|vivaldi|zen>
 # omarchy:examples=omarchy install browser firefox | omarchy install browser brave
 
 setup_policy_directory() {
@@ -78,6 +78,14 @@ firefox)
   setup_firefox_wayland
   announce_browser_installed "Firefox"
   ;;
+vivaldi)
+  echo "Installing Vivaldi..."
+  omarchy-pkg-add vivaldi || exit 1
+
+  copy_chromium_flags ~/.config/vivaldi-stable.conf
+  omarchy-theme-set-browser
+  announce_browser_installed "Vivaldi"
+  ;;
 zen)
   echo "Installing Zen..."
   omarchy-pkg-aur-add zen-browser-bin || exit 1
@@ -87,7 +95,7 @@ zen)
   announce_browser_installed "Zen"
   ;;
 *)
-  echo "Usage: omarchy-install-browser <chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-install-browser <chrome|brave|brave-origin|edge|firefox|vivaldi|zen>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -82,6 +82,10 @@ vivaldi)
   echo "Installing Vivaldi..."
   omarchy-pkg-add vivaldi || exit 1
 
+  sudo mkdir -p /etc/1password
+  grep -qx vivaldi-bin /etc/1password/custom_allowed_browsers 2>/dev/null || \
+    echo vivaldi-bin | sudo tee -a /etc/1password/custom_allowed_browsers >/dev/null
+
   copy_chromium_flags ~/.config/vivaldi-stable.conf
   announce_browser_installed "Vivaldi"
   ;;

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -87,6 +87,9 @@ vivaldi)
     echo vivaldi-bin | sudo tee -a /etc/1password/custom_allowed_browsers >/dev/null
 
   copy_chromium_flags ~/.config/vivaldi-stable.conf
+
+  hook="$OMARCHY_PATH/default/vivaldi/vivaldi-post-update"
+  omarchy-hook-install post-update "$hook" && "$hook"
   announce_browser_installed "Vivaldi"
   ;;
 zen)

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -83,7 +83,6 @@ vivaldi)
   omarchy-pkg-add vivaldi || exit 1
 
   copy_chromium_flags ~/.config/vivaldi-stable.conf
-  omarchy-theme-set-browser
   announce_browser_installed "Vivaldi"
   ;;
 zen)

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -402,6 +402,7 @@ show_setup_default_browser_menu() {
   browser_desktop_exists brave-origin-beta.desktop && options="${options:+$options\n}󰖟  Brave Origin"
   browser_desktop_exists microsoft-edge.desktop && options="${options:+$options\n}󰇩  Edge"
   browser_desktop_exists firefox.desktop && options="${options:+$options\n}󰈹  Firefox"
+  browser_desktop_exists vivaldi-stable.desktop && options="${options:+$options\n}󰰫  Vivaldi"
   browser_desktop_exists zen.desktop && options="${options:+$options\n}󰖟  Zen"
 
   local current=""
@@ -412,6 +413,7 @@ show_setup_default_browser_menu() {
   brave-origin) current="󰖟  Brave Origin" ;;
   edge) current="󰇩  Edge" ;;
   firefox) current="󰈹  Firefox" ;;
+  vivaldi) current="󰰫  Vivaldi" ;;
   zen) current="󰖟  Zen" ;;
   esac
 
@@ -422,6 +424,7 @@ show_setup_default_browser_menu() {
   *Brave*) omarchy-default-browser brave ;;
   *Edge*) omarchy-default-browser edge ;;
   *Firefox*) omarchy-default-browser firefox ;;
+  *Vivaldi*) omarchy-default-browser vivaldi ;;
   *Zen*) omarchy-default-browser zen ;;
   *) show_setup_default_menu ;;
   esac
@@ -544,12 +547,13 @@ show_install_menu() {
 }
 
 show_install_browser_menu() {
-  case $(menu "Install" "  Chrome\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n󰖟  Zen") in
+  case $(menu "Install" "  Chrome\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n󰰫  Vivaldi\n󰖟  Zen") in
   *Chrome*) present_terminal "omarchy-install-browser chrome" ;;
   *Edge*) present_terminal "omarchy-install-browser edge" ;;
   *"Brave Origin"*) present_terminal "omarchy-install-browser brave-origin" ;;
   *Brave*) present_terminal "omarchy-install-browser brave" ;;
   *Firefox*) present_terminal "omarchy-install-browser firefox" ;;
+  *Vivaldi*) present_terminal "omarchy-install-browser vivaldi" ;;
   *Zen*) present_terminal "omarchy-install-browser zen" ;;
   *) show_install_menu ;;
   esac
@@ -715,12 +719,13 @@ show_remove_security_menu() {
 }
 
 show_remove_browser_menu() {
-  case $(menu "Remove" "  Chrome\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n  Zen") in
+  case $(menu "Remove" "  Chrome\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n󰰫  Vivaldi\n  Zen") in
   *Chrome*) present_terminal "omarchy-remove-browser chrome" ;;
   *Edge*) present_terminal "omarchy-remove-browser edge" ;;
   *"Brave Origin"*) present_terminal "omarchy-remove-browser brave-origin" ;;
   *Brave*) present_terminal "omarchy-remove-browser brave" ;;
   *Firefox*) present_terminal "omarchy-remove-browser firefox" ;;
+  *Vivaldi*) present_terminal "omarchy-remove-browser vivaldi" ;;
   *Zen*) present_terminal "omarchy-remove-browser zen" ;;
   *) show_remove_menu ;;
   esac

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -66,6 +66,12 @@ vivaldi)
   set_fallback_default_browser vivaldi-stable.desktop
   omarchy-pkg-drop vivaldi
   rm -f ~/.config/vivaldi-stable.conf
+
+  sudo sed -i '/^vivaldi-bin$/d' /etc/1password/custom_allowed_browsers || true
+  if [[ -z "$(<"/etc/1password/custom_allowed_browsers")" ]]; then
+    sudo rm -f /etc/1password/custom_allowed_browsers
+    sudo rmdir /etc/1password || true
+  fi
   ;;
 zen)
   echo "Removing Zen..."

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -66,6 +66,7 @@ vivaldi)
   set_fallback_default_browser vivaldi-stable.desktop
   omarchy-pkg-drop vivaldi
   rm -f ~/.config/vivaldi-stable.conf
+  rm -f ~/.config/omarchy/hooks/post-update.d/vivaldi-post-update
 
   sudo sed -i '/^vivaldi-bin$/d' /etc/1password/custom_allowed_browsers || true
   if [[ -z "$(<"/etc/1password/custom_allowed_browsers")" ]]; then

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Remove a supported browser and clean up Omarchy browser defaults
-# omarchy:args=<chrome|brave|brave-origin|edge|firefox|zen>
+# omarchy:args=<chrome|brave|brave-origin|edge|firefox|vivaldi|zen>
 # omarchy:examples=omarchy remove browser firefox | omarchy remove browser brave
 # omarchy:requires-sudo=true
 
@@ -61,13 +61,19 @@ firefox)
   set_fallback_default_browser firefox.desktop
   omarchy-pkg-drop firefox
   ;;
+vivaldi)
+  echo "Removing Vivaldi..."
+  set_fallback_default_browser vivaldi-stable.desktop
+  omarchy-pkg-drop vivaldi
+  rm -f ~/.config/vivaldi-stable.conf
+  ;;
 zen)
   echo "Removing Zen..."
   set_fallback_default_browser zen.desktop
   omarchy-pkg-drop zen-browser-bin
   ;;
 *)
-  echo "Usage: omarchy-remove-browser <chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-remove-browser <chrome|brave|brave-origin|edge|firefox|vivaldi|zen>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Apply the current theme color to Chromium, Chrome, Edge, and Brave
+# omarchy:summary=Apply the current theme color to Chromium, Chrome, Edge, Brave, and Vivaldi
 # omarchy:hidden=true
 
 CHROMIUM_THEME=~/.config/omarchy/current/theme/chromium.theme
@@ -42,3 +42,5 @@ refresh_running_browser msedge microsoft-edge-stable
 set_browser_policy /etc/brave/policies/managed
 refresh_running_browser brave brave
 refresh_running_browser brave-origin-beta brave-origin-beta -f
+
+"$OMARCHY_PATH/default/vivaldi/vivaldi-theme-refresh"

--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -32,7 +32,6 @@ refresh_running_browser() {
 
 set_browser_policy /etc/chromium/policies/managed
 refresh_running_browser chromium chromium
-refresh_running_browser vivaldi-stable vivaldi-stable
 
 set_browser_policy /etc/opt/chrome/policies/managed
 refresh_running_browser chrome google-chrome-stable || refresh_running_browser chrome google-chrome

--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -32,6 +32,7 @@ refresh_running_browser() {
 
 set_browser_policy /etc/chromium/policies/managed
 refresh_running_browser chromium chromium
+refresh_running_browser vivaldi-stable vivaldi-stable
 
 set_browser_policy /etc/opt/chrome/policies/managed
 refresh_running_browser chrome google-chrome-stable || refresh_running_browser chrome google-chrome

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -15,6 +15,7 @@
         --colorAccentFg: ${fg} !important;
         --colorHighlightBg: color-mix(in srgb, ${accent}, ${bg} 25%) !important;
         --colorHighlightFg: ${fg} !important;
+        --colorFgFadedMore: color-mix(in srgb, ${fg}, gray 50%) !important; /* hints */
         --colorFgFadedMost: color-mix(in srgb, ${fg}, gray 75%) !important; /* address bar */
         --colorBgIntense: color-mix(in srgb, ${bg}, white 7%) !important; /* address bar */
         --colorFgIntense: ${fg} !important; /* address bar */

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -2,7 +2,7 @@
   let last = '';
   const refresh = async () => {
     try {
-      const colors = await (await fetch('style/omarchy.csv')).text();
+      const colors = await (await fetch('style/omarchy.csv', { cache: 'no-store' })).text();
 
       if (colors === last || !/^#[a-f\d]{6}(,#[a-f\d]{6}){2}$/i.test(colors)) return;
       const [bg, fg, accent] = colors.split(',');

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -13,7 +13,8 @@
         --colorFg: ${fg} !important;
         --colorAccentBg: ${bg} !important;
         --colorAccentFg: ${fg} !important;
-        --colorHighlightBg: ${accent} !important;
+        --colorHighlightBg: color-mix(in srgb, ${accent}, ${bg} 25%) !important;
+        --colorHighlightFg: ${fg} !important;
         --colorFgIntense: ${fg} !important; /* address bar font */
         --colorBgLightIntense: color-mix(in srgb, ${bg}, ${fg} 10%) !important;
       }`;

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -12,6 +12,7 @@
         --colorBg: ${bg} !important;
         --colorFg: ${fg} !important;
         --colorAccentBg: ${bg} !important;
+        --colorAccentFg: ${fg} !important;
         --colorHighlightBg: ${accent} !important;
       }`;
       last = colors;

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -11,7 +11,7 @@
       #browser {
         --colorBg: ${bg} !important;
         --colorFg: ${fg} !important;
-        --colorAccentBg: ${accent} !important;
+        --colorAccentBg: ${bg} !important;
         --colorHighlightBg: ${accent} !important;
       }`;
       last = colors;

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -1,0 +1,24 @@
+(() => {
+  let last = '';
+  const refresh = async () => {
+    try {
+      const colors = await (await fetch('style/omarchy.csv')).text();
+
+      if (colors === last || !/^#[a-f\d]{6}(,#[a-f\d]{6}){2}$/i.test(colors)) return;
+      const [bg, fg, accent] = colors.split(',');
+
+      document.getElementById('omarchy-theme').textContent = `
+      #browser {
+        --colorBg: ${bg} !important;
+        --colorFg: ${fg} !important;
+        --colorAccentBg: ${accent} !important;
+        --colorHighlightBg: ${accent} !important;
+      }`;
+      last = colors;
+    } catch (e) {
+      console.error(e);
+    }
+  };
+  refresh();
+  setInterval(refresh, 2000);
+})();

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -14,6 +14,7 @@
         --colorAccentBg: ${bg} !important;
         --colorAccentFg: ${fg} !important;
         --colorHighlightBg: ${accent} !important;
+        --colorFgIntense: ${fg} !important; /* address bar font */
         --colorBgLightIntense: color-mix(in srgb, ${bg}, ${fg} 10%) !important;
       }`;
       last = colors;

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -14,6 +14,7 @@
         --colorAccentBg: ${bg} !important;
         --colorAccentFg: ${fg} !important;
         --colorHighlightBg: ${accent} !important;
+        --colorBgLightIntense: color-mix(in srgb, ${bg}, ${fg} 10%) !important;
       }`;
       last = colors;
     } catch (e) {

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -15,7 +15,8 @@
         --colorAccentFg: ${fg} !important;
         --colorHighlightBg: color-mix(in srgb, ${accent}, ${bg} 25%) !important;
         --colorHighlightFg: ${fg} !important;
-        --colorFgIntense: ${fg} !important; /* address bar font */
+        --colorBgIntense: color-mix(in srgb, ${bg}, white 7%) !important; /* address bar */
+        --colorFgIntense: ${fg} !important; /* address bar */
         --colorBgLightIntense: color-mix(in srgb, ${bg}, ${fg} 10%) !important;
       }`;
       last = colors;

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -15,6 +15,7 @@
         --colorAccentFg: ${fg} !important;
         --colorHighlightBg: color-mix(in srgb, ${accent}, ${bg} 25%) !important;
         --colorHighlightFg: ${fg} !important;
+        --colorFgFadedMost: color-mix(in srgb, ${fg}, gray 75%) !important; /* address bar */
         --colorBgIntense: color-mix(in srgb, ${bg}, white 7%) !important; /* address bar */
         --colorFgIntense: ${fg} !important; /* address bar */
         --colorBgLightIntense: color-mix(in srgb, ${bg}, ${fg} 10%) !important;

--- a/default/vivaldi/omarchy-theme-loader.js
+++ b/default/vivaldi/omarchy-theme-loader.js
@@ -19,7 +19,7 @@
         --colorFgFadedMost: color-mix(in srgb, ${fg}, gray 75%) !important; /* address bar */
         --colorBgIntense: color-mix(in srgb, ${bg}, white 7%) !important; /* address bar */
         --colorFgIntense: ${fg} !important; /* address bar */
-        --colorBgLightIntense: color-mix(in srgb, ${bg}, ${fg} 10%) !important;
+        --colorBgLightIntense: color-mix(in srgb, ${bg}, white 10%) !important;
       }`;
       last = colors;
     } catch (e) {

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -6,8 +6,8 @@ JS="style/omarchy.js"
 
 sudo cp "${OMARCHY_PATH:-$HOME/.local/share/omarchy}/default/vivaldi/omarchy-theme-loader.js" "$JS"
 sudo sed -i \
-  -e "/omarchy-theme/d" -e "s|</head>|  <style id=\"omarchy-theme\"></style>\n&|" \
-  -e "\|$JS|d"          -e "s|</head>|  <script src=\"$JS\"></script>\n&|" window.html
+  -e "/$(basename $JS)/d"  -e "s|</body>|  <script src=\"$JS\"></script>\n&|" \
+  -e "/omarchy-theme/d"    -e "s|</head>|  <style id=\"omarchy-theme\"></style>\n&|" window.html
 
 sudo touch style/omarchy.csv
 sudo chown "$USER" style/omarchy.csv

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -4,7 +4,7 @@ cd /opt/vivaldi/resources/vivaldi || exit 0
 
 JS="style/omarchy.js"
 
-sudo cp "$OMARCHY_PATH/default/vivaldi/omarchy-theme-loader.js" "$JS"
+sudo cp "${OMARCHY_PATH:-$HOME/.local/share/omarchy}/default/vivaldi/omarchy-theme-loader.js" "$JS"
 sudo sed -i \
   -e "/omarchy-theme/d" -e "s|</head>|  <style id=\"omarchy-theme\"></style>\n&|" \
   -e "\|$JS|d"          -e "s|</head>|  <script src=\"$JS\"></script>\n&|" window.html

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -5,7 +5,8 @@ cd /opt/vivaldi/resources/vivaldi || exit 0
 JS="style/omarchy.js"
 
 sudo cp "$OMARCHY_PATH/default/vivaldi/omarchy-theme-loader.js" "$JS"
-sudo sed -i "\|$JS|d; s|</head>|  <style id=\"omarchy-theme\"></style>\n  <script src=\"$JS\"></script>\n&|" window.html
+sudo sed -i -e "/omarchy-theme/d; s|</head>| <style id=\"omarchy-theme\"></style>\n&|" window.html
+sudo sed -i -e "/$JS/d; s|</head>|  <script src=\"$JS\"></script>\n&|" window.html
 
 sudo touch style/omarchy.csv
 sudo chown "$USER" style/omarchy.csv

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -eu
 cd /opt/vivaldi/resources/vivaldi
 
 JS="style/omarchy.js"

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -5,8 +5,9 @@ cd /opt/vivaldi/resources/vivaldi || exit 0
 JS="style/omarchy.js"
 
 sudo cp "$OMARCHY_PATH/default/vivaldi/omarchy-theme-loader.js" "$JS"
-sudo sed -i -e "/omarchy-theme/d; s|</head>| <style id=\"omarchy-theme\"></style>\n&|" window.html
-sudo sed -i -e "/$JS/d; s|</head>|  <script src=\"$JS\"></script>\n&|" window.html
+sudo sed -i \
+  -e "/omarchy-theme/d" -e "s|</head>|  <style id=\"omarchy-theme\"></style>\n&|" \
+  -e "\|$JS|d"          -e "s|</head>|  <script src=\"$JS\"></script>\n&|" window.html
 
 sudo touch style/omarchy.csv
 sudo chown "$USER" style/omarchy.csv

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd /opt/vivaldi/resources/vivaldi || exit 0
+cd /opt/vivaldi/resources/vivaldi
 
 JS="style/omarchy.js"
 

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -7,8 +7,8 @@ JS="style/omarchy.js"
 
 sudo cp "${OMARCHY_PATH:-$HOME/.local/share/omarchy}/default/vivaldi/omarchy-theme-loader.js" "$JS"
 sudo sed -i \
-  -e "/$(basename $JS)/d"  -e "s|</body>|  <script src=\"$JS\"></script>\n&|" \
-  -e "/omarchy-theme/d"    -e "s|</head>|  <style id=\"omarchy-theme\"></style>\n&|" window.html
+  -e "/script.*omarchy/d" -e "s|</body>|  <script src=\"$JS\"></script>\n&|" \
+  -e "/omarchy-theme/d"   -e "s|</head>|  <style id=\"omarchy-theme\"></style>\n&|" window.html
 
 sudo touch style/omarchy.csv
 sudo chown "$USER" style/omarchy.csv

--- a/default/vivaldi/vivaldi-post-update
+++ b/default/vivaldi/vivaldi-post-update
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd /opt/vivaldi/resources/vivaldi || exit 0
+
+JS="style/omarchy.js"
+
+sudo cp "$OMARCHY_PATH/default/vivaldi/omarchy-theme-loader.js" "$JS"
+sudo sed -i "\|$JS|d; s|</head>|  <style id=\"omarchy-theme\"></style>\n  <script src=\"$JS\"></script>\n&|" window.html
+
+sudo touch style/omarchy.csv
+sudo chown "$USER" style/omarchy.csv
+
+omarchy-theme-set-browser

--- a/default/vivaldi/vivaldi-theme-refresh
+++ b/default/vivaldi/vivaldi-theme-refresh
@@ -7,4 +7,4 @@ bg=$(awk -F'"' '/^background/{print $2}' "$COLORS")
 fg=$(awk -F'"' '/^foreground/{print $2}' "$COLORS")
 accent=$(awk -F'"' '/^accent/{print $2}' "$COLORS")
 
-printf "$bg,$fg,$accent" > /opt/vivaldi/resources/vivaldi/style/omarchy.csv
+echo -n "$bg,$fg,$accent" > /opt/vivaldi/resources/vivaldi/style/omarchy.csv

--- a/default/vivaldi/vivaldi-theme-refresh
+++ b/default/vivaldi/vivaldi-theme-refresh
@@ -8,4 +8,4 @@ bg=$(awk -F'"' '/^background/{print $2}' "$COLORS")
 fg=$(awk -F'"' '/^foreground/{print $2}' "$COLORS")
 accent=$(awk -F'"' '/^accent/{print $2}' "$COLORS")
 
-echo -n "$bg,$fg,$accent" > /opt/vivaldi/resources/vivaldi/style/omarchy.csv
+echo -n "$bg,$fg,$accent" > /opt/vivaldi/resources/vivaldi/style/omarchy.csv # owned by user

--- a/default/vivaldi/vivaldi-theme-refresh
+++ b/default/vivaldi/vivaldi-theme-refresh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+omarchy-pkg-present vivaldi || exit 0
+
+COLORS="$HOME/.config/omarchy/current/theme/colors.toml"
+bg=$(awk -F'"' '/^background/{print $2}' "$COLORS")
+fg=$(awk -F'"' '/^foreground/{print $2}' "$COLORS")
+accent=$(awk -F'"' '/^accent/{print $2}' "$COLORS")
+
+printf "$bg,$fg,$accent" > /opt/vivaldi/resources/vivaldi/style/omarchy.csv

--- a/default/vivaldi/vivaldi-theme-refresh
+++ b/default/vivaldi/vivaldi-theme-refresh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 omarchy-pkg-present vivaldi || exit 0
 


### PR DESCRIPTION
This is a redo of https://github.com/basecamp/omarchy/pull/5746 with cherry-picked commits, based on @dhh feedback about working off of `dev` branch.

Please let me know if you need anything else.
Also, would love to get feedback on what we should do with theme support!

Original PR description:
---
This adds full Vivaldi browser support, similar to how other Chromium browsers are handled.
1Password support for Vivaldi is added as well.

All scripts seem to be working fine!

I didn't include Chromium theme setting, since Vivaldi seems to be using its own UI layer that doesn't follow Chromium conventions. That said, I did some investigation, and we could add theme support like this:
```sh
# Vivaldi uses its own theme engine and ignores BrowserThemeColor policy.
# This is an example just for accent color, would need to add other color types.
set_vivaldi_theme() {
  local theme_hex="$1"
  local new_theme
  new_theme=$(jq -n \
    --arg accent "$theme_hex" \
    '{
      accentFromPage: false,
      accentOnWindow: true,
      accentSaturationLimit: 1,
      alpha: 1,
      backgroundImage: "",
      backgroundPosition: "stretch",
      blur: 0,
      colorAccentBg: $accent,
      colorBg: "#2e2f37",
      colorFg: "#d3d9e3",
      colorHighlightBg: "#6590fd",
      colorWindowBg: "#1D1E21",
      contrast: 0,
      defaultBackground: "#1D1E21",
      dimBlurred: false,
      engineVersion: 1,
      id: "Omarchy",
      name: "Omarchy",
      preferSystemAccent: false,
      radius: 14,
      simpleScrollbar: true,
      transparencyTabBar: false,
      transparencyTabs: false,
      url: "",
      version: 1
    }')
  for prefs in ~/.config/vivaldi/*/Preferences; do
    [[ -f $prefs ]] || continue
    # Update or insert the Omarchy theme, then activate it
    jq --argjson theme "$new_theme" '
      .vivaldi.themes.user |= map(select(.id != "Omarchy")) + [$theme]
      | .vivaldi.theme.schedule.o_s.dark = "Omarchy"
      | .vivaldi.theme.schedule.o_s.light = "Omarchy"
    ' "$prefs" > "$prefs.tmp" && mv "$prefs.tmp" "$prefs"
  done
}
if omarchy-cmd-present vivaldi-stable; then
  set_vivaldi_theme "$THEME_HEX_COLOR"
fi
```
The caveat is that it would need to be applied while Vivaldi is closed, and then re-opened. It doesn't seem to be possible to apply the theme on-the-fly, unfortunately..