### PR TITLE
Mask network wait-online services to prevent boot delays

### DIFF
--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -4,3 +4,9 @@ sudo systemctl enable iwd.service
 # Prevent systemd-networkd-wait-online timeout on boot
 sudo systemctl disable systemd-networkd-wait-online.service
 sudo systemctl mask systemd-networkd-wait-online.service
+
+# Guarded: only mask if NetworkManager-wait-online exists (for systems using NM)
+if [ -f /usr/lib/systemd/system/NetworkManager-wait-online.service ] || systemctl list-unit-files | grep -q '^NetworkManager-wait-online'; then
+  sudo systemctl disable --now NetworkManager-wait-online.service 2>/dev/null || true
+  sudo systemctl mask NetworkManager-wait-online.service
+fi

--- a/migrations/1779090175.sh
+++ b/migrations/1779090175.sh
@@ -1,0 +1,9 @@
+echo "Guarded masking of NetworkManager-wait-online.service"
+
+if systemctl list-unit-files | grep -q NetworkManager-wait-online; then
+  systemctl disable --now NetworkManager-wait-online.service 2>/dev/null || true
+  systemctl mask NetworkManager-wait-online.service
+  echo "Masked NetworkManager-wait-online.service"
+else
+  echo "NetworkManager-wait-online not present, skipping"
+fi


### PR DESCRIPTION
[Since DHH asked me to create a PR for this on X](https://x.com/dhh/status/2056092360438628358)

Although it evolved and slimmed down from my original post, since the boot is already quite optimized.

**Summary**

This PR prevents some boot delays caused by systemd-networkd-wait-online and NetworkManager-wait-online services on some occasions.

**Changes**

- Updated install/config/hardware/network.sh to always mask systemd-networkd-wait-online.service and guarded-mask NetworkManager-wait-online.service (when present).
- Added a new migration (migrations/1779090175.sh) to safely apply the same change to existing Omarchy installations.

**Why**

These services wait for a network connection before marking the system as "online", which can cause timeouts on Wi-Fi systems or machines with flaky or unplugged interfaces.

**Effect**

- Faster and more reliable boot times.
- Guarded, so no impact on systems that don't have these services.
- Applies cleanly to both fresh installs and existing ones.