### PR TITLE
Add Julia installer

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -2,12 +2,12 @@
 
 # omarchy:summary=Install a supported development environment
 # omarchy:name=dev-env
-# omarchy:args=<ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>
+# omarchy:args=<ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala|julia>
 # omarchy:examples=omarchy install dev-env ruby | omarchy install dev-env node
 # omarchy:requires-sudo=true
 
 if [[ -z $1 ]]; then
-  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>" >&2
+  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala|julia>" >&2
   exit 1
 fi
 
@@ -151,5 +151,9 @@ scala)
   mise use --global java@latest
   mise use --global scala@latest
   mise use --global scala-cli@latest
+  ;;
+julia)
+  echo -e "Installing Julia...\n"
+  curl -fsSL https://install.julialang.org | sh -s -- --yes
   ;;
 esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -646,7 +646,7 @@ show_install_font_menu() {
 }
 
 show_install_development_menu() {
-  case $(menu "Install" "󰫏  Ruby on Rails\n  Docker DB\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala") in
+  case $(menu "Install" "󰫏  Ruby on Rails\n  Docker DB\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala\n  Julia") in
   *Rails*) present_terminal "omarchy-install-dev-env ruby" ;;
   *Docker*) present_terminal omarchy-install-docker-dbs ;;
   *JavaScript*) show_install_javascript_menu ;;
@@ -661,6 +661,7 @@ show_install_development_menu() {
   *OCaml*) present_terminal "omarchy-install-dev-env ocaml" ;;
   *Clojure*) present_terminal "omarchy-install-dev-env clojure" ;;
   *Scala*) present_terminal "omarchy-install-dev-env scala" ;;
+  *Julia*) present_terminal "omarchy-install-dev-env julia" ;;
   *) show_install_menu ;;
   esac
 }
@@ -744,7 +745,7 @@ show_remove_gaming_menu() {
 }
 
 show_remove_development_menu() {
-  case $(menu "Remove" "󰫏  Ruby on Rails\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala") in
+  case $(menu "Remove" "󰫏  Ruby on Rails\n  JavaScript\n  Go\n  PHP\n  Python\n  Elixir\n  Zig\n  Rust\n  Java\n  .NET\n  OCaml\n  Clojure\n  Scala\n  Julia") in
   *Rails*) present_terminal "omarchy-remove-dev-env ruby" ;;
   *JavaScript*) show_remove_javascript_menu ;;
   *Go*) present_terminal "omarchy-remove-dev-env go" ;;
@@ -758,6 +759,7 @@ show_remove_development_menu() {
   *OCaml*) present_terminal "omarchy-remove-dev-env ocaml" ;;
   *Clojure*) present_terminal "omarchy-remove-dev-env clojure" ;;
   *Scala*) present_terminal "omarchy-remove-dev-env scala" ;;
+  *Julia*) present_terminal "omarchy-remove-dev-env julia" ;;
   *) show_remove_menu ;;
   esac
 }

--- a/bin/omarchy-remove-dev-env
+++ b/bin/omarchy-remove-dev-env
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # omarchy:summary=Remove a development environment that was previously installed via omarchy-install-dev-env.
-# omarchy:args=<ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala>
+# omarchy:args=<ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala|julia>
 # omarchy:requires-sudo=true
 
 if [[ -z $1 ]]; then
-  echo "Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala>" >&2
+  echo "Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala|julia>" >&2
   exit 1
 fi
 
@@ -103,6 +103,26 @@ scala)
   mise uninstall scala-cli --all
   mise rm -g scala
   mise rm -g scala-cli
+  ;;
+julia)
+  echo -e "Removing Julia...\n"
+  juliaup self uninstall
+  if [[ -d ~/.julia/dev ]]; then
+    echo
+    echo "Warning: ~/.julia/dev contains packages under development:"
+    ls -1 ~/.julia/dev
+    echo
+    read -r -p "Have all your changes been pushed? Delete ~/.julia anyway? [y/N] " reply
+    if [[ $reply =~ ^[Yy]$ ]]; then
+      echo "Deleting the ~/.julia folder."
+      rm -rf ~/.julia
+    else
+      echo "Keeping ~/.julia"
+    fi
+  else
+    echo "Deleting the ~/.julia folder."
+    rm -rf ~/.julia
+  fi
   ;;
 *)
   echo "Unknown environment: $1"


### PR DESCRIPTION
Juliaup is the recommended way to install Julia (similar to rustup with Rust).
It creates `~/.juliaup` and `~/.julia/juliaup`. When using Julia, the downloaded packages gets added to `~/.julia/packages`, precompilation goes to `~/.julia/compiled` etc... so if the user requests to remove Julia we should remove the whole `~/.julia` folder, it might also be quite large when you have a lot of compiled binaries and artifacts downloaded.
One gotcha is that Julia puts packages you develop in `~/.julia/dev`. Since you manage them with git, it's usually fine to just erase that folder but I though we should at least display a warning in case the user forgot to push all the changes.