### PR TITLE
Enable tab and shift+tab to navigate back and forth the wallpaper/theme selector

### DIFF
--- a/default/quickshell/background-switcher.qml
+++ b/default/quickshell/background-switcher.qml
@@ -415,10 +415,10 @@ ShellRoot {
             if (root.filterText.length > 0)
               root.updateFilter(root.filterText.slice(0, -1))
             event.accepted = true
-          } else if (event.key === Qt.Key_Left) {
+          } else if (event.key === Qt.Key_Left || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier) || event.key === Qt.Key_Backtab) {
             root.selectAdjacent(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Right) {
+          } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Tab) {
             root.selectAdjacent(1)
             event.accepted = true
           } else if (root.filterable && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {


### PR DESCRIPTION
Not sure about you, but I expect the tab button to work for navigating right. Added shift + tab to navigate left.
