### PR TITLE
Fix gradient border syntax in last-horizon and solitude themes

### DIFF
--- a/themes/last-horizon/hyprland.lua
+++ b/themes/last-horizon/hyprland.lua
@@ -1,4 +1,4 @@
-local active_border_color = "rgba(8a8588ee) rgba(e2dddcee)"
+local active_border_color = { colors = { "rgba(8a8588ee)", "rgba(e2dddcee)" }, angle = 45 }
 local inactive_border_color = "rgba(584e51aa)"
 
 hl.config({

--- a/themes/solitude/hyprland.lua
+++ b/themes/solitude/hyprland.lua
@@ -1,4 +1,4 @@
-local active_border_color = "rgba(798186ee) rgba(caccccee)"
+local active_border_color = { colors = { "rgba(798186ee)", "rgba(caccccee)" }, angle = 45 }
 local inactive_border_color = "rgb(1e1e1e)"
 
 hl.config({


### PR DESCRIPTION
## Summary

Fix gradient border syntax in `last-horizon` and `solitude` Hyprland Lua theme files.

## Details

In `hl.config({...})`, gradient colors (two-color `active_border`) must be a table, not a space-separated string. The incorrect string format was causing `invalid color` errors at runtime.

**Before:**
```lua
local active_border_color = "rgba(798186ee) rgba(caccccee)"
```

**After:**
```lua
local active_border_color = { colors = { "rgba(798186ee)", "rgba(caccccee)" }, angle = 45 }
```
## Files changed

- `themes/last-horizon/hyprland.lua`
- `themes/solitude/hyprland.lua`
