### PR TITLE
Use delta for Git and LazyGit diffs

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -11,10 +11,16 @@
 	rebase = true 			 # Rebase (instead of merge) on pull
 [push]
 	autoSetupRemote = true   # Automatically set upstream branch on push
+[core]
+	pager = delta            # Use syntax-highlighted diffs
 [diff]
 	algorithm = histogram    # Clearer diffs on moved/edited lines
 	colorMoved = plain       # Highlight moved blocks in diffs
 	mnemonicPrefix = true    # More intuitive refs in diff output
+[interactive]
+	diffFilter = delta --color-only
+[delta]
+	navigate = true
 [commit]
 	verbose = true           # Include diff comment in commit message template
 [column]

--- a/config/lazygit/config.yml
+++ b/config/lazygit/config.yml
@@ -1,0 +1,4 @@
+git:
+  pagers:
+    - colorArg: always
+      pager: delta --paging=never --line-numbers

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -41,6 +41,7 @@ fontconfig
 foot
 fzf
 github-cli
+git-delta
 gnome-calculator
 gnome-keyring
 gnome-themes-extra

--- a/migrations/1780739890.sh
+++ b/migrations/1780739890.sh
@@ -1,0 +1,16 @@
+echo "Use delta for Git and LazyGit diffs"
+
+omarchy-pkg-add git-delta
+
+git_config="$HOME/.config/git/config"
+lazygit_config="$HOME/.config/lazygit/config.yml"
+
+mkdir -p "$(dirname "$git_config")" "$(dirname "$lazygit_config")"
+
+git config --file "$git_config" --get core.pager >/dev/null || git config --file "$git_config" core.pager delta
+git config --file "$git_config" --get interactive.diffFilter >/dev/null || git config --file "$git_config" interactive.diffFilter "delta --color-only"
+git config --file "$git_config" --get delta.navigate >/dev/null || git config --file "$git_config" delta.navigate true
+
+if [ ! -s "$lazygit_config" ]; then
+  cp "$OMARCHY_PATH/config/lazygit/config.yml" "$lazygit_config"
+fi


### PR DESCRIPTION
## Summary

Install `git-delta` and configure Git/LazyGit to use it for diffs.

Git gets:

```ini
[core]
  pager = delta
[interactive]
  diffFilter = delta --color-only
[delta]
  navigate = true
```

LazyGit gets a delta pager with paging disabled and line numbers enabled.

## Why

Omarchy already ships a curated terminal/dev setup. Delta makes Git diffs easier to scan with syntax highlighting while keeping the default config small and standard.

The migration is guarded: it only fills unset Git keys and only copies the LazyGit config if that file is empty.

## Testing

- `git config --file config/git/config --get core.pager`
- `git config --file config/git/config --get interactive.diffFilter`
- `lazygit --use-config-file config/lazygit/config.yml --version`
- smoke-tested the migration in a temporary HOME
- `bash -n migrations/1780739890.sh`
- `git diff --check origin/dev..cp/git-delta-defaults`
