### PR TITLE
Add --browser flag to omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -1,9 +1,29 @@
 #!/bin/bash
 
-# omarchy:summary=Launch a URL as a web app in the default supported browser
-# omarchy:args=<url>
+# omarchy:summary=Launch a URL as a web app in the default supported browser, or user specified browser
+# omarchy:args=[--browser <name>] <url>
 
-browser=$(xdg-settings get default-web-browser)
+browser=""
+
+while (( $# > 0 )); do
+  case $1 in
+    --browser)
+      browser="$2"
+      shift 2
+      ;;
+    --browser=*)
+      browser="${1#--browser=}"
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ -z $browser ]]; then
+  browser=$(xdg-settings get default-web-browser)
+fi
 
 case $browser in
 google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;


### PR DESCRIPTION
Adds `--browser` flag to `omarchy launch webapp`, allowing users to specify which browser opens the web app instead of always using the system default.

Supports `--browser <name>` and `--browser=<name>`. Falls back to `xdg-settings get default-web-browser` when omitted — no change in default behavior.

Usage:

    omarchy launch webapp --browser brave https://example.com