### PR TITLE
Keep brightness OSD popup width uniform across all percentages

### DIFF
--- a/bin/omarchy-swayosd-brightness
+++ b/bin/omarchy-swayosd-brightness
@@ -12,4 +12,4 @@ progress="$(awk -v p="$percent" 'BEGIN{printf "%.2f", p/100}')"
 omarchy-swayosd-client \
   --custom-icon display-brightness-symbolic \
   --custom-progress "$progress" \
-  --custom-progress-text "${percent}%"
+  --custom-progress-text "$(printf '%3d%%' "$percent")"


### PR DESCRIPTION
## Problem

When pressing the brightness keys, the SwayOSD popup visibly resizes between events because `omarchy-swayosd-brightness` passes the percent string as `--custom-progress-text`, and that string varies between 2 chars (`"5%"`) and 4 chars (`"100%"`). The label container expands or contracts to fit, so consecutive presses look jittery and the percent label appears to shift / flicker.

## Fix

Pad the percent to 3 chars with `printf '%3d%%'` so `"  5%"`, `" 50%"`, and `"100%"` all render at identical width. The OSD label uses `JetBrainsMono Nerd Font` (monospace), so visually the popup is now fixed-width regardless of the value.

```diff
-  --custom-progress-text "${percent}%"
+  --custom-progress-text "$(printf '%3d%%' "$percent")"
```

## Why now

#5525 made the percent values themselves step uniformly to avoid backlight-rounding jitter; this completes the same idea at the rendering layer.

## Scope

- One line in `bin/omarchy-swayosd-brightness`.
- No behavior change to brightness control, the Apple display branch in `omarchy-brightness-display`, the `--min-brightness` cap, or any binding.
- No theme or CSS change required.

## Tested

Locally on an ASUS Zenbook S14 (Panther Lake / intel_backlight) with `swayosd 0.3.1`. Triggered the OSD repeatedly at 5%, 50%, 100% via `omarchy-swayosd-brightness`; popup width is identical across all three. Brightness keys (`XF86MonBrightnessUp/Down`) feel uniform under rapid presses.