### PR TITLE
Open links originating from apps/terminals in the current workspace

### DIFF
--- a/applications/hidden/omarchy-handle-url.desktop
+++ b/applications/hidden/omarchy-handle-url.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+NoDisplay=true
+Type=Application
+Name=Omarchy URL Handler
+Comment=Open URLs with Omarchy's workspace-aware browser launcher
+Exec=omarchy-handle-url %u
+Terminal=false
+MimeType=x-scheme-handler/http;x-scheme-handler/https;

--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -33,8 +33,6 @@ zen) desktop_id="zen.desktop"; name="Zen"; glyph="󰖟" ;;
 esac
 
 xdg-settings set default-web-browser "$desktop_id"
-xdg-mime default "$desktop_id" x-scheme-handler/http
-xdg-mime default "$desktop_id" x-scheme-handler/https
 xdg-mime default "$desktop_id" text/html
 
 notify-send -u low "$glyph    $name is now the default browser"

--- a/bin/omarchy-handle-url
+++ b/bin/omarchy-handle-url
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# omarchy:summary=Open links in a browser for the current Hyprland workspace
+# omarchy:args=<url>
+
+# This script is meant to be registered as the XDG handler for http/https links.
+# It keeps Omarchy's normal browser behavior, but adds one workspace-aware decision
+# before launching:
+#
+# - If there is already a browser window on the current workspace, focus it and open
+#   the URL there.
+# - Otherwise, ask the default browser for a new window, which Hyprland will place on
+#   the current workspace.
+
+if (($# == 0)); then
+  echo "Usage: omarchy-link-handler <url>" >&2
+  exit 1
+fi
+
+# New browser windows open on the active Hyprland workspace by default.
+CURRENT_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
+
+BROWSER_TAG='^(chromium|firefox)-based-browser\*?$'
+
+# Find a Chromium- or Firefox-based browser already tagged on this workspace.
+BROWSER_ADDRESS=$(
+  hyprctl clients -j | jq -r \
+    --argjson workspace "$CURRENT_WORKSPACE" \
+    --arg tag "$BROWSER_TAG" '
+      .[]
+      | select(.workspace.id == $workspace)
+      | select(any(.tags[]?; test($tag)))
+      | .address
+    ' | head -1
+)
+
+if [[ -n $BROWSER_ADDRESS ]]; then
+  # Focus the current workspace's browser so the URL is opened there.
+  hyprctl dispatch focuswindow "address:$BROWSER_ADDRESS" >/dev/null
+  exec omarchy-launch-browser "$1"
+else
+  # No browser exists in this workspace, so create a new default browser window here.
+  exec omarchy-launch-browser --new-window "$1"
+fi

--- a/bin/omarchy-handle-url
+++ b/bin/omarchy-handle-url
@@ -12,7 +12,7 @@
 #   the current workspace.
 
 if (($# == 0)); then
-  echo "Usage: omarchy-link-handler <url>" >&2
+  echo "Usage: omarchy-handle-url <url>" >&2
   exit 1
 fi
 

--- a/bin/omarchy-handle-url
+++ b/bin/omarchy-handle-url
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-# omarchy:summary=Open links in a browser for the current Hyprland workspace
+# omarchy:summary=Open links in the current Hyprland workspace
 # omarchy:args=<url>
 
 # This script is meant to be registered as the XDG handler for http/https links.
-# It keeps Omarchy's normal browser behavior, but adds one workspace-aware decision
-# before launching:
+# It makes a workspace-aware decision before launching:
 #
 # - If there is already a browser window on the current workspace, focus it and open
 #   the URL there.
@@ -17,12 +16,11 @@ if (($# == 0)); then
   exit 1
 fi
 
-# New browser windows open on the active Hyprland workspace by default.
 CURRENT_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
-
+# Tags applied to true browser windows.
 BROWSER_TAG='^(chromium|firefox)-based-browser\*?$'
 
-# Find a Chromium- or Firefox-based browser already tagged on this workspace.
+# Find a browser in this workspace.
 BROWSER_ADDRESS=$(
   hyprctl clients -j | jq -r \
     --argjson workspace "$CURRENT_WORKSPACE" \
@@ -37,8 +35,10 @@ BROWSER_ADDRESS=$(
 if [[ -n $BROWSER_ADDRESS ]]; then
   # Focus the current workspace's browser so the URL is opened there.
   hyprctl dispatch focuswindow "address:$BROWSER_ADDRESS" >/dev/null
+  # Assumes the discovered browser is the default, otherwise falls back to Hyprland behavior.
   exec omarchy-launch-browser "$1"
 else
-  # No browser exists in this workspace, so create a new default browser window here.
+  # No browser found in this workspace, so create a new default browser window here.
+  # New browser windows open on the active Hyprland workspace by default.
   exec omarchy-launch-browser --new-window "$1"
 fi

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -12,7 +12,7 @@ cp ~/.local/share/omarchy/applications/*.desktop ~/.local/share/applications/
 cp ~/.local/share/omarchy/applications/hidden/*.desktop ~/.local/share/applications/
 
 if omarchy-cmd-present alacritty; then
-  cp ~/.local/share/omarchy/default/alacritty/alacritty.desktop ~/.local/share/applications/
+  cp ~/.local/share/omarchy/default/alacritty/Alacritty.desktop ~/.local/share/applications/
 fi
 
 # Refresh the webapps, TUIs, and npm wrappers

--- a/install/config/mimetypes.sh
+++ b/install/config/mimetypes.sh
@@ -17,8 +17,10 @@ xdg-mime default org.gnome.Evince.desktop application/pdf
 
 # Use Chromium as the default browser
 xdg-settings set default-web-browser chromium.desktop
-xdg-mime default chromium.desktop x-scheme-handler/http
-xdg-mime default chromium.desktop x-scheme-handler/https
+
+# Route URLs through Omarchy's handler
+xdg-mime default omarchy-handle-url.desktop x-scheme-handler/http
+xdg-mime default omarchy-handle-url.desktop x-scheme-handler/https
 
 # Open video files with mpv
 xdg-mime default mpv.desktop video/mp4

--- a/migrations/1779417257.sh
+++ b/migrations/1779417257.sh
@@ -1,0 +1,12 @@
+echo "Add Omarchy URL Handler"
+
+omarchy-refresh-applications
+
+APP_DIR="$HOME/.local/share/applications"
+if omarchy-cmd-present update-desktop-database; then
+  update-desktop-database "$APP_DIR" &>/dev/null || true
+fi
+
+DESKTOP_ID="omarchy-handle-url.desktop"
+xdg-mime default "$DESKTOP_ID" x-scheme-handler/http
+xdg-mime default "$DESKTOP_ID" x-scheme-handler/https

--- a/migrations/1779417257.sh
+++ b/migrations/1779417257.sh
@@ -2,11 +2,6 @@ echo "Add Omarchy URL Handler"
 
 omarchy-refresh-applications
 
-APP_DIR="$HOME/.local/share/applications"
-if omarchy-cmd-present update-desktop-database; then
-  update-desktop-database "$APP_DIR" &>/dev/null || true
-fi
-
 DESKTOP_ID="omarchy-handle-url.desktop"
 xdg-mime default "$DESKTOP_ID" x-scheme-handler/http
 xdg-mime default "$DESKTOP_ID" x-scheme-handler/https


### PR DESCRIPTION
Right now, apps and terminals open outside links in the last focused browser window, which is not desirable because that might be in an unrelated workspace. This change registers a URL handler that opens links in a browser window from the current workspace, or opens a new browser window if there isn't one.

**Problematic Behavior:** I was looking at pictures of ferns in one workspace, and a cybersecurity report in another. When clicking a link in the report, it opened in my fern workspace.

https://github.com/user-attachments/assets/afa0f415-76fc-4455-8517-fd341c728eea



