### PR TITLE
Avoid registry checks when launching npm wrappers

### DIFF
--- a/bin/omarchy-npm-install
+++ b/bin/omarchy-npm-install
@@ -13,6 +13,25 @@ command=${2:-$1}
 
 mkdir -p "$HOME/.local/bin"
 
+# Refreshes happen while Omarchy is installing/updating wrappers, not every time
+# a generated wrapper launches. Normal launches prefer pnpm's local store below.
+if ! node_root="$(mise where node@latest 2>/dev/null)"; then
+  mise use -g node@latest >/dev/null
+  node_root="$(mise where node@latest)"
+fi
+
+if omarchy-cmd-missing pnpm; then
+  echo "Installing pnpm for $package..."
+  omarchy-pkg-add pnpm
+  hash -r
+fi
+
+export PNPM_CONFIG_MINIMUM_RELEASE_AGE=7200
+
+if [[ ${OMARCHY_NPM_REFRESH:-0} == 1 ]]; then
+  PATH="$node_root/bin:$PATH" pnpm dlx --package "$package" true
+fi
+
 cat > "$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 package="$package"
@@ -57,14 +76,14 @@ exec_package_bin() {
 }
 
 # Resolve the package bin inside pnpm dlx, then run it with node@latest available for node shebangs.
+# Prefer the local store during normal launches so transient registry or DNS
+# failures do not prevent cached npm wrappers from starting.
 # Some wrappers are aliases, e.g. playwright-cli wraps the playwright bin.
-PATH="\$node_root/bin:\$PATH" pnpm dlx --package "\$package" true
-
-package_bin_path=\$(PATH="\$node_root/bin:\$PATH" pnpm dlx --package "\$package" which "\$package" 2>/dev/null)
+package_bin_path=\$(PATH="\$node_root/bin:\$PATH" pnpm dlx --prefer-offline --package "\$package" which "\$package" 2>/dev/null)
 exec_package_bin "\$package_bin_path" "\$@"
 
 # Scoped packages like @openai/codex expose an unscoped bin like codex.
-package_bin_path=\$(PATH="\$node_root/bin:\$PATH" pnpm dlx --package "\$package" which "\$command" 2>/dev/null)
+package_bin_path=\$(PATH="\$node_root/bin:\$PATH" pnpm dlx --prefer-offline --package "\$package" which "\$command" 2>/dev/null)
 exec_package_bin "\$package_bin_path" "\$@"
 
 echo "Could not resolve npm bin for \$package / \$command" >&2

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -19,6 +19,6 @@ fi
 bash $OMARCHY_PATH/install/packaging/icons.sh
 bash $OMARCHY_PATH/install/packaging/webapps.sh
 bash $OMARCHY_PATH/install/packaging/tuis.sh
-bash $OMARCHY_PATH/install/packaging/npm.sh
+OMARCHY_NPM_REFRESH=1 bash $OMARCHY_PATH/install/packaging/npm.sh
 
 update-desktop-database ~/.local/share/applications

--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -14,6 +14,7 @@ omarchy-update-available-reset
 omarchy-update-system-pkgs
 omarchy-migrate
 omarchy-update-aur-pkgs
+OMARCHY_NPM_REFRESH=1 bash "$OMARCHY_PATH/install/packaging/npm.sh"
 omarchy-update-orphan-pkgs
 omarchy-hook post-update
 


### PR DESCRIPTION
 ## Summary

  This changes Omarchy-generated npm wrappers so normal command launches prefer pnpm's local store instead of checking the registry every time.

  Previously, wrappers generated by `omarchy-npm-install` ran a `pnpm dlx --package ... true` warmup during every command invocation. If DNS or the npm registry was
  slow/unavailable, commands like `opencode`, `codex`, or `gemini` could hang or fail before the actual CLI started.

  ## Changes

  - Remove the per-launch `pnpm dlx --package "$package" true` warmup from generated wrappers.
  - Use `pnpm dlx --prefer-offline` when resolving package binaries during normal wrapper launches.
  - Add `OMARCHY_NPM_REFRESH=1` as an explicit refresh mode for npm wrappers.
  - Run npm wrapper refreshes during:
    - `omarchy refresh applications`
    - `omarchy update`
  - Keep `PNPM_CONFIG_MINIMUM_RELEASE_AGE=7200` behavior intact.

Small warning, the changes in this PR are gpt-5.5. generated as I am not a bash expert. Please review them carefully.