### PR TITLE
Fix webapp removal picker UX

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -19,7 +19,7 @@ if (( $# == 0 )); then
   if ((${#WEB_APPS[@]})); then
     IFS=$'\n' SORTED_WEB_APPS=($(sort <<<"${WEB_APPS[*]}"))
     unset IFS
-    APP_NAMES_STRING=$(gum choose --no-limit --header "Select web app to remove..." --selected-prefix="✗ " "${SORTED_WEB_APPS[@]}")
+    APP_NAMES_STRING=$(gum choose --no-limit --header "Space to toggle, Enter to confirm" --selected-prefix="✓ " "${SORTED_WEB_APPS[@]}")
     # Convert newline-separated string to array
     APP_NAMES=()
     while IFS= read -r line; do
@@ -35,8 +35,8 @@ else
 fi
 
 if (( ${#APP_NAMES[@]} == 0 )); then
-  echo "You must select at least one web app to remove."
-  exit 1
+  echo "Cancelled — no apps selected."
+  exit 130
 fi
 
 for APP_NAME in "${APP_NAMES[@]}"; do


### PR DESCRIPTION
## Problem

When removing web apps via the Omarchy menu (Remove → Web App), two UX issues make the picker appear broken:

1. **Misleading selections and no interaction hint**: `gum choose --no-limit` uses `✗` as the selected-prefix, suggesting exclusion. More critically, `--no-limit` requires pressing Space to toggle items before pressing Enter to confirm — but the header "Select web app to remove..." gives no hint about this. Users scroll to items and press Enter without toggling, resulting in zero selections and nothing being removed.

2. **False "Done!" on cancellation**: When no items are selected (user presses Escape or navigates without toggling), the script exits with code 1. The terminal wrapper (`omarchy-launch-floating-terminal-with-presentation`) only suppresses the "Done!" message for exit code 130 (the Ctrl+C convention). So the user sees "Done! Press any key to close..." and thinks removal succeeded when nothing was removed.

Command-line usage (`omarchy-webapp-remove AppName`) works correctly — the bug is purely in the interactive picker UX.

## Fix

- Changed `--selected-prefix` from `"✗ "` to `"✓ "` — selected items are unambiguously marked
- Changed `--header` from `"Select web app to remove..."` to `"Space to toggle, Enter to confirm"` — makes the interaction model discoverable
- Changed empty-selection exit code from `1` to `130` — the terminal wrapper already skips the "Done!" message for exit code 130, so a cancelled/empty selection silently closes the terminal instead of showing a misleading success message

## Testing

- `omarchy-webapp-remove Agentur` (explicit arg) — confirmed file deletion and walker restart
- Command-line removal works for any app name including names with spaces (`"Google Contacts"`)
- Interactive path now shows `✓` on selected items and explains key bindings