### PR TITLE
Fix Undercurl

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -1,7 +1,7 @@
 general.import = [ "~/.config/omarchy/current/theme/alacritty.toml" ]
 
 [env]
-TERM = "xterm-256color"
+TERM = "alacritty"
 
 [terminal]
 osc52 = "CopyPaste"

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -64,6 +64,8 @@ bind -n M-Down switch-client -n
 # General
 set -g default-terminal "tmux-256color"
 set -ag terminal-overrides ",*:RGB"
+set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
+set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
 set -g mouse on
 set -g base-index 1
 setw -g pane-base-index 1


### PR DESCRIPTION
Undercurl was not working for me in tmux or in neovim within a direct alacritty terminal

This fixes those issues by
1. Adding undercurl capability to tmux with terminal overrides
2. Setting the terminal to alacritty to allow neovim to detect undercurl support in alacritty

The second change changes a specific default, and I'm not sure what other downstream changes would be from it or why it was explicitly set to `xterm-256color`. Let me know if there are concerns with this part as there are other fix options.