### PR TITLE
Add Vim-style Ctrl-n / Ctrl-p shortcuts for walker navigation

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -9,6 +9,8 @@ hide_action_hints = true                                                    # gl
 
 [keybinds]
 quick_activate = []
+next = ["Down", "ctrl n"]     # move selection down (ctrl n like Vim/readline)
+previous = ["Up", "ctrl p"]   # move selection up (ctrl p like Vim/readline)
 
 [columns]
 symbols = 1 # providers to be queried by default

--- a/migrations/1780929365.sh
+++ b/migrations/1780929365.sh
@@ -1,0 +1,10 @@
+echo "Add Ctrl+n/Ctrl+p navigation keybinds to Walker"
+
+CONFIG_FILE="$HOME/.config/walker/config.toml"
+
+if [[ -f $CONFIG_FILE ]] &&
+  grep -q '^quick_activate = \[\]' "$CONFIG_FILE" &&
+  ! grep -qE '^next =' "$CONFIG_FILE" &&
+  ! grep -qE '^previous =' "$CONFIG_FILE"; then
+  sed -i '/^quick_activate = \[\]/a next = ["Down", "ctrl n"]     # move selection down (ctrl n like Vim/readline)\nprevious = ["Up", "ctrl p"]   # move selection up (ctrl p like Vim/readline)' "$CONFIG_FILE"
+fi


### PR DESCRIPTION
## What
Added Vim-style keyboard shortcuts to walker navigation:
- `Ctrl-n` — select next
- `Ctrl-p` — select previous

## Why
Lets you navigate the walker without leaving the home row, consistent with Vim keybindings many users already have in muscle memory.

## Testing
Manually tested in walker — both shortcuts move the selection as expected.