### PR TITLE
Remove suspend-then-hibernate cleanup steps

### DIFF
--- a/bin/omarchy-hibernation-remove
+++ b/bin/omarchy-hibernation-remove
@@ -44,11 +44,6 @@ if grep -Fq "$SWAP_FILE" /etc/fstab; then
   sudo sed -i '/^# Btrfs swapfile for system hibernation$/d' /etc/fstab
 fi
 
-# Remove suspend-then-hibernate configuration
-echo "Removing suspend-then-hibernate configuration"
-sudo rm -f /etc/systemd/logind.conf.d/lid.conf
-sudo rm -f /etc/systemd/sleep.conf.d/hibernate.conf
-
 # Remove mkinitcpio resume hook
 echo "Removing resume hook"
 sudo rm "$MKINITCPIO_CONF"


### PR DESCRIPTION
Those files are not present anymore (removed here e4b737266687e8ea4d5e97cb7e22f107335028c1)

Removed suspend-then-hibernate configuration cleanup steps from the script.