### PR TITLE
Fix keyboard backlight not restoring after suspend and lock

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Adjust keyboard backlight brightness using available steps.
-# omarchy:args=<up|down|cycle|off|restore>
+# omarchy:args=<up|down|cycle|off|save|restore>
 
 direction="${1:-up}"
 
@@ -21,6 +21,11 @@ fi
 
 if [[ $direction == "off" ]]; then
   brightnessctl -sd "$device" set 0 >/dev/null
+  exit 0
+elif [[ $direction == "save" ]]; then
+  # Save current brightness without changing it (used before suspend).
+  current=$(brightnessctl -d "$device" get)
+  brightnessctl -sd "$device" set "$current" >/dev/null
   exit 0
 elif [[ $direction == "restore" ]]; then
   brightnessctl -rd "$device" >/dev/null

--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -27,7 +27,9 @@ if [[ ${OMARCHY_LOCK_ONLY:-false} != "true" ]]; then
   (
     sleep 3
     pidof hyprlock >/dev/null || exit 0
-    omarchy-brightness-keyboard off
+    omarchy-brightness-keyboard save
     omarchy-brightness-display off
   ) &
+else
+  omarchy-brightness-keyboard save
 fi


### PR DESCRIPTION
## Summary

Keyboard backlight turns off after suspend/resume and is not restored when waking the lock screen.

### Root cause (suspend)

`hypridle.conf` uses `OMARCHY_LOCK_ONLY=true omarchy-system-lock` as `before_sleep_cmd`, which skips `omarchy-brightness-keyboard off` (the step that saves brightness via `brightnessctl -sd`). On resume, `omarchy-system-wake` calls `omarchy-brightness-keyboard restore` (`brightnessctl -rd`), but with no saved state, the backlight is not restored.

### Root cause (lock)

`omarchy-system-lock` turns off the keyboard in a background subshell 3 seconds after locking, bypassing hypridle's idle tracking. When the user wakes the display on the lock screen (press a key / move mouse), hypridle's `on-resume` does not fire because the keyboard off happened outside hypridle's control. The keyboard only restores when `hyprlock` exits (after entering password), not when the lock screen becomes visible — leaving the user typing their password with no keyboard backlight.

### Why suspend restores immediately but lock doesn't

On suspend resume, `hypridle`'s `after_sleep_cmd` runs `omarchy-system-wake` 1 second after wake — independent of `hyprlock` — so the keyboard lights up immediately on the lock screen.

On lock, `omarchy-system-wake` is called inside a subshell that waits for `hyprlock` to exit (i.e., after the user enters their password). The keyboard only restores once the desktop is visible. Turning off the keyboard via `off` on lock also can't be reversed by `hypridle`'s `on-resume` because the keyboard off happened in a background subshell outside `hypridle`'s idle tracking.

### Fix

- **`omarchy-brightness-keyboard`**: Add a `save` command that saves current brightness without changing it (`brightnessctl -sd set <current>`)
- **`omarchy-system-lock`**: Replace `off` with `save` in the lock path so the keyboard stays lit while the lock screen is displayed, and brightness is saved for restore after suspend/resume. In `LOCK_ONLY` mode (before suspend), also save keyboard brightness.

### Behavior after fix

- **Lock**: keyboard brightness is saved but stays on (useful for typing passwords in the dark) → display turns off → user wakes display → keyboard is already lit → unlock → `restore` is a no-op
- **Suspend**: `save` preserves current brightness → resume → `restore` restores saved value

Tested on ASUS ROG Flow Z13 (2025) with CachyOS kernel. The issue likely affects any device where the embedded controller resets keyboard backlight during suspend.