### PR TITLE
Add condensed mode toggle (SUPER + SHIFT + BACKSPACE)

### DIFF
--- a/bin/omarchy-hyprland-window-condensed-toggle
+++ b/bin/omarchy-hyprland-window-condensed-toggle
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle condensed mode: no gaps, borders hidden for single windows.
+
+case $(omarchy-hyprland-toggle window-condensed) in
+  on) omarchy-notification-send "Condensed mode on" -g  ;;
+  off) omarchy-notification-send "Condensed mode off" -g  ;;
+esac

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -19,7 +19,7 @@ o.bind("SUPER + SHIFT + CTRL + RIGHT", "Move Waybar to right", "omarchy-style-wa
 o.bind_menu("SUPER + CTRL + SPACE", "Background switcher", "background")
 o.bind_menu("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "theme")
 o.bind("SUPER + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")
-o.bind("SUPER + SHIFT + BACKSPACE", "Toggle window gaps", "omarchy-hyprland-window-gaps-toggle")
+o.bind("SUPER + SHIFT + BACKSPACE", "Toggle condensed mode", "omarchy-hyprland-window-condensed-toggle")
 o.bind("SUPER + CTRL + BACKSPACE", "Toggle single-window square aspect", "omarchy-hyprland-window-single-square-aspect-toggle")
 
 o.bind("SUPER + COMMA", "Dismiss last notification", "makoctl dismiss")

--- a/default/hypr/toggles/window-condensed.lua
+++ b/default/hypr/toggles/window-condensed.lua
@@ -1,0 +1,12 @@
+-- Condensed mode: no gaps, borders hidden for single windows.
+hl.config({
+  general = {
+    gaps_out = 0,
+    gaps_in = 0,
+  },
+  decoration = {
+    shadow = { enabled = false },
+  },
+})
+
+hl.workspace_rule({ workspace = "w[1]", border_size = 0 })


### PR DESCRIPTION
Condensed mode removes all gaps and shadow, and hides window borders
when only one window is open -- borders reappear automatically when
a second window is tiled on the same workspace.

Replaces the simpler "no gaps" toggle at the same keybind.
