### PR TITLE
Remove custom clipboard shortcuts to align with terminal defaults

### DIFF
--- a/config/foot/foot.ini
+++ b/config/foot/foot.ini
@@ -14,6 +14,4 @@ style=block
 blink=no
 
 [key-bindings]
-clipboard-copy=Control+Insert
 primary-paste=none
-clipboard-paste=Shift+Insert


### PR DESCRIPTION
Remove custom clipboard key bindings from `foot.ini` to restore the terminal defaults.

The custom shortcuts diverged from the standard `Ctrl+Shift+C` / `Ctrl+Shift+V` bindings used in all other terminal. Removing them aligns foot's behaviour with the rest of the ecosystem.

- Removed explicit `copy` and `paste` key binding entries from `foot.ini`
- Foot will now fall back to its built-in defaults (`Ctrl+Shift+C` / `Ctrl+Shift+V`)