### PR TITLE
Drop stale frame artifacts on bar tooltip/popup hover transitions

### DIFF
--- a/default/quickshell/omarchy-shell/plugins/bar/Bar.qml
+++ b/default/quickshell/omarchy-shell/plugins/bar/Bar.qml
@@ -72,6 +72,13 @@ Item {
   property var tooltipTarget: null
   property string tooltipText: ""
   property bool tooltipShown: false
+  // tooltipMapped tracks whether the popup surface is currently mapped to
+  // the compositor. Driven by tooltipWindow.onVisibleChanged with a deferred
+  // off-transition so a same-tick re-show still routes through the safe path.
+  property bool tooltipMapped: false
+  property var pendingTooltipTarget: null
+  property string pendingTooltipText: ""
+  property bool tooltipPending: false
   property var activePopout: null
 
   function requestPopout(owner) {
@@ -409,24 +416,34 @@ Item {
   }
 
   // Changing tooltipText resizes the bubble (and thus the popup window). If
-  // we do that while the popup is still mapped (or in the same QML tick as
-  // the visible→false flip), Hyprland gets a resize commit before the unmap
-  // and retains the post-resize frame at the new size — that's where the
-  // partial "ot running" stale-tooltip artifact comes from. The fix is to
-  // make sure visible flips false (popup unmaps) before tooltipText ever
-  // changes to a different value, by deferring the text/target update with
-  // Qt.callLater and leaving the old text in place across the gap.
+  // we do that while the popup is still mapped, Hyprland gets a resize
+  // commit before the unmap and retains the post-resize frame at the new
+  // size — that's where the partial "ot running" stale-tooltip artifact
+  // comes from. When the surface is currently mapped, stage the new
+  // target/text in the pending fields and apply them after the unmap on the
+  // next tick; rapid retargeting overwrites the pending pair and collapses
+  // to a single queued callback. When the surface is already unmapped (the
+  // common case — any first hover after an idle gap), apply directly so
+  // tooltips don't pay an unnecessary frame of latency.
   function showTooltip(target, text) {
     if (!text) return
 
-    if (tooltipShown || tooltipTarget !== null) {
+    if (tooltipMapped) {
+      pendingTooltipTarget = target
+      pendingTooltipText = text
       tooltipShown = false
       tooltipTimer.stop()
-      Qt.callLater(function() {
-        tooltipTarget = target
-        tooltipText = text
-        tooltipTimer.restart()
-      })
+      if (!tooltipPending) {
+        tooltipPending = true
+        Qt.callLater(function() {
+          tooltipPending = false
+          tooltipTarget = pendingTooltipTarget
+          tooltipText = pendingTooltipText
+          pendingTooltipTarget = null
+          pendingTooltipText = ""
+          tooltipTimer.restart()
+        })
+      }
       return
     }
 
@@ -441,9 +458,9 @@ Item {
 
     tooltipTimer.stop()
     tooltipShown = false
-    // Leave tooltipText/tooltipTarget intact. The popup is now unmapped and
-    // its size no longer matters; the next showTooltip will overwrite both
-    // after the surface has fully torn down.
+    // tooltipText/tooltipTarget stay set; tooltipMapped (driven by the
+    // popup's own visibleChanged) is what tells showTooltip whether a
+    // resize is still dangerous.
   }
 
   function parseModuleJson(raw) {
@@ -948,6 +965,19 @@ Item {
       id: tooltipWindow
 
       visible: root.tooltipShown && root.tooltipTarget !== null && root.tooltipText !== ""
+      // Off-transition is deferred a tick so a same-tick re-show is still
+      // treated as "popup currently mapped" and routed through showTooltip's
+      // safe (deferred) path. Once the unmap has settled, the next hover
+      // takes the fast direct path.
+      onVisibleChanged: {
+        if (visible) {
+          root.tooltipMapped = true
+        } else {
+          Qt.callLater(function() {
+            if (!tooltipWindow.visible) root.tooltipMapped = false
+          })
+        }
+      }
       color: "transparent"
       implicitWidth: tooltipBubble.implicitWidth
       implicitHeight: tooltipBubble.implicitHeight

--- a/default/quickshell/omarchy-shell/plugins/bar/Bar.qml
+++ b/default/quickshell/omarchy-shell/plugins/bar/Bar.qml
@@ -408,8 +408,27 @@ Item {
       process.running = true
   }
 
+  // Changing tooltipText resizes the bubble (and thus the popup window). If
+  // we do that while the popup is still mapped (or in the same QML tick as
+  // the visible→false flip), Hyprland gets a resize commit before the unmap
+  // and retains the post-resize frame at the new size — that's where the
+  // partial "ot running" stale-tooltip artifact comes from. The fix is to
+  // make sure visible flips false (popup unmaps) before tooltipText ever
+  // changes to a different value, by deferring the text/target update with
+  // Qt.callLater and leaving the old text in place across the gap.
   function showTooltip(target, text) {
     if (!text) return
+
+    if (tooltipShown || tooltipTarget !== null) {
+      tooltipShown = false
+      tooltipTimer.stop()
+      Qt.callLater(function() {
+        tooltipTarget = target
+        tooltipText = text
+        tooltipTimer.restart()
+      })
+      return
+    }
 
     tooltipTarget = target
     tooltipText = text
@@ -421,9 +440,10 @@ Item {
     if (tooltipTarget !== target) return
 
     tooltipTimer.stop()
-    tooltipTarget = null
-    tooltipText = ""
     tooltipShown = false
+    // Leave tooltipText/tooltipTarget intact. The popup is now unmapped and
+    // its size no longer matters; the next showTooltip will overwrite both
+    // after the surface has fully torn down.
   }
 
   function parseModuleJson(raw) {

--- a/default/quickshell/omarchy-shell/plugins/bar/common/PopupCard.qml
+++ b/default/quickshell/omarchy-shell/plugins/bar/common/PopupCard.qml
@@ -33,7 +33,10 @@ PopupWindow {
   // with the card still at full opacity — Hyprland holds onto that frame
   // and leaves a stale outline at the popup's last position. By waiting for
   // the inner opacity to actually reach 0, the last committed buffer is
-  // transparent and the surface tears down cleanly.
+  // transparent and the surface tears down cleanly. `hideTimer.interval`
+  // derives from `fadeDurationMs` so the timer can't drift out of sync with
+  // the opacity Behavior below.
+  readonly property int fadeDurationMs: 140
   property bool _surfaceVisible: open
   visible: _surfaceVisible
   color: "transparent"
@@ -41,8 +44,12 @@ PopupWindow {
   implicitHeight: contentHeight
 
   onOpenChanged: {
-    if (open) _surfaceVisible = true
-    else hideTimer.restart()
+    if (open) {
+      hideTimer.stop()
+      _surfaceVisible = true
+    } else {
+      hideTimer.restart()
+    }
 
     if (!bar) return
     if (open) bar.requestPopout(coordinatorKey)
@@ -51,7 +58,7 @@ PopupWindow {
 
   Timer {
     id: hideTimer
-    interval: 160 // matches the card opacity Behavior duration with a small buffer
+    interval: root.fadeDurationMs + 20 // small buffer past the card opacity fade
     onTriggered: if (!root.open) root._surfaceVisible = false
   }
 
@@ -112,7 +119,7 @@ PopupWindow {
     opacity: root.open ? 1.0 : 0
 
     Behavior on opacity {
-      NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
+      NumberAnimation { duration: root.fadeDurationMs; easing.type: Easing.OutCubic }
     }
 
     Item {

--- a/default/quickshell/omarchy-shell/plugins/bar/common/PopupCard.qml
+++ b/default/quickshell/omarchy-shell/plugins/bar/common/PopupCard.qml
@@ -28,15 +28,31 @@ PopupWindow {
 
   default property alias contentItem: contentHolder.children
 
-  visible: open
+  // Keep the surface mapped through the card's fade-out animation. If we
+  // unmap the moment `open` flips false, the popup commits its final frame
+  // with the card still at full opacity — Hyprland holds onto that frame
+  // and leaves a stale outline at the popup's last position. By waiting for
+  // the inner opacity to actually reach 0, the last committed buffer is
+  // transparent and the surface tears down cleanly.
+  property bool _surfaceVisible: open
+  visible: _surfaceVisible
   color: "transparent"
   implicitWidth: contentWidth
   implicitHeight: contentHeight
 
   onOpenChanged: {
+    if (open) _surfaceVisible = true
+    else hideTimer.restart()
+
     if (!bar) return
     if (open) bar.requestPopout(coordinatorKey)
     else if (bar.activePopout === coordinatorKey) bar.releasePopout(coordinatorKey)
+  }
+
+  Timer {
+    id: hideTimer
+    interval: 160 // matches the card opacity Behavior duration with a small buffer
+    onTriggered: if (!root.open) root._surfaceVisible = false
   }
 
   // Outside-click dismissal via Hyprland's focus grab. While `active`, input


### PR DESCRIPTION
## Summary

Quickshell `PopupWindow` surfaces in the bar leave stale outline frames on Hyprland during rapid hover transitions. When a popup commits a resized buffer (because its text changed and the bubble shrank) in the same QML tick as `visible` flipping false, Hyprland retains the post-resize frame at the new smaller size and only damages the smaller region on unmap, so pixels from the original, larger surface stay on screen.


https://github.com/user-attachments/assets/ebe88d57-195e-453a-adef-08b3dd1f4814



Two surfaces were affected:

- **`Bar.qml`'s shared tooltip `PopupWindow`** — `hideTooltip` blanked `tooltipText` to `""` before the popup unmapped, shrinking the bubble and producing a partial-tooltip artifact (e.g. `ot running` left behind from `cliamp is not running`). `showTooltip` now flips visible false first and defers the new target/text via `Qt.callLater` so the popup fully unmaps before its size can change; `hideTooltip` leaves text/target intact so the popup unmaps at its current size.
- **`PopupCard.qml`** (hover-mode flyouts like `weatherFlyout`, `systemStats`) — `visible` was bound directly to `open`, so the surface unmapped while the inner Rectangle's opacity Behavior was still mid-fade and Hyprland kept the last opaque frame. A `_surfaceVisible` property gated by a 160 ms `hideTimer` (matching the 140 ms opacity Behavior duration with a small buffer) keeps the surface mapped until opacity reaches 0, so the last committed buffer is transparent before the unmap.

## Test plan

- [ ] Hover quickly between widgets with very different tooltip widths (omarchy menu ↔ wifi ↔ clock ↔ cliamp) — no stale tooltip outlines, no partial/clipped tooltip boxes
- [ ] Hover the weather and system-stats widgets repeatedly, moving away each time — no small slivers left at the panel's anchor position
- [ ] Open the wifi / audio / bluetooth panels via click — they still open with the fade-in animation intact and close cleanly with no artifacts