### PR TITLE
fix looknfeel.conf compat with Hyprland 0.55.x

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -50,8 +50,8 @@ decoration {
 group {
     col.border_active = $activeBorderColor
     col.border_inactive = $inactiveBorderColor
-    col.border_locked_active = -1
-    col.border_locked_inactive = -1
+    col.border_locked_active = $activeBorderColor
+    col.border_locked_inactive = $inactiveBorderColor
 
     groupbar {
         font_size = 12
@@ -108,9 +108,8 @@ animations {
 
 # See https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/ for more
 dwindle {
-    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
-    preserve_split = true # You probably want this
-    force_split = 2 # Always split on the right
+    preserve_split = true
+    force_split = 2
 }
 
 scrolling {


### PR DESCRIPTION
fixes #5921

two things broke on 0.55.x:

- `-1` is no longer valid as a gradient color, replaced with the existing `$activeBorderColor`/`$inactiveBorderColor` vars that are already used right above
- `dwindle:pseudotile` was removed from Hyprland, causes a config error on every load

both trigger the big red error overlay. `dev` already has these fixed in the lua rewrite, this just patches master in the meantime.