### PR TITLE
Use dua for disk usage

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -26,7 +26,7 @@ docker-buildx
 docker-compose
 dosfstools
 dotnet-runtime-9.0
-dust
+dua-cli
 evince
 exfatprogs
 expac

--- a/install/packaging/tuis.sh
+++ b/install/packaging/tuis.sh
@@ -1,4 +1,4 @@
 ICON_DIR="$HOME/.local/share/applications/icons"
 
-omarchy-tui-install "Disk Usage" "bash -c 'dust -r; read -n 1 -s'" float "$ICON_DIR/Disk Usage.png"
+omarchy-tui-install "Disk Usage" "dua i" float "$ICON_DIR/Disk Usage.png"
 omarchy-tui-install "Docker" "lazydocker" tile "$ICON_DIR/Docker.png"

--- a/migrations/1780739888.sh
+++ b/migrations/1780739888.sh
@@ -1,0 +1,12 @@
+echo "Use dua for Disk Usage TUI"
+
+omarchy-pkg-add dua-cli
+omarchy-pkg-drop dust
+
+APP_DIR="$HOME/.local/share/applications"
+ICON_DIR="$APP_DIR/icons"
+
+if [ -f "$APP_DIR/Disk Usage.desktop" ]; then
+  rm "$APP_DIR/Disk Usage.desktop"
+  omarchy-tui-install "Disk Usage" "dua i" float "$ICON_DIR/Disk Usage.png"
+fi


### PR DESCRIPTION
## Summary

Replace `dust` with `dua-cli` for the Disk Usage TUI launcher.

New installs use:

```sh
dua i
```

The migration installs `dua-cli`, drops `dust`, and regenerates the existing Disk Usage launcher if present.

Demo: https://terminaltrove.com/dua/

## Why

`dua i` gives the Disk Usage launcher an interactive interface while staying fast. This changes the TUI disk usage tool only; `gnome-disk-utility` remains installed for graphical disk management.

## Testing

- `dua i --help`
- `bash -n migrations/1780739888.sh install/packaging/tuis.sh`
- `git diff --check origin/dev..cp/dua-disk-usage`
