### PR TITLE
Fix: Remove unwanted tint from daylight toggle

### DIFF
--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -4,7 +4,7 @@
 # omarchy:examples=omarchy toggle nightlight
 
 ON_TEMP=4000
-OFF_TEMP=6000
+OFF_TEMP=6500
 
 # Ensure hyprsunset is running
 if ! pgrep -x hyprsunset; then


### PR DESCRIPTION
The nightlight toggle currently cycles between 4000K and 6000K, but 6000K is not neutral. It leaves a slight warm tint, so there is no way to reach a true 'off' state once you pressed the shortcut once.

The script previously had an `OFF_TEMP` value of 6500 in 3fb1bf9 but was changed to 6000K in d9efaac which seems like a mistake?

  #4723 already explored using `hyprctl hyprsunset identity` instead of hardcoding an 'off' temperature, but it does not correctly restore the value of `hyprctl hyprsunset temperature`.  As noted in hyprwm/hyprsunset#26  this is a known issue with hyprsunset and the practical workaround is **"don't use identity, set the temperature instead"** 

So the best (current) solution is to stick to the previous 6500K value until there is a more reliable solution upstream.

Side note: hyprwm/hyprsunset#26 specifically notes that 6650K is technically 'closer' to identity, but 6500K is standard regardless and the difference is miniscule