### PR TITLE
fix: window-pop behavior

### DIFF
--- a/bin/omarchy-hyprland-window-float
+++ b/bin/omarchy-hyprland-window-float
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle float/tile and remove pop tag if pinned
+
+active=$(hyprctl activewindow -j)
+pinned=$(echo "$active" | jq ".pinned")
+addr=$(echo "$active" | jq -r ".address")
+window="address:$addr"
+
+hypr_dispatch() {
+  local lua="$1"
+  shift
+
+  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
+}
+
+if [[ $pinned == "true" ]]; then
+  hypr_dispatch "hl.dsp.window.pin({ window = \"$window\" })" pin "$window"
+  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" tagwindow -pop "$window"
+else
+  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+fi

--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -11,6 +11,7 @@ y=${4:-}
 active=$(hyprctl activewindow -j)
 pinned=$(echo "$active" | jq ".pinned")
 addr=$(echo "$active" | jq -r ".address")
+floating=$(echo "$active" | jq -r ".floating")
 window="address:$addr"
 
 hypr_dispatch() {
@@ -25,7 +26,9 @@ if [[ $pinned == "true" ]]; then
   hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
   hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" tagwindow -pop "$window"
 elif [[ -n $addr ]]; then
-  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  if [[ $floating == "false" ]]; then
+    hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  fi
   hypr_dispatch "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" resizeactive exact "$width" "$height" "$window"
 
   if [[ -n $x && -n $y ]]; then

--- a/default/hypr/bindings/tiling-v2.lua
+++ b/default/hypr/bindings/tiling-v2.lua
@@ -3,7 +3,7 @@ o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-clos
 
 o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
-o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
+o.bind("SUPER + T", "Toggle window floating/tiling", "omarchy-hyprland-window-float")
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))
 o.bind("SUPER + CTRL + F", "Tiled full screen", hl.dsp.window.fullscreen_state({ internal = 0, client = 2 }))
 o.bind("SUPER + ALT + F", "Full width", hl.dsp.window.fullscreen({ mode = "maximized" }))


### PR DESCRIPTION
### Problem
Triggering window-pop on an already-floating, non-pinned window would toggle it back to tiled while keeping the pop tag and decorations. Similarly, using the float toggle dispatch on a pinned window would tile it without removing the pop tag.

### Fix
- omarchy-hyprland-window-pop now skips togglefloating if the window is already floating and not pinned. 
- omarchy-hyprland-window-float instead of just toggling dispatch for proper pop tag removal when the window is pinned.
- updated toggle window floating/tiling binding.