### PR TITLE
Screen recording: add optional max duration

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -184,19 +184,59 @@ show_webcam_select_menu() {
 show_screenrecord_menu() {
   omarchy-capture-screenrecording --stop-recording && exit 0
 
+  local audio="" webcam=""
   case $(menu "Screenrecord" "  With no audio\n  With desktop audio\n  With desktop + microphone audio\n  With desktop + microphone audio + webcam") in
-  *"With no audio") omarchy-capture-screenrecording ;;
-  *"With desktop audio") omarchy-capture-screenrecording --with-desktop-audio ;;
-  *"With desktop + microphone audio") omarchy-capture-screenrecording --with-desktop-audio --with-microphone-audio ;;
+  *"With no audio") ;;
+  *"With desktop audio") audio="--with-desktop-audio" ;;
+  *"With desktop + microphone audio") audio="--with-desktop-audio --with-microphone-audio" ;;
   *"With desktop + microphone audio + webcam")
     local device=$(show_webcam_select_menu) || {
       back_to show_capture_menu
       return
     }
-    omarchy-capture-screenrecording --with-desktop-audio --with-microphone-audio --with-webcam --webcam-device="$device"
+    audio="--with-desktop-audio --with-microphone-audio"
+    webcam="--with-webcam --webcam-device=$device"
     ;;
-  *) back_to show_capture_menu ;;
+  *) back_to show_capture_menu; return ;;
   esac
+
+  local dur=0
+  case $(menu "Max duration" "  Unlimited\n  15 minutes\n  30 minutes\n  1 hour\n  2 hours") in
+  *Unlimited) dur=0 ;;
+  *"15 minutes") dur=900 ;;
+  *"30 minutes") dur=1800 ;;
+  *"1 hour") dur=3600 ;;
+  *"2 hours") dur=7200 ;;
+  *) back_to show_capture_menu; return ;;
+  esac
+
+  omarchy-capture-screenrecording $audio $webcam
+
+  if [[ $dur -gt 0 ]]; then
+    local pid
+    pid=$(wait_for_screenrecorder_pid) && schedule_screenrecord_autostop "$pid" "$dur"
+  fi
+}
+
+# Polls for a freshly-started gpu-screen-recorder PID for up to ~2s.
+# Prints the PID on success and returns 0; returns 1 if it never appeared.
+wait_for_screenrecorder_pid() {
+  local pid="" i
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    pid=$(pgrep -n gpu-screen-recorder) && [[ -n $pid ]] && { echo "$pid"; return 0; }
+    sleep 0.2
+  done
+  return 1
+}
+
+# Schedules SIGINT to $pid after $dur seconds, in a detached subshell.
+# Re-checks /proc/$pid before signaling so a recording that was manually
+# stopped (Alt+Print or waybar) can't have its successor killed by an
+# orphaned timer.
+schedule_screenrecord_autostop() {
+  local pid=$1 dur=$2
+  (sleep "$dur"; [[ -d /proc/$pid ]] && kill -INT "$pid") &
+  disown
 }
 
 show_share_menu() {


### PR DESCRIPTION
Closes #5782.

Adds a Max duration submenu to the screenrecord flow (Unlimited / 15min / 30min / 1h / 2h). "Unlimited" is first and preserves today's behavior. When a finite duration is picked, an auto-stop is scheduled against the specific `gpu-screen-recorder` PID, so a manual stop (Alt+Print or the waybar indicator) followed by a new recording can't be killed by an orphaned timer — the timer re-checks `/proc/$pid` before signaling.

The duration prompt happens *before* `omarchy-capture-screenrecording` is invoked, so the prompt itself isn't captured. The two helpers (`wait_for_screenrecorder_pid`, `schedule_screenrecord_autostop`) keep the call site to a single line and document the safety property.

## Test plan
- Unlimited → records until manual stop (unchanged behavior).
- 15min → records and auto-stops at 15min.
- Start 30min, manually stop at ~10s (Alt+Print or waybar click), immediately start a new Unlimited → new recording is not killed at t=30min.
- All four audio/webcam combos still selectable.