### PR TITLE
Fix power profile race on plug/unplug events

### DIFF
--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -11,6 +11,11 @@ action="${1-}"
 # events, and also avoids false negatives from per-port USB-C devices
 # that are present-but-empty (online=0) while another port supplies power.
 if [[ -z $action || $action == "autodetect" ]]; then
+  # On plug/unplug, udev fires the rule before sysfs `online` is updated
+  # on some laptops (notably Lenovo Yoga Pro 7 with USB-C charging). A
+  # short settle delay lets the kernel update before we read state.
+  sleep 0.3
+
   action=battery
   for ps in /sys/class/power_supply/*; do
     [[ -r $ps/online && -r $ps/type ]] || continue


### PR DESCRIPTION
## Problem

On some laptops (notably Lenovo Yoga Pro 7 14IAH10 with USB-C charging), the power profile auto-switcher gets the state wrong after plug/unplug:

- Cable unplugged, profile stays on `performance`
- Cable plugged in, profile sometimes stays on `balanced`
- Running `omarchy-powerprofiles-set` manually after the fact sets it correctly

## Root cause

Two compounding issues in the autodetect branch:

1. **Sysfs lag** — udev fires the rule on `power_supply` change events before the kernel finishes updating `/sys/class/power_supply/*/online`. The script reads the stale value and dispatches the wrong branch.

2. **Multi-event storm** — a single plug/unplug fires 3-4 udev events in <1s (ACAD + each USB-C port). With `systemd-run --unit=omarchy-power-profile --collect`, duplicate invocations against the same unit name can be dropped while the first instance is still running, so the surviving event isn't guaranteed to be the latest one.

Combined, the system can latch onto whichever event happened to fire while sysfs was inconsistent.

## Fix

Add a 0.3s settle delay at the top of the autodetect branch, guarded so it only runs when no explicit action was passed. `omarchy-powerprofiles-set ac` and `omarchy-powerprofiles-set battery` remain instant.

```diff
 if [[ -z $action || $action == "autodetect" ]]; then
+  # On plug/unplug, udev fires the rule before sysfs `online` is updated
+  # on some laptops (notably Lenovo Yoga Pro 7 with USB-C charging). A
+  # short settle delay lets the kernel update before we read state.
+  sleep 0.3
+
   action=battery
```

## Testing

Tested on Lenovo Yoga Pro 7 14IAH10 (Intel Core Ultra 9 285H, Omarchy 3.8.1):

- `bash bin/omarchy-powerprofiles-set autodetect` — 0.44s, sets the correct profile after plug/unplug
- `bash bin/omarchy-powerprofiles-set ac` — 0.14s, no delay
- `bash bin/omarchy-powerprofiles-set battery` — 0.17s, no delay
- Repeated plug/unplug cycles now consistently flip `performance` <-> `balanced`

The 0.3s delay is invisible to the user (the udev path already runs async via `systemd-run --no-block`) and only affects the autodetect path.