### PR TITLE
add user-defined keybindings extension for keybindings menu

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -26,6 +26,10 @@ declare -A FALLBACK_KEYCODE_SYM_MAP=(
 # source-derived key cache so the menu can still show those bindings.
 declare -A LUA_BIND_KEY_MAP
 
+# Allow user-defined keybinding extensions
+USER_EXTENSIONS="$HOME/.config/omarchy/extensions/keybindings.sh"
+[[ -f $USER_EXTENSIONS ]] && source "$USER_EXTENSIONS"
+
 build_keymap_cache() {
   local keymap
   keymap="$(xkbcli compile-keymap)" || {
@@ -382,6 +386,7 @@ output_binding_records() {
   {
     dynamic_bindings
     static_bindings
+    [[ $(type -t user_bindings) == "function" ]] && user_bindings
   } |
     sort -u |
     parse_keycodes |

--- a/config/omarchy/extensions/keybindings.sh
+++ b/config/omarchy/extensions/keybindings.sh
@@ -14,3 +14,4 @@
 #   echo "ALT,1,Tmux: window 1"
 #   echo "CTRL ALT,Left,Tmux: navigate pane left"
 #   echo "ALT,1,Tmux: window 1"
+#   }

--- a/config/omarchy/extensions/keybindings.sh
+++ b/config/omarchy/extensions/keybindings.sh
@@ -1,0 +1,16 @@
+# Add custom keybindings to the Omarchy keybindings menu (Super + K).
+# See $OMARCHY_PATH/bin/omarchy-menu-keybindings for the expected output format.
+#
+# $OMARCHY_PATH/bin/omarchy-menu-keybindings will invoke a user_bindings()
+# function in this file if present.
+#
+# Each line output by user_bindings() must be comma-separated:
+#   MODIFIERS,KEY,Description
+#
+# Example:
+# user_bindings() {
+#   echo ",prefix h,Tmux: split pane vertically"
+#   echo ",prefix v,Tmux: split pane horizontally"
+#   echo "ALT,1,Tmux: window 1"
+#   echo "CTRL ALT,Left,Tmux: navigate pane left"
+#   echo "ALT,1,Tmux: window 1"


### PR DESCRIPTION
Allow users to add custom keybindings to the omarchy keybindings menu via ~/.config/omarchy/extensions/keybindings.sh
Useful for app bindings that don't get automatically detected in omarchy's default bindings (e.g. STEAM or discord overlays, etc.). 

Implementation keeps in line with the way it's been done for the Omarchy menu customisation