### PR TITLE
Simplify omarchy-dev-add-migration and make it possible to override OMARCHY_PATH for dev

### DIFF
--- a/bin/omarchy-dev-add-migration
+++ b/bin/omarchy-dev-add-migration
@@ -2,8 +2,7 @@
 
 # omarchy:summary=Creates a new Omarchy migration named after the unix timestamp of the last commit.
 
-cd ~/.local/share/omarchy
-migration_file="$HOME/.local/share/omarchy/migrations/$(git log -1 --format=%cd --date=unix).sh"
+migration_file="$OMARCHY_PATH/migrations/$(git log -1 --format=%cd --date=unix).sh"
 touch $migration_file
 
 if [[ $1 != "--no-edit" ]]; then


### PR DESCRIPTION
While simplifying the script and making more consistent use of the `OMARCHY_PATH`, this simple change makes it much easier to create migrations in a local Omarchy repo clone without affecting the main installation.

Example: `OMARCHY_PATH=. omarchy-dev-add-migration`


