### PR TITLE
Rebind Super+Ctrl+N to launch hstui nightlight manager

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -359,7 +359,7 @@ prioritize_entries() {
     if (match(line, /notification/))  prio = 37
     if (match(line, /Toggle window transparency/))  prio = 38
     if (match(line, /Toggle workspace gaps/))  prio = 39
-    if (match(line, /Toggle nightlight/))  prio = 40
+    if (match(line, /Manage nightlight/))  prio = 40
     if (match(line, /Toggle locking/))  prio = 41
     if (match(line, /group/))  prio = 94
     if (match(line, /Scroll active workspace/))  prio = 95

--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -1,6 +1,6 @@
 o.window({ tag = "floating-window" }, { float = true, center = true, size = { 875, 600 } })
 
-o.window("(org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.codeberg.dnkl.foot|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)", { tag = "+floating-window" })
+o.window("(org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.hstui|org.omarchy.terminal|org.omarchy.bash|org.codeberg.dnkl.foot|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)", { tag = "+floating-window" })
 o.window({ class = "(xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus)", title = "^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)" }, { tag = "+floating-window" })
 o.window("org.gnome.Calculator", { float = true })
 

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -29,7 +29,7 @@ o.bind("SUPER + ALT + COMMA", "Invoke last notification", "makoctl invoke")
 o.bind("SUPER + SHIFT + ALT + COMMA", "Restore last notification", "makoctl restore")
 
 o.bind_toggle("SUPER + CTRL + I", "Toggle locking on idle", "idle")
-o.bind_toggle("SUPER + CTRL + N", "Toggle nightlight", "nightlight")
+o.bind("SUPER + CTRL + N", "Manage nightlight", { tui = "hstui", focus = true })
 o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monitor-internal toggle")
 o.bind("SUPER + CTRL + ALT + Delete", "Toggle laptop display mirroring", "omarchy-hyprland-monitor-internal-mirror toggle")
 o.bind("switch:on:Lid Switch", nil, "omarchy-hw-external-monitors && omarchy-hyprland-monitor-internal off", { locked = true })

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -50,6 +50,7 @@ gum
 gvfs-mtp
 gvfs-nfs
 gvfs-smb
+hstui
 hypridle
 hyprland
 hyprland-guiutils

--- a/migrations/1780929365.sh
+++ b/migrations/1780929365.sh
@@ -1,0 +1,3 @@
+echo "Install hstui for the new Super + Ctrl + N nightlight manager binding"
+
+omarchy-pkg-add hstui


### PR DESCRIPTION
## What

Rebind `Super + Ctrl + N` from the instant nightlight toggle to launch [**hstui**](https://github.com/mplaczek99/hstui) — a terminal UI for managing `hyprsunset` (the nightlight). The instant toggle (`omarchy-toggle-nightlight`) stays available via the Omarchy menu; it only loses its dedicated shortcut.

## Changes

- `default/hypr/bindings/utilities.lua` — `Super+Ctrl+N` now does `{ tui = "hstui", focus = true }` (launch-or-focus, single instance, app-id `org.omarchy.hstui`). Renamed to "Manage nightlight".
- `install/omarchy-base.packages` — add `hstui` so the default binding works on fresh installs / ISO.
- `migrations/1780929365.sh` — install `hstui` on existing installs (binding propagates via the default Lua module, so without this existing users would get a binding with no binary).
- `default/hypr/apps/system.lua` — float + center `org.omarchy.hstui`, matching the other Omarchy TUIs (btop, bluetui, …).
- `bin/omarchy-menu-keybindings` — keep the entry's sort priority after the rename.

## Notes for reviewers (blocking prerequisites)

1. **Repo availability:** `omarchy-pkg-add` uses `pacman` only, so `hstui` must be carried by the Omarchy package repo (it is currently AUR-only). Until then the base.packages entry + migration fail on real machines. Min-version, if any, is best enforced as a repo check (`pacman -Si hstui`) rather than a version expression — `omarchy-pkg-add`/`omarchy-pkg-missing` validate with `pacman -Q` and don't parse `pkg>=x`.
2. **hyprsunset bootstrap:** the old `omarchy-toggle-nightlight` starts `hyprsunset` if it isn't running (it's not autostarted by default). hstui must do the same on a fresh session, otherwise the binding looks broken. (Handled in hstui upstream.)

## Testing

- `Super+Ctrl+N` opens hstui floating/centered; second press focuses the existing window.
- Keybindings menu (`Super+K`) shows "Manage nightlight" in its prior position.
- Nightlight instant-toggle still reachable from the Omarchy menu.
