### PR TITLE
Set corner radius to 0 for notification elements

### DIFF
--- a/default/quickshell/omarchy-shell/plugins/bar/widgets/notificationCenter.qml
+++ b/default/quickshell/omarchy-shell/plugins/bar/widgets/notificationCenter.qml
@@ -51,7 +51,7 @@ Item {
   readonly property color colBorder: Qt.rgba(Color.foreground.r, Color.foreground.g, Color.foreground.b, 0.18)
   readonly property color colSurface: Qt.rgba(Color.foreground.r, Color.foreground.g, Color.foreground.b, 0.06)
   readonly property color colAccent: Color.accent
-  readonly property int cardRadius: notificationService ? notificationService.cornerRadius : 10
+  readonly property int cardRadius: notificationService ? notificationService.cornerRadius : 0
 
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight

--- a/default/quickshell/omarchy-shell/plugins/notifications/Service.qml
+++ b/default/quickshell/omarchy-shell/plugins/notifications/Service.qml
@@ -36,8 +36,8 @@ Item {
 
   // Corner radius is shared with omarchy-shell menu and settings panel —
   // `omarchy style corners <sharp|round>` writes this file once and every
-  // surface reads it. Default 10 keeps the popup looking like it did pre-toggle.
-  property int cornerRadius: 10
+  // surface reads it. Default 0 for sharp corners.
+  property int cornerRadius: 0
 
   // Surfaces anchor relative to the omarchy bar so popups and history land
   // alongside the other shell panels rather than on top of the bar itself.
@@ -53,9 +53,9 @@ Item {
     try {
       var parsed = JSON.parse(raw || "{}")
       var n = Number(parsed.radius)
-      cornerRadius = isFinite(n) && n >= 0 ? n : 10
+      cornerRadius = isFinite(n) && n >= 0 ? n : 0
     } catch (e) {
-      cornerRadius = 10
+      cornerRadius = 0
     }
   }
 

--- a/default/quickshell/omarchy-shell/plugins/notifications/components/NotificationCard.qml
+++ b/default/quickshell/omarchy-shell/plugins/notifications/components/NotificationCard.qml
@@ -22,7 +22,7 @@ Rectangle {
   // NotificationUrgency: Low=0, Normal=1, Critical=2 (upstream).
   property int urgency: 1
   property double timestamp: 0
-  property int cornerRadius: 10
+  property int cornerRadius: 0
 
   property real progress: 1.0
   property bool showProgress: false


### PR DESCRIPTION
I think this was leftover from a default config file. Sorry if this was intentional (doubt it).
