### PR TITLE
Stop naming tmux shortcut sessions Work

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -1,6 +1,6 @@
 # Application bindings
 bindd = SUPER, RETURN, Terminal, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)"
-bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" bash -c "tmux attach || tmux new -s Work"
+bindd = SUPER ALT, RETURN, Tmux, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" bash -c "tmux attach || tmux new"
 bindd = SUPER SHIFT, RETURN, Browser, exec, omarchy-launch-browser
 bindd = SUPER SHIFT, F, File manager, exec, uwsm-app -- nautilus --new-window
 bindd = SUPER ALT SHIFT, F, File manager (cwd), exec, uwsm-app -- nautilus --new-window "$(omarchy-cmd-terminal-cwd)"

--- a/migrations/1778272261.sh
+++ b/migrations/1778272261.sh
@@ -1,0 +1,7 @@
+echo "Stop naming new Super+Alt+Return tmux sessions Work"
+
+bindings_file="$HOME/.config/hypr/bindings.conf"
+
+if [[ -f $bindings_file ]] && grep -qF "tmux attach || tmux new -s Work" "$bindings_file"; then
+  sed -i 's/tmux attach || tmux new -s Work/tmux attach || tmux new/' "$bindings_file"
+fi


### PR DESCRIPTION
## Summary
- stop SUPER+ALT+ENTER from creating new tmux sessions named Work
- add migration to update existing Hypr bindings

Fixes #5849