### PR TITLE
fix: use grim -o for fullscreen screenshots to avoid white borders with fractional scaling

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -87,6 +87,7 @@ windows)
   SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
   ;;
 fullscreen)
+  FULLSCREEN_OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')
   SELECTION=$(hyprctl monitors -j | jq -r "${JQ_MONITOR_GEO} .[] | select(.focused == true) | format_geo")
   ;;
 smart | *)
@@ -128,7 +129,11 @@ FILEPATH="$OUTPUT_DIR/$FILENAME"
 
 case "$PROCESSING" in
   slurp)
-    grim -g "$SELECTION" "$FILEPATH" || exit 1
+    if [[ $MODE == "fullscreen" ]]; then
+      grim -o "$FULLSCREEN_OUTPUT" "$FILEPATH" || exit 1
+    else
+      grim -g "$SELECTION" "$FILEPATH" || exit 1
+    fi
     echo "$FILEPATH"
     wl-copy <"$FILEPATH"
 
@@ -138,10 +143,18 @@ case "$PROCESSING" in
     ) >/dev/null 2>&1 &
     ;;
   copy)
-    grim -g "$SELECTION" - | wl-copy
+    if [[ $MODE == "fullscreen" ]]; then
+      grim -o "$FULLSCREEN_OUTPUT" - | wl-copy
+    else
+      grim -g "$SELECTION" - | wl-copy
+    fi
     ;;
   save)
-    grim -g "$SELECTION" "$FILEPATH" || exit 1
+    if [[ $MODE == "fullscreen" ]]; then
+      grim -o "$FULLSCREEN_OUTPUT" "$FILEPATH" || exit 1
+    else
+      grim -g "$SELECTION" "$FILEPATH" || exit 1
+    fi
     echo "$FILEPATH"
     ;;
 esac


### PR DESCRIPTION
## Problem

When using fractional scaling (e.g. `monitor=,preferred,auto,1.33`), fullscreen screenshots have a white line/border on the bottom and right edges.

## Root Cause

The jq geometry calculation uses `floor(width / scale)`. With 1.33x scaling on a 1920x1080 display:

- `floor(1920 / 1.33) = 1443` (but actual is 1443.61)
- `floor(1080 / 1.33) = 812`  (but actual is 812.03)

The truncated ~0.6px on each axis leaves a visible white sliver at the bottom and right edges of the captured image.

## Fix

For fullscreen mode, use `grim -o <output-name>` instead of `grim -g <calculated-geometry>`. The `-o` flag captures the output buffer directly and handles fractional scaling internally, avoiding the off-by-one rounding error entirely.

Other modes (region, windows, smart) are unaffected — they still use geometry with slurp.