### PR TITLE
Add Vivaldi as a default browser candidate.

### DIFF
--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default browser for Omarchy and XDG handlers
-# omarchy:args=[chromium|chrome|brave|brave-origin|edge|firefox|zen]
+# omarchy:args=[chromium|chrome|brave|brave-origin|edge|firefox|vivaldi|zen]
 # omarchy:examples=omarchy default browser firefox | omarchy default browser brave
 
 if (($# == 0)); then
@@ -12,6 +12,7 @@ if (($# == 0)); then
   brave-origin-beta.desktop) echo "brave-origin" ;;
   microsoft-edge.desktop) echo "edge" ;;
   firefox.desktop) echo "firefox" ;;
+  vivaldi-stable.desktop) echo "vivaldi" ;;
   zen.desktop) echo "zen" ;;
   *) xdg-settings get default-web-browser ;;
   esac
@@ -25,9 +26,10 @@ brave) desktop_id="brave-browser.desktop"; name="Brave"; glyph="󰖟" ;;
 brave-origin) desktop_id="brave-origin-beta.desktop"; name="Brave Origin"; glyph="󰖟" ;;
 edge) desktop_id="microsoft-edge.desktop"; name="Edge"; glyph="󰇩" ;;
 firefox) desktop_id="firefox.desktop"; name="Firefox"; glyph="󰈹" ;;
+vivaldi) desktop_id="vivaldi-stable.desktop"; name="Vivaldi"; glyph="󰖟" ;;
 zen) desktop_id="zen.desktop"; name="Zen"; glyph="󰖟" ;;
 *)
-  echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|vivaldi|zen>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -403,6 +403,7 @@ show_setup_default_browser_menu() {
   browser_desktop_exists brave-origin-beta.desktop && options="${options:+$options\n}󰖟  Brave Origin"
   browser_desktop_exists microsoft-edge.desktop && options="${options:+$options\n}󰇩  Edge"
   browser_desktop_exists firefox.desktop && options="${options:+$options\n}󰈹  Firefox"
+  browser_desktop_exists vivaldi-stable.desktop && options="${options:+$options\n}󰖟  Vivaldi"
   browser_desktop_exists zen.desktop && options="${options:+$options\n}󰖟  Zen"
 
   local current=""
@@ -413,6 +414,7 @@ show_setup_default_browser_menu() {
   brave-origin) current="󰖟  Brave Origin" ;;
   edge) current="󰇩  Edge" ;;
   firefox) current="󰈹  Firefox" ;;
+  vivaldi) current="󰖟  Vivaldi" ;;
   zen) current="󰖟  Zen" ;;
   esac
 
@@ -423,6 +425,7 @@ show_setup_default_browser_menu() {
   *Brave*) omarchy-default-browser brave ;;
   *Edge*) omarchy-default-browser edge ;;
   *Firefox*) omarchy-default-browser firefox ;;
+  *Vivaldi*) omarchy-default-browser vivaldi ;;
   *Zen*) omarchy-default-browser zen ;;
   *) show_setup_default_menu ;;
   esac


### PR DESCRIPTION
I like Vivaldi I think.

I have added it to the default browser commands and menus. 

I did not add it to the install/uninstall browser tools as I just installed it with Pacman -S nothing special and so far that seems fine. 

If this PR is otherwise acceptable but you would like other support added for Vivaldi before merging I presently have time and am willing to do the work as far as I am capable. 