### PR TITLE
Unmute when adjusting volume from the volume keys

### DIFF
--- a/bin/omarchy-audio-output-volume
+++ b/bin/omarchy-audio-output-volume
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# omarchy:summary=Adjust output volume with OSD, unmuting first so volume keys recover from a muted sink in a single press.
+# omarchy:args=raise|lower|(±)number
+
+# Raising or lowering the volume while the sink is muted should unmute it, the
+# way hardware volume keys behave on other desktops. swayosd's --output-volume
+# only changes the level and leaves the mute flag set, so a muted laptop stays
+# silent until the user separately hits mute. Clear the flag first, then let
+# swayosd apply the change and render the OSD (which reflects the unmuted state).
+wpctl set-mute @DEFAULT_AUDIO_SINK@ 0 >/dev/null 2>&1
+
+omarchy-swayosd-client --output-volume "$1"

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -1,6 +1,6 @@
 # Laptop multimedia keys for volume and LCD brightness (with OSD)
-bindeld = ,XF86AudioRaiseVolume, Volume up, exec, omarchy-swayosd-client --output-volume raise
-bindeld = ,XF86AudioLowerVolume, Volume down, exec, omarchy-swayosd-client --output-volume lower
+bindeld = ,XF86AudioRaiseVolume, Volume up, exec, omarchy-audio-output-volume raise
+bindeld = ,XF86AudioLowerVolume, Volume down, exec, omarchy-audio-output-volume lower
 bindeld = ,XF86AudioMute, Mute, exec, omarchy-swayosd-client --output-volume mute-toggle
 bindeld = ,XF86AudioMicMute, Mute microphone, exec, omarchy-audio-input-mute
 bindeld = ,XF86MonBrightnessUp, Brightness up, exec, omarchy-brightness-display +5%
@@ -15,8 +15,8 @@ bindld = ,XF86TouchpadOn, Enable touchpad, exec, omarchy-toggle-touchpad on
 bindld = ,XF86TouchpadOff, Disable touchpad, exec, omarchy-toggle-touchpad off
 
 # Precise 1% multimedia adjustments with Alt modifier
-bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, omarchy-swayosd-client --output-volume +1
-bindeld = ALT, XF86AudioLowerVolume, Volume down precise, exec, omarchy-swayosd-client --output-volume -1
+bindeld = ALT, XF86AudioRaiseVolume, Volume up precise, exec, omarchy-audio-output-volume +1
+bindeld = ALT, XF86AudioLowerVolume, Volume down precise, exec, omarchy-audio-output-volume -1
 bindeld = ALT, XF86MonBrightnessUp, Brightness up precise, exec, omarchy-brightness-display +1%
 bindeld = ALT, XF86MonBrightnessDown, Brightness down precise, exec, omarchy-brightness-display 1%-
 


### PR DESCRIPTION
## Problem

The laptop volume keys are bound to:

```conf
bindeld = ,XF86AudioRaiseVolume, Volume up,   exec, omarchy-swayosd-client --output-volume raise
bindeld = ,XF86AudioLowerVolume, Volume down, exec, omarchy-swayosd-client --output-volume lower
```

`swayosd-client --output-volume raise/lower` changes the sink's volume *level* but leaves the **mute flag** untouched. So when the machine is muted (e.g. you pressed `XF86AudioMute`), pressing volume up/down does nothing audible — the level changes behind a still-set mute flag.

To actually get sound back you have to press mute first, *then* adjust. That extra step doesn't match how volume keys behave on macOS/Windows/GNOME/KDE, where nudging the volume up or down also unmutes.

## Fix

Add `bin/omarchy-audio-output-volume`, a small wrapper that clears the mute flag before delegating the raise/lower to swayosd:

```bash
wpctl set-mute @DEFAULT_AUDIO_SINK@ 0 >/dev/null 2>&1
omarchy-swayosd-client --output-volume "$1"
```

Because swayosd reads the sink state when it renders, the OSD still pops up and correctly shows the new, unmuted level. `set-mute … 0` is idempotent, so when you're already unmuted it's a no-op and normal volume changes behave exactly as before.

`default/hypr/bindings/media.conf` now points the volume up/down keys — and their ALT precise (`+1`/`-1`) variants — at the wrapper. **Mute-toggle is intentionally left on `omarchy-swayosd-client --output-volume mute-toggle`** so it keeps toggling rather than unconditionally unmuting.

This follows the existing convention of small dedicated `omarchy-*` audio scripts (`omarchy-audio-input-mute`, `omarchy-audio-output-switch`).

## Testing

On a Zenbook S14 (PipeWire/WirePlumber):

```
$ wpctl set-mute @DEFAULT_AUDIO_SINK@ 1
$ wpctl get-volume @DEFAULT_AUDIO_SINK@
Volume: 0.50 [MUTED]
$ omarchy-audio-output-volume raise
$ wpctl get-volume @DEFAULT_AUDIO_SINK@
Volume: 0.55          # unmuted and raised in one press; OSD shown
```

- Volume up/down while muted → unmutes and adjusts, single keypress.
- Volume up/down while already unmuted → unchanged behavior.
- Mute-toggle (`XF86AudioMute`) → unchanged.
