### PR TITLE
fix active terminal cwd finder logic

### DIFF
--- a/bin/omarchy-cmd-terminal-cwd
+++ b/bin/omarchy-cmd-terminal-cwd
@@ -4,7 +4,7 @@
 # omarchy:hidden=true
 
 terminal_pid=$(hyprctl activewindow | awk '/pid:/ {print $2}')
-shell_pid=$(pgrep -P "$terminal_pid" | tail -n1)
+shell_pid=$(ps --ppid "$terminal_pid" -o pid=,tty= | awk '$2 != "?" {print $1}' | tail -n1)
 
 if [[ -n $shell_pid ]]; then
   cwd=$(readlink -f "/proc/$shell_pid/cwd" 2>/dev/null)


### PR DESCRIPTION
Before it was just assuming last spawn is our cwd but it's not always true

for example the scenario is like this 

```bash
❯ pgrep -P "$terminal_id"
1884112
1884114
1884120
```

Looking in full details

```bash
              
omarchy dev 
❯ pgrep -P "$terminal_id" | xargs ps -fp
UID          PID    PPID  C STIME TTY      STAT   TIME CMD
user    1884112 1883788  0 17:41 ?        Sl     0:00 /usr/bin/kitten __atexit__
user    1884114 1883788  0 17:41 pts/1    Ss     0:06 /usr/bin/fish
user    1884120 1883788  0 17:41 ?        Sl     0:00 /usr/bin/kitten __watch_con
```


Old script was taking last pid, but there is chance last pid is not our shell. 

This PR just change one line to filter out non interactive processes and select last process pid ( in case of multiple shell terminal)




