### PR TITLE
Fix Microsoft Edge web apps failing to launch

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -10,4 +10,10 @@ google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' \
+  {~/.local,~/.nix-profile,/usr}/share/applications/$browser \
+  2>/dev/null | head -1)
+
+[[ -n "$browser_exec" ]] || browser_exec=$(command -v microsoft-edge-stable)
+
+exec setsid uwsm-app -- "$browser_exec" --app="$1" "${@:2}"


### PR DESCRIPTION
## Summary

Fix Omarchy web apps failing to launch when Microsoft Edge is the default browser.

## Problem

Launching a web app with Microsoft Edge fails with an error similar to:

```text
Path "--app=http:/youtube.com" does not exist
```

The browser executable lookup can return an empty result for the Microsoft Edge desktop entry. This causes `uwsm-app` to interpret the `--app` argument incorrectly instead of launching Edge.

## Change

Fall back to resolving `microsoft-edge-stable` from `PATH` when the existing desktop-entry lookup does not return an executable.

The existing behavior remains unchanged for other supported browsers.

## Testing

Verified with Microsoft Edge as the default browser:

```bash
omarchy-launch-webapp "https://youtube.com"
```

The web app now launches correctly in Edge app mode.
