### PR TITLE
Enable Docker multi-arch builds by default

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -105,6 +105,7 @@ power-profiles-daemon
 python-gobject
 python-poetry-core
 python-terminaltexteffects
+qemu-user-static-binfmt
 qt5-wayland
 quickshell
 ripgrep

--- a/migrations/1779171487.sh
+++ b/migrations/1779171487.sh
@@ -1,0 +1,3 @@
+echo "Install qemu-user-static-binfmt for multi-arch Docker image building"
+
+omarchy-pkg-add qemu-user-static-binfmt


### PR DESCRIPTION
This enables the building of Docker images for other archs such as **linux/arm64** out of the box, with no additional config needed.

### Before

```
~ ❯ docker buildx ls
NAME/NODE     DRIVER/ENDPOINT   STATUS    BUILDKIT         PLATFORMS
default*      docker
 \_ default    \_ default       running   v0.0.0+unknown   linux/amd64 (+3)
```

`docker buildx build --platform=linux/arm64 ...`  -> **Fails**

### After

```
~ ❯ docker buildx ls
NAME/NODE     DRIVER/ENDPOINT   STATUS    BUILDKIT         PLATFORMS
default*      docker
 \_ default    \_ default       running   v0.0.0+unknown   linux/amd64 (+3), linux/arm64, linux/arm (+2), linux/ppc64le, (6 more)
```

`docker buildx build --platform=linux/arm64 ...`  -> **Succeeds**