### PR TITLE
Add reminder indicator to waybar

### DIFF
--- a/bin/omarchy-reminder
+++ b/bin/omarchy-reminder
@@ -86,6 +86,7 @@ clear_reminders() {
 
   rm -f "$reminder_dir"/omarchy-reminder-*.message 2>/dev/null || true
   omarchy-notification-send -g 󰔛 "All reminders have been cleared"
+  pkill -RTMIN+11 waybar 2>/dev/null || true
 }
 
 case ${1:-} in
@@ -131,6 +132,7 @@ if [[ -n $custom_message ]]; then
 fi
 
 systemd-run --user --quiet --collect --on-active="${minutes}m" --unit="$unit" \
-  bash -c 'omarchy-notification-send -g 󰔛 "Reminder" "$1" -u critical; rm -f "$2"' bash "$message" "$message_file"
+  bash -c 'omarchy-notification-send -g 󰔛 "Reminder" "$1" -u critical; rm -f "$2"; pkill -RTMIN+11 waybar 2>/dev/null' bash "$message" "$message_file"
 
 omarchy-notification-send -g 󰔛 "$confirmation_title" "$confirmation"
+pkill -RTMIN+11 waybar 2>/dev/null || true

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -6,7 +6,7 @@
   "height": 26,
   "width": 0,
   "modules-left": ["custom/omarchy", "hyprland/workspaces"],
-  "modules-center": ["clock#horizontal", "clock#vertical", "custom/weather", "custom/update", "custom/voxtype", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-center": ["clock#horizontal", "clock#vertical", "custom/weather", "custom/update", "custom/voxtype", "custom/screenrecording-indicator", "custom/reminder-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
   "modules-right": [
     "group/tray-expander",
     "bluetooth",
@@ -168,6 +168,14 @@
     "on-click": "omarchy-capture-screenrecording",
     "exec": "$OMARCHY_PATH/default/waybar/indicators/screen-recording.sh",
     "signal": 8,
+    "return-type": "json"
+  },
+  "custom/reminder-indicator": {
+    "on-click": "omarchy-reminder show",
+    "on-click-right": "omarchy-reminder clear",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/reminders.sh",
+    "signal": 11,
+    "interval": 30,
     "return-type": "json"
   },
   "custom/idle-indicator": {

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -84,6 +84,7 @@ tooltip {
 }
 
 #custom-screenrecording-indicator,
+#custom-reminder-indicator,
 #custom-idle-indicator,
 #custom-notification-silencing-indicator {
   min-width: 12px;
@@ -138,6 +139,7 @@ tooltip {
 .left #custom-weather, .right #custom-weather { margin: 1.5px 0; padding: 6px 0; min-height: 12px; min-width: 14px; margin-right: 4px; }
 
 .left #custom-screenrecording-indicator, .right #custom-screenrecording-indicator,
+.left #custom-reminder-indicator, .right #custom-reminder-indicator,
 .left #custom-idle-indicator, .right #custom-idle-indicator,
 .left #custom-notification-silencing-indicator, .right #custom-notification-silencing-indicator {
   margin: 5px 0 0 0;

--- a/default/waybar/indicators/reminders.sh
+++ b/default/waybar/indicators/reminders.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
+now=$(date +%s)
+count=0
+tooltip_lines=()
+
+while IFS=$'\t' read -r timer next; do
+  [[ -z $timer || -z $next ]] && continue
+
+  next=$((next / 1000000))
+  ((next <= now)) && continue
+
+  remaining=$((next - now))
+  minutes=$((remaining / 60))
+  reminder=${timer%.timer}
+  reminder=${reminder#omarchy-reminder-}
+  reminder_minutes=${reminder%%m-*}
+  reminder_message=""
+  [[ -f $reminder_dir/${timer%.timer}.message ]] && reminder_message=$(<"$reminder_dir/${timer%.timer}.message")
+
+  if [[ -n $reminder_message ]]; then
+    tooltip_lines+=("$reminder_message in ${minutes}m")
+  else
+    tooltip_lines+=("${reminder_minutes}m reminder in ${minutes}m")
+  fi
+
+  count=$((count + 1))
+done < <(systemctl --user list-timers --all --output=json "omarchy-reminder-*.timer" 2>/dev/null | jq -r '.[] | [.unit, .next] | @tsv')
+
+if ((count == 0)); then
+  echo '{"text": ""}'
+else
+  tooltip=$(printf '%s\n' "${tooltip_lines[@]}")
+  tooltip=${tooltip%$'\n'}
+
+  if ((count == 1)); then
+    text=$(printf '\U000F009E')
+  else
+    text=$(printf '\U000F009E %d' "$count")
+  fi
+
+  jq -n --arg text "$text" --arg tooltip "$tooltip" \
+    '{"text": $text, "tooltip": $tooltip, "class": "active"}'
+fi


### PR DESCRIPTION
## Summary

Adds a waybar indicator that shows active reminders at a glance -- a bell icon appears when reminders are set, hidden when there aren't any.

<img width="600" height="167" alt="image" src="https://github.com/user-attachments/assets/5be468d5-1490-43ec-b5d3-54562af042e5" />

- **New indicator script** (`default/waybar/indicators/reminders.sh`) follows the existing indicator pattern, reuses the same `systemctl --output=json | jq` approach as `omarchy-reminder`
- **Signal-based refresh** (RTMIN+11) so the indicator updates instantly when reminders are set, fire, or cleared -- plus a 30s interval to keep the countdown tooltip current
- **Click to show**, right-click to clear
- **Tooltip** lists each reminder with its message and time remaining

### How it looks

When reminders are active: `󰔛` (single) or `󰔛 3` (multiple). Hidden when empty. Hover shows e.g. "Check the oven in 12m".

### Changes

- `default/waybar/indicators/reminders.sh` -- new indicator script
- `bin/omarchy-reminder` -- sends `pkill -RTMIN+11 waybar` on set, fire, and clear
- `config/waybar/config.jsonc` -- adds `custom/reminder-indicator` module
- `config/waybar/style.css` -- adds indicator to existing indicator style rules (horizontal + vertical bar)