### PR TITLE
Load HID modules early in initramfs

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -67,6 +67,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
 
+run_logged $OMARCHY_INSTALL/config/hardware/hid-modules.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh

--- a/install/config/hardware/hid-modules.sh
+++ b/install/config/hardware/hid-modules.sh
@@ -1,0 +1,3 @@
+if [[ ! -f /etc/mkinitcpio.conf.d/early-hid-modules.conf ]]; then
+  echo "MODULES=(xhci_pci usbhid hid_generic hid_apple)" | sudo tee /etc/mkinitcpio.conf.d/early-hid-modules.conf
+fi


### PR DESCRIPTION
Adds an install hardware step that writes early HID modules to mkinitcpio
    when no existing early HID module config is present, fixing wireless input devices that not works in LUKS decryption screen. References: #5944