### PR TITLE
Expand Nautilus into usage as file picker in Open/Save dialog (provides space to preview)

### DIFF
--- a/config/xdg-desktop-portal/hyprland-portals.conf
+++ b/config/xdg-desktop-portal/hyprland-portals.conf
@@ -1,0 +1,3 @@
+[preferred]
+default = hyprland;gtk
+org.freedesktop.impl.portal.FileChooser = gnome

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -145,6 +145,7 @@ wiremix
 wireplumber
 wl-clipboard
 woff2-font-awesome
+xdg-desktop-portal-gnome
 xdg-desktop-portal-gtk
 xdg-desktop-portal-hyprland
 xdg-terminal-exec

--- a/migrations/1780365321.sh
+++ b/migrations/1780365321.sh
@@ -1,0 +1,8 @@
+echo "Use GNOME file picker portal for previews in Open/Save dialogs"
+
+omarchy-pkg-add xdg-desktop-portal-gnome
+
+mkdir -p ~/.config/xdg-desktop-portal
+cp $OMARCHY_PATH/config/xdg-desktop-portal/hyprland-portals.conf ~/.config/xdg-desktop-portal/
+
+systemctl --user restart xdg-desktop-portal

--- a/migrations/1780365321.sh
+++ b/migrations/1780365321.sh
@@ -2,7 +2,6 @@ echo "Use GNOME file picker portal for previews in Open/Save dialogs"
 
 omarchy-pkg-add xdg-desktop-portal-gnome
 
-mkdir -p ~/.config/xdg-desktop-portal
-cp $OMARCHY_PATH/config/xdg-desktop-portal/hyprland-portals.conf ~/.config/xdg-desktop-portal/
+omarchy-refresh-config xdg-desktop-portal/hyprland-portals.conf
 
 systemctl --user restart xdg-desktop-portal


### PR DESCRIPTION
## Summary

- Routes the `org.freedesktop.impl.portal.FileChooser` portal interface to `xdg-desktop-portal-gnome` so Open/Save dialogs use the Nautilus-style file picker (sidebar, preview, modern layout) instead of the basic `GtkFileChooser` shown by `xdg-desktop-portal-gtk`.
- Other portal interfaces (screenshot, screencast, settings, etc.) continue to be served by `hyprland` and `gtk` — the override is scoped to FileChooser only.

## What changed

| File | Change |
|---|---|
| `install/omarchy-base.packages` | Adds `xdg-desktop-portal-gnome` |
| `config/xdg-desktop-portal/hyprland-portals.conf` | New file with the FileChooser override (copied to `~/.config/` by the existing `install/config/config.sh`) |
| `migrations/1780365321.sh` | Installs the package, copies the portal config, restarts `xdg-desktop-portal` for existing users |

## Why

The current default — `xdg-desktop-portal-gtk` handling FileChooser — gives the legacy `GtkFileChooser` dialog: no sidebar, no space to preview, single-column file list. This is jarring next to Nautilus, which is already Omarchy's default file manager and which the floating-window rule at `default/hypr/apps/system.lua:3` already expects to see for save/open dialogs.

`xdg-desktop-portal-gnome` launches Nautilus itself as the picker (verified via `hyprctl clients`: the picker window's class is `org.gnome.Nautilus`, matching the existing floating-window rule), so no Hyprland rule changes are needed.

## Trade-offs

- Adds `xdg-desktop-portal-gnome` as an explicit dep. It pulls `gnome-desktop-4` and `libadwaita`; most of its other deps (`nautilus`, `gtk4`, `gdk-pixbuf2`) are already installed via Omarchy's base set.
- Behavior change for existing users — the migration handles the transition automatically.

## Test plan

- [x] Fresh install: confirm `xdg-desktop-portal-gnome` is pulled in and `~/.config/xdg-desktop-portal/hyprland-portals.conf` is in place
- [x] Trigger a file picker from Chromium / Firefox / Discord — confirm the Nautilus-style picker appears with sidebar and preview
- [x] Existing install: run the migration and confirm the picker swap takes effect after the portal restart (no logout required)
- [x] Confirm screenshot / screencast portals still work (still routed to `hyprland`)
- [x] Active use -- Have run configuration for 3 months

<img width="1026" height="697" alt="screenshot-2026-06-01_19-41-07" src="https://github.com/user-attachments/assets/a06971f7-60c9-4342-96f7-d7f6c1b89226" />
