### PR TITLE
Add CTRL + n/p for walker up and down config bindings

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -9,6 +9,8 @@ hide_action_hints = true                                                    # gl
 
 [keybinds]
 quick_activate = []
+next = ["Down", "ctrl n"]
+previous = ["Up", "ctrl p"]
 
 [columns]
 symbols = 1 # providers to be queried by default


### PR DESCRIPTION
I am not sure how you guys like to use Neovim or the Terminal, but I find it very useful to use CTRL + n for next and CTRL + p for previous on menus. For example, in the terminal press ctrl + p goes up one command in your history and vice versa. Same goes with neovim autocomplete popups and telescope selection menus. I find it very useful to use in walker as well. 

p.s.: love omarchy, its been 1 year since I've made the move!