### PR TITLE
fix: Stable channel update uses tagged release #5948

### DIFF
--- a/bin/omarchy-update-git
+++ b/bin/omarchy-update-git
@@ -12,7 +12,16 @@ omarchy-update-time
 hyprctl keyword debug:suppress_errors true &>/dev/null || true
 hyprctl eval 'hl.config({ debug = { suppress_errors = true } })' &>/dev/null || true
 
-git -C $OMARCHY_PATH pull --autostash
-git -C $OMARCHY_PATH --no-pager diff --check || git -C $OMARCHY_PATH reset --merge
+# Use the actual tagged release for stable, not master
+channel=$(omarchy-version-channel 2>/dev/null || echo "stable")
+
+if [[ $channel == "stable" ]]; then
+  latest_tag=$(gh release list --repo basecamp/omarchy --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
+  git -C $OMARCHY_PATH fetch --tags
+  git -C $OMARCHY_PATH checkout --detach "$latest_tag"
+else
+  git -C $OMARCHY_PATH pull --autostash
+  git -C $OMARCHY_PATH --no-pager diff --check || git -C $OMARCHY_PATH reset --merge
+fi
 
 hyprctl reload &>/dev/null || true

--- a/test/omarchy-update-git-test.sh
+++ b/test/omarchy-update-git-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+TMPDIR=""
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+cleanup() {
+  [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Test: stable channel checks out the latest non-pre-release GitHub release, not master tip
+#
+# Fetches the real latest stable tag from GitHub, builds a local git repo with
+# that tag plus a fake pre-release commit on master, and verifies the script
+# lands on the stable tag rather than the master tip.
+
+TMPDIR=$(mktemp -d)
+
+latest_tag=$(gh release list --repo basecamp/omarchy --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
+
+UPSTREAM="$TMPDIR/upstream"
+git init --bare "$UPSTREAM" -q
+
+SEED="$TMPDIR/seed"
+git init "$SEED" -q
+git -C "$SEED" remote add origin "file://$UPSTREAM"
+git -C "$SEED" commit --allow-empty -m "$latest_tag" -q
+git -C "$SEED" tag "$latest_tag"
+git -C "$SEED" commit --allow-empty -m "pre-release on master" -q
+git -C "$SEED" tag v99.0.0alpha
+git -C "$SEED" push origin HEAD:master --tags -q 2>/dev/null
+
+OMARCHY_PATH="$TMPDIR/omarchy"
+git clone "file://$UPSTREAM" "$OMARCHY_PATH" -q
+git -C "$OMARCHY_PATH" reset --hard "$latest_tag" -q
+
+STUBS="$TMPDIR/bin"
+mkdir -p "$STUBS"
+printf '#!/bin/bash\necho stable\n' > "$STUBS/omarchy-version-channel"
+printf '#!/bin/bash\n'              > "$STUBS/omarchy-update-time"
+printf '#!/bin/bash\n'              > "$STUBS/hyprctl"
+chmod +x "$STUBS/"*
+
+OMARCHY_PATH="$OMARCHY_PATH" PATH="$STUBS:$ROOT/bin:$PATH" bash "$ROOT/bin/omarchy-update-git" 2>/dev/null
+
+checked_out=$(git -C "$OMARCHY_PATH" describe --tags --exact-match HEAD 2>/dev/null || echo "none")
+
+if [[ $checked_out == "$latest_tag" ]]; then
+  pass "stable channel checks out latest non-pre-release GitHub release ($latest_tag), skipping pre-release on master"
+else
+  fail "stable channel checks out latest non-pre-release GitHub release ($latest_tag), skipping pre-release on master (got: $checked_out)"
+fi


### PR DESCRIPTION
This PR updates `bin/omarchy-update-git` to use the latest non-pre-release GitHub release for the stable channel instead of pulling from the tip of master.

## Before

The stable channel update pulled from master, meaning any commit pushed to master (including pre-release code) would be delivered to stable users. Running a stable-channel update jumped me from 3.8.0 to 4.0.0alpha!

## After

The stable channel now queries GitHub for the latest non-pre-release release and checks out that tag. The rc, edge, and dev channels are unchanged.

## To test

1. I added a test here you can run:
  ```sh
  bash test/omarchy-update-git-test.sh
  ```
2. Or manually run an update:
  ```sh
  OMARCHY_PATH=~/.local/share/omarchy bash bin/omarchy-update-git
  git -C ~/.local/share/omarchy describe --tags --exact-match HEAD
  ```

Closes #5948 