### PR TITLE
Add early-hid-modules to initramfs for wireless keyboards and mice

### DIFF
--- a/install/config/hardware/load-hid-modules.sh
+++ b/install/config/hardware/load-hid-modules.sh
@@ -1,0 +1,4 @@
+# Enable early module loading for USB/wireless HID devices at the boot screen
+if [[ ! -f /etc/mkinitcpio.conf.d/early-hid-modules.conf ]]; then
+  echo "MODULES=(xhci_pci usbhid hid_generic hid_apple)" | sudo tee /etc/mkinitcpio.conf.d/early-hid-modules.conf
+fi

--- a/install/config/hardware/load-hid-modules.sh
+++ b/install/config/hardware/load-hid-modules.sh
@@ -1,4 +1,6 @@
 # Enable early module loading for USB/wireless HID devices at the boot screen
+sudo mkdir -p /etc/mkinitcpio.conf.d
 if [[ ! -f /etc/mkinitcpio.conf.d/early-hid-modules.conf ]]; then
   echo "MODULES=(xhci_pci usbhid hid_generic hid_apple)" | sudo tee /etc/mkinitcpio.conf.d/early-hid-modules.conf
+  sudo mkinitcpio -P
 fi

--- a/install/config/hardware/load-hid-modules.sh
+++ b/install/config/hardware/load-hid-modules.sh
@@ -1,6 +1,6 @@
 # Enable early module loading for USB/wireless HID devices at the boot screen
 sudo mkdir -p /etc/mkinitcpio.conf.d
 if [[ ! -f /etc/mkinitcpio.conf.d/early-hid-modules.conf ]]; then
-  echo "MODULES=(xhci_pci usbhid hid_generic hid_apple)" | sudo tee /etc/mkinitcpio.conf.d/early-hid-modules.conf
+  echo "MODULES+=(xhci_pci usbhid hid_generic hid_apple)" | sudo tee /etc/mkinitcpio.conf.d/early-hid-modules.conf
   sudo mkinitcpio -P
 fi


### PR DESCRIPTION
## Description
### Reference: #5944 

This PR resolves a common issue where external USB and 2.4GHz wireless peripherals (e.g., Keychron, Logitech, NuPhy receivers) are unresponsive during the early boot process. This primarily prevents users from typing their LUKS decryption passwords or interacting with early login managers using external keyboards.

By default, the necessary Human Interface Device (HID) modules load too late in the boot sequence for these peripherals.

## Changes Made
- Added an idempotent check to create a drop-in mkinitcpio configuration file (/etc/mkinitcpio.conf.d/early-hid-modules.conf).

- Add the core USB and HID modules (xhci_pci, usbhid, hid_generic, hid_apple) to the MODULES array.

- While fixing the keyboard issue, this also enables early-boot support for external mice and other HID devices. Includes hid_apple, which is required for many custom mechanical keyboards that use Mac-compatible firmware layouts.