### PR TITLE
Remove voxtype enable symlink in voxtype-remove

### DIFF
--- a/bin/omarchy-voxtype-remove
+++ b/bin/omarchy-voxtype-remove
@@ -13,6 +13,7 @@ if omarchy-cmd-present voxtype; then
   # Remove services
   systemctl --user stop voxtype.service 2>/dev/null || true
   rm -f ~/.config/systemd/user/voxtype*
+  rm -f ~/.config/systemd/user/*/voxtype.service
   systemctl --user daemon-reload
 
   # Remove packages and configs


### PR DESCRIPTION
omarchy-voxtype-remove cleans up ~/.config/systemd/user/voxtype* but misses the enable symlink at ~/.config/systemd/user/graphical-session.target.wants/voxtype.service. After uninstalling, systemd still sees a broken symlink and generates warnings on boot.
One additional rm -f line using a glob one level deeper catches it.