### PR TITLE
fix: multi-monitor window highlighting in slurp capture

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -100,15 +100,18 @@ default_resolution() {
   fi
 }
 
-# Monitor + window rectangles on the focused workspace, in slurp's "X,Y WxH" format.
+# All monitor geometries + windows on visible workspaces, in slurp's "X,Y WxH" format.
 # Mirrors omarchy-capture-screenshot so the picker UX is identical.
 get_rectangles() {
-  local active_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id')
-  hyprctl monitors -j | jq -r --arg ws "$active_workspace" '
-    .[] | select(.activeWorkspace.id == ($ws | tonumber)) |
-    "\(.x),\(.y) \(.width / .scale | floor)x\(.height / .scale | floor)"'
-  hyprctl clients -j | jq -r --arg ws "$active_workspace" '
-    .[] | select(.workspace.id == ($ws | tonumber)) |
+  local monitors_json=$(hyprctl monitors -j)
+  local clients_json=$(hyprctl clients -j)
+
+  echo "$monitors_json" | jq -r '
+    .[] | "\(.x),\(.y) \(.width / .scale | floor)x\(.height / .scale | floor)"'
+
+  echo "$clients_json" | jq -r --argjson active \
+    "$(echo "$monitors_json" | jq -c 'map(.activeWorkspace.id)')" '
+    .[] | select(.workspace.id as $id | $active | index($id)) |
     "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
 }
 

--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -60,9 +60,15 @@ JQ_MONITOR_GEO='
 '
 
 get_rectangles() {
-  local active_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id')
-  hyprctl monitors -j | jq -r --arg ws "$active_workspace" "${JQ_MONITOR_GEO} .[] | select(.activeWorkspace.id == (\$ws | tonumber)) | format_geo"
-  hyprctl clients -j | jq -r --arg ws "$active_workspace" '.[] | select(.workspace.id == ($ws | tonumber)) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
+  local monitors_json=$(hyprctl monitors -j)
+  local clients_json=$(hyprctl clients -j)
+
+  echo "$monitors_json" | jq -r "${JQ_MONITOR_GEO} .[] | format_geo"
+
+  echo "$clients_json" | jq -r --argjson active \
+    "$(echo "$monitors_json" | jq -c 'map(.activeWorkspace.id)')" '
+    .[] | select(.workspace.id as $id | $active | index($id)) |
+    "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"'
 }
 
 # Keep hyprpicker alive until after grim captures so the screenshot sees the


### PR DESCRIPTION
Fixes multi-monitor window highlighting in slurp.

The Issue: get_rectangles() only queried the focused monitor. Moving the cursor to a second or third monitor slurp was blind to the windows of that monitor and the window capture feature didn't work(meaning you needed to click and drag manually).

The Fix:

Updated the logic to return geometries for all connected monitors.

Built an array of active workspace IDs across all screens and filtered the hyprctl clients list to match.

Optimized the data passing using jq --argjson.
