### PR TITLE
Drop orphan .desktop entries when their backing command is gone

### DIFF
--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -20,5 +20,7 @@ pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
 if [[ -n $pkg_names ]]; then
   # Convert newline-separated selections to space-separated for yay
   echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
+  # Reconcile .desktop entries — drops orphans for removed packages (#5933).
+  omarchy-refresh-applications
   omarchy-show-done
 fi

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -6,13 +6,27 @@ mkdir -p ~/.local/share/icons/hicolor/48x48/apps/
 cp ~/.local/share/omarchy/applications/icons/*.png ~/.local/share/icons/hicolor/48x48/apps/
 gtk-update-icon-cache ~/.local/share/icons/hicolor &>/dev/null
 
-# Copy .desktop declarations
+# Copy .desktop declarations. For top-level entries (i.e. visible launchers),
+# also clean up the destination when the referenced Exec command is missing —
+# otherwise removing a preinstalled package via `omarchy-pkg-remove` leaves an
+# orphan .desktop that still shows up in the launcher and "App failure"s on
+# click (see #5933).
 mkdir -p ~/.local/share/applications
-cp ~/.local/share/omarchy/applications/*.desktop ~/.local/share/applications/
+for src in ~/.local/share/omarchy/applications/*.desktop; do
+  dest=~/.local/share/applications/$(basename "$src")
+  cmd=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' "$src" | head -1)
+  if [[ -n $cmd ]] && command -v "$cmd" &>/dev/null; then
+    cp "$src" "$dest"
+  else
+    rm -f "$dest"
+  fi
+done
 cp ~/.local/share/omarchy/applications/hidden/*.desktop ~/.local/share/applications/
 
 if omarchy-cmd-present alacritty; then
   cp ~/.local/share/omarchy/default/alacritty/alacritty.desktop ~/.local/share/applications/
+else
+  rm -f ~/.local/share/applications/alacritty.desktop
 fi
 
 # Refresh the webapps, TUIs, and npm wrappers


### PR DESCRIPTION
## Summary

Fixes #5933. `omarchy-refresh-applications` now reconciles top-level `applications/*.desktop` entries instead of just copying them, and `omarchy-pkg-remove` triggers a reconcile after `pacman -Rns` so orphan launcher entries disappear immediately on uninstall.

## Symptom

Reproduction from the issue:

1. Omarchy ships with `typora` in `install/omarchy-base.packages` (preinstalled).
2. User: **Remove → Package → typora**. `omarchy-pkg-remove` runs `pacman -Rns typora`.
3. `~/.local/share/applications/typora.desktop` stays — pacman didn't put it there, omarchy did via `omarchy-refresh-applications`.
4. Walker still lists "Typora". Clicking it shows _App failure: Command not found: "typora"_.

Same shape affects every preinstalled package that omarchy ships a `.desktop` override for. Today that's just typora in the visible set, but the bug class is general.

## Fix

### 1. `bin/omarchy-refresh-applications` — reconcile instead of copy

Before:
```bash
cp ~/.local/share/omarchy/applications/*.desktop ~/.local/share/applications/
```

After:
```bash
for src in ~/.local/share/omarchy/applications/*.desktop; do
  dest=~/.local/share/applications/$(basename "$src")
  cmd=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' "$src" | head -1)
  if [[ -n $cmd ]] && command -v "$cmd" &>/dev/null; then
    cp "$src" "$dest"
  else
    rm -f "$dest"
  fi
done
```

For each shipped entry, look at the `Exec=` command:
- present on PATH → copy the entry (current behaviour)
- not present → remove any stale copy at the destination

The same symmetric cleanup is added to the existing `alacritty` conditional, which had the same latent issue.

`applications/hidden/*.desktop` is intentionally untouched — those are `NoDisplay` overrides that should ship regardless of whether the upstream command is currently installed (they exist to *suppress* generic vendor entries, not advertise installed apps).

### 2. `bin/omarchy-pkg-remove` — trigger the reconcile

```bash
echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
+ omarchy-refresh-applications
  omarchy-show-done
```

Without this, the fix only kicks in on the next `omarchy update` or manual refresh. With this, removing typora from the Remove menu immediately drops the orphan and walker reflects the change after its own refresh.

## Why generic rather than typora-specific

Hardcoding typora would be a smaller diff but would leave the same trap for the next preinstalled-then-removed app (any future addition to `applications/*.desktop` of an optional preinstall would hit the identical bug). The `Exec=` introspection is 5 lines and uses primitives already present in the codebase (`sed`, `command -v`, the basename + cp/rm pattern). It also matches the spirit of the existing `omarchy-cmd-present alacritty` conditional — generalising it rather than adding a new special case for each app.

## Master backport

Both files are identical between `master` and `dev` (verified with `git diff origin/master:bin/omarchy-{refresh-applications,pkg-remove} origin/dev:...`). Happy to open a parallel PR if you want it backported.

## Test plan

- [x] `bash -n` clean on both modified scripts
- [x] Dry-run the `Exec=` extraction against the current `applications/*.desktop` set (foot, imv, mpv, typora) — sed correctly pulls out the bare command in each case, and `command -v` resolves the ones present on PATH
- [x] Inspected the existing alacritty pattern, which also lacks cleanup; same fix applied there for consistency
- [ ] No machine here with the exact "typora was preinstalled, user removed it via the Remove menu" state to live-verify, but the reproduction is the linear path described in #5933. If a reviewer can confirm on a fresh stock install that does have typora, that closes the loop.
