### PR TITLE
Add floating terminal launcher without omarchy presentation wrapper

### DIFF
--- a/bin/omarchy-launch-floating-terminal
+++ b/bin/omarchy-launch-floating-terminal
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# omarchy:summary=Launch a floating terminal
+# omarchy:args=<command>
+
+cmd="$*"
+exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$cmd"


### PR DESCRIPTION
I used omarchy-launch-floating-terminal-with-presentation for some waybar modules. And it gets pretty annoying to press any key again after closing tui. So lets add this floating terminal launcher without omarchy  presentation wrapper