### PR TITLE
Ceil tooltip popup size so right/bottom borders render

### DIFF
--- a/default/quickshell/omarchy-shell/plugins/bar/Bar.qml
+++ b/default/quickshell/omarchy-shell/plugins/bar/Bar.qml
@@ -929,8 +929,8 @@ Item {
 
       visible: root.tooltipShown && root.tooltipTarget !== null && root.tooltipText !== ""
       color: "transparent"
-      implicitWidth: tooltipBubble.implicitWidth
-      implicitHeight: tooltipBubble.implicitHeight
+      implicitWidth: Math.ceil(tooltipBubble.implicitWidth)
+      implicitHeight: Math.ceil(tooltipBubble.implicitHeight)
 
       anchor {
         id: tooltipAnchor


### PR DESCRIPTION
## Summary
- The bar tooltip popup sized its `PopupWindow` directly from `tooltipBubble.implicitWidth`/`implicitHeight`, which chain down to `Text.implicitWidth/Height` and routinely return fractional values.
- On Wayland the popup surface is rounded to integer pixels (effectively floor), so the bubble's 1px right/bottom border was drawn just past the surface edge and clipped — visible when hovering the date or `cliamp` widgets (see screenshots below).
- `Math.ceil` the popup's implicit dimensions so the surface is always at least as large as the bubble it contains.

## Screenshots
<img width="603" height="185" alt="screenshot-2026-05-15_10-10-31" src="https://github.com/user-attachments/assets/396f6285-542f-4c98-bcdc-56293931ed46" />
<img width="731" height="203" alt="screenshot-2026-05-15_10-10-41" src="https://github.com/user-attachments/assets/8c5df62c-dd4b-4aeb-8d06-31ac2fd2e15d" />


## Test plan
- [ ] Hover the date widget — full rectangular border on the tooltip
- [ ] Hover the `cliamp` widget (running and not-running states) — full rectangular border on the tooltip
- [ ] Hover a few other tooltipped widgets (battery, network, audio) — no visual regressions