### PR TITLE
Add support for Firefox-based browsers in omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,7 +7,17 @@ browser=$(xdg-settings get default-web-browser)
 
 case $browser in
 google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+zen* | firefox* | librewolf* | floorp*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1)
+
+case $browser in
+zen* | firefox* | librewolf* | floorp*)
+  exec setsid uwsm-app -- "$browser_exec" --new-window "$1" "${@:2}"
+  ;;
+*)
+  exec setsid uwsm-app -- "$browser_exec" --app="$1" "${@:2}"
+  ;;
+esac


### PR DESCRIPTION
### Problem
`omarchy-launch-webapp` only handles Chromium-based browsers. When the system default is a Firefox-based browser (Zen, Firefox, LibreWolf, Floorp), the script falls through to the `*)` catch-all and forces `chromium.desktop`, ignoring the user's actual default.

### Solution
Add a Firefox-based browser arm to both `case` statements:
- The first `case` preserves the detected browser instead of overwriting it with `chromium.desktop`
- The second `case` uses `--new-window` instead of `--app`, which is Chromium-specific and unsupported in Firefox

### Changes
```diff
 case $browser in
 google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+zen* | firefox* | librewolf* | floorp*) ;;
 *) browser="chromium.desktop" ;;
 esac
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1)
+case $browser in
+zen* | firefox* | librewolf* | floorp*)
+  exec setsid uwsm-app -- "$browser_exec" --new-window "$1" "${@:2}"
+  ;;
+*)
+  exec setsid uwsm-app -- "$browser_exec" --app="$1" "${@:2}"
+  ;;
+esac
```

Tested with Zen Browser