### PR TITLE
feat(browser): add opt-in Google Chrome Beta support

### DIFF
--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default browser for Omarchy and XDG handlers
-# omarchy:args=[chromium|chrome|brave|brave-origin|edge|firefox|zen]
+# omarchy:args=[chromium|chrome|chrome-beta|brave|brave-origin|edge|firefox|zen]
 # omarchy:examples=omarchy default browser firefox | omarchy default browser brave
 
 if (($# == 0)); then
   case "$(xdg-settings get default-web-browser)" in
   chromium.desktop) echo "chromium" ;;
   google-chrome.desktop) echo "chrome" ;;
+  google-chrome-beta.desktop) echo "chrome-beta" ;;
   brave-browser.desktop) echo "brave" ;;
   brave-origin-beta.desktop) echo "brave-origin" ;;
   microsoft-edge.desktop) echo "edge" ;;
@@ -21,13 +22,14 @@ fi
 case "$1" in
 chromium) desktop_id="chromium.desktop"; name="Chromium"; glyph="" ;;
 chrome) desktop_id="google-chrome.desktop"; name="Chrome"; glyph="󰊯" ;;
+chrome-beta) desktop_id="google-chrome-beta.desktop"; name="Chrome Beta"; glyph="󰊯" ;;
 brave) desktop_id="brave-browser.desktop"; name="Brave"; glyph="󰖟" ;;
 brave-origin) desktop_id="brave-origin-beta.desktop"; name="Brave Origin"; glyph="󰖟" ;;
 edge) desktop_id="microsoft-edge.desktop"; name="Edge"; glyph="󰇩" ;;
 firefox) desktop_id="firefox.desktop"; name="Firefox"; glyph="󰈹" ;;
 zen) desktop_id="zen.desktop"; name="Zen"; glyph="󰖟" ;;
 *)
-  echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-default-browser <chromium|chrome|chrome-beta|brave|brave-origin|edge|firefox|zen>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Install a supported browser
-# omarchy:args=<chrome|brave|brave-origin|edge|firefox|zen>
-# omarchy:examples=omarchy install browser firefox | omarchy install browser brave
+# omarchy:args=<chrome|chrome-beta|brave|brave-origin|edge|firefox|zen>
+# omarchy:examples=omarchy install browser firefox | omarchy install browser chrome-beta
 
 setup_policy_directory() {
   sudo mkdir -p "$1"
@@ -40,6 +40,17 @@ chrome)
   copy_chromium_flags ~/.config/chrome-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Chrome"
+  ;;
+chrome-beta)
+  # Opt-in only: tracks upstream Chromium closely for browser automation
+  # (Playwright / Chrome DevTools Protocol). Does not change the default browser.
+  echo "Installing Chrome Beta..."
+  omarchy-pkg-aur-add google-chrome-beta || exit 1
+
+  setup_policy_directory /etc/opt/chrome/policies/managed
+  copy_chromium_flags ~/.config/chrome-beta-flags.conf
+  omarchy-theme-set-browser
+  announce_browser_installed "Chrome Beta"
   ;;
 edge)
   echo "Installing Edge..."
@@ -87,7 +98,7 @@ zen)
   announce_browser_installed "Zen"
   ;;
 *)
-  echo "Usage: omarchy-install-browser <chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-install-browser <chrome|chrome-beta|brave|brave-origin|edge|firefox|zen>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -399,6 +399,7 @@ show_setup_default_browser_menu() {
   local options=""
   browser_desktop_exists chromium.desktop && options="$options  Chromium"
   browser_desktop_exists google-chrome.desktop && options="${options:+$options\n}󰊯  Chrome"
+  browser_desktop_exists google-chrome-beta.desktop && options="${options:+$options\n}󰊯  Chrome Beta"
   browser_desktop_exists brave-browser.desktop && options="${options:+$options\n}󰖟  Brave"
   browser_desktop_exists brave-origin-beta.desktop && options="${options:+$options\n}󰖟  Brave Origin"
   browser_desktop_exists microsoft-edge.desktop && options="${options:+$options\n}󰇩  Edge"
@@ -409,6 +410,7 @@ show_setup_default_browser_menu() {
   case "$(omarchy-default-browser)" in
   chromium) current="  Chromium" ;;
   chrome) current="󰊯  Chrome" ;;
+  chrome-beta) current="󰊯  Chrome Beta" ;;
   brave) current="󰖟  Brave" ;;
   brave-origin) current="󰖟  Brave Origin" ;;
   edge) current="󰇩  Edge" ;;
@@ -418,6 +420,7 @@ show_setup_default_browser_menu() {
 
   case $(menu "Default Browser" "$options" "" "$current") in
   *Chromium*) omarchy-default-browser chromium ;;
+  *"Chrome Beta"*) omarchy-default-browser chrome-beta ;;
   *Chrome*) omarchy-default-browser chrome ;;
   *"Brave Origin"*) omarchy-default-browser brave-origin ;;
   *Brave*) omarchy-default-browser brave ;;
@@ -545,7 +548,8 @@ show_install_menu() {
 }
 
 show_install_browser_menu() {
-  case $(menu "Install" "  Chrome\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n󰖟  Zen") in
+  case $(menu "Install" "  Chrome\n  Chrome Beta\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n󰖟  Zen") in
+  *"Chrome Beta"*) present_terminal "omarchy-install-browser chrome-beta" ;;
   *Chrome*) present_terminal "omarchy-install-browser chrome" ;;
   *Edge*) present_terminal "omarchy-install-browser edge" ;;
   *"Brave Origin"*) present_terminal "omarchy-install-browser brave-origin" ;;
@@ -717,7 +721,8 @@ show_remove_security_menu() {
 }
 
 show_remove_browser_menu() {
-  case $(menu "Remove" "  Chrome\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n  Zen") in
+  case $(menu "Remove" "  Chrome\n  Chrome Beta\n  Edge\n  Brave\n  Brave Origin\n  Firefox\n  Zen") in
+  *"Chrome Beta"*) present_terminal "omarchy-remove-browser chrome-beta" ;;
   *Chrome*) present_terminal "omarchy-remove-browser chrome" ;;
   *Edge*) present_terminal "omarchy-remove-browser edge" ;;
   *"Brave Origin"*) present_terminal "omarchy-remove-browser brave-origin" ;;

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Remove a supported browser and clean up Omarchy browser defaults
-# omarchy:args=<chrome|brave|brave-origin|edge|firefox|zen>
+# omarchy:args=<chrome|chrome-beta|brave|brave-origin|edge|firefox|zen>
 # omarchy:examples=omarchy remove browser firefox | omarchy remove browser brave
 # omarchy:requires-sudo=true
 
@@ -27,7 +27,20 @@ chrome)
   set_fallback_default_browser google-chrome.desktop
   omarchy-pkg-drop google-chrome
   rm -f ~/.config/chrome-flags.conf
-  sudo rm -f /etc/opt/chrome/policies/managed/color.json
+
+  if omarchy-pkg-missing google-chrome-beta; then
+    sudo rm -f /etc/opt/chrome/policies/managed/color.json
+  fi
+  ;;
+chrome-beta)
+  echo "Removing Chrome Beta..."
+  set_fallback_default_browser google-chrome-beta.desktop
+  omarchy-pkg-drop google-chrome-beta
+  rm -f ~/.config/chrome-beta-flags.conf
+
+  if omarchy-pkg-missing google-chrome; then
+    sudo rm -f /etc/opt/chrome/policies/managed/color.json
+  fi
   ;;
 edge)
   echo "Removing Edge..."
@@ -67,7 +80,7 @@ zen)
   omarchy-pkg-drop zen-browser-bin
   ;;
 *)
-  echo "Usage: omarchy-remove-browser <chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-remove-browser <chrome|chrome-beta|brave|brave-origin|edge|firefox|zen>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -35,6 +35,7 @@ refresh_running_browser chromium chromium
 
 set_browser_policy /etc/opt/chrome/policies/managed
 refresh_running_browser chrome google-chrome-stable || refresh_running_browser chrome google-chrome
+refresh_running_browser chrome-beta google-chrome-beta
 
 set_browser_policy /etc/opt/edge/policies/managed
 refresh_running_browser msedge microsoft-edge-stable

--- a/test/omarchy-cli-test.sh
+++ b/test/omarchy-cli-test.sh
@@ -263,3 +263,141 @@ assert_output_contains "partial metadata command dispatches" "$output" "partial-
 
 output=$("$TMPDIR/omarchy" body metadata test)
 assert_output_contains "body metadata command dispatches by filename" "$output" "body-metadata-ok"
+
+# --- chrome-beta opt-in browser wiring -------------------------------------
+# Covers the opt-in Google Chrome Beta channel added alongside chrome/brave/
+# edge/firefox/zen. Help + metadata are assertion-only; default-browser is
+# exercised with real execution against PATH stubs (no package installs, no
+# sudo, no real xdg changes); menu/theme wiring is checked at the source level.
+
+# 1. Install route: help text and JSON metadata expose chrome-beta.
+output=$("$CLI" install browser --help)
+assert_output_contains "install browser help lists chrome-beta arg" "$output" "chrome-beta"
+assert_output_contains "install browser help shows chrome-beta example" "$output" "omarchy install browser chrome-beta"
+"$CLI" commands --json | jq -e '.commands[] | select(.binary == "omarchy-install-browser") | (.args | contains("chrome-beta")) and (.examples | index("omarchy install browser chrome-beta"))' >/dev/null
+pass "install-browser JSON args + examples include chrome-beta"
+
+# 2. Remove route: help args and JSON metadata expose chrome-beta + sudo.
+output=$("$CLI" remove browser --help)
+assert_output_contains "remove browser help lists chrome-beta arg" "$output" "chrome-beta"
+"$CLI" commands --json | jq -e '.commands[] | select(.binary == "omarchy-remove-browser") | (.args | contains("chrome-beta")) and .requires_sudo == true' >/dev/null
+pass "remove-browser JSON args include chrome-beta and requires_sudo"
+
+# 3. Default-browser bidirectional mapping (real execution, stubbed PATH).
+BROWSER_STUBDIR=$(mktemp -d)
+STUB_LOG="$BROWSER_STUBDIR/calls.log"
+
+make_default_browser_stubs() {
+  # $1 is the desktop id that `xdg-settings get` should report.
+  : >"$STUB_LOG"
+  cat >"$BROWSER_STUBDIR/xdg-settings" <<EOF
+#!/bin/bash
+if [[ "\$1" == "get" ]]; then echo "$1"; exit 0; fi
+echo "xdg-settings \$*" >>"$STUB_LOG"
+exit 0
+EOF
+  cat >"$BROWSER_STUBDIR/xdg-mime" <<EOF
+#!/bin/bash
+echo "xdg-mime \$*" >>"$STUB_LOG"
+exit 0
+EOF
+  cat >"$BROWSER_STUBDIR/notify-send" <<EOF
+#!/bin/bash
+echo "notify-send \$*" >>"$STUB_LOG"
+exit 0
+EOF
+  chmod +x "$BROWSER_STUBDIR/xdg-settings" "$BROWSER_STUBDIR/xdg-mime" "$BROWSER_STUBDIR/notify-send"
+}
+
+# Reverse: a chrome-beta desktop id reports back as chrome-beta.
+make_default_browser_stubs "google-chrome-beta.desktop"
+output=$(PATH="$BROWSER_STUBDIR:$PATH" "$ROOT/bin/omarchy-default-browser")
+assert_output_contains "default-browser reports chrome-beta from google-chrome-beta.desktop" "$output" "chrome-beta"
+
+# Negative guard: a plain chrome desktop id still reports chrome, not chrome-beta.
+make_default_browser_stubs "google-chrome.desktop"
+output=$(PATH="$BROWSER_STUBDIR:$PATH" "$ROOT/bin/omarchy-default-browser")
+if [[ $output != "chrome" ]]; then
+  printf 'Expected exactly "chrome", got: %s\n' "$output" >&2
+  fail "default-browser maps google-chrome.desktop to chrome (not chrome-beta)"
+fi
+pass "default-browser maps google-chrome.desktop to chrome (not chrome-beta)"
+
+# Forward: selecting chrome-beta sets the chrome-beta desktop id and names it.
+make_default_browser_stubs "google-chrome.desktop"
+PATH="$BROWSER_STUBDIR:$PATH" "$ROOT/bin/omarchy-default-browser" chrome-beta
+log=$(cat "$STUB_LOG")
+assert_output_contains "default-browser chrome-beta sets google-chrome-beta.desktop" "$log" "xdg-settings set default-web-browser google-chrome-beta.desktop"
+assert_output_contains "default-browser chrome-beta notifies as Chrome Beta" "$log" "Chrome Beta is now the default browser"
+
+rm -rf "$BROWSER_STUBDIR"
+
+# 4. Invalid-arg usage strings list chrome-beta (no side effects on this path).
+output=$("$ROOT/bin/omarchy-install-browser" bogus 2>&1 || true)
+assert_output_contains "install-browser usage lists chrome-beta" "$output" "Usage:"
+assert_output_contains "install-browser usage includes chrome-beta" "$output" "chrome-beta"
+output=$("$ROOT/bin/omarchy-remove-browser" bogus 2>&1 || true)
+assert_output_contains "remove-browser usage lists chrome-beta" "$output" "Usage:"
+assert_output_contains "remove-browser usage includes chrome-beta" "$output" "chrome-beta"
+output=$("$ROOT/bin/omarchy-default-browser" bogus 2>&1 || true)
+assert_output_contains "default-browser usage lists chrome-beta" "$output" "Usage:"
+assert_output_contains "default-browser usage includes chrome-beta" "$output" "chrome-beta"
+
+# 5. Menu submenu wiring + arm ordering (source-level, glob-shadowing guard).
+# Each browser submenu must carry a "Chrome Beta" label and a chrome-beta
+# dispatch arm, and the specific *"Chrome Beta"* arm must precede the broader
+# *Chrome* arm so the latter does not shadow the former.
+assert_menu_arm_ordering() {
+  local description="$1" func="$2" beta_arm="$3" chrome_arm="$4"
+  local block beta_line chrome_line
+  block=$(awk -v fn="$func" '
+    $0 ~ "^" fn "\\(\\) \\{" { inblock=1 }
+    inblock { print }
+    inblock && /^\}/ { exit }
+  ' "$ROOT/bin/omarchy-menu")
+
+  if [[ $block != *"Chrome Beta"* ]]; then
+    printf 'Function %s has no "Chrome Beta" label\n' "$func" >&2
+    fail "$description"
+  fi
+  if [[ $block != *"$beta_arm"* ]]; then
+    printf 'Function %s missing dispatch arm: %s\n' "$func" "$beta_arm" >&2
+    fail "$description"
+  fi
+  beta_line=$(grep -nF -- "$beta_arm" <<<"$block" | head -n1 | cut -d: -f1)
+  chrome_line=$(grep -nF -- "$chrome_arm" <<<"$block" | head -n1 | cut -d: -f1)
+  if [[ -z $beta_line || -z $chrome_line ]]; then
+    printf 'Function %s missing one of the arms (beta=%s chrome=%s)\n' "$func" "$beta_line" "$chrome_line" >&2
+    fail "$description"
+  fi
+  if ((beta_line >= chrome_line)); then
+    printf 'In %s the Chrome Beta arm (line %s) must precede the Chrome arm (line %s)\n' "$func" "$beta_line" "$chrome_line" >&2
+    fail "$description"
+  fi
+  pass "$description"
+}
+
+assert_menu_arm_ordering \
+  "install submenu wires Chrome Beta before Chrome" \
+  "show_install_browser_menu" \
+  'present_terminal "omarchy-install-browser chrome-beta"' \
+  'present_terminal "omarchy-install-browser chrome"'
+
+assert_menu_arm_ordering \
+  "remove submenu wires Chrome Beta before Chrome" \
+  "show_remove_browser_menu" \
+  'present_terminal "omarchy-remove-browser chrome-beta"' \
+  'present_terminal "omarchy-remove-browser chrome"'
+
+assert_menu_arm_ordering \
+  "default submenu wires Chrome Beta before Chrome" \
+  "show_setup_default_browser_menu" \
+  'omarchy-default-browser chrome-beta' \
+  'omarchy-default-browser chrome '
+
+# 6. theme-set-browser refreshes a running Chrome Beta (source-level).
+if ! grep -qF 'refresh_running_browser chrome-beta google-chrome-beta' "$ROOT/bin/omarchy-theme-set-browser"; then
+  printf 'Expected omarchy-theme-set-browser to refresh chrome-beta\n' >&2
+  fail "theme-set-browser refreshes chrome-beta google-chrome-beta"
+fi
+pass "theme-set-browser refreshes chrome-beta google-chrome-beta"


### PR DESCRIPTION
## Summary

Adds an **opt-in** way to install and use **Google Chrome Beta** (`google-chrome-beta` from the AUR) as a selectable browser in Omarchy, alongside the existing chrome/brave/edge/firefox/zen choices.

**This does not change the default browser.** omarchy-chromium remains the default for everyone. Chrome Beta only appears as an additional choice a user explicitly opts into via `Setup > Install > Browser > Chrome Beta` (or `omarchy install browser chrome-beta`). Nobody who doesn't ask for it is affected.

## Motivation

A growing number of Omarchy users run AI coding agents that drive a browser programmatically — via **Playwright** or the **Chrome DevTools Protocol (CDP)** — for tasks like end-to-end testing, scraping, and agentic web automation. That workload has a hard requirement that ordinary browsing doesn't: the local browser has to stay close to upstream Chromium.

Concretely:

- **DevTools Protocol surface.** Automation tools target a moving CDP surface. A browser that tracks upstream closely exposes the newer CDP domains/commands those tools expect; a lagging stable build silently lacks them, producing confusing "method not found" / "unsupported" failures.
- **`--remote-debugging-port` reliability under Wayland.** Headless and remote-controlled launches on Wayland are sensitive to the exact Chromium build and its packaging. The upstream-tracking Google channel behaves predictably here, where distro-patched builds sometimes don't.
- **Version-skew against Playwright's expected revision.** Playwright pins an expected browser revision. Running a stable distro Chromium that lags upstream — or carries downstream packaging patches — is a common source of flaky, hard-to-debug automation, because the driver and the browser disagree about capabilities.

A stable distro Chromium is the right default for daily browsing, but for the automation use case it's frequently either behind upstream or patched in ways that make headless/remote-controlled use flaky. An opt-in Chrome Beta gives those users a browser that **"just works" for automation** without imposing a beta channel on everyone else.

Chrome Beta (not Dev/Canary) is deliberately chosen: it tracks upstream closely enough to solve the skew problem while still being stable enough for real use.

## What changed

Wiring mirrors the existing `chrome` channel exactly — no new patterns introduced:

| File | Change |
|------|--------|
| `bin/omarchy-install-browser` | New `chrome-beta` case: installs AUR `google-chrome-beta`, writes `~/.config/chrome-beta-flags.conf` (the flags file the Chrome Beta wrapper actually reads), reuses the shared `/etc/opt/chrome/policies/managed` policy dir, applies the current theme color. |
| `bin/omarchy-remove-browser` | New `chrome-beta` case. Both `chrome` and `chrome-beta` now guard removal of the **shared** `color.json` so removing one Chrome channel doesn't strip the managed policy while the other channel is still installed (same shared-dir guard pattern already used for Brave / Brave Origin). |
| `bin/omarchy-default-browser` | Maps `chrome-beta` ↔ `google-chrome-beta.desktop` (both directions). |
| `bin/omarchy-theme-set-browser` | Refreshes a running `google-chrome-beta` so theme color changes apply live. |
| `bin/omarchy-menu` | Adds **Chrome Beta** to the Install, Remove, and Default Browser submenus. The `*"Chrome Beta"*` glob arm is ordered before `*Chrome*` (same specific-before-general ordering already used for Brave Origin vs Brave). |

Command metadata (`omarchy:args` / usage strings) updated to include `chrome-beta`.

## How a user opts in

Via the menu:

```
Super (Omarchy menu) > Install > Browser > Chrome Beta
```

Or directly:

```bash
omarchy install browser chrome-beta
```

The install prints `Chrome Beta browser installed. Make it the default via Setup > Defaults > Browser.` — it intentionally leaves the default browser untouched. Setting it as default (optional) is a separate explicit step:

```bash
omarchy default browser chrome-beta
```

Removal:

```bash
omarchy remove browser chrome-beta
```

## Testing

- `bash test/omarchy-cli-test.sh` — full suite passes (including the metadata/route assertions).
- `bash -n` clean on all five modified scripts.
- Verified `omarchy install browser --help` and the usage strings surface `chrome-beta`.

---

Opened as a **draft** for maintainer review of the approach before finalizing.