### PR TITLE
[codex] Fix clipboard sendshortcut target

### DIFF
--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -1,5 +1,5 @@
 # Copy / Paste
-bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert,
-bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert,
-bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X,
+bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert, activewindow
+bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert, activewindow
+bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X, activewindow
 bindd = SUPER CTRL, V, Clipboard manager, exec, omarchy-launch-walker -m clipboard


### PR DESCRIPTION
## What changed

Adds `activewindow` as the explicit target for the universal copy, paste, and cut `sendshortcut` bindings on the `master` Hyprland config.

## Why

Current Hyprland rejects these `sendshortcut` calls without a target window:

```console
hyprctl dispatch sendshortcut "SHIFT, Insert,"
sendshortcut: invalid args
```

The same shortcut works when targeting the active window explicitly:

```console
hyprctl dispatch sendshortcut "SHIFT, Insert, activewindow"
ok
```

## Impact

This restores `SUPER+C`, `SUPER+V`, and `SUPER+X` for installs using the `.conf` clipboard bindings on `master`, while preserving the intended behavior of sending the shortcut to the focused window.

## Validation

- Reproduced the failure locally with the existing `sendshortcut` argument shape.
- Verified `hyprctl dispatch sendshortcut "SHIFT, Insert, activewindow"` returns `ok`.
- Ran `git diff --check`.
