### PR TITLE
Enable HDMI audio auto-profile for AMD controllers

### DIFF
--- a/default/wireplumber/wireplumber.conf.d/amd-hdmi-audio-autoactivate.conf
+++ b/default/wireplumber/wireplumber.conf.d/amd-hdmi-audio-autoactivate.conf
@@ -1,0 +1,21 @@
+## Auto-activate HDMI audio output profiles.
+## WirePlumber defaults api.acp.auto-profile to false, which leaves
+## HDMI audio cards on the "off" profile — monitors never appear as
+## audio outputs. This rule enables automatic profile selection for
+## AMD/ATI HDMI audio controllers.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        device.vendor.id = "0x1002"
+      }
+    ]
+    actions = {
+      update-props = {
+        api.acp.auto-profile = true
+        api.acp.auto-port = true
+      }
+    }
+  }
+]

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -36,6 +36,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/network.sh
 run_logged $OMARCHY_INSTALL/config/hardware/set-wireless-regdom.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-fkeys.sh
 run_logged $OMARCHY_INSTALL/config/hardware/bluetooth.sh
+run_logged $OMARCHY_INSTALL/config/hardware/hdmi-audio.sh
 run_logged $OMARCHY_INSTALL/config/hardware/printer.sh
 run_logged $OMARCHY_INSTALL/config/hardware/usb-autosuspend.sh
 run_logged $OMARCHY_INSTALL/config/hardware/ignore-power-button.sh

--- a/install/config/hardware/hdmi-audio.sh
+++ b/install/config/hardware/hdmi-audio.sh
@@ -1,0 +1,18 @@
+# Enable HDMI audio auto-profile for AMD/ATI HDMI audio controllers.
+# Without this, WirePlumber leaves HDMI audio cards on the "off" profile
+# and monitors never appear as audio output devices.
+
+destination=~/.config/wireplumber/wireplumber.conf.d/amd-hdmi-audio-autoactivate.conf
+
+mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/amd-hdmi-audio-autoactivate.conf" \
+  "$destination"
+
+# Clear stale "off" profiles for AMD HDMI cards from WirePlumber state,
+# otherwise the stored profile overrides auto-profile selection.
+wp_state="$HOME/.local/state/wireplumber/default-profile"
+if [[ -f $wp_state ]] && lspci -d 1002: 2>/dev/null | grep -qi "audio"; then
+  sed -i '/^alsa_card\.pci-.*00\.1=off$/d' "$wp_state"
+fi
+
+systemctl --user restart wireplumber pipewire pipewire-pulse 2>/dev/null || true

--- a/migrations/1778757303.sh
+++ b/migrations/1778757303.sh
@@ -1,0 +1,3 @@
+echo "Enable HDMI audio auto-profile for AMD HDMI controllers"
+
+source "$OMARCHY_PATH/install/config/hardware/hdmi-audio.sh"


### PR DESCRIPTION
## Summary

- HDMI monitors never appear as audio output devices on AMD hardware because WirePlumber defaults `api.acp.auto-profile` to `false`, leaving HDMI audio cards on the `off` profile
- Adds a WirePlumber rule that enables automatic profile selection for AMD/ATI HDMI audio controllers (`device.vendor.id = "0x1002"`)
- Clears stale `off` profile entries from the WirePlumber state file (scoped to machines with AMD audio hardware via `lspci`), which otherwise override the auto-profile config on restart

## Details

**Root cause:** Two issues combine to prevent HDMI audio:
1. WirePlumber sets `api.acp.auto-profile = false` for all ALSA devices by default, so HDMI audio cards start with profile `off`
2. WirePlumber's state file (`~/.local/state/wireplumber/default-profile`) persists `off` across restarts via `device/state-profile.lua`, so even after enabling auto-profile, the stored state takes priority

**Fix:** A `monitor.alsa.rules` entry matching AMD/ATI HDMI controllers that sets `api.acp.auto-profile = true` and `api.acp.auto-port = true`, plus cleanup of stale state entries on AMD hardware only.

**Files added:**
- `default/wireplumber/wireplumber.conf.d/amd-hdmi-audio-autoactivate.conf` — the WirePlumber rule (AMD-only scope)
- `install/config/hardware/hdmi-audio.sh` — unconditional deploy script (same pattern as `bluetooth.sh`)
- `migrations/1778757303.sh` — migration for existing users

**Tested on:** ASUS ROG Flow Z13 (2025) with AMD Ryzen AI 9 HX 370 / Radeon 890M, HDMI output to LG TV. After applying, the Radeon HDMI sink appears in `wpctl status` and is selectable via wiremix and `omarchy-audio-output-switch`.

**Note:** The root cause is vendor-agnostic — WirePlumber's `alsa.lua` sets `api.acp.auto-profile = false` for all ALSA devices unconditionally. This fix is scoped to AMD (`0x1002`) since that's what I've tested on my Z13. I can't confirm it affects all AMD hardware, but I suspect it does. Intel and NVIDIA HDMI controllers likely hit the same issue but are not covered here. Adding their vendor IDs would be a one-line change if confirmed.