### PR TITLE
Default git init branch to main

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -6,7 +6,7 @@
 	ci = commit
 	st = status
 [init]
-	defaultBranch = master
+	defaultBranch = main
 [pull]
 	rebase = true 			 # Rebase (instead of merge) on pull
 [push]

--- a/migrations/1780929365.sh
+++ b/migrations/1780929365.sh
@@ -1,0 +1,3 @@
+echo "Set git init.defaultBranch to main"
+
+git config --global init.defaultBranch main


### PR DESCRIPTION
Change the default git branch name from `master` to `main` which is the default for new repositories pretty much everywhere.