### PR TITLE
Convert rounded-corners.conf to lua, fix migration

### DIFF
--- a/default/hypr/toggles/rounded-corners.conf
+++ b/default/hypr/toggles/rounded-corners.conf
@@ -1,4 +1,0 @@
-decoration {
-    rounding = 6
-    rounding_power = 3
-}

--- a/default/hypr/toggles/rounded-corners.lua
+++ b/default/hypr/toggles/rounded-corners.lua
@@ -1,0 +1,7 @@
+-- Use rounded window corners.
+hl.config({
+  decoration = {
+    rounding = 6,
+    rounding_power = 3,
+  },
+})

--- a/migrations/1778321093.sh
+++ b/migrations/1778321093.sh
@@ -37,7 +37,7 @@ for conf_toggle in "$toggle_state_dir"/*.conf; do
 
   if [[ ! -f $lua_toggle ]]; then
     case "$toggle_name" in
-      flags | single-window-aspect-ratio | window-no-gaps)
+      flags | rounded-corners | single-window-aspect-ratio | window-no-gaps)
         if [[ -f $toggle_defaults_dir/$toggle_name.lua ]]; then
           cp -f "$toggle_defaults_dir/$toggle_name.lua" "$lua_toggle"
         fi

--- a/migrations/1778861001.sh
+++ b/migrations/1778861001.sh
@@ -1,0 +1,19 @@
+echo "Convert rounded-corners Hyprland toggle from conf to Lua"
+
+toggle_state_dir="$HOME/.local/state/omarchy/toggles/hypr"
+toggle_defaults_dir="$OMARCHY_PATH/default/hypr/toggles"
+timestamp=$(date +%s)
+
+conf_toggle="$toggle_state_dir/rounded-corners.conf"
+lua_toggle="$toggle_state_dir/rounded-corners.lua"
+
+mkdir -p "$toggle_state_dir"
+
+if [[ -f $conf_toggle ]]; then
+  if [[ ! -f $lua_toggle ]] && [[ -f $toggle_defaults_dir/rounded-corners.lua ]]; then
+    cp -f "$toggle_defaults_dir/rounded-corners.lua" "$lua_toggle"
+    echo "Converted rounded-corners toggle to Lua"
+  fi
+
+  mv "$conf_toggle" "$conf_toggle.bak.$timestamp"
+fi


### PR DESCRIPTION
A previous migration did not seem to ensure rounded-corners.conf was properly migrated to lua and placed into the proper location. This change enables properly toggling hyprland corners.