### PR TITLE
Fix webapp removal picker UX

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -19,7 +19,7 @@ if (( $# == 0 )); then
   if ((${#WEB_APPS[@]})); then
     IFS=$'\n' SORTED_WEB_APPS=($(sort <<<"${WEB_APPS[*]}"))
     unset IFS
-    APP_NAMES_STRING=$(gum choose --no-limit --header "Select web app to remove..." --selected-prefix="✗ " "${SORTED_WEB_APPS[@]}")
+    APP_NAMES_STRING=$(gum choose --no-limit --header "Space to toggle, Enter to confirm" --selected-prefix="✓ " "${SORTED_WEB_APPS[@]}")
     # Convert newline-separated string to array
     APP_NAMES=()
     while IFS= read -r line; do


### PR DESCRIPTION
## Problem

When removing web apps via the Omarchy menu (Remove → Web App), two UX issues made the `gum choose` picker confusing:

1. **✗ prefix on selected items**: Selected (to-be-removed) items were shown with `✗`, which reads as "excluded/cancelled". Users thought they were *deselecting* apps, not selecting them for removal.

2. **No hint about interaction model**: The header said "Select web app to remove..." but `gum choose --no-limit` requires pressing Space to toggle items before pressing Enter. Users would scroll to items and press Enter without toggling — resulting in zero selections and a confusing "must select at least one" error. This made it appear that removal simply "did not work."

Command-line usage (`omarchy-webapp-remove Agentur`) worked correctly — the bug is purely in the interactive picker UX.

## Fix

- Changed `--selected-prefix` from `"✗ "` to `"✓ "` so selected items are unambiguously marked
- Changed `--header` from `"Select web app to remove..."` to `"Space to toggle, Enter to confirm"` so users understand the interaction model

## Testing

- `omarchy-webapp-remove Agentur` (explicit arg) — confirmed removal works, walker restarts
- Interactive picker now shows ✓ on selected items and explains the key bindings