### PR TITLE
feat(webapps): add Zen browser support to launcher

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -6,7 +6,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium* | zen*) ;;
 *) browser="chromium.desktop" ;;
 esac
 


### PR DESCRIPTION
This adds support to run webapps via the [Zen browser](https://zen-browser.app/welcome/).