### PR TITLE
Install mpv MPRIS support

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -82,6 +82,7 @@ man-db
 mariadb-libs
 mise
 mpv
+mpv-mpris
 nautilus
 nautilus-python
 gnome-disk-utility

--- a/migrations/1778623107.sh
+++ b/migrations/1778623107.sh
@@ -1,0 +1,5 @@
+echo "Install MPRIS support for mpv"
+
+if omarchy-pkg-missing mpv-mpris; then
+  omarchy-pkg-add mpv-mpris
+fi


### PR DESCRIPTION
Replaces #5790, which GitHub would not allow to be reopened after rebasing.

Adds mpv MPRIS support to the base package list and installs it for existing systems via migration.