### PR TITLE
Add Mako theme and user overrides

### DIFF
--- a/config/omarchy/mako.ini
+++ b/config/omarchy/mako.ini
@@ -1,0 +1,1 @@
+# User-specific Mako overrides.

--- a/default/themed/mako-theme.ini.tpl
+++ b/default/themed/mako-theme.ini.tpl
@@ -1,0 +1,1 @@
+# Theme-specific Mako overrides.

--- a/default/themed/mako.ini.tpl
+++ b/default/themed/mako.ini.tpl
@@ -4,3 +4,6 @@ include=~/.local/state/omarchy/toggles/mako.ini
 text-color={{ foreground }}
 border-color={{ accent }}
 background-color={{ background }}
+
+include=~/.config/omarchy/current/theme/mako-theme.ini
+include=~/.config/omarchy/mako.ini

--- a/migrations/1780740711.sh
+++ b/migrations/1780740711.sh
@@ -1,0 +1,14 @@
+echo "Add Mako override config"
+
+config_dir="$HOME/.config/omarchy"
+theme_dir="$config_dir/current/theme"
+
+mkdir -p "$config_dir" "$theme_dir"
+
+if [ ! -f "$config_dir/mako.ini" ]; then
+  cp "$OMARCHY_PATH/config/omarchy/mako.ini" "$config_dir/mako.ini"
+fi
+
+if [ ! -f "$theme_dir/mako-theme.ini" ]; then
+  cp "$OMARCHY_PATH/default/themed/mako-theme.ini.tpl" "$theme_dir/mako-theme.ini"
+fi


### PR DESCRIPTION
## Summary

Add two override layers to Omarchy's generated Mako config:

```ini
include=~/.config/omarchy/current/theme/mako-theme.ini
include=~/.config/omarchy/mako.ini
```

Themes can now ship `mako-theme.ini` for notification styling, while users get a persistent `~/.config/omarchy/mako.ini` override that survives theme switches. Default empty files are included so Mako never fails on a missing include.

## Why

Core notification behavior, Omarchy toggles, and generated theme colors should stay in the main Mako config. Theme-specific and user-specific tweaks are better as small override fragments instead of replacing the whole generated file.

## Testing

- `bash -n migrations/1780740711.sh bin/omarchy-theme-set-templates`
- `git diff --check origin/dev..cp/mako-overrides`
- generated a Mako config from Catppuccin colors and verified both include lines plus the default empty `mako-theme.ini`
- parsed a temporary generated Mako config with both included files present
