### PR TITLE
Add Antigravity editor support

### DIFF
--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default editor for $EDITOR
-# omarchy:args=[code|cursor|zed|sublime_text|helix|vim|emacs|nvim]
+# omarchy:args=[antigravity|code|cursor|zed|sublime_text|helix|vim|emacs|nvim]
 # omarchy:examples=omarchy default editor | omarchy default editor code | omarchy default editor helix
 
 if (($# == 0)); then
@@ -10,6 +10,7 @@ if (($# == 0)); then
 fi
 
 case "$1" in
+antigravity) editor="antigravity"; name="Antigravity"; glyph="" ;;
 code) editor="code"; name="VSCode"; glyph="" ;;
 cursor) editor="cursor"; name="Cursor"; glyph="" ;;
 zed | zeditor) editor="zeditor"; name="Zed"; glyph="" ;;
@@ -19,7 +20,7 @@ vim) editor="vim"; name="Vim"; glyph="" ;;
 emacs) editor="emacs"; name="Emacs"; glyph="" ;;
 nvim) editor="nvim"; name="Neovim"; glyph="" ;;
 *)
-  echo "Usage: omarchy-default-editor <code|cursor|zed|sublime_text|helix|vim|emacs|nvim>"
+  echo "Usage: omarchy-default-editor <antigravity|code|cursor|zed|sublime_text|helix|vim|emacs|nvim>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -455,6 +455,7 @@ show_setup_default_terminal_menu() {
 show_setup_default_editor_menu() {
   local options=""
   omarchy-cmd-present nvim && options="$options  Neovim"
+  omarchy-cmd-present antigravity && options="${options:+$options\n}  Antigravity"
   omarchy-cmd-present code && options="${options:+$options\n}  VSCode"
   omarchy-cmd-present cursor && options="${options:+$options\n}  Cursor"
   omarchy-cmd-present zeditor && options="${options:+$options\n}  Zed"
@@ -466,6 +467,7 @@ show_setup_default_editor_menu() {
   local current=""
   case "$(omarchy-default-editor)" in
   nvim) current="  Neovim" ;;
+  antigravity) current="  Antigravity" ;;
   code) current="  VSCode" ;;
   cursor) current="  Cursor" ;;
   zed | zeditor) current="  Zed" ;;
@@ -477,6 +479,7 @@ show_setup_default_editor_menu() {
 
   case $(menu "Default Editor" "$options" "" "$current") in
   *Neovim*) omarchy-default-editor nvim ;;
+  *Antigravity*) omarchy-default-editor antigravity ;;
   *VSCode*) omarchy-default-editor code ;;
   *Cursor*) omarchy-default-editor cursor ;;
   *Zed*) omarchy-default-editor zed ;;
@@ -570,8 +573,9 @@ show_install_service_menu() {
 }
 
 show_install_editor_menu() {
-  case $(menu "Install" "  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Vim\n  Emacs") in
+  case $(menu "Install" "  Antigravity\n  VSCode\n  Cursor\n  Zed\n  Sublime Text\n  Helix\n  Vim\n  Emacs") in
   *VSCode*) present_terminal omarchy-install-vscode ;;
+  *Antigravity*) install_and_launch "Antigravity" "antigravity" "antigravity" ;;
   *Cursor*) install_and_launch "Cursor" "cursor-bin" "cursor" ;;
   *Zed*) present_terminal omarchy-install-zed ;;
   *Sublime*) install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;


### PR DESCRIPTION
## Summary

Adds [Antigravity](https://antigravity.dev) (a VS Code fork available on Arch/AUR) as a selectable editor option in Omarchy.

- `bin/omarchy-default-editor`: adds `antigravity` as a valid argument, so `omarchy default editor antigravity` works
- `bin/omarchy-menu`: Antigravity appears in **Setup → Default → Editor** (only if installed) and **Install → Editor**

The implementation follows the same pattern as other GUI editors (VSCode, Cursor).