### PR TITLE
Gracefully handle installations on ZFS file systems

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -26,6 +26,11 @@ if ! $NO_REBUILD && ! command -v limine-mkinitcpio &>/dev/null; then
   exit 0
 fi
 
+if [[ $(findmnt -n -o FSTYPE /) != "btrfs" ]]; then
+  echo "Skipping hibernation setup (requires Btrfs root filesystem)"
+  exit 0
+fi
+
 MKINITCPIO_CONF="/etc/mkinitcpio.conf.d/omarchy_resume.conf"
 SWAP_FILE="/swap/swapfile"
 RESUME_DROP_IN="/etc/limine-entry-tool.d/resume.conf"

--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Create or restore system snapshots with snapper
+# omarchy:summary=Create or restore system snapshots
 # omarchy:args=<create|restore>
 # omarchy:requires-sudo=true
 
@@ -14,26 +14,44 @@ if [[ -z $COMMAND ]]; then
   exit 1
 fi
 
-if ! command -v snapper &>/dev/null; then
-  exit 127 # omarchy-update can use this to just ignore if snapper is not available
-fi
-
 case "$COMMAND" in
 create)
-  DESC="$(omarchy-version)"
+  root_fstype=$(findmnt -n -o FSTYPE /)
 
   echo -e "\e[32mCreate system snapshot\e[0m"
 
-  # Get existing snapper config names from CSV output
-  mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
+  if [[ $root_fstype == "zfs" ]]; then
+    command -v zfs &>/dev/null || exit 127 # omarchy-update ignores this when snapshots are unavailable
 
-  for config in "${CONFIGS[@]}"; do
-    sudo snapper -c "$config" create -c number -d "$DESC"
-    sudo snapper -c "$config" cleanup number
-  done
+    root_dataset=$(findmnt -n -o SOURCE /)
+    version=$(omarchy-version)
+    version=${version//[^A-Za-z0-9_.:-]/-}
+    snapshot="omarchy-$version-$(date +%Y%m%d%H%M%S)"
+
+    sudo zfs snapshot "$root_dataset@$snapshot"
+
+    mapfile -t snapshots < <(sudo zfs list -H -t snapshot -o name -s creation -d 1 "$root_dataset" 2>/dev/null | grep -F "$root_dataset@omarchy-" || true)
+    while ((${#snapshots[@]} > 5)); do
+      sudo zfs destroy "${snapshots[0]}"
+      snapshots=("${snapshots[@]:1}")
+    done
+  else
+    command -v snapper &>/dev/null || exit 127 # omarchy-update ignores this when snapshots are unavailable
+
+    DESC="$(omarchy-version)"
+
+    # Get existing snapper config names from CSV output
+    mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
+
+    for config in "${CONFIGS[@]}"; do
+      sudo snapper -c "$config" create -c number -d "$DESC"
+      sudo snapper -c "$config" cleanup number
+    done
+  fi
   echo
   ;;
 restore)
+  command -v snapper &>/dev/null || exit 127
   sudo limine-snapper-restore
   ;;
 esac

--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -24,16 +24,27 @@ create)
     command -v zfs &>/dev/null || exit 127 # omarchy-update ignores this when snapshots are unavailable
 
     root_dataset=$(findmnt -n -o SOURCE /)
+    home_dataset=""
+    if [[ $(findmnt -n -o FSTYPE "$HOME" 2>/dev/null || true) == "zfs" ]]; then
+      home_dataset=$(findmnt -n -o SOURCE "$HOME")
+    fi
     version=$(omarchy-version)
     version=${version//[^A-Za-z0-9_.:-]/-}
     snapshot="omarchy-$version-$(date +%Y%m%d%H%M%S)"
 
-    sudo zfs snapshot "$root_dataset@$snapshot"
+    datasets=("$root_dataset")
+    if [[ -n $home_dataset && $home_dataset != $root_dataset ]]; then
+      datasets+=("$home_dataset")
+    fi
 
-    mapfile -t snapshots < <(sudo zfs list -H -t snapshot -o name -s creation -d 1 "$root_dataset" 2>/dev/null | grep -F "$root_dataset@omarchy-" || true)
-    while ((${#snapshots[@]} > 5)); do
-      sudo zfs destroy "${snapshots[0]}"
-      snapshots=("${snapshots[@]:1}")
+    for dataset in "${datasets[@]}"; do
+      sudo zfs snapshot "$dataset@$snapshot"
+
+      mapfile -t snapshots < <(sudo zfs list -H -t snapshot -o name -s creation -d 1 "$dataset" 2>/dev/null | grep -F "$dataset@omarchy-" || true)
+      while ((${#snapshots[@]} > 5)); do
+        sudo zfs destroy "${snapshots[0]}"
+        snapshots=("${snapshots[@]:1}")
+      done
     done
   else
     command -v snapper &>/dev/null || exit 127 # omarchy-update ignores this when snapshots are unavailable

--- a/install/helpers/all.sh
+++ b/install/helpers/all.sh
@@ -1,4 +1,5 @@
 source $OMARCHY_INSTALL/helpers/chroot.sh
+source $OMARCHY_INSTALL/helpers/pacman.sh
 source $OMARCHY_INSTALL/helpers/presentation.sh
 source $OMARCHY_INSTALL/helpers/errors.sh
 source $OMARCHY_INSTALL/helpers/logging.sh

--- a/install/helpers/pacman.sh
+++ b/install/helpers/pacman.sh
@@ -12,7 +12,7 @@ use_omarchy_pacman_config() {
   sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$mirror.conf" /etc/pacman.conf
   sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$mirror" /etc/pacman.d/mirrorlist
 
-  if [[ -n $archzfs_repo ]]; then
+  if [[ -n $archzfs_repo ]] && ! grep -q '^\[archzfs\]$' /etc/pacman.conf; then
     printf "\n" | sudo tee -a /etc/pacman.conf >/dev/null
     printf "%s\n" "$archzfs_repo" | sudo tee -a /etc/pacman.conf >/dev/null
   fi

--- a/install/helpers/pacman.sh
+++ b/install/helpers/pacman.sh
@@ -1,25 +1,21 @@
 use_omarchy_pacman_config() {
   local mirror="${OMARCHY_MIRROR:-stable}"
-  local archzfs_repo
-
-  archzfs_repo=$(mktemp)
+  local archzfs_repo=""
 
   if [[ -f /etc/pacman.conf ]]; then
-    awk '
+    archzfs_repo=$(awk '
       /^\[/ { in_archzfs = ($0 == "[archzfs]") }
       in_archzfs { print }
-    ' /etc/pacman.conf >"$archzfs_repo"
+    ' /etc/pacman.conf)
   fi
 
   sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$mirror.conf" /etc/pacman.conf
   sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$mirror" /etc/pacman.d/mirrorlist
 
-  if [[ -s $archzfs_repo ]]; then
+  if [[ -n $archzfs_repo ]]; then
     printf "\n" | sudo tee -a /etc/pacman.conf >/dev/null
-    sudo tee -a /etc/pacman.conf <"$archzfs_repo" >/dev/null
+    printf "%s\n" "$archzfs_repo" | sudo tee -a /etc/pacman.conf >/dev/null
   fi
-
-  rm -f "$archzfs_repo"
 }
 
 export -f use_omarchy_pacman_config

--- a/install/helpers/pacman.sh
+++ b/install/helpers/pacman.sh
@@ -1,0 +1,25 @@
+use_omarchy_pacman_config() {
+  local mirror="${OMARCHY_MIRROR:-stable}"
+  local archzfs_repo
+
+  archzfs_repo=$(mktemp)
+
+  if [[ -f /etc/pacman.conf ]]; then
+    awk '
+      /^\[/ { in_archzfs = ($0 == "[archzfs]") }
+      in_archzfs { print }
+    ' /etc/pacman.conf >"$archzfs_repo"
+  fi
+
+  sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$mirror.conf" /etc/pacman.conf
+  sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$mirror" /etc/pacman.d/mirrorlist
+
+  if [[ -s $archzfs_repo ]]; then
+    printf "\n" | sudo tee -a /etc/pacman.conf >/dev/null
+    sudo tee -a /etc/pacman.conf <"$archzfs_repo" >/dev/null
+  fi
+
+  rm -f "$archzfs_repo"
+}
+
+export -f use_omarchy_pacman_config

--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -5,6 +5,9 @@ if command -v limine &>/dev/null; then
     sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
 HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt zfs filesystems)
 EOF
+    sudo tee /etc/mkinitcpio.conf.d/zfs_hostid.conf <<EOF >/dev/null
+FILES+=(/etc/hostid)
+EOF
   else
     sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
 HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)

--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -42,7 +42,7 @@ EOF
   # post-transaction deploy hook runs limine-install and reads this file. Without
   # it, ESP_PATH falls back to bootctl, which in a chroot prints a warning that
   # gets captured as the path and trips a spurious "invalid ESP" error.
-  sudo cp $OMARCHY_PATH/default/limine/default.conf /etc/default/limine
+  sudo cp "$OMARCHY_PATH/default/limine/default.conf" /etc/default/limine
   sudo sed -i "s|@@CMDLINE@@|$CMDLINE|g" /etc/default/limine
 
   # Append any drop-in kernel cmdline configs (from hardware fix scripts, etc.)
@@ -62,7 +62,7 @@ EOF
   fi
 
   # We overwrite the whole thing knowing the limine-update will add the entries for us
-  sudo cp $OMARCHY_PATH/default/limine/limine.conf /boot/limine.conf
+  sudo cp "$OMARCHY_PATH/default/limine/limine.conf" /boot/limine.conf
 
   if [[ $root_fstype == "btrfs" ]]; then
     sudo pacman -S --noconfirm --needed limine-snapper-sync limine-mkinitcpio-hook
@@ -75,7 +75,7 @@ EOF
     if ! sudo snapper list-configs 2>/dev/null | grep -q "root"; then
       sudo snapper -c root create-config /
     fi
-    sudo cp $OMARCHY_PATH/default/snapper/root /etc/snapper/configs/root
+    sudo cp "$OMARCHY_PATH/default/snapper/root" /etc/snapper/configs/root
 
     # Disable btrfs quotas — full qgroup accounting is a major performance drag
     sudo btrfs quota disable / 2>/dev/null || true

--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -3,7 +3,7 @@ root_fstype=$(findmnt -n -o FSTYPE /)
 if command -v limine &>/dev/null; then
   if [[ $root_fstype == "zfs" ]]; then
     sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
-HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block zfs filesystems)
+HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt zfs filesystems)
 EOF
   else
     sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null

--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -1,7 +1,15 @@
+root_fstype=$(findmnt -n -o FSTYPE /)
+
 if command -v limine &>/dev/null; then
-  sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
+  if [[ $root_fstype == "zfs" ]]; then
+    sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
+HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block zfs filesystems)
+EOF
+  else
+    sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
 HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
 EOF
+  fi
   sudo tee /etc/mkinitcpio.conf.d/thunderbolt_module.conf <<EOF >/dev/null
 MODULES+=(thunderbolt)
 EOF
@@ -10,22 +18,22 @@ EOF
   [[ -d /sys/firmware/efi ]] && EFI=true
 
   # Find config location
-  if [[ -f /boot/EFI/arch-limine/limine.conf ]]; then
+  if sudo test -f /boot/EFI/arch-limine/limine.conf; then
     limine_config="/boot/EFI/arch-limine/limine.conf"
-  elif [[ -f /boot/EFI/BOOT/limine.conf ]]; then
+  elif sudo test -f /boot/EFI/BOOT/limine.conf; then
     limine_config="/boot/EFI/BOOT/limine.conf"
-  elif [[ -f /boot/EFI/limine/limine.conf ]]; then
+  elif sudo test -f /boot/EFI/limine/limine.conf; then
     limine_config="/boot/EFI/limine/limine.conf"
-  elif [[ -f /boot/limine/limine.conf ]]; then
+  elif sudo test -f /boot/limine/limine.conf; then
     limine_config="/boot/limine/limine.conf"
-  elif [[ -f /boot/limine.conf ]]; then
+  elif sudo test -f /boot/limine.conf; then
     limine_config="/boot/limine.conf"
   else
     echo "Error: Limine config not found" >&2
     exit 1
   fi
 
-  CMDLINE=$(grep "^[[:space:]]*cmdline:" "$limine_config" | head -1 | sed 's/^[[:space:]]*cmdline:[[:space:]]*//')
+  CMDLINE=$(sudo grep "^[[:space:]]*cmdline:" "$limine_config" | head -1 | sed 's/^[[:space:]]*cmdline:[[:space:]]*//')
 
   # Write /etc/default/limine *before* installing limine-mkinitcpio-hook, whose
   # post-transaction deploy hook runs limine-install and reads this file. Without
@@ -46,25 +54,31 @@ EOF
 
   # Remove the original config file if it's not /boot/limine.conf, so the deploy
   # hook doesn't see conflicting configs on the same ESP.
-  if [[ $limine_config != "/boot/limine.conf" ]] && [[ -f $limine_config ]]; then
+  if [[ $limine_config != "/boot/limine.conf" ]] && sudo test -f "$limine_config"; then
     sudo rm "$limine_config"
   fi
 
   # We overwrite the whole thing knowing the limine-update will add the entries for us
   sudo cp $OMARCHY_PATH/default/limine/limine.conf /boot/limine.conf
 
-  sudo pacman -S --noconfirm --needed limine-snapper-sync limine-mkinitcpio-hook
-
-  # Only snapshot root — /home is user data; rolling it back loses user work
-  if ! sudo snapper list-configs 2>/dev/null | grep -q "root"; then
-    sudo snapper -c root create-config /
+  if [[ $root_fstype == "btrfs" ]]; then
+    sudo pacman -S --noconfirm --needed limine-snapper-sync limine-mkinitcpio-hook
+  else
+    sudo pacman -S --noconfirm --needed limine-mkinitcpio-hook
   fi
-  sudo cp $OMARCHY_PATH/default/snapper/root /etc/snapper/configs/root
 
-  # Disable btrfs quotas — full qgroup accounting is a major performance drag
-  sudo btrfs quota disable / 2>/dev/null || true
+  if [[ $root_fstype == "btrfs" ]]; then
+    # Only snapshot root — /home is user data; rolling it back loses user work
+    if ! sudo snapper list-configs 2>/dev/null | grep -q "root"; then
+      sudo snapper -c root create-config /
+    fi
+    sudo cp $OMARCHY_PATH/default/snapper/root /etc/snapper/configs/root
 
-  chrootable_systemctl_enable limine-snapper-sync.service
+    # Disable btrfs quotas — full qgroup accounting is a major performance drag
+    sudo btrfs quota disable / 2>/dev/null || true
+
+    chrootable_systemctl_enable limine-snapper-sync.service
+  fi
 fi
 
 echo "Re-enabling mkinitcpio hooks..."
@@ -85,11 +99,11 @@ echo "mkinitcpio hooks re-enabled"
 # boot entries into /boot/limine.conf. Only fall back to limine-update if those
 # hooks didn't run for some reason — running it unconditionally rebuilds every
 # UKI a second time.
-if ! grep -q "^/+" /boot/limine.conf; then
+if ! sudo grep -q "^/+" /boot/limine.conf; then
   sudo limine-update
 fi
 
-if ! grep -q "^/+" /boot/limine.conf; then
+if ! sudo grep -q "^/+" /boot/limine.conf; then
   echo "Error: failed to add boot entries to /boot/limine.conf" >&2
   exit 1
 fi

--- a/install/post-install/pacman.sh
+++ b/install/post-install/pacman.sh
@@ -1,6 +1,5 @@
 # Configure pacman
-sudo cp -f ~/.local/share/omarchy/default/pacman/pacman-${OMARCHY_MIRROR:-stable}.conf /etc/pacman.conf
-sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-${OMARCHY_MIRROR:-stable} /etc/pacman.d/mirrorlist
+use_omarchy_pacman_config
 
 if lspci -nn | grep -q "106b:180[12]"; then
   cat <<EOF | sudo tee -a /etc/pacman.conf >/dev/null

--- a/install/post-install/pacman.sh
+++ b/install/post-install/pacman.sh
@@ -1,3 +1,7 @@
+if ! declare -F use_omarchy_pacman_config >/dev/null; then
+  source "${OMARCHY_INSTALL:-${BASH_SOURCE[0]%/*}/..}/helpers/pacman.sh"
+fi
+
 # Configure pacman
 use_omarchy_pacman_config
 

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -39,8 +39,10 @@ fi
 # Must have limine installed
 command -v limine &>/dev/null || abort "Limine bootloader"
 
-# Must have btrfs root filesystem
-[[ $(findmnt -n -o FSTYPE /) = "btrfs" ]] || abort "Btrfs root filesystem" 
+root_fstype=$(findmnt -n -o FSTYPE /)
+
+# Must have a supported snapshot-capable root filesystem
+[[ $root_fstype == "btrfs" || $root_fstype == "zfs" ]] || abort "Btrfs or ZFS root filesystem"
 
 # Cleared all guards
 echo "Guards: OK"

--- a/install/preflight/pacman.sh
+++ b/install/preflight/pacman.sh
@@ -3,8 +3,7 @@ if [[ -n ${OMARCHY_ONLINE_INSTALL:-} ]]; then
   omarchy-pkg-add base-devel
 
   # Configure pacman
-  sudo cp -f ~/.local/share/omarchy/default/pacman/pacman-${OMARCHY_MIRROR:-stable}.conf /etc/pacman.conf
-  sudo cp -f ~/.local/share/omarchy/default/pacman/mirrorlist-${OMARCHY_MIRROR:-stable} /etc/pacman.d/mirrorlist
+  use_omarchy_pacman_config
 
   sudo pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver keys.openpgp.org
   sudo pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571

--- a/install/preflight/pacman.sh
+++ b/install/preflight/pacman.sh
@@ -2,6 +2,10 @@ if [[ -n ${OMARCHY_ONLINE_INSTALL:-} ]]; then
   # Install build tools
   omarchy-pkg-add base-devel
 
+  if ! declare -F use_omarchy_pacman_config >/dev/null; then
+    source "${OMARCHY_INSTALL:-${BASH_SOURCE[0]%/*}/..}/helpers/pacman.sh"
+  fi
+
   # Configure pacman
   use_omarchy_pacman_config
 


### PR DESCRIPTION
## Summary
- Recognize ZFS as a supported existing root filesystem during install preflight.
- Preserve an existing `[archzfs]` pacman repo when Omarchy replaces pacman config.
- Use ZFS-aware Limine/mkinitcpio hooks on ZFS roots while keeping Snapper setup on Btrfs roots.
- Embed `/etc/hostid` in the ZFS initramfs so imported pools continue to boot reliably.
- Skip Btrfs-only hibernation setup on non-Btrfs roots.
- Create `omarchy-*` ZFS snapshots for ZFS roots and retain the newest five snapshots; keep the existing Snapper snapshot path for non-ZFS roots.

This does not enable or install ZFS. It only keeps Omarchy from rejecting or breaking an already configured ZFS-root system, preserves the ZFS boot requirements, and lets Omarchy's snapshot command create root dataset snapshots on those systems.

## Tests
- Installed on standard Arch with ZFS: working.
- Installed on patched `omarchy-iso` repo: working, [PR here](https://github.com/omacom-io/omarchy-iso/pull/80).
- Installed and running in actual Dell XPS 14 2026.
- Tested on CachyOS: not working without this patch and still not working with this patch due to unrelated reasons.

## ISO
A full test ISO is available here: https://www.berenddeboer.net/tmp/omarchy-2026.05.14-x86_64-master.iso

Replaces #5637.