### PR TITLE
Install mpv MPRIS support

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -82,6 +82,7 @@ man-db
 mariadb-libs
 mise
 mpv
+mpv-mpris
 nautilus
 nautilus-python
 gnome-disk-utility

--- a/migrations/1778623107.sh
+++ b/migrations/1778623107.sh
@@ -1,0 +1,5 @@
+echo "Install MPRIS support for mpv"
+
+if omarchy-pkg-missing mpv-mpris; then
+  omarchy-pkg-add mpv-mpris
+fi


### PR DESCRIPTION
## Summary
- Install `mpv-mpris` alongside `mpv` for fresh Omarchy installs.
- Add a migration so existing systems receive `mpv-mpris` on upgrade.

## Context
`mpv-mpris` enables MPRIS media controls for mpv, including headset stop/start buttons. This has been validated on a machine with `mpv-mpris` installed and working.