### PR TITLE
Fix confusing selected prefix in webapp removal picker

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -19,7 +19,7 @@ if (( $# == 0 )); then
   if ((${#WEB_APPS[@]})); then
     IFS=$'\n' SORTED_WEB_APPS=($(sort <<<"${WEB_APPS[*]}"))
     unset IFS
-    APP_NAMES_STRING=$(gum choose --no-limit --header "Select web app to remove..." --selected-prefix="✗ " "${SORTED_WEB_APPS[@]}")
+    APP_NAMES_STRING=$(gum choose --no-limit --header "Select web app to remove..." --selected-prefix="✓ " "${SORTED_WEB_APPS[@]}")
     # Convert newline-separated string to array
     APP_NAMES=()
     while IFS= read -r line; do


### PR DESCRIPTION
## Problem

When removing web apps via the Omarchy menu (Remove → Web App), the `gum choose` picker uses `--selected-prefix="✗ "` to mark items that will be removed. The `✗` symbol reads as "excluded/cancelled", so users think they are *excluding* items from removal, when in fact they are *selecting* them for removal.

This caused web apps to persist after the user thought they had removed them — the user confirmed the wrong set of items and the apps they wanted gone were not selected.

## Fix

Changed `✗` to `✓` as the `selected-prefix` in the `gum choose` call. Selected items (the ones that **will** be removed) now show `✓`, making the intent unambiguous.

## Testing

- Ran `omarchy-webapp-remove <app_name>` with an explicit argument — the app was correctly removed and walker restarted
- Confirmed the interactive picker now marks selected-for-removal items with ✓ instead of ✗