### PR TITLE
Only bind F9 to Voxtype if installed (#5882)

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -20,6 +20,7 @@ if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
   fi
   voxtype setup systemd
 
+  omarchy-hyprland-toggle voxtype on
   omarchy-restart-waybar
   notify-send "    Voxtype Dictation Ready" "Hold F9 to dictate (or toggle with Super + Ctrl + X)." -t 10000
 fi

--- a/bin/omarchy-voxtype-remove
+++ b/bin/omarchy-voxtype-remove
@@ -18,6 +18,7 @@ if omarchy-cmd-present voxtype; then
   omarchy-pkg-drop voxtype-bin
   rm -rf ~/.config/voxtype
   rm -rf ~/.local/share/voxtype
+  omarchy-hyprland-toggle voxtype off
 else
   echo "Voxtype was not installed."
 fi

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -57,10 +57,6 @@ o.bind("SUPER + CTRL + B", "Bluetooth controls", { omarchy = "bluetooth" })
 o.bind("SUPER + CTRL + W", "Wifi controls", { omarchy = "wifi" })
 o.bind("SUPER + CTRL + T", "Activity", { tui = "btop" })
 
-o.bind("SUPER + CTRL + X", "Toggle dictation", "voxtype record toggle")
-o.bind("F9", "Start dictation (push-to-talk)", "voxtype record start")
-o.bind("F9", "Stop dictation (push-to-talk)", "voxtype record stop", { release = true })
-
 o.bind("SUPER + CTRL + Z", "Zoom in", function()
   local zoom = hl.get_config("cursor.zoom_factor") or 1
   hl.config({ cursor = { zoom_factor = zoom + 1 } })

--- a/default/hypr/toggles/voxtype.lua
+++ b/default/hypr/toggles/voxtype.lua
@@ -1,0 +1,3 @@
+o.bind("SUPER + CTRL + X", "Toggle dictation", "voxtype record toggle")
+o.bind("F9", "Start dictation (push-to-talk)", "voxtype record start")
+o.bind("F9", "Stop dictation (push-to-talk)", "voxtype record stop", { release = true })

--- a/migrations/1779297337.sh
+++ b/migrations/1779297337.sh
@@ -1,0 +1,5 @@
+echo "Enable Voxtype keybindings toggle for existing installs"
+
+if omarchy-cmd-present voxtype; then
+  omarchy-hyprland-toggle voxtype on
+fi


### PR DESCRIPTION
**Only bind F9 to Voxtype if installed (#5882)**

Fixes #5882

Currently, F9 is globally bound to Voxtype dictation, which overrides default app bindings even for users who don't have it installed. 

This PR:
- Conditionally binds F9 in `utilities.lua` only if the `voxtype` command is present.
- Adds an `o.has_command` helper in `helpers.lua`. Had to use `io.popen` instead of an inline `if os.execute("omarchy-cmd-present voxtype")...` for this because Hyprland intercepts the `SIGCHLD` signal. This causes `os.execute` to miss the child's exit code (returning `nil` with an `ECHILD` "No child processes" error), making it fail silently. Reading `stdout` via `.popen`  solves this.

No migration needed.

This is my first proper PR, so I apologize for any oversights on contribution standards; couldn't really find any.