### PR TITLE
Fix ghost entries after web app removal

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -45,4 +45,8 @@ for APP_NAME in "${APP_NAMES[@]}"; do
   echo "Removed $APP_NAME"
 done
 
+if command -v update-desktop-database &>/dev/null; then
+  update-desktop-database "$DESKTOP_DIR" &>/dev/null || true
+fi
+
 omarchy-restart-walker


### PR DESCRIPTION
## Problem

When removing a single web app via `omarchy-webapp-remove`, the `.desktop` file and icon are deleted but `update-desktop-database` is never called. The desktop database cache stays stale, so the app launcher (Hyprland/walker) continues showing removed apps as ghost entries.

`omarchy-webapp-remove-all` already calls `update-desktop-database` after cleanup — the single-item removal script is missing the same call.

## Fix

Add `update-desktop-database` call after the removal loop in `bin/omarchy-webapp-remove`, matching what `omarchy-webapp-remove-all` already does.

## Testing

1. Install a web app via `omarchy-webapp-install`
2. Remove it via `omarchy-webapp-remove`
3. Before this fix: app still shows in launcher (stale cache)
4. After this fix: app disappears immediately from launcher